### PR TITLE
Fix shell escaping issues in GitHub Actions workflows

### DIFF
--- a/.github/actions/display-debug-info/action.yml
+++ b/.github/actions/display-debug-info/action.yml
@@ -1,0 +1,17 @@
+name: Display debug info
+description: Display information about the environment and event payload
+runs:
+  using: composite
+  steps:
+    - name: Display environment
+      shell: bash
+      run: |
+        echo "::group::Environment"
+        env
+        echo "::endgroup"
+    - name: Display GitHub event payload
+      shell: bash
+      run: |
+        echo "::group::GitHub event payload"
+        jq . "$GITHUB_EVENT_PATH"
+        echo "::endgroup"

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -48,8 +48,8 @@ jobs:
           - ubuntu-18.04
           - windows-latest
     steps:
-      - uses: ./.github/actions/display-debug-info
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/display-debug-info
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -48,9 +48,7 @@ jobs:
           - ubuntu-18.04
           - windows-latest
     steps:
-      - name: Display debug info
-        run: |
-          echo '${{ toJSON(matrix) }}'
+      - uses: ./.github/actions/display-debug-info
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,8 +50,8 @@ jobs:
           - ubuntu-18.04
           - windows-latest
     steps:
-      - uses: ./.github/actions/display-debug-info
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/display-debug-info
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,10 +50,7 @@ jobs:
           - ubuntu-18.04
           - windows-latest
     steps:
-      - name: Display debug info
-        run: |
-          echo '${{ toJSON(matrix) }}'
-          echo '${{ toJSON(github.event) }}'
+      - uses: ./.github/actions/display-debug-info
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
## Fixes #181 

## Changes proposed in this PR:
- Use dedicated actions to display debug info consistently and without causing errors due to shell escaping issues that would occur with the previous strategy

Testing problematic characters: it's this one, `maybe_this_one_too`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
