### PR TITLE
GitHub Actions CI hotfix: use correct field for integration workflow trigger on PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
     # NOTE: the name of the special label is hardcoded here
     # it would be better to extract it to a more global location, e.g. the workflow-level env context,
     # but the env context is not available in job-level if expressions (only step-level ones)
-    if: (github.event.name != 'labeled') || (github.event.label.name == 'CI:run-integration')
+    if: (github.event.action != 'labeled') || (github.event.label.name == 'CI:run-integration')
     runs-on: ubuntu-latest
     steps:
       - name: Notify


### PR DESCRIPTION
## Summary/motivation

Once #171 was merged, I realized that the integration tests were being triggered by every label being added to the PR, as opposed to the intended behavior of skipping the run unless the added label was the correct one. This was due to the wrong field of the `github.event` object being used in the condition. The fix in this PR has been tested on the branches in my fork of `idaes-pse` that I'm using to test changes to the CI configuration before deploying them here,

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
