### PR TITLE
Improve example for Generic Reaction Framework

### DIFF
--- a/idaes/generic_models/properties/core/examples/reactions/reaction_example.py
+++ b/idaes/generic_models/properties/core/examples/reactions/reaction_example.py
@@ -41,15 +41,56 @@ from idaes.generic_models.properties.core.reactions.equilibrium_forms import \
 
 # First, create a thermophsyical property definition that will be used
 # with the reactions
+import idaes.generic_models.properties.core.pure.Perrys as Perrys
 
 # For this example, the thermophsycial properties will only define components
 # and phases, but in practice users would also need to define some properties
 thermo_configuration = {
     "components": {
-        'A': {"type": Component},
-        'B': {"type": Component},
-        'C': {"type": Component},
-        'D': {"type": Component}},
+        'A': {"type": Component,
+              "enth_mol_liq_comp": Perrys,
+              "parameter_data": {
+                  "cp_mol_liq_comp_coeff": {
+                      '1': (1E2, pyunits.J/pyunits.kmol/pyunits.K),
+                      '2': (-2E-1, pyunits.J/pyunits.kmol/pyunits.K**2),
+                      '3': (6.5E-4, pyunits.J/pyunits.kmol/pyunits.K**3),
+                      '4': (0, pyunits.J/pyunits.kmol/pyunits.K**4),
+                      '5': (0, pyunits.J/pyunits.kmol/pyunits.K**5)},
+                  "enth_mol_form_liq_comp_ref": (
+                      5e4, pyunits.J/pyunits.mol)}},
+        'B': {"type": Component,
+              "enth_mol_liq_comp": Perrys,
+              "parameter_data": {
+                  "cp_mol_liq_comp_coeff": {
+                      '1': (1E2, pyunits.J/pyunits.kmol/pyunits.K),
+                      '2': (-2E-1, pyunits.J/pyunits.kmol/pyunits.K**2),
+                      '3': (6.5E-4, pyunits.J/pyunits.kmol/pyunits.K**3),
+                      '4': (0, pyunits.J/pyunits.kmol/pyunits.K**4),
+                      '5': (0, pyunits.J/pyunits.kmol/pyunits.K**5)},
+                  "enth_mol_form_liq_comp_ref": (
+                      5e4, pyunits.J/pyunits.mol)}},
+        'C': {"type": Component,
+              "enth_mol_liq_comp": Perrys,
+              "parameter_data": {
+                  "cp_mol_liq_comp_coeff": {
+                      '1': (1E2, pyunits.J/pyunits.kmol/pyunits.K),
+                      '2': (-2E-1, pyunits.J/pyunits.kmol/pyunits.K**2),
+                      '3': (6.5E-4, pyunits.J/pyunits.kmol/pyunits.K**3),
+                      '4': (0, pyunits.J/pyunits.kmol/pyunits.K**4),
+                      '5': (0, pyunits.J/pyunits.kmol/pyunits.K**5)},
+                  "enth_mol_form_liq_comp_ref": (
+                      5e4, pyunits.J/pyunits.mol)}},
+        'D': {"type": Component,
+              "enth_mol_liq_comp": Perrys,
+              "parameter_data": {
+                  "cp_mol_liq_comp_coeff": {
+                      '1': (1E2, pyunits.J/pyunits.kmol/pyunits.K),
+                      '2': (-2E-1, pyunits.J/pyunits.kmol/pyunits.K**2),
+                      '3': (6.5E-4, pyunits.J/pyunits.kmol/pyunits.K**3),
+                      '4': (0, pyunits.J/pyunits.kmol/pyunits.K**4),
+                      '5': (0, pyunits.J/pyunits.kmol/pyunits.K**5)},
+                  "enth_mol_form_liq_comp_ref": (
+                      5e4, pyunits.J/pyunits.mol)}}},
     "phases":  {'Liq': {"type": LiquidPhase,
                         "equation_of_state": Ideal}},
     "state_definition": FcTP,


### PR DESCRIPTION

## Fixes None


## Summary/Motivation:
In demonstrating the generic reaction framework to a user, it was discovered that the associated thermophsyical parameter block was missing methods for defining the specific molar enthalpy, and thus that it could not be used in an example with an actual reactor model. This PR adds the necessary property methods and parameters to the thermo package so that the example can be coupled with a CSTR if desired.

## Changes proposed in this PR:
- Adds methods and parameters to example thermophysical parameter configuration dict.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
