### PR TITLE
Adding support for cp calculations to generic property framework

### DIFF
--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -54,6 +54,11 @@ class ComponentData(ProcessBlockData):
 
     CONFIG.declare("dens_mol_liq_comp", ConfigValue(
         description="Method to use to calculate liquid phase molar density"))
+    CONFIG.declare("cp_mol_liq_comp", ConfigValue(
+        description="Method to calculate liquid component specific heats"))
+    CONFIG.declare("cp_mol_ig_comp", ConfigValue(
+        description="Method to calculate ideal gas component specific heats"
+        ))
     CONFIG.declare("enth_mol_liq_comp", ConfigValue(
         description="Method to calculate liquid component molar enthalpies"))
     CONFIG.declare("enth_mol_ig_comp", ConfigValue(

--- a/idaes/generic_models/properties/core/eos/ceos.py
+++ b/idaes/generic_models/properties/core/eos/ceos.py
@@ -347,6 +347,8 @@ class Cubic(EoSBase):
         else:
             raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))
 
+    # TODO: Need to add functions to calculate cp
+
     @staticmethod
     def enth_mol_phase(blk, p):
         pobj = blk.params.get_phase(p)

--- a/idaes/generic_models/properties/core/eos/ideal.py
+++ b/idaes/generic_models/properties/core/eos/ideal.py
@@ -62,6 +62,23 @@ class Ideal(EoSBase):
             raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))
 
     @staticmethod
+    def cp_mol_phase(b, p):
+        return sum(b.mole_frac_phase_comp[p, j]*b.cp_mol_phase_comp[p, j]
+                   for j in b.components_in_phase(p))
+
+    @staticmethod
+    def cp_mol_phase_comp(b, p, j):
+        pobj = b.params.get_phase(p)
+        if pobj.is_vapor_phase():
+            return get_method(b, "cp_mol_ig_comp", j)(
+                b, cobj(b, j), b.temperature)
+        elif pobj.is_liquid_phase():
+            return get_method(b, "cp_mol_liq_comp", j)(
+                b, cobj(b, j), b.temperature)
+        else:
+            raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))
+
+    @staticmethod
     def enth_mol_phase(b, p):
         return sum(b.mole_frac_phase_comp[p, j]*b.enth_mol_phase_comp[p, j]
                    for j in b.components_in_phase(p))

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -642,6 +642,9 @@ class GenericParameterData(PhysicalParameterBlock):
              'dens_mass_phase': {'method': '_dens_mass_phase'},
              'dens_mol': {'method': '_dens_mol'},
              'dens_mol_phase': {'method': '_dens_mol_phase'},
+             'cp_mol': {'method': '_cp_mol'},
+             'cp_mol_phase': {'method': '_cp_mol_phase'},
+             'cp_mol_phase_comp': {'method': '_cp_mol_phase_comp'},
              'enth_mol': {'method': '_enth_mol'},
              'enth_mol_phase': {'method': '_enth_mol_phase'},
              'enth_mol_phase_comp': {'method': '_enth_mol_phase_comp'},
@@ -1365,6 +1368,40 @@ class GenericStateBlockData(StateBlockData):
                     rule=rule_dens_mol_phase)
         except AttributeError:
             self.del_component(self.dens_mol_phase)
+            raise
+
+    def _cp_mol(self):
+        try:
+            def rule_cp_mol(b):
+                return sum(b.cp_mol_phase[p]*b.phase_frac[p]
+                           for p in b.params.phase_list)
+            self.cp_mol = Expression(rule=rule_cp_mol,
+                                     doc="Mixture molar heat capacity")
+        except AttributeError:
+            self.del_component(self.cp_mol)
+            raise
+
+    def _cp_mol_phase(self):
+        try:
+            def rule_cp_mol_phase(b, p):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.cp_mol_phase(b, p)
+            self.cp_mol_phase = Expression(self.params.phase_list,
+                                           rule=rule_cp_mol_phase)
+        except AttributeError:
+            self.del_component(self.cp_mol_phase)
+            raise
+
+    def _cp_mol_phase_comp(self):
+        try:
+            def rule_cp_mol_phase_comp(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.cp_mol_phase_comp(b, p, j)
+            self.cp_mol_phase_comp = Expression(
+                self.params._phase_component_set,
+                rule=rule_cp_mol_phase_comp)
+        except AttributeError:
+            self.del_component(self.cp_mol_phase_comp)
             raise
 
     def _enth_mol(self):


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Support for calculating specific heat capacities was missing from the generic property framework.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
