### PR TITLE
Rename "master" to "main"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - idaes_dev:
           context: IDAES

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ scale-up, operation and troubleshooting of innovative, advanced energy systems.
 ## Build statuses
 | idaes-dev | idaes-pse |
 |:---------:|:---------:|
-| [![CircleCI](https://circleci.com/gh/IDAES/idaes-dev.svg?style=svg&circle-token=f01aa6337105a565ae7caa0e0eab66826bd8ea81)](https://circleci.com/gh/IDAES/idaes-dev) [![Coverage Status](https://coveralls.io/repos/github/IDAES/idaes-dev/badge.svg?t=PJNalC)](https://coveralls.io/github/IDAES/idaes-dev) |[![CircleCI](https://circleci.com/gh/IDAES/idaes-pse.svg?style=svg)](https://circleci.com/gh/IDAES/idaes-pse) [![Coverage Status](https://coveralls.io/repos/github/IDAES/idaes-pse/badge.svg?branch=master)](https://coveralls.io/github/IDAES/idaes-pse?branch=master)|
+| [![CircleCI](https://circleci.com/gh/IDAES/idaes-dev.svg?style=svg&circle-token=f01aa6337105a565ae7caa0e0eab66826bd8ea81)](https://circleci.com/gh/IDAES/idaes-dev) [![Coverage Status](https://coveralls.io/repos/github/IDAES/idaes-dev/badge.svg?t=PJNalC)](https://coveralls.io/github/IDAES/idaes-dev) |[![CircleCI](https://circleci.com/gh/IDAES/idaes-pse.svg?style=svg)](https://circleci.com/gh/IDAES/idaes-pse) [![Coverage Status](https://coveralls.io/repos/github/IDAES/idaes-pse/badge.svg?branch=main)](https://coveralls.io/github/IDAES/idaes-pse?branch=main)|
 <!-- END Status badges -->
 
 ## System requirements

--- a/docs/advanced_user_guide/advanced_install/index.rst
+++ b/docs/advanced_user_guide/advanced_install/index.rst
@@ -127,7 +127,7 @@ The not integration tag skips some tests that are slow. If you like, you can run
 
 Update IDAES
 ^^^^^^^^^^^^^^^^^^^^^^^
-The master branch of idaes-pse is frequently updated and a new IDAES release occurs quarterly. It is recommended that you update your fork and local repositories and conda environment periodically. 
+The main branch of idaes-pse is frequently updated and a new IDAES release occurs quarterly. It is recommended that you update your fork and local repositories and conda environment periodically. 
 
 .. code-block:: sh
     

--- a/docs/advanced_user_guide/advanced_install/terms_commands.rst
+++ b/docs/advanced_user_guide/advanced_install/terms_commands.rst
@@ -38,7 +38,7 @@ together, and keep separable from other series of commits. From Git's perspectiv
 the branch is just a name for the first commit in that series.
 
 It is recommended that you create new branches on which to develop your work,
-and reserve the "master" branch for merging in work that has been completed
+and reserve the "main" branch for merging in work that has been completed
 and approved on GitHub. One way to do this is to create branches that correspond
 directly to issues on GitHub, and include the issue number in the branch name.
 
@@ -72,7 +72,7 @@ helpful:
 
 Pull requests are a mechanism that GitHub provides to look at what the
 code on some branch from your fork of the repository would be like if it
-were merged with the master branch in the main (e.g., idaes-pse/idaes-dev)
+were merged with the main branch in the main (e.g., idaes-pse/idaes-dev)
 repository. You can think of it as a staging area where the code is merged
 and all the tests are run, without changing the target repository.
 Everyone on the team can see a pull request, comment on it, and review

--- a/docs/advanced_user_guide/developer/codereview.rst
+++ b/docs/advanced_user_guide/developer/codereview.rst
@@ -102,6 +102,6 @@ rerun the tests after every change (in this case, every new Pull Request
 or update to the code in an existing Pull Request) and report the
 results back to Github for display in the web pages. This status
 information can then be used as an automatic gatekeeper on whether the
-code can be merged into the master branch – if tests fail, then no merge
-is allowed. Following this procedure, it is not possible for the master
+code can be merged into the main branch – if tests fail, then no merge
+is allowed. Following this procedure, it is not possible for the main
 branch to ever be failing its own tests.

--- a/docs/advanced_user_guide/developer/devsw.rst
+++ b/docs/advanced_user_guide/developer/devsw.rst
@@ -220,7 +220,7 @@ below shows where you need to click to do this.
 
 Create a branch on your fork
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-It is certainly possible to do your work on your fork in the "master"
+It is certainly possible to do your work on your fork in the "main"
 branch. The problem that can arise here is if you need to do two unrelated
 things at the same time, for example working on a new feature and fixing
 a bug in the current code. This can be quite tricky to manage as a single set
@@ -353,7 +353,7 @@ A typical workflow goes like this:
     M  file1
     A  file3
     $ git commit -m "made some changes"
-    [master 067c16e] made some changes
+    [main 067c16e] made some changes
     2 files changed, 2 insertions(+)
     create mode 100644 file3
 
@@ -374,7 +374,7 @@ commands::
     git pull
     # OR -- explicit
     git fetch --all
-    git merge upstream/master
+    git merge upstream/main
 
 You'll notice that this merge command is using the name of the "upstream" remote
 that you :ref:`created earlier <sw-add-upstream>`.
@@ -413,7 +413,7 @@ did to the other developers. Through the Github "review" mechanism, people will
 be able to suggest changes and improvements. You can make changes to the code (other
 people can also make changes, see :ref:`sw-share-forks`), and then push those
 changes up into the same Pull Request. When you get enough approving reviews,
-the code is merged into the master repository. At this point, you can delete the
+the code is merged into the main repository. At this point, you can delete the
 "topic branch" used for the pull request, and go back to :ref:`initiate <sw-wf-initiate>` your
 next set of changes.
 
@@ -480,11 +480,11 @@ big green "merge" button.
 Before you close the laptop and go down to the pub, you should tidy up. First,
 delete your local branch (you can also delete that branch on Github)::
 
-    git checkout master # switch back to master branch
+    git checkout main # switch back to main branch
     git branch -d mychanges-issue3000
 
-Next, you should make sure your master reflects the current state of the main
-master branch, i.e. go back and :ref:`synchronize with the upstream remote <sw-sync-upstream>`,
+Next, you should make sure your main reflects the current state of the upstream
+main branch, i.e. go back and :ref:`synchronize with the upstream remote <sw-sync-upstream>`,
 i.e. run ``git pull``.
 
 Now you can go and enjoy a tasty beverage. Cheers!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,8 +62,8 @@ source_suffix = '.rst'
 #
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'IDAES'
@@ -289,7 +289,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'IDAES.tex', u'IDAES Documentation', u'IDAES team', 'manual')
+    (main_doc, 'IDAES.tex', u'IDAES Documentation', u'IDAES team', 'manual')
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -343,7 +343,7 @@ man_pages = [('dmf/cli', 'dmf', u'Data Management Framework', [author], 1)]
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        main_doc,
         'IDAES',
         u'IDAES Documentation',
         author,

--- a/docs/user_guide/modeling_extensions/matopt/index.rst
+++ b/docs/user_guide/modeling_extensions/matopt/index.rst
@@ -145,7 +145,7 @@ The results of the optimization process will be loaded into ``Design`` objects a
 MatOpt Examples
 ---------------
 Five `case studies
-<https://github.com/IDAES/examples-pse/tree/master/src/matopt>`_ are provided to illustrate the detailed usage of MatOpt. In each case, a Jupyter notebook with explanations as well as an equivalent Python script is provided.
+<https://github.com/IDAES/examples-pse/tree/main/src/matopt>`_ are provided to illustrate the detailed usage of MatOpt. In each case, a Jupyter notebook with explanations as well as an equivalent Python script is provided.
 
 References
 ----------

--- a/idaes/apps/matopt/README.md
+++ b/idaes/apps/matopt/README.md
@@ -204,7 +204,7 @@ The results of the optimization process will be loaded into `Design` objects aut
 MatOpt Examples
 ---------------
 
-Five [case studies](https://github.com/IDAES/examples-pse/tree/master/src/matopt) are provided to illustrate the detailed usage of MatOpt. In each case, a Jupyter notebook with explanations as well as an equivalent Python script is provided.
+Five [case studies](https://github.com/IDAES/examples-pse/tree/main/src/matopt) are provided to illustrate the detailed usage of MatOpt. In each case, a Jupyter notebook with explanations as well as an equivalent Python script is provided.
 
 References
 ----------


### PR DESCRIPTION
**NOTE:** When this PR is approved, you *must* do the following so it can be merged:
* Add the "approved" tag to the pull-request
* Trigger tests by pushing a commit or manually re-running in CircleCI

See [this wiki page](https://github.com/IDAES/idaes-dev/wiki/Github-Pull-Request-Workflow-with-Approval-Tag) for details.

----
## Fixes

Misc breakages caused by renaming the default branch to `main`

## Summary/Motivation:

- Align to updated GitHub convention of naming the default branch `main`

## Changes proposed in this PR:

Change references to `master` to use `main` instead for:

- Tools (e.g. CircleCI)
- Documentation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.

----

## Reviewer Checklist
* Reviewer 1
- [ ] Tests: do they pass, do they cover functionality, are they understandable?
- [ ] Documentation: is the code commented, are there user-level docs where needed?
* Reviewer 2
- [ ] Tests: do they pass, do they cover functionality, are they understandable?
- [ ] Documentation: is the code commented, are there user-level docs where needed?
