### PR TITLE
Address all pylint errors in the current codebase

### DIFF
--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -21,7 +21,7 @@ runs:
         pylint_exit_status=$?
 
         # render report
-        base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/main/$GITHUB_SHA"
+        base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/$GITHUB_SHA"
         pylint_output_path=pylint.json
         echo "::group::Rendered pylint report"
         python .pylint/render_report.py --base-url="$base_url" "$pylint_output_path"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -8,17 +8,21 @@ runs:
       shell: bash
       run: |
         PIP_INSTALL="pip --no-cache-dir install --progress-bar off"
+        echo "::group::Output of `pip install` commands"
         $PIP_INSTALL --upgrade pip setuptools wheel
         # TODO the pylint version will have to be pinned
         # TODO installing idaes is necessary in our case because we import some idaes code in pylint plugins
         $PIP_INSTALL -r requirements-dev.txt
+        echo "::endgroup::"
         # don't think we need to install the extensions, though
     - name: Run pylint (errors only)
       # use custom options for bash since the default causes the step to fail immediately for any non-zero return code of intermediate commands
       shell: bash --noprofile --norc {0}
       run: |
+        echo "::group::Real-time pylint log"
         pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_reporters.MultiReporter idaes/
         pylint_exit_status=$?
+        echo "::endgroup::"
 
         # render report
         base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blame/$GITHUB_SHA"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -34,10 +34,11 @@ runs:
 
         # show PYLINT-TODO left in the codebase
         todo_sentinel="PYLINT-TODO"
-        grep_opts="--recursive --include '*.py' --color=always --after-context=2 --line-number --initial-tab"
+        # use a bash array to save options containing quotes to a variable, then use the double-quoted array expansion "${arr[@]}"
+        grep_opts=( --recursive --include '*.py' --color=always --after-context=2 --line-number --initial-tab )
 
         echo "::group::Show pylint \"$todo_sentinel\" sentinel comments in the codebase"
-        grep "$todo_sentinel" $grep_opts "$pylint_target_dir" || echo "No \"$todo_sentinel\" comments found in $pylint_target_dir"
+        grep "$todo_sentinel" "${grep_opts[@]}" "$pylint_target_dir" || echo "No \"$todo_sentinel\" comments found in $pylint_target_dir"
         echo "::endgroup::"
 
         exit "$pylint_exit_status"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -19,8 +19,9 @@ runs:
       # use custom options for bash since the default causes the step to fail immediately for any non-zero return code of intermediate commands
       shell: bash --noprofile --norc {0}
       run: |
+        pylint_target_dir="idaes/"
         echo "::group::Real-time pylint log"
-        pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_reporters.MultiReporter idaes/
+        pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_reporters.MultiReporter "$pylint_target_dir"
         pylint_exit_status=$?
         echo "::endgroup::"
 
@@ -29,6 +30,13 @@ runs:
         pylint_output_path=pylint.json
         echo "::group::Rendered pylint report"
         python .pylint/render_report.py --base-url="$base_url" "$pylint_output_path"
+        echo "::endgroup::"
+
+        # show PYLINT-TODO left in the codebase
+        todo_sentinel="PYLINT-TODO"
+
+        echo "::group::Show pylint \"$todo_sentinel\" sentinel comments in the codebase"
+        rg --type=py "$todo_sentinel" "$pylint_target_dir" || echo "No \"$todo_sentinel\" comments found in $pylint_target_dir"
         echo "::endgroup::"
 
         exit "$pylint_exit_status"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -34,9 +34,10 @@ runs:
 
         # show PYLINT-TODO left in the codebase
         todo_sentinel="PYLINT-TODO"
+        grep_opts="--color=always --after-context=2 --line-number --initial-tab"
 
         echo "::group::Show pylint \"$todo_sentinel\" sentinel comments in the codebase"
-        rg --type=py "$todo_sentinel" "$pylint_target_dir" || echo "No \"$todo_sentinel\" comments found in $pylint_target_dir"
+        grep "$todo_sentinel" $pylint_target_dir/**.py $grep_opts || echo "No \"$todo_sentinel\" comments found in $pylint_target_dir"
         echo "::endgroup::"
 
         exit "$pylint_exit_status"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -16,4 +16,4 @@ runs:
     - name: Run pylint (errors only)
       shell: bash
       run: |
-        pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_transform.MultiReporter idaes/
+        pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_reporters.MultiReporter idaes/

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -17,9 +17,13 @@ runs:
       shell: bash
       run: |
         pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_reporters.MultiReporter idaes/
-    - name: Create report
-      shell: bash
-      run: |
+        pylint_exit_status=$?
+
+        # render report
         base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/main/$GITHUB_SHA"
         pylint_output_path=pylint.json
+        echo "::group::Rendered pylint report"
         python .pylint/render_report.py --base-url="$base_url" "$pylint_output_path"
+        echo "::endgroup::"
+
+        exit "$pylint_exit_status"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -21,7 +21,7 @@ runs:
         pylint_exit_status=$?
 
         # render report
-        base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/$GITHUB_SHA"
+        base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blame/$GITHUB_SHA"
         pylint_output_path=pylint.json
         echo "::group::Rendered pylint report"
         python .pylint/render_report.py --base-url="$base_url" "$pylint_output_path"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: |
         PIP_INSTALL="pip --no-cache-dir install --progress-bar off"
-        echo "::group::Output of `pip install` commands"
+        echo "::group::Output of pip install commands"
         $PIP_INSTALL --upgrade pip setuptools wheel
         # TODO the pylint version will have to be pinned
         # TODO installing idaes is necessary in our case because we import some idaes code in pylint plugins

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -17,3 +17,9 @@ runs:
       shell: bash
       run: |
         pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_reporters.MultiReporter idaes/
+    - name: Create report
+      shell: bash
+      run: |
+        base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/main/$GITHUB_SHA"
+        pylint_output_path=pylint.json
+        python .pylint/render_report.py --base-url="$base_url" "$pylint_output_path"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -16,4 +16,4 @@ runs:
     - name: Run pylint (errors only)
       shell: bash
       run: |
-        pylint -E --ignore-patterns="test_.*" idaes || true
+        pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_transform.MultiReporter idaes/

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -34,10 +34,10 @@ runs:
 
         # show PYLINT-TODO left in the codebase
         todo_sentinel="PYLINT-TODO"
-        grep_opts="--color=always --after-context=2 --line-number --initial-tab"
+        grep_opts="--recursive --include '*.py' --color=always --after-context=2 --line-number --initial-tab"
 
         echo "::group::Show pylint \"$todo_sentinel\" sentinel comments in the codebase"
-        grep "$todo_sentinel" $pylint_target_dir/**.py $grep_opts || echo "No \"$todo_sentinel\" comments found in $pylint_target_dir"
+        grep "$todo_sentinel" $grep_opts "$pylint_target_dir" || echo "No \"$todo_sentinel\" comments found in $pylint_target_dir"
         echo "::endgroup::"
 
         exit "$pylint_exit_status"

--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -14,7 +14,8 @@ runs:
         $PIP_INSTALL -r requirements-dev.txt
         # don't think we need to install the extensions, though
     - name: Run pylint (errors only)
-      shell: bash
+      # use custom options for bash since the default causes the step to fail immediately for any non-zero return code of intermediate commands
+      shell: bash --noprofile --norc {0}
       run: |
         pylint --rcfile=./.pylint/pylintrc --disable=W,C,R,I --output-format=idaes_reporters.MultiReporter idaes/
         pylint_exit_status=$?

--- a/.pylint/idaes_reporters.py
+++ b/.pylint/idaes_reporters.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import time
+
+from pylint.reporters import BaseReporter, text, JSONReporter
+
+
+class MultiReporter(BaseReporter):
+    """
+    Combines multiple reporters so that the pylint message stream can be displayed in real time
+    and simultaneously saved in a machine-readable format for further "offline" processing.
+    """
+    name = 'multi'
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.console = text.ColorizedTextReporter()
+        self.json = JSONReporter(output=open('pylint.json', 'w'))
+        self._start = None
+
+    def __iter__(self):
+        yield self.console
+        yield self.json
+
+    def handle_message(self, msg):
+        for rep in self:
+            rep.handle_message(msg)
+
+    def writeln(self, **kwargs):
+        self.console.writeln(**kwargs)
+
+    @property
+    def elapsed(self):
+        f = time.clock
+        if self._start is None:
+            self._start = f()
+            return 0.
+        return f() - self._start
+
+    def on_set_current_module(self, module, filepath):
+        self.writeln(string=f'{self.elapsed:07.3f} {filepath}')
+        self.console._template = self.console.line_format
+
+    def display_messages(self, layout):
+        for rep in [self.json]:
+            rep.display_messages(layout)
+
+    def _display(self, layout):
+        ...
+
+
+def register(linter):
+    "This function needs to be defined for the plugin to be picked up by pylint"
+    linter.register_reporter(MultiReporter)

--- a/.pylint/idaes_transform.py
+++ b/.pylint/idaes_transform.py
@@ -1,0 +1,113 @@
+"""
+Pylint transform plugin to make Pylint aware of custom `ProcessBlock` classes
+dynamically created through the `declare_process_block_class()` decorator.
+
+See #1159 for more information.
+"""
+import functools
+import logging
+
+import astroid
+from astroid.builder import extract_node
+
+
+_logger = logging.getLogger('pylint.ideas_plugin')
+
+
+# TODO figure out a better way to integrate this with pylint logging and/or verbosity settings
+_display = _notify = print
+
+
+def has_declare_block_class_decorator(cls_node, decorator_name="declare_process_block_class"):
+    if 'idaes' not in cls_node.root().name:
+        return False
+    decorators = cls_node.decorators
+    if not decorators:
+        return False
+    for dec_subnode in decorators.nodes:
+        if hasattr(dec_subnode, 'func'):
+            # this is true for decorators with arguments
+            return dec_subnode.func.as_string() == decorator_name
+    return False
+
+
+# this will be called N times if running with N processes
+# returning the cached result on subsequent calls
+@functools.lru_cache(maxsize=1)
+def get_base_class_node():
+    _notify('Getting base class node')
+    import_node = extract_node('from idaes.core.process_block import ProcessBlock; ProcessBlock')
+    cls_node = next(import_node.infer())
+    return cls_node
+
+
+def add_attribute_nodes(node: astroid.ClassDef, attr_names):
+    for attr_name in attr_names:
+        rhs_node = astroid.Unknown(
+            lineno=node.lineno,
+            parent=node,
+        )
+        node.locals[attr_name] = [rhs_node]
+        node.instance_attrs[attr_name] = [rhs_node]
+
+
+def create_declared_class_node(decorated_cls_node: astroid.ClassDef):
+    decorators = decorated_cls_node.decorators
+    call = decorators.nodes[0]
+    name_arg_node = call.args[0]
+    decl_class_name = name_arg_node.value
+
+    base_class_node = get_base_class_node()
+    decl_class_node = astroid.ClassDef(
+        decl_class_name,
+        # TODO the real doc should be available as the "doc" kwarg of the decorator
+        # but it's not clear if we're going to need it anyway
+        doc=f"Declared from {decorated_cls_node.name}",
+        parent=decorated_cls_node.parent,
+        lineno=decorated_cls_node.lineno,
+    )
+    decl_class_node.bases.extend(
+        [
+            base_class_node,
+            decorated_cls_node,
+        ]
+    )
+    # doesn't seem to be needed at the moment
+    # add_attribute_nodes(decl_class_node, ['_orig_name', '_orig_module'])
+    return decl_class_node
+
+
+def is_idaes_module(mod_node: astroid.Module):
+    return 'idaes' in mod_node.name
+
+
+def register_process_block_class(decorated_cls_node: astroid.ClassDef):
+    module_node = decorated_cls_node.parent
+    _display(module_node.name)
+    decl_class_node = create_declared_class_node(decorated_cls_node)
+
+
+def iter_process_block_data_classes(mod_node: astroid.Module):
+    for node in mod_node.body:
+        if isinstance(node, astroid.ClassDef):
+            if has_declare_block_class_decorator(node):
+                yield node
+
+
+def register_process_block_classes(mod_node: astroid.Module):
+    _display(mod_node.name)
+    for decorated_cls_node in iter_process_block_data_classes(mod_node):
+        decl_cls_node = create_declared_class_node(decorated_cls_node)
+        _display(f'{decorated_cls_node.name} -> {decl_cls_node.name}')
+
+
+def register(linter):
+    "This function needs to be defined for the plugin to be picked up by Pylint"
+
+
+astroid.MANAGER.register_transform(
+    # NOTE both these options were tried to see if there was a difference in performance,
+    # but it doesn't seem to be the case at this point
+    # astroid.ClassDef, register_process_block_class, has_declare_block_class_decorator
+    astroid.Module, register_process_block_classes, is_idaes_module,
+)

--- a/.pylint/idaes_transform.py
+++ b/.pylint/idaes_transform.py
@@ -169,47 +169,5 @@ astroid.MANAGER.register_transform(
 )
 
 
-from pylint.reporters import BaseReporter, text, JSONReporter
-
-
-class MultiReporter(BaseReporter):
-    name = 'multi'
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.console = text.ColorizedTextReporter()
-        self.json = JSONReporter(output=open('pylint.json', 'w'))
-        self._start = None
-
-    def __iter__(self):
-        yield self.console
-        yield self.json
-
-    def handle_message(self, msg):
-        for rep in self:
-            rep.handle_message(msg)
-
-    def writeln(self, **kwargs):
-        self.console.writeln(**kwargs)
-
-    @property
-    def elapsed(self):
-        f = time.clock
-        if self._start is None:
-            self._start = f()
-            return 0.
-        return f() - self._start
-
-    def on_set_current_module(self, module, filepath):
-        self.writeln(string=f'{self.elapsed:07.3f} {filepath}')
-        self.console._template = self.console.line_format
-
-    def display_messages(self, layout):
-        self.json.display_messages(layout)
-
-    def _display(self, layout):
-        ...
-
-
 def register(linter):
     "This function needs to be defined for the plugin to be picked up by pylint"
-    linter.register_reporter(MultiReporter)

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -6,6 +6,7 @@ ignore-patterns=test_.*
 [MESSAGES CONTROL]
 disable=no-self-argument,
     bad-super-call,
+    assignment-from-none,
 
 [TYPECHECK]
 # prevents members specified here from causing E1101 (no-member)

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -6,3 +6,11 @@ ignore-patterns=test_.*
 [MESSAGES CONTROL]
 disable=no-self-argument,
     bad-super-call,
+
+[TYPECHECK]
+# prevents members specified here from causing E1101 (no-member)
+# the regular expression is currently matched against the name used at the call site
+# eventually pylint should be able to support using the fully qualified name instead
+# (see e.g. https://github.com/PyCQA/pylint/issues/2498)
+# here "cm" refers to matplotlib.cm
+generated-members=cm\..*,

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -1,0 +1,4 @@
+[MASTER]
+init-hook="import sys; sys.path.append('.pylint')"
+load-plugins=idaes_transform
+ignore-patterns="test_.*"

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -2,3 +2,7 @@
 init-hook="import sys; sys.path.append('.pylint')"
 load-plugins=idaes_transform
 ignore-patterns=test_.*
+
+[MESSAGES CONTROL]
+disable=no-self-argument,
+    bad-super-call,

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -8,6 +8,9 @@ disable=no-self-argument,
     bad-super-call,
     assignment-from-none,
 
+[IMPORTS]
+ignored-modules=cvalsim,almsim
+
 [TYPECHECK]
 # prevents members specified here from causing E1101 (no-member)
 # the regular expression is currently matched against the name used at the call site

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -1,4 +1,4 @@
 [MASTER]
 init-hook="import sys; sys.path.append('.pylint')"
 load-plugins=idaes_transform
-ignore-patterns="test_.*"
+ignore-patterns=test_.*

--- a/.pylint/render_report.py
+++ b/.pylint/render_report.py
@@ -66,7 +66,6 @@ class RecordsByModule:
             )
 
 
-
 class RecordRenderer:
     def __call__(self, records: Iterable[PylintRecord]) -> Iterable[str]:
         yield from []
@@ -83,9 +82,9 @@ class MarkdownChecklistRenderer(RecordRenderer):
 
     def render_record_group(self, record_group: RecordsByModule) -> Iterable[str]:
         group_header = f'[`{record_group.module}`]({record_group.url})'
-        yield f'- {group_header}'
+        yield f'\n#### {group_header}'
         for rec in record_group:
-            yield f'  - [ ] {self.render_record(rec)}'
+            yield f'- [ ] {self.render_record(rec)}'
 
     def __call__(self, records: Iterable[PylintRecord]) -> Iterable[str]:
         for record_group in RecordsByModule.from_records(records):

--- a/.pylint/render_report.py
+++ b/.pylint/render_report.py
@@ -1,0 +1,133 @@
+import argparse
+from dataclasses import dataclass
+import itertools
+import json
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+@dataclass
+class PylintRecord:
+    type: str
+    module: str
+    obj: str
+    line: int
+    column: int
+    path: Path
+    symbol: str
+    message: str
+    message_id: str
+
+    path_url: str
+    line_url: str = None
+
+    @classmethod
+    def from_pylint_output(cls, path: Path, **kwargs) -> Iterable['PylintRecord']:
+        with Path(path).open() as f:
+            dicts = json.load(f)
+        for d in dicts:
+            yield cls.from_dict(d, **kwargs)
+
+    @classmethod
+    def from_dict(cls, d: dict, base_url: str = 'file://') -> 'PylintRecord':
+        path = Path(d.pop('path'))
+        line = int(d.pop('line'))
+        path_url = f'{base_url}/{path}'
+        line_url = f'{path_url}#L{line}'
+        return cls(
+            message_id=d.pop('message-id'),
+            path=path,
+            line=line,
+            path_url=path_url,
+            line_url=line_url,
+            **d
+        )
+
+
+@dataclass
+class RecordsByModule:
+    module: str
+    url: str
+    records: Iterable[PylintRecord]
+
+    def __iter__(self):
+        return iter(self.records)
+
+    @classmethod
+    def from_records(cls, all_records: Iterable[PylintRecord]) -> Iterable['RecordsByModule']:
+        grouped = itertools.groupby(all_records, key=lambda r: r.module)
+        for groupby_key, records_for_module in grouped:
+            records = list(records_for_module)
+            first = records[0]
+            yield cls(
+                module=first.module,
+                url=first.path_url,
+                records=records
+            )
+
+
+
+class RecordRenderer:
+    def __call__(self, records: Iterable[PylintRecord]) -> Iterable[str]:
+        yield from []
+
+
+class MarkdownChecklistRenderer(RecordRenderer):
+
+    def render_record(self, record: PylintRecord) -> str:
+        location = f'At line {record.line}'
+        if record.obj:
+            location += f', in `{record.obj}`'
+        descr = f'(`{record.message_id}`) `{record.message}` (`{record.symbol}`)'
+        return f'{location}: ([link]({record.line_url})) {descr}'
+
+    def render_record_group(self, record_group: RecordsByModule) -> Iterable[str]:
+        group_header = f'[`{record_group.module}`]({record_group.url})'
+        yield f'- {group_header}'
+        for rec in record_group:
+            yield f'  - [ ] {self.render_record(rec)}'
+
+    def __call__(self, records: Iterable[PylintRecord]) -> Iterable[str]:
+        for record_group in RecordsByModule.from_records(records):
+            yield from self.render_record_group(record_group)
+
+
+@dataclass
+class Options:
+    pylint_output_path: Path
+    base_url: str
+
+    @classmethod
+    def from_cli_args(cls, args: Optional[Iterable[str]] = None) -> 'Options':
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            'pylint_output_path', default='./pylint.json'
+        )
+        parser.add_argument(
+            '--base-url', default='https://github.com/IDAES/idaes-pse/tree/main',
+        )
+        parsed = parser.parse_args()
+
+        return cls(
+            pylint_output_path=Path(parsed.pylint_output_path),
+            base_url=str(parsed.base_url),
+        )
+
+
+def main(args=None):
+    options = Options.from_cli_args(args=args)
+
+    try:
+        records = PylintRecord.from_pylint_output(options.pylint_output_path, base_url=options.base_url)
+    except Exception as e:
+        raise e
+
+    # TODO add other renderers as needed
+    render = MarkdownChecklistRenderer()
+
+    for line in render(records):
+        print(line)
+
+
+if __name__ == '__main__':
+    main()

--- a/idaes/commands/base.py
+++ b/idaes/commands/base.py
@@ -109,4 +109,6 @@ def import_time(name="import-time"):
     click.echo(f"Time: {_command_import_total_time}")
 
 if __name__ == "__main__":
+    # PYLINT-TODO-FIX fix error bypassed by directive
+    # pylint: disable=no-value-for-parameter
     command_base()

--- a/idaes/core/process_base.py
+++ b/idaes/core/process_base.py
@@ -268,6 +268,9 @@ class ProcessBlockData(_BlockData):
                           f"Activated Blocks: {nb}")
 
         if performance is not None:
+            # PYLINT-WHY: pylint has no way of knowing that performance is supposed to be dict-like
+            # pylint: disable=unsubscriptable-object
+            # PYLINT-TODO: alternatively, have the function return an empty dict and test with `if performance:`
             ostream.write("\n"+"-"*max_str_length+"\n")
             ostream.write(f"{prefix}{tab}Unit Performance")
             ostream.write("\n"*2)

--- a/idaes/core/process_block.py
+++ b/idaes/core/process_block.py
@@ -145,7 +145,7 @@ class ProcessBlock(Block):
                decorator.
 
         """
-        return cls._orig_name
+        return cls._orig_name  # pylint: disable=no-member
 
     @classmethod
     def base_class_module(cls):
@@ -158,7 +158,7 @@ class ProcessBlock(Block):
               was *not* wrapped by the `declare_process_block_class` decorator.
 
         """
-        return cls._orig_module
+        return cls._orig_module  # pylint: disable=no-member
 
 
 def declare_process_block_class(name, block_class=ProcessBlock, doc=""):

--- a/idaes/core/property_base.py
+++ b/idaes/core/property_base.py
@@ -411,6 +411,11 @@ class StateBlock(ProcessBlock):
         return self._get_parameter_block().has_inherent_reactions
 
     def _get_parameter_block(self):
+        # PYLINT-WHY: self._block_data_config_default is set elsewhere,
+        # and is supposed to already exist as an attribute by the time
+        # (or, it will raise AttributeError at L410)
+        # this method is called, so the pylint errors here are false positives
+        # pylint: disable=no-member,access-member-before-definition
         try:
             return self._block_data_config_default["parameters"]
         except (KeyError, TypeError):

--- a/idaes/core/property_base.py
+++ b/idaes/core/property_base.py
@@ -200,8 +200,8 @@ class PhysicalParameterBlock(ProcessBlockData,
 
         return self.state_block_class(  # pylint: disable=not-callable
             *args,
-                                      **kwargs,
-                                      default=default,
+            **kwargs,
+            default=default,
             initialize=initialize
         )
 
@@ -899,7 +899,7 @@ should be constructed in this state block,
             raise PropertyNotSupportedError(
                     '{} {} is not supported by property package (property is '
                     'not listed in package metadata properties).'
-                    .format(self.name, attr, attr))
+                    .format(self.name, attr))
 
         # Get method name from resulting properties
         try:

--- a/idaes/core/property_base.py
+++ b/idaes/core/property_base.py
@@ -198,10 +198,12 @@ class PhysicalParameterBlock(ProcessBlockData,
             for i in initialize.keys():
                 initialize[i]["parameters"] = self
 
-        return self.state_block_class(*args,
+        return self.state_block_class(  # pylint: disable=not-callable
+            *args,
                                       **kwargs,
                                       default=default,
-                                      initialize=initialize)
+            initialize=initialize
+        )
 
     def get_phase_component_set(self):
         """

--- a/idaes/core/property_meta.py
+++ b/idaes/core/property_meta.py
@@ -345,6 +345,7 @@ class PropertyClassMetadata(object):
             raise PropertyPackageError(
                 "{} cannot determine derived units, as property package has "
                 "not defined a set of base units.".format(self.name))
+                # PYLINT-TODO: maybe str(self) or self.__class__.__name__?
 
 
 class PropertyMetadata(dict):

--- a/idaes/core/property_meta.py
+++ b/idaes/core/property_meta.py
@@ -344,8 +344,7 @@ class PropertyClassMetadata(object):
         except TypeError:
             raise PropertyPackageError(
                 "{} cannot determine derived units, as property package has "
-                "not defined a set of base units.".format(self.name))
-                # PYLINT-TODO: maybe str(self) or self.__class__.__name__?
+                "not defined a set of base units.".format(str(self)))
 
 
 class PropertyMetadata(dict):

--- a/idaes/core/reaction_base.py
+++ b/idaes/core/reaction_base.py
@@ -198,10 +198,12 @@ class ReactionParameterBlock(ProcessBlockData,
             for i in initialize.keys():
                 initialize[i]["parameters"] = self
 
-        return self.reaction_block_class(*args,
+        return self.reaction_block_class(  # pylint: disable=no-callable
+            *args,
                                          **kwargs,
                                          default=default,
-                                         initialize=initialize)
+            initialize=initialize
+        )
 
     def _validate_property_parameter_units(self):
         """

--- a/idaes/core/reaction_base.py
+++ b/idaes/core/reaction_base.py
@@ -45,7 +45,6 @@ _log = idaeslog.getLogger(__name__)
 __author__ = "Andrew Lee, John Eslick"
 
 __all__ = [
-    'ReactionBlockData',
     'ReactionBlock',  # pylint: disable=undefined-all-variable
     'ReactionParameterBlock'  # pylint: disable=undefined-all-variable
 ]

--- a/idaes/core/reaction_base.py
+++ b/idaes/core/reaction_base.py
@@ -535,7 +535,7 @@ should be constructed in this reaction block,
             raise PropertyNotSupportedError(
                     '{} {} is not supported by reaction package (property is '
                     'not listed in get_supported_properties).'
-                    .format(self.name, attr, attr))
+                    .format(self.name, attr))
 
         # Get method name from get_supported_properties
         try:

--- a/idaes/core/reaction_base.py
+++ b/idaes/core/reaction_base.py
@@ -198,10 +198,10 @@ class ReactionParameterBlock(ProcessBlockData,
             for i in initialize.keys():
                 initialize[i]["parameters"] = self
 
-        return self.reaction_block_class(  # pylint: disable=no-callable
+        return self.reaction_block_class(  # pylint: disable=not-callable
             *args,
-                                         **kwargs,
-                                         default=default,
+            **kwargs,
+            default=default,
             initialize=initialize
         )
 

--- a/idaes/core/reaction_base.py
+++ b/idaes/core/reaction_base.py
@@ -44,9 +44,11 @@ _log = idaeslog.getLogger(__name__)
 # Some more information about this module
 __author__ = "Andrew Lee, John Eslick"
 
-__all__ = ['ReactionBlockData',
-           'ReactionBlock',
-           'ReactionParameterBlock']
+__all__ = [
+    'ReactionBlockData',
+    'ReactionBlock',  # pylint: disable=undefined-all-variable
+    'ReactionParameterBlock'  # pylint: disable=undefined-all-variable
+]
 
 
 class _lock_attribute_creation_context(object):

--- a/idaes/core/tests/test_control_volume_base.py
+++ b/idaes/core/tests/test_control_volume_base.py
@@ -39,7 +39,7 @@ def test_material_balance_type():
 
     # Test that error is raised when given non-member
     with pytest.raises(AttributeError):
-        MaterialBalanceType.foo
+        MaterialBalanceType.foo  # pylint: disable=no-member
 
 
 @pytest.mark.unit
@@ -48,7 +48,7 @@ def test_energy_balance_type():
 
     # Test that error is raised when given non-member
     with pytest.raises(AttributeError):
-        EnergyBalanceType.foo
+        EnergyBalanceType.foo  # pylint: disable=no-member
 
 
 @pytest.mark.unit
@@ -57,7 +57,7 @@ def test_momentum_balance_type():
 
     # Test that error is raised when given non-member
     with pytest.raises(AttributeError):
-        MomentumBalanceType.foo
+        MomentumBalanceType.foo  # pylint: disable=no-member
 
 @pytest.mark.unit
 def testflow_direction():
@@ -65,7 +65,7 @@ def testflow_direction():
 
     # Test that error is raised when given non-member
     with pytest.raises(AttributeError):
-        FlowDirection.foo
+        FlowDirection.foo  # pylint: disable=no-member
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/core/util/convergence/convergence_base.py
+++ b/idaes/core/util/convergence/convergence_base.py
@@ -645,11 +645,14 @@ class Stats(object):
         json.dump(self.to_dict(), fp, indent=4)
 
     def to_dmf(self, dmf):
+        # PYLINT-TODO-FIX fix error due to undefined variable "stats"
         rsrc = resource.Resource(value={
             'name': 'convergence_results',
             'desc': 'statistics returned from run_convergence_evaluation',
             'creator': {'name': getpass.getuser()},
+            # pylint: disable=undefined-variable
             'data': stats.to_dict()}, type_=resource.ResourceTypes.data)
+            # pylint: enable=undefined-variable
         dmf.add(rsrc)
 
     def report(self, fp=sys.stdout):

--- a/idaes/core/util/convergence/mpi_utils.py
+++ b/idaes/core/util/convergence/mpi_utils.py
@@ -134,6 +134,9 @@ class ParallelTaskManager:
         comm = self._mpi_interface.comm
         global_data_list = comm.allgather(local_data)
 
+        # PYLINT-TODO-FIX fix the error due to the
+        # non-existing global_data_list_of_lists variable
+        # pylint: disable=undefined-variable
         return self._stack_global_data(global_data_list_of_lists)
 
     def gather_global_data(self, local_data):

--- a/idaes/core/util/convergence/mpi_utils.py
+++ b/idaes/core/util/convergence/mpi_utils.py
@@ -47,7 +47,7 @@ class MPIInterface:
         self._rank = None
 
         if self.have_mpi:
-            self._comm = MPI.COMM_WORLD
+            self._comm = MPI.COMM_WORLD  # pylint: disable=undefined-variable
             self._size = self._comm.Get_size()
             self._rank = self._comm.Get_rank()
 

--- a/idaes/core/util/dyn_utils.py
+++ b/idaes/core/util/dyn_utils.py
@@ -609,7 +609,7 @@ def copy_non_time_indexed_values(
 
         if var_src is None:
             # Log a warning
-            msg = ('Warning copying values: ' + varname + 
+            msg = ('Warning copying values: ' + var_src.name + 
                    ' does not exist in source block ' + fs_src.name)
             init_log = idaeslog.getInitLogger(__name__, outlvl)
             init_log.warning(msg)

--- a/idaes/core/util/unit_costing.py
+++ b/idaes/core/util/unit_costing.py
@@ -408,7 +408,8 @@ def pressure_changer_costing(self, Mat_factor="stain_steel",
                     material_factor_reciprocal_pumps[Mat_factor]
                 self.FT = 1
             else:
-                raise ValueError('{} - pump type not supported. '
+                # PYLINT-TODO-FIX fix exception message with correct number of arguments
+                raise ValueError('{} - pump type not supported. '  # pylint: disable=E1305
                                  'Please see documentation for '
                                  'supported options.'.format(self.name,
                                                              pump_type))
@@ -435,7 +436,8 @@ def pressure_changer_costing(self, Mat_factor="stain_steel",
                             + 0.26986*log(PB)
                             + 0.06718*log(PB)**2)
                 else:
-                    raise ValueError('{} - pump type not supported. '
+                    # PYLINT-TODO-FIX fix exception message with correct number of arguments
+                    raise ValueError('{} - pump type not supported. '  # pylint: disable=E1305
                                      'Please see documentation for '
                                      'supported options.'.format(self.name,
                                                                  pump_type))
@@ -503,7 +505,8 @@ def pressure_changer_costing(self, Mat_factor="stain_steel",
         # (costing not needed)
         elif (self.parent_block().config.
               thermodynamic_assumption.name) == 'isothermal':
-            raise ValueError('{} - pressure changers with isothermal '
+            # PYLINT-TODO-FIX fix exception message with correct number of arguments
+            raise ValueError('{} - pressure changers with isothermal '  # pylint: disable=E1305
                              'assumption are too simple to be costed. '.
                              format(self.name, mover_type))
         # if config.compressor is = True
@@ -571,7 +574,8 @@ def pressure_changer_costing(self, Mat_factor="stain_steel",
                         properties_in[0].flow_vol*60  # 1ft3/s*60s/min = ft3/m
                 # end volumetric flow units
                 else:
-                    raise ValueError('{} - volumetric flowrate units '
+                    # PYLINT-TODO-FIX fix exception message with correct number of arguments
+                    raise ValueError('{} - volumetric flowrate units '  # pylint: disable=E1305
                                      'not supported. '
                                      'Please see documentation for list of '
                                      'supported units.'.format(self.name,
@@ -658,7 +662,8 @@ def pressure_changer_costing(self, Mat_factor="stain_steel",
                             CE_index/500)*self.base_cost)
                 self.cp_cost_eq = Constraint(rule=CP_rule)
             else:
-                raise ValueError('{} - mover type not supported. '
+                # PYLINT-TODO-FIX fix exception message with correct number of arguments
+                raise ValueError('{} - mover type not supported. '  # pylint: disable=E1305
                                  'Please see documentation for list of '
                                  'supported mover types.'.format(self.name,
                                                                  mover_type))
@@ -855,14 +860,16 @@ def platforms_ladders(self, alignment='horizontal', L_D_range='option1',
                     309.9*(D/pyunits.foot)**0.63316 *
                     (L/pyunits.foot)**0.80161)
             else:
-                raise ValueError('{} - L_D_range option not supported. '
+                # PYLINT-TODO-FIX fix exception message with correct number of arguments
+                raise ValueError('{} - L_D_range option not supported. '  # pylint: disable=E1305
                                  'Please see documentation for list of '
                                  'supported options.'.format(self.name,
                                                              L_D_range))
         self.CPL_eq = Constraint(rule=CPL_rule)
 
     else:
-        raise ValueError('{} - vessel alignment type not supported. '
+        # PYLINT-TODO-FIX fix exception message with correct number of arguments
+        raise ValueError('{} - vessel alignment type not supported. '  # pylint: disable=E1305
                                  'Please see documentation for list of '
                                  'supported options.'.format(self.name,
                                                              alignment))
@@ -1002,7 +1009,8 @@ def fired_heater_costing(self,
             return self.base_cost_per_unit ==\
                 0.367*(Q/pyunits.BTU*pyunits.hr)**0.77
         else:
-            raise ValueError('{} - fired heater type not supported. '
+            # PYLINT-TODO-FIX fix exception message with correct number of arguments
+            raise ValueError('{} - fired heater type not supported. '  # pylint: disable=E1305
                                  'Please see documentation for list of '
                                  'supported FH types.'.format(self.name,
                                                               fired_type))

--- a/idaes/dmf/commands.py
+++ b/idaes/dmf/commands.py
@@ -521,7 +521,7 @@ def _import_jupyternb(path):
     Returns:
           (Resource) DMF Resource representing the notebook.
     """
-    r = resource.Resource(type_=resourceResourceTypes.notebook)
+    r = resource.Resource(type_=resource.ResourceTypes.notebook)
     filename = os.path.splitext(os.path.split(path)[1])[0]
     # XXX: add notebook 'metadata' as FilePath metadata attr
     r.v["datafiles"].append({"desc": filename, "path": path})
@@ -539,7 +539,7 @@ def _import_python(path):
     Returns:
           (Resource) DMF Resource representing the notebook.
     """
-    r = resource.Resource(type_=resourceResourceTypes.code)
+    r = resource.Resource(type_=resource.ResourceTypes.code)
     filename = os.path.splitext(os.path.split(path)[1])[0]
     r.v["codes"].append({"name": filename, "language": "python", "type": "module"})
     r.v["datafiles"].append({"desc": filename, "path": path})
@@ -556,7 +556,7 @@ def _import_file(path):
     Returns:
           (Resource) DMF Resource representing the notebook.
     """
-    r = resource.Resource(type_=resourceResourceTypes.data)
+    r = resource.Resource(type_=resource.ResourceTypes.data)
     filename = os.path.split(path)[1]
     r.v["datafiles"].append({"desc": filename, "path": path})
     r.v["desc"] = filename

--- a/idaes/dmf/magics.py
+++ b/idaes/dmf/magics.py
@@ -405,7 +405,7 @@ def register():
     if _registered:
         return
     try:
-        ip = get_ipython()  # noqa: F821
+        ip = get_ipython()  # noqa: F821  pylint: disable=undefined-variable
         _log.debug('Registering DMF magics')
         ip.register_magics(DmfMagics)
     except:  # noqa: E722

--- a/idaes/generic_models/properties/core/eos/enrtl.py
+++ b/idaes/generic_models/properties/core/eos/enrtl.py
@@ -512,8 +512,8 @@ class ENRTL(EoSBase):
     @staticmethod
     def log_act_coeff(b, p, j):
         # Overall log gamma
-        pdh = getattr(p, +"_log_gamma_pdh")
-        lc = getattr(p, +"_log_gamma_lc")
+        pdh = getattr(p + "_log_gamma_pdh")
+        lc = getattr(p + "_log_gamma_lc")
         return pdh[j] + lc[j]
 
     @staticmethod

--- a/idaes/generic_models/properties/core/eos/enrtl_parameters.py
+++ b/idaes/generic_models/properties/core/eos/enrtl_parameters.py
@@ -25,6 +25,7 @@ _log = idaeslog.getLogger(__name__)
 
 
 class ConstantAlpha(object):
+    @staticmethod
     def build_parameters(b):
         param_block = b.parent_block()
 
@@ -81,6 +82,7 @@ class ConstantAlpha(object):
                 doc='Symmetric non-randomness parameters',
                 units=pyunits.dimensionless))
 
+    @staticmethod
     def return_expression(b, pobj, i, j, T):
         if (i, j) in pobj.alpha:
             return pobj.alpha[i, j]
@@ -96,6 +98,7 @@ class ConstantAlpha(object):
 
 
 class ConstantTau(object):
+    @staticmethod
     def build_parameters(b):
         param_block = b.parent_block()
 
@@ -131,6 +134,7 @@ class ConstantTau(object):
                 doc='Binary interaction energy parameters',
                 units=pyunits.dimensionless))
 
+    @staticmethod
     def return_expression(b, pobj, i, j, T):
         if (i, j) in pobj.tau:
             return pobj.tau[i, j]

--- a/idaes/generic_models/properties/core/generic/tests/dummy_eos.py
+++ b/idaes/generic_models/properties/core/generic/tests/dummy_eos.py
@@ -54,12 +54,15 @@ class DummyEoS(EoSBase):
     def dens_mol_phase(b, p):
         return 55e3
 
+    @staticmethod
     def energy_internal_mol_phase(b, p):
         return 2e2*b.temperature
 
+    @staticmethod
     def energy_internal_mol_phase_comp(b, p, j):
         return 2e2*b.temperature
 
+    @staticmethod
     def enth_mol_phase(b, p):
         return 1e2*b.temperature
 

--- a/idaes/generic_models/properties/core/generic/tests/dummy_eos.py
+++ b/idaes/generic_models/properties/core/generic/tests/dummy_eos.py
@@ -22,6 +22,7 @@ class DummyEoS(EoSBase):
     # Add attribute indicating support for electrolyte systems
     electrolyte_support = True
 
+    @staticmethod
     def common(b, pobj):
         # Create dummy var to be returned by expression calls
         # This Var is used to create expressions where required.
@@ -36,16 +37,20 @@ class DummyEoS(EoSBase):
         else:
             b.eos_common = 1
 
+    @staticmethod
     def calculate_scaling_factors(b, pobj):
         pass
 
+    @staticmethod
     def build_parameters(b):
         if not hasattr(b, "dummy_param"):
             b.dummy_param = Var(initialize=42)
 
+    @staticmethod
     def dens_mass_phase(b, p):
         return 42
 
+    @staticmethod
     def dens_mol_phase(b, p):
         return 55e3
 
@@ -58,23 +63,30 @@ class DummyEoS(EoSBase):
     def enth_mol_phase(b, p):
         return 1e2*b.temperature
 
+    @staticmethod
     def enth_mol_phase_comp(b, p, j):
         return 1e2*b.temperature
 
+    @staticmethod
     def entr_mol_phase(b, p):
         return 42
 
+    @staticmethod
     def entr_mol_phase_comp(b, p, j):
         return 42
 
+    @staticmethod
     def fug_phase_comp(b, p, j):
         return 42
 
+    @staticmethod
     def fug_coeff_phase_comp(b, p, j):
         return 42
 
+    @staticmethod
     def gibbs_mol_phase(b, p):
         return 42
 
+    @staticmethod
     def gibbs_mol_phase_comp(b, p, j):
         return 42

--- a/idaes/generic_models/unit_models/pressure_changer.py
+++ b/idaes/generic_models/unit_models/pressure_changer.py
@@ -609,7 +609,7 @@ see property package for documentation.}""",
                 for t in blk.flowsheet().config.time
             ):
                 _log.warning(
-                    "{} Expander/turbine maybe set with pressure ",
+                    "{} Expander/turbine maybe set with pressure "
                     "increase.".format(blk.name),
                 )
             # Check that work is not positive

--- a/idaes/logger.py
+++ b/idaes/logger.py
@@ -39,6 +39,8 @@ levelname = { # the level name of all our extra info levels is "INFO"
 
 class _TagFilter(logging.Filter):
     """Filter applied to IDAES loggers returned by this modulue."""
+
+    @staticmethod
     def filter(record):
         """Add in the custom level name and let the record through"""
         if record.levelno in levelname:
@@ -62,6 +64,7 @@ def __info_high(self, *args, **kwargs):
 
 
 def __add_methods(log, tag=None):
+    # pylint: disable=assignment-from-no-return,no-value-for-parameter
     log.addFilter(_TagFilter)
     log = logging.LoggerAdapter(log, {"tag": tag})
     log.info_high = __info_high.__get__(log)

--- a/idaes/power_generation/flowsheets/gas_turbine/gas_turbine.py
+++ b/idaes/power_generation/flowsheets/gas_turbine/gas_turbine.py
@@ -172,6 +172,13 @@ def performance_curves(m, flow_scale=0.896):
     m.fs.performace_flow_scale.fix()
     fscale = m.fs.performace_flow_scale
 
+    # PYLINT-TODO the names "eff_isen_eqn" and "head_isen_eqn" are reused below to define other constraint functions,
+    # causing pylint to report function-redefined errors
+    # this likely does not actually cause issues at runtime,
+    # but it could be worth to check anyway if the pylint errors can be addressed
+    # e.g. by giving unique names to each of the affected functions
+    # pylint: disable=function-redefined
+
     # Efficiency curves for three stages
     @m.fs.gts1.performance_curve.Constraint(m.fs.config.time)
     def eff_isen_eqn(b, t):

--- a/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py
+++ b/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py
@@ -181,6 +181,12 @@ def create_model():
     @m.fs.condenser_mix.Constraint(m.fs.time)
     def mixer_pressure_constraint(b, t):
         return b.main_state[t].pressure == b.mixed_state[t].pressure
+    # PYLINT-TODO the name "mixer_pressure_constraint" is reused below to define other constraint functions,
+    # causing pylint to report function-redefined errors
+    # this likely does not actually cause issues at runtime,
+    # but it could be worth to check anyway if the pylint errors can be addressed
+    # e.g. by giving a unique name to each of the affected functions
+    # pylint: disable=function-redefined
 
     # The condenser model uses the physical property model with TPx state
     # variables, while the rest of the model uses PH state variables. To
@@ -229,10 +235,6 @@ def create_model():
     @m.fs.hotwell.Constraint(m.fs.time)
     def mixer_pressure_constraint(b, t):
         return b.condensate_state[t].pressure == b.mixed_state[t].pressure
-    # PYLINT-TODO check if the "function-redefined" pylint error can be addressed
-    # by refactoring the code, e.g. defining mixer_pressure_constraint() once
-    # and registering it with the constraint with call syntax instead of decorators
-    # @m.fs.hotwell.Constraint(m.fs.time)(mixer_pressure_constraint)
 
     # Condensate pump (Use compressor model, since it is more robust if vapor form)
     m.fs.cond_pump = HelmIsentropicCompressor(

--- a/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py
+++ b/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py
@@ -229,6 +229,10 @@ def create_model():
     @m.fs.hotwell.Constraint(m.fs.time)
     def mixer_pressure_constraint(b, t):
         return b.condensate_state[t].pressure == b.mixed_state[t].pressure
+    # PYLINT-TODO check if the "function-redefined" pylint error can be addressed
+    # by refactoring the code, e.g. defining mixer_pressure_constraint() once
+    # and registering it with the constraint with call syntax instead of decorators
+    # @m.fs.hotwell.Constraint(m.fs.time)(mixer_pressure_constraint)
 
     # Condensate pump (Use compressor model, since it is more robust if vapor form)
     m.fs.cond_pump = HelmIsentropicCompressor(

--- a/idaes/power_generation/unit_models/boiler_fireside.py
+++ b/idaes/power_generation/unit_models/boiler_fireside.py
@@ -78,6 +78,7 @@ from idaes.core import (declare_process_block_class,
 from idaes.core.util.model_statistics import degrees_of_freedom
 
 from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
 
 

--- a/idaes/power_generation/unit_models/helm/condenser_ntu.py
+++ b/idaes/power_generation/unit_models/helm/condenser_ntu.py
@@ -25,6 +25,7 @@ from idaes.core import declare_process_block_class, UnitModelBlockData
 from idaes.core.util import get_solver, from_json, to_json, StoreSpec
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.misc import add_object_reference
+from idaes.core.util.exceptions import ConfigurationError
 from idaes.generic_models.unit_models.heater import (
     _make_heater_config_block, _make_heater_control_volume)
 import idaes.core.util.unit_costing as costing

--- a/idaes/power_generation/unit_models/helm/mixer.py
+++ b/idaes/power_generation/unit_models/helm/mixer.py
@@ -172,7 +172,9 @@ between flow and pressure driven simulations.}""",
         self._get_property_package()
 
         # Create list of inlet names
-        inlet_list = self.create_inlet_list()
+        # PYLINT-TODO: assigning the result of self.create_inlet_list() to unused local variable inlet_list
+        # causes pylint error assignment-from-no-return; check if removing assignment is OK
+        self.create_inlet_list()
 
         # Build StateBlocks
         self.add_inlet_state_blocks()

--- a/idaes/surrogate/alamopy/allcard.py
+++ b/idaes/surrogate/alamopy/allcard.py
@@ -19,7 +19,10 @@ def allcard(xdata, zdata, xval, zval, **kwargs):
     # enumerate all model cardinalities via ccmiqp and 
     # use validation/cross-validaiton to determine 
     from idaes.surrogate import alamopy
+    # PYLINT-TODO-FIX alamopy.writethis.writethis doesn't seem to exist
+    # pylint: disable=import-error
     from alamopy.writethis import writethis
+    # pylint: enable=import-error
     import numpy as np
     import math
     # import sympy

--- a/idaes/surrogate/alamopy/doalamo.py
+++ b/idaes/surrogate/alamopy/doalamo.py
@@ -458,10 +458,11 @@ def getTrainingData(xdata, zdata, data, debug):
         data["opts"]["noutputs"] = 1
     else:
         data["opts"]["noutputs"] = np.shape(zdata)[1]
+    # PYLINT-TODO-FIX use almerror correctly instead of calling it directly
     if np.shape(zdata)[0] != data["opts"]["ndata"]:
-        almerror("p1")
+        almerror("p1")  # pylint: disable=not-callable
     elif np.shape(xdata)[0] != data["opts"]["ndata"]:
-        almerror("p1")
+        almerror("p1")  # pylint: disable=not-callable
     zdata = np.asarray(zdata)
     return xdata, zdata
 
@@ -631,6 +632,8 @@ def addBasisConstraints(groups_constraints):
     format: group-id output_id constraint_type integer_parameter
     """
 
+    # PYLINT-TODO-FIX "group_constraints" and "basis_constraints" are undefined
+    # pylint: disable=undefined-variable
     global group_constraints, basis_constraints
     print("Adding basis selection constraint", group_constraints)
 
@@ -798,6 +801,8 @@ def parseKwargs(data, debug, kwargs):
             else:
                 if arg not in (["xlabels", "zlabels", "xval", "zval"]):
                     sys.stdout.write("Problem with option : " + arg)
+                    # PYLINT-TODO-FIX use almerror correctly insted of calling it directly
+                    # pylint: disable=not-callable
                     almerror("p3")
 
 
@@ -993,6 +998,8 @@ def readTraceFile(vargs, data, debug):
         from sympy.parsing.sympy_parser import parse_expr
         from sympy import symbols, lambdify
     except Exception:
+        # PYLINT-TODO-FIX "writethis" is not defined
+        # pylint: disable=undefined-variable
         writethis("Cannot import sympy")
 
     lf2 = lf.split("\n")
@@ -1210,6 +1217,8 @@ def _construct_mock(data):
          * x1^6 + 1.0000000000008837375276 * x1*x2"
     data["results"]["nbas"] = "15"
 
+    # PYLINT-TODO-FIX "debug" is undefined
+    # pylint: disable=undefined-variable
     if debug["expandoutput"]:
         data["results"]["ssrval"] = 0
         data["results"]["R2val"] = 0

--- a/idaes/surrogate/helmet/BasisFunctions.py
+++ b/idaes/surrogate/helmet/BasisFunctions.py
@@ -24,6 +24,8 @@ itt_val = 0
 rtt_vals = []
 dtrdt_vals = []
 d2rd_vals = []
+# PYLINT-TODO check if fix OK: adding d2rdt_vals variable here to address the undefined-variable error on L286
+d2rdt_vals = []
 d3rd_vals = []
 d4rd_vals = []
 d5rd_Vals = []

--- a/idaes/surrogate/helmet/GAMSDataWrite.py
+++ b/idaes/surrogate/helmet/GAMSDataWrite.py
@@ -211,6 +211,9 @@ def SNDdt(textFile, DataToWrite, Combination=False, PlotData=False):
             textFile.write("delta('%s', '%d') = %.13f ;\n" % ("SND", i, x[0]))
             textFile.write("tau('%s','%d') = %.13f ;\n" % ("SND", i, x[1]))
         else:
+            pass  # required by pylint so that the block directive applies
+            # PYLINT-TODO-FIX use correct number of args in format strings
+            # pylint: disable=too-few-format-args
             textFile.write("itt('%s','%d') = %.13f ;\n" % (i, itt_val))
             textFile.write("delta('%s', '%d') = %.13f ;\n" % (i, x[0]))
             textFile.write("tau('%s','%d') = %.13f ;\n" % (i, x[1]))

--- a/idaes/surrogate/helmet/Helmet.py
+++ b/idaes/surrogate/helmet/Helmet.py
@@ -239,6 +239,7 @@ def viewMultResults(lstFile, numTerms=0):
     """
     View mutliple results from a lst file 
     """
+    # PYLINT-TODO: this seems to be a genuine error, as this function doesn't exist in the Plotting module
     Plotting.multSSECombo(lstFile, numTerms)
 
 

--- a/idaes/surrogate/helmet/Helmet.py
+++ b/idaes/surrogate/helmet/Helmet.py
@@ -239,7 +239,8 @@ def viewMultResults(lstFile, numTerms=0):
     """
     View mutliple results from a lst file 
     """
-    # PYLINT-TODO: this seems to be a genuine error, as this function doesn't exist in the Plotting module
+    # PYLINT-TODO-FIX the multSSECombo function doesn't seem exist in the Plotting module
+    # pylint: disable=no-member
     Plotting.multSSECombo(lstFile, numTerms)
 
 

--- a/idaes/surrogate/main.py
+++ b/idaes/surrogate/main.py
@@ -440,7 +440,9 @@ class Pysmo_rbf(Surrogate):
             list_vars = []
             for i in feature_vec.keys():
                 list_vars.append(feature_vec[i])
-            # PYLINT-TODO: maybe the name of the method should be "generate_expression" like in the self.pyomo_vars case?
+            # PYLINT-TODO-FIX the method "rbf_generate_expression" does not exist for this class
+            # maybe the name of the method should be "generate_expression" like in the self.pyomo_vars case?
+            # pylint: disable=no-member
             self._model = self.pysmo_rbf_results.rbf_generate_expression(list_vars)
 
 
@@ -492,7 +494,9 @@ class Pysmo_kriging(Surrogate):
             list_vars = []
             for i in feature_vec.keys():
                 list_vars.append(feature_vec[i])
-            # PYLINT-TODO: maybe the name of the method should be "generate_expression" like in the self.pyomo_vars case?
+            # PYLINT-TODO-FIX the method "kriging_generate_expression" does not exist for this class
+            # maybe the name of the method should be "generate_expression" like in the self.pyomo_vars case?
+            # pylint: disable=no-member
             self._model = self.pysmo_kriging_results.kriging_generate_expression(list_vars)
 
 

--- a/idaes/surrogate/main.py
+++ b/idaes/surrogate/main.py
@@ -440,6 +440,7 @@ class Pysmo_rbf(Surrogate):
             list_vars = []
             for i in feature_vec.keys():
                 list_vars.append(feature_vec[i])
+            # PYLINT-TODO: maybe the name of the method should be "generate_expression" like in the self.pyomo_vars case?
             self._model = self.pysmo_rbf_results.rbf_generate_expression(list_vars)
 
 
@@ -491,6 +492,7 @@ class Pysmo_kriging(Surrogate):
             list_vars = []
             for i in feature_vec.keys():
                 list_vars.append(feature_vec[i])
+            # PYLINT-TODO: maybe the name of the method should be "generate_expression" like in the self.pyomo_vars case?
             self._model = self.pysmo_kriging_results.kriging_generate_expression(list_vars)
 
 

--- a/idaes/surrogate/my_surrogate_base.py
+++ b/idaes/surrogate/my_surrogate_base.py
@@ -194,7 +194,7 @@ class Surrogate:
             Tuple        : Tuple of two elements containing validation data v_in (samples) and v_out (output values).
 
         """
-        return (self._vdata_in, self._vdata.out)
+        return (self._vdata_in, self._vdata_out)
 
     def validation_data(self, v_in, v_out):  # 2D Numparray
         """
@@ -207,7 +207,8 @@ class Surrogate:
         self._vdata_out = v_out
 
     # Using regressed model
-    def calculate_outputs(inputs):  # 2D Numparray, use pyomo expression
+    # PYLINT-TODO: check if adding self as arg to fix pylint "undefined-variable 'self'" is valid
+    def calculate_outputs(self, inputs):  # 2D Numparray, use pyomo expression
         """
         ``calculate_outputs`` evaluates the output predictions from the surrogate for an array of input samples **inputs**
         Args:
@@ -226,7 +227,8 @@ class Surrogate:
     #         return
     #     pass
 
-    def get_validated_metrics(xval, zval):  # 2D, 2D Numparray, use pyomo expression
+    # PYLINT-TODO: check if adding as an argument and using self._b_built in the body is valid
+    def get_validated_metrics(self, xval, zval):  # 2D, 2D Numparray, use pyomo expression
         """
         ``get_validated_metrics`` evaluates the performance metrics for the surrogate model based on a set of off-design points (xval, zval)
         Args:
@@ -238,7 +240,7 @@ class Surrogate:
                 - mean squared error (MSE), and
                 - :math:`R^{2}`of the surrogate fit based on the off-design data points.
         """
-        if not _b_built:
+        if not self._b_built:
             print("Warning: No surrogate model regressed.")
             return
         pass

--- a/idaes/surrogate/pysmo/polynomial_regression.py
+++ b/idaes/surrogate/pysmo/polynomial_regression.py
@@ -354,8 +354,7 @@ class PolynomialRegression:
 
         if no_adaptive_samples is None:
             no_adaptive_samples = 4
-        # PYLINT-TODO: check if using int() here to fix the "invalid-unary-operand-type" error on L961 is OK
-        self.no_adaptive_samples = int(no_adaptive_samples)
+        self.no_adaptive_samples = no_adaptive_samples
 
         self.number_of_samples = regression_data.shape[0]
 

--- a/idaes/surrogate/pysmo/polynomial_regression.py
+++ b/idaes/surrogate/pysmo/polynomial_regression.py
@@ -1245,7 +1245,10 @@ class PolynomialRegression:
                     )
                 ]
                 adaptive_samples = sorted_comparison_vector_unique[
+                    # PYLINT-WHY: pylint considers self.no_adaptive_samples to be None here
+                    # pylint: disable=invalid-unary-operand-type
                     -self.no_adaptive_samples :, :
+                    # pylint: enable=invalid-unary-operand-type
                 ]
                 self.regression_data = np.concatenate(
                     (self.regression_data, adaptive_samples), axis=0

--- a/idaes/surrogate/pysmo/polynomial_regression.py
+++ b/idaes/surrogate/pysmo/polynomial_regression.py
@@ -354,7 +354,8 @@ class PolynomialRegression:
 
         if no_adaptive_samples is None:
             no_adaptive_samples = 4
-        self.no_adaptive_samples = no_adaptive_samples
+        # PYLINT-TODO: check if using int() here to fix the "invalid-unary-operand-type" error on L961 is OK
+        self.no_adaptive_samples = int(no_adaptive_samples)
 
         self.number_of_samples = regression_data.shape[0]
 

--- a/idaes/surrogate/ripe/__init__.py
+++ b/idaes/surrogate/ripe/__init__.py
@@ -40,6 +40,7 @@ __all__ = ["ripemodel", "ems", "rspace", "sharedata", "debug",
            "gb3d",
            "zlt",
            "grain",
+           # PYLINT-TODO: this seems to be a genuine error since "massact" is not imported from .mechs
            "massact",
            "massactm",
            "getmechs"]

--- a/idaes/surrogate/ripe/__init__.py
+++ b/idaes/surrogate/ripe/__init__.py
@@ -40,8 +40,8 @@ __all__ = ["ripemodel", "ems", "rspace", "sharedata", "debug",
            "gb3d",
            "zlt",
            "grain",
-           # PYLINT-TODO: this seems to be a genuine error since "massact" is not imported from .mechs
-           "massact",
+           # PYLINT-TODO-FIX: this seems to be a genuine error since "massact" is not imported from .mechs
+           "massact",  # pylint: disable=undefined-all-variable
            "massactm",
            "getmechs"]
 

--- a/idaes/surrogate/ripe/read.py
+++ b/idaes/surrogate/ripe/read.py
@@ -16,7 +16,7 @@
 def read(infile):
     # Arguemnts
     # infile : ripe input file to be parsed
-    import ripe
+    import ripe  # pylint: disable=import-error
     import sys
     import numpy as np
 
@@ -268,7 +268,7 @@ def read(infile):
 
 
 def readtimeseries(rd, ln, dlm, st1, st2):
-    import ripe
+    import ripe  # pylint: disable=import-error
 
     # Read time series data
     import numpy as np

--- a/idaes/surrogate/ripe/write.py
+++ b/idaes/surrogate/ripe/write.py
@@ -12,6 +12,9 @@
 #################################################################################
 # This subroutine is no longer used in the ripe-pyomo implementation
 
+# PYLINT-TODO-CHECK "ripe" and "alamopy" cause pylint to report import errors
+# this should be checked to see if these are real errors and/or this module is still in use
+# pylint: disable=import-error
 
 def writeripe(aterm, ccon):
     import os


### PR DESCRIPTION
## Summary/Motivation

Get rid of all pylint errors to obtain a "clean slate" so that pylint can be activated as a required check for future PRs.

## Strategy

This PR implement changes aimed to address everything that pylint reports as an error in different ways, depending if the reported error is a *false positive*, i.e. a statement that pylint considers a cause of runtime error, but that doesn't actually cause errors at runtime, or a *true positive*, i.e. a statement that would (or does) result in a runtime error if that portion of the code is run:

- For **false positives**, the fixes only affect pylint and **do not change the runtime behavior of the code**
  - For *one-off* errors, add a [pylint directive](http://pylint.pycqa.org/en/latest/user_guide/message-control.html) instructing pylint to ignore a particular error for that statement or scope
  - For *systematic* errors, i.e. a construct or implementation that's used in multiple places in the codebase, develop general solutions that address all related error at the same time. Typically this is done by either:
    - Adding a *global directive* affecting the entire codebase as a pylint configuration option
    - Creating a [pylint transform plugin](http://pylint.pycqa.org/en/latest/how_tos/transform_plugins.html) that "explains" the offending construct to pylint so that it matches the runtime behavior
- For **true positives**, more care is needed as the fixes **will change the runtime behavior of the code**
  - If the cause of the error is clear, the intended behavior of the code is unambiguous, and the fixed implementation has no or very little chance of affecting the rest of the code, then I'll try to fix the issue myself, asking reviewers to confirm that the fix is valid
  - If these conditions do not apply, I'll refrain from making assumptions and ask the original author(s) to review the affected statement and comment or suggest a fix
  - For intermediate cases, I'll suggest a fix in a code comment, but refrain from actually implementing that fix until it has been reviewed
  - For all cases, I've marked the comment with `PYLINT-TODO` so that it's easy to find these fixes within the codebase

## Changes proposed in this PR

- Create `.pylint` top-level directory to store all pylint-related code and configuration
- Move pylint configuration to `pylintrc` file
- Add pylint transform plugins to address systematic false-positive errors specific to IDAES and/or Pyomo
- Add custom pylint reporter to display a real-time log of errors in the CI interface and simultaneously save a machine-readable (JSON) dump of the error messages for further
- Multiple unrelated changes throughout the codebase addressing true-positive errors detected by pylint

## Reviewing

- Changes that are already implemented in the code (i.e. anything that can be reviewed from the usual GitHub "[Files changed](https://github.com/IDAES/idaes-pse/pull/58/files)" interface): please feel free to review as normal
- Changes that are not implemented in the code: **UPDATE 2021-05-21** All changes, including adding directives for errors still needing to be addressed, have been made in the code; see https://github.com/IDAES/idaes-pse/pull/58#issuecomment-846317973 for details
  - ~~Remaining errors are listed in the checkist below. There is a link to each affected file in the header, and links pointing to the specific line where the error was detected (using the GitHub `/blame/` URL endpoint to display the edit history of the affected line)~~
  - ~~I'll be pinging the author(s) of the affected code (as indicated by `git blame` and/or previous conversations) both by requesting a PR review and by @-mentioning them pointing to specific lines; of course, everyone is more than welcome to chime in and clarify~~
  - ~~The same applies to errors with an unchecked checkbox where I haven't yet mentioned anyone (either for lack of a clear author, because I forgot, etc)~~
  - ~~In general, I expect that a number of these errors to be in parts of the code that are rarely or not used anymore (which is why they haven't been fixed until now); if this is the case, let me know if it makes  sense for me to try to address the pylint errors  at all or they can be skipped (because e.g. the files will be removed or deprecated soon)~~
- pylint-specific functionality: as mentioned above, this only affects pylint and not the IDAES code itself, but feel free to ask questions about the intended behavior, implementation, impact on existing CI workflows, etc

---

## Errors left to fix (list compiled on 2021-05-07, redundant as of 2021-05-21)

- The set of errors still needing to be address is now encoded directly in the code through `# PYLINT-TODO` sentinel comments; see https://github.com/IDAES/idaes-pse/pull/58#issuecomment-846317973 for details

<details>
<summary>Click to display the original checklist</summary>
 
#### [`idaes.core.reaction_base`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/reaction_base.py)
- [x] At line 536, in `ReactionBlockDataBase.__getattr__`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/reaction_base.py#L536)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- ~~@andrewlee94: the error comes from the format string having two "slots" but three arguments being used: `.format(self.name, attr, attr)`. Would it be OK to change that to `.format(self.name, attr)`?~~

#### [`idaes.core.util.dyn_utils`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/dyn_utils.py)
- [x] At line 614, in `copy_non_time_indexed_values`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/dyn_utils.py#L614)) (`E0602`) `Undefined variable 'varname'` (`undefined-variable`)
- ~~@Robbybp what should be used here instead of the non-existing `varname`?~~

#### [`idaes.core.util.unit_costing`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py)
- [ ] At line 411, in `pressure_changer_costing`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py#L411)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- [ ] At line 438, in `pressure_changer_costing.base_pump_rule`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py#L438)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- [ ] At line 506, in `pressure_changer_costing`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py#L506)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- [ ] At line 574, in `pressure_changer_costing`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py#L574)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- [ ] At line 661, in `pressure_changer_costing`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py#L661)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- [ ] At line 858, in `platforms_ladders.CPL_rule`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py#L858)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- [ ] At line 865, in `platforms_ladders`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py#L865)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- [ ] At line 1005, in `fired_heater_costing.CB_rule`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/unit_costing.py#L1005)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)
- @MAZamarripa , all of these look similar (and similarly easy to fix). Could you take a look and let me know what the correct format args are supposed to be?

#### [`idaes.core.util.convergence.convergence_base`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/convergence/convergence_base.py)
- [ ] At line 652, in `Stats.to_dmf`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/convergence/convergence_base.py#L652)) (`E0602`) `Undefined variable 'stats'` (`undefined-variable`)
- @eslickj the variable `stats` doesn't exist, but this is a method of the `Stats` class. Should `stats` be `self` instead?

#### [`idaes.core.util.convergence.mpi_utils`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/convergence/mpi_utils.py)
- [ ] At line 137, in `ParallelTaskManager.allgather_global_data`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/core/util/convergence/mpi_utils.py#L137)) (`E0602`) `Undefined variable 'global_data_list_of_lists'` (`undefined-variable`)

#### [`idaes.commands.base`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/commands/base.py)
- [ ] At line 108: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/commands/base.py#L108)) (`E1120`) `No value for argument 'verbose' in function call` (`no-value-for-parameter`)
- [ ] At line 108: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/commands/base.py#L108)) (`E1120`) `No value for argument 'quiet' in function call` (`no-value-for-parameter`)
- @eslickj is this function still used here? if so, what arguments should be provided?

#### [`idaes.generic_models.unit_models.pressure_changer`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/generic_models/unit_models/pressure_changer.py)
- [x] At line 620, in `PressureChangerData.model_check`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/generic_models/unit_models/pressure_changer.py#L620)) (`E1305`) `Too many arguments for format string` (`too-many-format-args`)

#### [`idaes.power_generation.flowsheets.supercritical_steam_cycle.supercritical_steam_cycle`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py)
- [ ] At line 230, in `create_model.mixer_pressure_constraint`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py#L230)) (`E0102`) `function already defined line 182` (`function-redefined`)
- [ ] At line 275, in `create_model.mixer_pressure_constraint`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py#L275)) (`E0102`) `function already defined line 182` (`function-redefined`)
- [ ] At line 326, in `create_model.mixer_pressure_constraint`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py#L326)) (`E0102`) `function already defined line 182` (`function-redefined`)
- @eslickj @andrewlee94: referring to our previous discussion about this in this PR, I'd do one of the following:
  - **A** Add a pylint directive so that this (false-positive) error is ignored (my choice all else being equal)
  - **B** Change the names of the functions so that they're unique (I'd need your input on what new names to use)

#### [`idaes.surrogate.main`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/main.py)
- [ ] At line 432, in `Pysmo_rbf.handle_results`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/main.py#L432)) (`E1101`) `Instance of 'RadialBasisFunctions' has no 'rbf_generate_expression' member` (`no-member`)
- [ ] At line 484, in `Pysmo_kriging.handle_results`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/main.py#L484)) (`E1101`) `Instance of 'KrigingModel' has no 'kriging_generate_expression' member` (`no-member`)
- @mengleCMU  both of these errors are due non-existing methods, but the classes have methods with similar names that do exist: can you check if my guesses/assumptions in the comments above the affected line makes sense?

#### [`idaes.surrogate.ripe`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/ripe/__init__.py)
- [ ] At line 32: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/ripe/__init__.py#L32)) (`E0603`) `Undefined variable name 'massact' in __all__` (`undefined-all-variable`)

#### [`idaes.surrogate.ripe.write`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/ripe/write.py)
- [ ] At line 19, in `writeripe`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/ripe/write.py#L19)) (`E0401`) `Unable to import 'ripe'` (`import-error`)
- [ ] At line 73, in `writemodel`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/ripe/write.py#L73)) (`E0401`) `Unable to import 'ripe'` (`import-error`)
- [ ] At line 74, in `writemodel`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/ripe/write.py#L74)) (`E0401`) `Unable to import 'alamopy'` (`import-error`)
- [ ] At line 294, in `writeminlp`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/ripe/write.py#L294)) (`E0401`) `Unable to import 'ripe'` (`import-error`)
- @mengleCMU these errors are fixable, but the file starts with a comment saying that it is no longer used. Can you clarify what is the status of the file, and whether it would make sense for me to try and address the pylint errors or not?

#### [`idaes.surrogate.helmet.Helmet`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/helmet/Helmet.py)
- [ ] At line 243, in `viewMultResults`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/helmet/Helmet.py#L243)) (`E1101`) `Module 'idaes.surrogate.helmet.Plotting' has no 'multSSECombo' member` (`no-member`)

#### [`idaes.surrogate.helmet.GAMSDataWrite`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/helmet/GAMSDataWrite.py)
- [ ] At line 214, in `SNDdt`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/helmet/GAMSDataWrite.py#L214)) (`E1306`) `Not enough arguments for format string` (`too-few-format-args`)
- [ ] At line 215, in `SNDdt`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/helmet/GAMSDataWrite.py#L215)) (`E1306`) `Not enough arguments for format string` (`too-few-format-args`)
- [ ] At line 216, in `SNDdt`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/helmet/GAMSDataWrite.py#L216)) (`E1306`) `Not enough arguments for format string` (`too-few-format-args`)

#### [`idaes.surrogate.alamopy.doalamo`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/doalamo.py)
- [ ] At line 462, in `getTrainingData`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/doalamo.py#L462)) (`E1102`) `almerror is not callable` (`not-callable`)
- [ ] At line 464, in `getTrainingData`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/doalamo.py#L464)) (`E1102`) `almerror is not callable` (`not-callable`)
- [ ] At line 635, in `addBasisConstraints`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/doalamo.py#L635)) (`E0602`) `Undefined variable 'group_constraints'` (`undefined-variable`)
- [ ] At line 637, in `addBasisConstraints`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/doalamo.py#L637)) (`E0602`) `Undefined variable 'basis_constraints'` (`undefined-variable`)
- [ ] At line 801, in `parseKwargs`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/doalamo.py#L801)) (`E1102`) `almerror is not callable` (`not-callable`)
- [ ] At line 996, in `readTraceFile`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/doalamo.py#L996)) (`E0602`) `Undefined variable 'writethis'` (`undefined-variable`)
- [ ] At line 1213, in `_construct_mock`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/doalamo.py#L1213)) (`E0602`) `Undefined variable 'debug'` (`undefined-variable`)

#### [`idaes.surrogate.alamopy.allcard`](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/allcard.py)
- [ ] At line 22, in `allcard`: ([link](https://github.com/IDAES/idaes-pse/blame/60bfa4f38cafb9bbc9b61c8e71dd051eea6bc62c/idaes/surrogate/alamopy/allcard.py#L22)) (`E0401`) `Unable to import 'alamopy.writethis'` (`import-error`)

</details>

---

## Original Summary/Motivation (superseded and only partially relevant as of 2021-05-07)

<details>
Transferred here from IDAES/idaes-dev#1199

This PR implements changes aimed at getting rid of false-positives errors, i.e. portions of the code that do not cause runtime errors, but are erroneously flagged as such by pylint because of limitations in pylint's static analysis.

In particular, it introduces a pylint transform plugin that makes pylint aware of `ProcessBlock` subclasses that are dynamically generated at runtime. This eliminates the pylint errors described in IDAES/idaes-dev#1159 without requiring any changes to the code.

This is part of the efforts towards IDAES/idaes-dev#1149. Specifically, this PR contains only changes that affect pylint exclusively, and thus do not alter the runtime behavior of the code in any way, i.e.:

- pylint configuration
- pylint commands in the CI configuration
- pylint directives expressed as comments throughout the codebase

The idea is to keep those sets of changes that do affect the code itself (and that therefore could alter the runtime behavior) in dedicated PRs, to streamline both the fixes and the review process. In other words, reviews for this PR can concentrate entirely on the pylint analysis, without having to take into account compatibility, introducing regressions, or other code-specific considerations.

In addition, these changes aggregate most of the configuration into the pylint RC file located at .pylint/pylintrc, allowing to share the same settings among different use cases in addition to CI checks, e.g. direct invocation, and integration with IDEs/editors supporting static analysis with pylint.

## Changes proposed in this PR

- Add pylint transform plugin addressing `ProcessBlock` subclasses false positives
- Restructure pylint setup so that the same configuration can be reused in multiple contexts such as CI and IDE/editor code check

</details>

---

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.

