### PR TITLE
Fixing misnamed variable in generic reactions

### DIFF
--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
@@ -125,6 +125,12 @@ class TestStateBlock(object):
                 [1],
                 default={"defined_state": True})
 
+        model.props[1].flow_mol.fix(10)
+        model.props[1].temperature.fix(323.15)
+        model.props[1].pressure.fix(108900)
+        model.props[1].mole_frac_comp["H2O"].fix(0.5)
+        model.props[1].mole_frac_comp["CO2"].fix(0.5)
+
         return model
 
     @pytest.mark.unit
@@ -258,13 +264,6 @@ class TestStateBlock(object):
 
     @pytest.mark.unit
     def test_dof(self, model):
-        # Fix state
-        model.props[1].flow_mol.fix(10)
-        model.props[1].temperature.fix(323.15)
-        model.props[1].pressure.fix(108900)
-        model.props[1].mole_frac_comp["H2O"].fix(0.5)
-        model.props[1].mole_frac_comp["CO2"].fix(0.5)
-
         assert degrees_of_freedom(model.props[1]) == 0
 
     @pytest.mark.initialize

--- a/idaes/generic_models/properties/core/generic/generic_reaction.py
+++ b/idaes/generic_models/properties/core/generic/generic_reaction.py
@@ -77,7 +77,7 @@ def get_concentration_term(blk, r_idx):
             "Please ensure that this argument is included in your "
             "configuration dict.".format(blk.name))
     elif conc_form == ConcentrationForm.molarity:
-        conc_term = getattr(blk.state_ref, "conc_mole_phase_comp")
+        conc_term = getattr(blk.state_ref, "conc_mol_phase_comp")
     elif conc_form == ConcentrationForm.activity:
         conc_term = getattr(blk.state_ref, "act_phase_comp")
     elif conc_form == ConcentrationForm.molality:


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Development in NAWI identified a misnamed variable in the generic reaction framework.

## Changes proposed in this PR:
- Fixed misnaming.
- Also fixed a interdependency in a test.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
