### PR TITLE
Modify name of pytest job in integration workflow

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - rel_*
+      - '*_rel'
   schedule:
     # run daily at 5:00 am UTC (12 am ET/9 pm PT)
     - cron: '0 5 * * *'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: Integration
 on:
   push:
     branches:
-      - rel_*
+      - '*_rel'
   schedule:
     # run daily at 5:00 am UTC (12 am ET/9 pm PT)
     - cron: '0 5 * * *'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Notify
         run: echo "The integration tests will run"
   pytest:
-    name: pytest (py${{ matrix.python-version }}/${{ matrix.os }})
+    name: pytest (py${{ matrix.python-version }}/${{ matrix.os }}/integration)
     runs-on: ${{ matrix.os }}
     needs: [check-skip]
     strategy:


### PR DESCRIPTION
Hotfix for #168 because only job names (and not workflow names) seem to count as check names for populating the branch protection rules menu.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
