### PR TITLE
Re-creating PR To fix CSTR configuration bug

### DIFF
--- a/idaes/generic_models/unit_models/cstr.py
+++ b/idaes/generic_models/unit_models/cstr.py
@@ -196,7 +196,7 @@ see reaction package for documentation.}"""))
             balance_type=self.config.material_balance_type,
             has_rate_reactions=True,
             has_equilibrium_reactions=self.config.has_equilibrium_reactions,
-            has_phase_equilibrium=self.config.has_equilibrium_reactions)
+            has_phase_equilibrium=self.config.has_phase_equilibrium)
 
         self.control_volume.add_energy_balances(
             balance_type=self.config.energy_balance_type,


### PR DESCRIPTION
**NOTE:** When this PR is approved, you *must* do the following so it can be merged:
* Add the "approved" tag to the pull-request
* Trigger tests by pushing a commit or manually re-running in CircleCI

See [this wiki page](https://github.com/IDAES/idaes-dev/wiki/Github-Pull-Request-Workflow-with-Approval-Tag) for details.

----
## Fixes


## Summary/Motivation:
A bug was found where the wrong argument from the config block was being used in creating the material balance constraints for the CSTR model (affected cases with chemical equilibrium).

This is a re-creation of PR #45 to address some lingering issues with the switch to the open repository.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.

----

## Reviewer Checklist
* Reviewer 1
- [ ] Tests: do they pass, do they cover functionality, are they understandable?
- [ ] Documentation: is the code commented, are there user-level docs where needed?
* Reviewer 2
- [ ] Tests: do they pass, do they cover functionality, are they understandable?
- [ ] Documentation: is the code commented, are there user-level docs where needed?
