### PR TITLE
Adding checks on state_bounds argument to find unexpected keys

### DIFF
--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -23,6 +23,11 @@ from idaes.generic_models.properties.core.generic.utility import \
     get_bounds_from_config
 from idaes.generic_models.properties.core.state_definitions.FTPx import (
     state_initialization)
+from idaes.core.util.exceptions import ConfigurationError
+import idaes.logger as idaeslog
+
+# Set up logger
+_log = idaeslog.getLogger(__name__)
 
 
 # TODO : Need a way to get a guess for T during initialization
@@ -38,6 +43,23 @@ def define_state(b):
     # FTPx formulation always requires a flash, so set flag to True
     # TODO: should have some checking to make sure developers implement this properly
     b.always_flash = True
+
+    # Check that only necessary state_bounds are defined
+    expected_keys = ["flow_mol", "enth_mol", "temperature", "pressure"]
+    if (b.params.config.state_bounds is not None and
+            any(b.params.config.state_bounds.keys()) not in expected_keys):
+        for k in b.params.config.state_bounds.keys():
+            if "mole_frac" in k:
+                _log.warning("{} - found state_bounds argument for {}."
+                             " Mole fraction bounds are set automatically and "
+                             "this argument will be ignored."
+                             .format(b.name, k))
+            elif k not in expected_keys:
+                raise ConfigurationError(
+                    "{} - found unexpected state_bounds key {}. Please ensure "
+                    "bounds are provided only for expected state variables "
+                    "and that you have typed the variable names correctly."
+                    .format(b.name, k))
 
     units = b.params.get_metadata().derived_units
     # Get bounds and initial values from config args

--- a/idaes/generic_models/properties/core/state_definitions/FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcTP.py
@@ -24,6 +24,11 @@ from idaes.generic_models.properties.core.state_definitions.FTPx import (
     state_initialization)
 from idaes.generic_models.properties.core.generic.utility import \
     get_bounds_from_config
+from idaes.core.util.exceptions import ConfigurationError
+import idaes.logger as idaeslog
+
+# Set up logger
+_log = idaeslog.getLogger(__name__)
 
 
 def set_metadata(b):
@@ -35,6 +40,18 @@ def define_state(b):
     # FcTP formulation always requires a flash, so set flag to True
     # TODO: should have some checking to make sure developers implement this properly
     b.always_flash = True
+
+    # Check that only necessary state_bounds are defined
+    expected_keys = ["flow_mol_comp", "temperature", "pressure"]
+    if (b.params.config.state_bounds is not None and
+            any(b.params.config.state_bounds.keys()) not in expected_keys):
+        for k in b.params.config.state_bounds.keys():
+            if k not in expected_keys:
+                raise ConfigurationError(
+                    "{} - found unexpected state_bounds key {}. Please ensure "
+                    "bounds are provided only for expected state variables "
+                    "and that you have typed the variable names correctly."
+                    .format(b.name, k))
 
     units = b.params.get_metadata().derived_units
     # Get bounds and initial values from config args

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
@@ -35,6 +35,8 @@ from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterData)
 from idaes.generic_models.properties.core.generic.tests import dummy_eos
 from idaes.core.util.misc import add_object_reference
+from idaes.core.util.exceptions import ConfigurationError
+import idaes.logger as idaeslog
 
 
 @declare_process_block_class("DummyParameterBlock")
@@ -45,6 +47,72 @@ class DummyParameterData(GenericParameterData):
 @pytest.mark.unit
 def test_set_metadata():
     assert set_metadata(None) is None
+
+
+class TestInvalidBounds(object):
+    def test_bad_name(self):
+        m = ConcreteModel()
+
+        m.params = DummyParameterBlock(default={
+                "components": {"c1": {}, "c2": {}, "c3": {}},
+                "phases": {
+                    "p1": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_bounds": {"foo": (None, None, None)}})
+
+        # Create a dummy state block
+        m.props = Block([1])
+        m.props[1].config = ConfigBlock()
+        m.props[1].config.declare("defined_state", ConfigValue(default=False))
+        add_object_reference(m.props[1], "params", m.params)
+
+        with pytest.raises(
+                ConfigurationError,
+                match="props\[1\] - found unexpected state_bounds key foo. "
+                "Please ensure bounds are provided only for expected state "
+                "variables and that you have typed the variable names "
+                "correctly."):
+            define_state(m.props[1])
+
+    def test_mole_frac(self, caplog):
+        m = ConcreteModel()
+        
+        caplog.set_level(
+            idaeslog.WARNING,
+            logger=("idaes.generic_models.properties.core."))
+
+        m.params = DummyParameterBlock(default={
+                "components": {"c1": {}, "c2": {}, "c3": {}},
+                "phases": {
+                    "p1": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_bounds": {"mole_frac_comp": (None, None, None)}})
+
+        # Create a dummy state block
+        m.props = Block([1])
+        m.props[1].config = ConfigBlock()
+        m.props[1].config.declare("defined_state", ConfigValue(default=False))
+        add_object_reference(m.props[1], "params", m.params)
+
+        define_state(m.props[1])
+
+        assert ("props[1] - found state_bounds argument for mole_frac_comp."
+                " Mole fraction bounds are set automatically and "
+                "this argument will be ignored." in caplog.text)
 
 
 class Test1PhaseDefinedStateFalseNoBounds(object):

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
@@ -36,6 +36,8 @@ from idaes.generic_models.properties.core.generic.generic_property import (
 from idaes.generic_models.properties.core.generic.tests import dummy_eos
 from idaes.core.util.misc import add_object_reference
 from idaes.core.util.testing import PhysicalParameterTestBlock
+from idaes.core.util.exceptions import ConfigurationError
+import idaes.logger as idaeslog
 
 
 @declare_process_block_class("DummyParameterBlock")
@@ -54,6 +56,74 @@ def test_set_metadata():
     set_metadata(m.props)
 
     assert m.props.get_metadata().properties["enth_mol"] == {'method': None}
+
+
+class TestInvalidBounds(object):
+    def test_bad_name(self):
+        m = ConcreteModel()
+
+        m.params = DummyParameterBlock(default={
+                "components": {"c1": {}, "c2": {}, "c3": {}},
+                "phases": {
+                    "p1": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_bounds": {"foo": (None, None, None)}})
+
+        # Create a dummy state block
+        m.props = Block([1])
+        m.props[1].config = ConfigBlock()
+        m.props[1].config.declare("defined_state", ConfigValue(default=False))
+        add_object_reference(m.props[1], "params", m.params)
+
+        with pytest.raises(
+                ConfigurationError,
+                match="props\[1\] - found unexpected state_bounds key foo. "
+                "Please ensure bounds are provided only for expected state "
+                "variables and that you have typed the variable names "
+                "correctly."):
+            define_state(m.props[1])
+
+    def test_mole_frac(self, caplog):
+        m = ConcreteModel()
+        
+        caplog.set_level(
+            idaeslog.WARNING,
+            logger=("idaes.generic_models.properties.core."))
+
+        m.params = DummyParameterBlock(default={
+                "components": {"c1": {}, "c2": {}, "c3": {}},
+                "phases": {
+                    "p1": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_bounds": {"mole_frac_comp": (None, None, None)}})
+
+        # Create a dummy state block
+        m.props = Block([1])
+        m.props[1].config = ConfigBlock()
+        m.props[1].config.declare("defined_state", ConfigValue(default=False))
+        add_object_reference(m.props[1], "params", m.params)
+
+        with pytest.raises(
+                ConfigurationError,
+                match="props\[1\] - found unexpected state_bounds key "
+                "mole_frac_comp. Please ensure bounds are provided only for "
+                "expected state variables and that you have typed the "
+                "variable names correctly."):
+            define_state(m.props[1])
 
 
 class Test1PhaseDefinedStateFalseNoBounds(object):

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
@@ -35,6 +35,8 @@ from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterData)
 from idaes.generic_models.properties.core.generic.tests import dummy_eos
 from idaes.core.util.misc import add_object_reference
+from idaes.core.util.exceptions import ConfigurationError
+import idaes.logger as idaeslog
 
 
 @declare_process_block_class("DummyParameterBlock")
@@ -45,6 +47,74 @@ class DummyParameterData(GenericParameterData):
 @pytest.mark.unit
 def test_set_metadata():
     assert set_metadata(None) is None
+
+
+class TestInvalidBounds(object):
+    def test_bad_name(self):
+        m = ConcreteModel()
+
+        m.params = DummyParameterBlock(default={
+                "components": {"c1": {}, "c2": {}, "c3": {}},
+                "phases": {
+                    "p1": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_bounds": {"foo": (None, None, None)}})
+
+        # Create a dummy state block
+        m.props = Block([1])
+        m.props[1].config = ConfigBlock()
+        m.props[1].config.declare("defined_state", ConfigValue(default=False))
+        add_object_reference(m.props[1], "params", m.params)
+
+        with pytest.raises(
+                ConfigurationError,
+                match="props\[1\] - found unexpected state_bounds key foo. "
+                "Please ensure bounds are provided only for expected state "
+                "variables and that you have typed the variable names "
+                "correctly."):
+            define_state(m.props[1])
+
+    def test_mole_frac(self, caplog):
+        m = ConcreteModel()
+        
+        caplog.set_level(
+            idaeslog.WARNING,
+            logger=("idaes.generic_models.properties.core."))
+
+        m.params = DummyParameterBlock(default={
+                "components": {"c1": {}, "c2": {}, "c3": {}},
+                "phases": {
+                    "p1": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_bounds": {"mole_frac_comp": (None, None, None)}})
+
+        # Create a dummy state block
+        m.props = Block([1])
+        m.props[1].config = ConfigBlock()
+        m.props[1].config.declare("defined_state", ConfigValue(default=False))
+        add_object_reference(m.props[1], "params", m.params)
+
+        with pytest.raises(
+                ConfigurationError,
+                match="props\[1\] - found unexpected state_bounds key "
+                "mole_frac_comp. Please ensure bounds are provided only for "
+                "expected state variables and that you have typed the "
+                "variable names correctly."):
+            define_state(m.props[1])
 
 
 class Test1PhaseDefinedStateFalseNoBounds(object):

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
@@ -35,6 +35,8 @@ from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterData)
 from idaes.generic_models.properties.core.generic.tests import dummy_eos
 from idaes.core.util.misc import add_object_reference
+from idaes.core.util.exceptions import ConfigurationError
+import idaes.logger as idaeslog
 
 
 @declare_process_block_class("DummyParameterBlock")
@@ -45,6 +47,74 @@ class DummyParameterData(GenericParameterData):
 @pytest.mark.unit
 def test_set_metadata():
     assert set_metadata(None) is None
+
+
+class TestInvalidBounds(object):
+    def test_bad_name(self):
+        m = ConcreteModel()
+
+        m.params = DummyParameterBlock(default={
+                "components": {"c1": {}, "c2": {}, "c3": {}},
+                "phases": {
+                    "p1": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_bounds": {"foo": (None, None, None)}})
+
+        # Create a dummy state block
+        m.props = Block([1])
+        m.props[1].config = ConfigBlock()
+        m.props[1].config.declare("defined_state", ConfigValue(default=False))
+        add_object_reference(m.props[1], "params", m.params)
+
+        with pytest.raises(
+                ConfigurationError,
+                match="props\[1\] - found unexpected state_bounds key foo. "
+                "Please ensure bounds are provided only for expected state "
+                "variables and that you have typed the variable names "
+                "correctly."):
+            define_state(m.props[1])
+
+    def test_mole_frac(self, caplog):
+        m = ConcreteModel()
+        
+        caplog.set_level(
+            idaeslog.WARNING,
+            logger=("idaes.generic_models.properties.core."))
+
+        m.params = DummyParameterBlock(default={
+                "components": {"c1": {}, "c2": {}, "c3": {}},
+                "phases": {
+                    "p1": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_bounds": {"mole_frac_comp": (None, None, None)}})
+
+        # Create a dummy state block
+        m.props = Block([1])
+        m.props[1].config = ConfigBlock()
+        m.props[1].config.declare("defined_state", ConfigValue(default=False))
+        add_object_reference(m.props[1], "params", m.params)
+
+        with pytest.raises(
+                ConfigurationError,
+                match="props\[1\] - found unexpected state_bounds key "
+                "mole_frac_comp. Please ensure bounds are provided only for "
+                "expected state variables and that you have typed the "
+                "variable names correctly."):
+            define_state(m.props[1])
 
 
 class Test1PhaseDefinedStateFalseNoBounds(object):


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
A couple of people have noted that the generic properties framework does not inform the user if they mis-type an entry in the `state_bounds` configuration dict. This PR adds checks for unexpected keys and raises a `ConfigurationError` if one is found (or  logs a warning in the case of mole fractions if they are a state variable).

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
