### PR TITLE
Adding support for molarity to generic properties

### DIFF
--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -16,6 +16,7 @@ Author: Andrew Lee
 import pytest
 from pyomo.environ import (ConcreteModel,
                            Constraint,
+                           Expression,
                            Set,
                            SolverStatus,
                            TerminationCondition,
@@ -247,6 +248,13 @@ class TestStateBlock(object):
                          "Pressure"]
 
     @pytest.mark.unit
+    def test_conc_mol(self, model):
+        assert isinstance(model.props[1].conc_mol_comp, Expression)
+        assert len(model.props[1].conc_mol_comp) == 2
+        assert isinstance(model.props[1].conc_mol_phase_comp, Expression)
+        assert len(model.props[1].conc_mol_phase_comp) == 4
+
+    @pytest.mark.unit
     def test_dof(self, model):
         # Fix state
         model.props[1].flow_mol.fix(1)
@@ -303,6 +311,9 @@ class TestStateBlock(object):
             pytest.approx(0.6339, abs=1e-4)
         assert model.props[1].phase_frac["Vap"].value == \
             pytest.approx(0.3961, abs=1e-4)
+
+        assert value(model.props[1].conc_mol_phase_comp["Vap", "benzene"]) == \
+            pytest.approx(20.9946, abs=1e-4)
 
     @pytest.mark.ui
     @pytest.mark.unit


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
In support of the NAWI project, support for molar concentrations is required for use in reactions that are written in concentration form.

## Changes proposed in this PR:
- Add methods for calculating molar concentrations (both average and by phase)
- Add a couple of simple tests for new methods.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
