### PR TITLE
Correcting units of measurement in docs

### DIFF
--- a/docs/user_guide/components/property_package/general/pure/NIST.rst
+++ b/docs/user_guide/components/property_package/general/pure/NIST.rst
@@ -58,7 +58,7 @@ Units are :math:`\text{J/mol}`.
    ":math:`H`", "cp_mol_ig_comp_coeff_H", ":math:`\text{kJ/mol}`", ""
 
 .. note::
-    This correlation uses the same parameters as for the ideal gas heat capacity with additional parameters `F` and `H`. These parameters account for the enthalpy at the reference state defined by NIST. Users wanting to use a different reference state will need to update `H`.
+    This correlation uses the same parameters as for the ideal gas heat capacity with additional parameters `F` and `H`. These parameters account for the enthalpy at the reference state defined by NIST, where `F` is the constant of integration and `H` is the standard molar heat of formation. Note that the default form of the expression used by NIST subtracts the heat of formation from the specific enthalpy.
     Due to the division of temperature by 1000 in the expression form, most temperature units are in kilo-Kelvins and reference enthalpies (F and H) are in kJ/mol.
 
 Ideal Gas Molar Entropy

--- a/docs/user_guide/components/property_package/general/pure/Perrys.rst
+++ b/docs/user_guide/components/property_package/general/pure/Perrys.rst
@@ -51,10 +51,11 @@ Units are :math:`\text{J/kmol}`.
    ":math:`C_3`", "cp_mol_ig_comp_coeff_3", ":math:`\text{J/kmol}\cdotp\text{K}^3`", ""
    ":math:`C_4`", "cp_mol_ig_comp_coeff_4", ":math:`\text{J/kmol}\cdotp\text{K}^4`", ""
    ":math:`C_5`", "cp_mol_ig_comp_coeff_5", ":math:`\text{J/kmol}\cdotp\text{K}^5`", ""
-   ":math:`\Delta h_{\text{form, Liq}}`", "enth_mol_form_liq_comp_ref", ":math:`\text{J/kmol}`", "Molar heat of formation at reference state"
+   ":math:`\Delta h_{\text{form, Liq}}`", "enth_mol_form_liq_comp_ref", "Base units", "Molar heat of formation at reference state"
 
 .. note::
     This correlation uses the same parameters as the ideal liquid heat capacity.
+    Units of molar heat of formation will be derived from the base units defined for the property package.
 
 Ideal Liquid Molar Entropy
 ---------------------------
@@ -75,10 +76,11 @@ Units are :math:`\text{J/kmol}\cdotp\text{K}`.
    ":math:`C_3`", "cp_mol_ig_comp_coeff_3", ":math:`\text{J/kmol}\cdotp\text{K}^3`", ""
    ":math:`C_4`", "cp_mol_ig_comp_coeff_4", ":math:`\text{J/kmol}\cdotp\text{K}^4`", ""
    ":math:`C_5`", "cp_mol_ig_comp_coeff_5", ":math:`\text{J/kmol}\cdotp\text{K}^5`", ""
-   ":math:`s_{\text{form, Liq}}`", "entr_mol_form_liq_comp_ref", ":math:`\text{J/kmol}\cdotp\text{K}`", "Standard molar entropy of formation at reference state"
+   ":math:`s_{\text{form, Liq}}`", "entr_mol_form_liq_comp_ref", "Base units", "Standard molar entropy of formation at reference state"
 
 .. note::
     This correlation uses the same parameters as the ideal liquid heat capacity.
+    Units of molar entropy of formation will be derived from the base units defined for the property package.
 
 Liquid Molar Density
 --------------------

--- a/docs/user_guide/components/property_package/general/pure/RPP.rst
+++ b/docs/user_guide/components/property_package/general/pure/RPP.rst
@@ -47,10 +47,11 @@ The correlation for the ideal gas molar enthalpy is derived from the correlation
    ":math:`B`", "cp_mol_ig_comp_coeff_B", ":math:`\text{J/mol}\cdotp\text{K}^2`", ""
    ":math:`C`", "cp_mol_ig_comp_coeff_C", ":math:`\text{J/mol}\cdotp\text{K}^3`", ""
    ":math:`D`", "cp_mol_ig_comp_coeff_D", ":math:`\text{J/mol}\cdotp\text{K}^4`", ""
-   ":math:`\Delta h_{\text{form, Vap}}`", "enth_mol_form_vap_comp_ref", ":math:`\text{J/mol}`", "Molar heat of formation at reference state"
+   ":math:`\Delta h_{\text{form, Vap}}`", "enth_mol_form_vap_comp_ref", "Base units", "Molar heat of formation at reference state"
 
 .. note::
     This correlation uses the same parameters as the ideal gas heat capacity correlation.
+    Units of molar heat of formation will be derived from the base units defined for the property package.
 
 Ideal Gas Molar Entropy
 ------------------------
@@ -68,10 +69,11 @@ The correlation for the ideal gas molar entropy is derived from the correlation 
    ":math:`B`", "cp_mol_ig_comp_coeff_B", ":math:`\text{J/mol}\cdotp\text{K}^2`", ""
    ":math:`C`", "cp_mol_ig_comp_coeff_C", ":math:`\text{J/mol}\cdotp\text{K}^3`", ""
    ":math:`D`", "cp_mol_ig_comp_coeff_D", ":math:`\text{J/mol}\cdotp\text{K}^4`", ""
-   ":math:`s_{\text{form, Vap}}`", "entr_mol_form_vap_comp_ref", ":math:`\text{J/mol}\cdotp\text{K}`", "Standard molar entropy of formation at reference state"
+   ":math:`s_{\text{form, Vap}}`", "entr_mol_form_vap_comp_ref", "Base units", "Standard molar entropy of formation at reference state"
 
 .. note::
     This correlation uses the same parameters as the ideal gas heat capacity correlation .
+    Units of molar entropy of formation will be derived from the base units defined for the property package.
 
 Saturation (Vapor) Pressure
 ---------------------------

--- a/docs/user_guide/components/property_package/general/pure/RPP3.rst
+++ b/docs/user_guide/components/property_package/general/pure/RPP3.rst
@@ -49,10 +49,11 @@ Units are calories per gram-mole kelvin and Kelvin.
    ":math:`B`", "cp_mol_ig_comp_coeff_B", ":math:`\text{cal/mol}\cdotp\text{K}^2`", ""
    ":math:`C`", "cp_mol_ig_comp_coeff_C", ":math:`\text{cal/mol}\cdotp\text{K}^3`", ""
    ":math:`D`", "cp_mol_ig_comp_coeff_D", ":math:`\text{cal/mol}\cdotp\text{K}^4`", ""
-   ":math:`\Delta h_{\text{form, Vap}}`", "enth_mol_form_vap_comp_ref", ":math:`\text{cal/mol}`", "Molar heat of formation at reference state"
+   ":math:`\Delta h_{\text{form, Vap}}`", "enth_mol_form_vap_comp_ref", "Base units", "Molar heat of formation at reference state"
 
 .. note::
     This correlation uses the same parameters as the ideal gas heat capacity correlation.
+    Units of molar heat of formation will be derived from the base units defined for the property package.
 
 Ideal Gas Molar Entropy
 ------------------------
@@ -72,10 +73,11 @@ Units are calories per gram-mole kelvin and Kelvin.
    ":math:`B`", "cp_mol_ig_comp_coeff_B", ":math:`\text{cal/mol}\cdotp\text{K}^2`", ""
    ":math:`C`", "cp_mol_ig_comp_coeff_C", ":math:`\text{cal/mol}\cdotp\text{K}^3`", ""
    ":math:`D`", "cp_mol_ig_comp_coeff_D", ":math:`\text{cal/mol}\cdotp\text{K}^4`", ""
-   ":math:`s_{\text{form, Vap}}`", "entr_mol_form_vap_comp_ref", ":math:`\text{cal/mol}\cdotp\text{K}`", "Standard molar entropy of formation at reference state"
+   ":math:`s_{\text{form, Vap}}`", "entr_mol_form_vap_comp_ref", "Base units", "Standard molar entropy of formation at reference state"
 
 .. note::
     This correlation uses the same parameters as the ideal gas heat capacity correlation .
+    Units of molar entropy of formation will be derived from the base units defined for the property package.
 
 Saturation (Vapor) Pressure
 ---------------------------


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
The units of measurement specified in the docs for the generic property package are incorrect for heats and entropies of formation. The docs state specific units (generally SI), whereas the actual parameters are specified in units consistent with the base units specified for the property package.

## Changes proposed in this PR:
- Correct units in docs
- Add a few clarifying comments, notably about the F and H parameters in the NIST Shomate equation.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
