### PR TITLE
Avoid false positive in project coverage status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,12 @@ coverage:
   precision: 2
   round: down
   range: "1...100"
-  threshold: 20%
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+    project:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
## Summary/Motivation
Spurious fluctuations in coverage reports cause the Codecov `project` status check (which can be, and often is, completely unrelated to a particular PR's changes) to report a negative coverage delta, resulting in the entire PR to be flagged as failing the checks. This is because the default behavior is to use a threshold of 0 to classify a coverage report. 

## Changes proposed in this PR:
- Increase the accepted threshold to 1% for the `project` check
- Specify a tolerance of 0% for the `patch` check, which is limited to the files changed in the PR.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
