### PR TITLE
Enable newer Pyomo version in setup.py

### DIFF
--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -28,7 +28,9 @@ runs:
     - name: Install extensions
       shell: bash
       run: |
+        echo '::group::Output of "idaes get-extensions" command'
         idaes get-extensions --verbose
+        echo '::endgroup::'
         # add bin directory to $PATH (only valid for subsequent steps)
         echo "$(idaes bin-directory)" >> $GITHUB_PATH
     - name: Test access to executables

--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -18,7 +18,12 @@ runs:
     - name: Install idaes and dependencies
       shell: bash
       run: |
+        echo '::group::Output of "pip install" command'
         ${{ inputs.install-command }} ${{ inputs.install-target}}
+        echo '::endgroup::'
+        echo '::group::Output of "pip show pyomo idaes-pse"'
+        pip show pyomo idaes-pse
+        echo '::endgroup::'
         idaes --version
     - name: Install extensions
       shell: bash

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -35,40 +35,9 @@ defaults:
 
 jobs:
   pytest:
+    # description: Run pytest with dev dependencies
     name: pytest (py${{ matrix.python-version }}/${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - '3.6'
-          - '3.7'
-          - '3.8'
-        os:
-          - ubuntu-18.04
-          - windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/display-debug-info
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Set up idaes
-        uses: ./.github/actions/setup-idaes
-        with:
-          install-target: '.'
-      - name: Run pytest (not integration) with coverage
-        uses: ./.github/actions/pytest
-        with:
-          markexpr: not integration
-          extra-args: --cov
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1
-  pytest-dev:
-    name: pytest-dev (py${{ matrix.python-version }}/${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    continue-on-error: true  # avoid failing the workflow if an instance of this job fails
     strategy:
       fail-fast: false
       matrix:
@@ -91,6 +60,39 @@ jobs:
         uses: ./.github/actions/setup-idaes
         with:
           install-target: -r requirements-dev.txt
+      - name: Run pytest (not integration) with coverage
+        uses: ./.github/actions/pytest
+        with:
+          markexpr: not integration
+          extra-args: --cov
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1
+  pytest-rel:
+    # description: Run pytest with release/standard dependencies defined in setup.py
+    name: pytest (rel/py${{ matrix.python-version }}/${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true  # avoid failing the workflow if an instance of this job fails
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.6'
+          - '3.7'
+          - '3.8'
+        os:
+          - ubuntu-18.04
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/display-debug-info
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up idaes
+        uses: ./.github/actions/setup-idaes
+        with:
+          install-target: '.'
       - name: Run pytest (not integration) without coverage
         uses: ./.github/actions/pytest
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -65,6 +65,36 @@ jobs:
           extra-args: --cov
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1
+  pytest-dev:
+    name: pytest-dev (py${{ matrix.python-version }}/${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true  # avoid failing the workflow if an instance of this job fails
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+        os:
+          - ubuntu-18.04
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/display-debug-info
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up idaes
+        uses: ./.github/actions/setup-idaes
+        with:
+          install-target: -r requirements-dev.txt
+      - name: Run pytest (not integration) without coverage
+        uses: ./.github/actions/pytest
+        with:
+          markexpr: not integration
   build-docs:
     name: Build Sphinx docs
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,7 @@ jobs:
           - '3.6'
           - '3.7'
           - '3.8'
+          - '3.9'
         os:
           - ubuntu-18.04
           - windows-latest
@@ -59,7 +60,7 @@ jobs:
       - name: Set up idaes
         uses: ./.github/actions/setup-idaes
         with:
-          install-target: '.'
+          install-target: -r requirements-dev.txt
       - name: Run pytest (integration)
         uses: ./.github/actions/pytest
         with:

--- a/docs/technical_specs/model_libraries/generic/property_models/swco2.rst
+++ b/docs/technical_specs/model_libraries/generic/property_models/swco2.rst
@@ -20,7 +20,7 @@ provides a simple example for using water properties.
 .. testcode::
 
   from idaes.generic_models.properties import swco2
-  from pyomo.environ import ConcreteModel, units as pyunits # Pyomo environment
+  from pyomo.environ import ConcreteModel, units as pyunits, SolverFactory # Pyomo environment
   from idaes.generic_models.unit_models import Compressor
   from idaes.core import FlowsheetBlock
 
@@ -40,6 +40,8 @@ provides a simple example for using water properties.
   model.fs.unit.deltaP.fix(Pout - Pin)
   model.fs.unit.efficiency_isentropic.fix(0.9)
   model.fs.unit.initialize(optarg={'tol': 1e-6})
+
+  solver = SolverFactory("ipopt")
   solver.solve(model)
 
 

--- a/docs/technical_specs/model_libraries/generic/property_models/swco2.rst
+++ b/docs/technical_specs/model_libraries/generic/property_models/swco2.rst
@@ -20,11 +20,11 @@ provides a simple example for using water properties.
 .. testcode::
 
   from idaes.generic_models.properties import swco2
-  import pyomo.environ as pe # Pyomo environment
+  from pyomo.environ import ConcreteModel, units as pyunits # Pyomo environment
   from idaes.generic_models.unit_models import Compressor
   from idaes.core import FlowsheetBlock
 
-  m = pe.ConcreteModel()
+  m = ConcreteModel()
   m.fs = FlowsheetBlock(default={"dynamic": False})
   m.fs.properties = swco2.SWCO2ParameterBlock()
   m.fs.unit = Compressor(default={"property_package": m.fs.properties})

--- a/docs/technical_specs/model_libraries/generic/property_models/swco2.rst
+++ b/docs/technical_specs/model_libraries/generic/property_models/swco2.rst
@@ -24,7 +24,7 @@ provides a simple example for using water properties.
   from idaes.generic_models.unit_models import Compressor
   from idaes.core import FlowsheetBlock
 
-  m = ConcreteModel()
+  m = pe.ConcreteModel()
   m.fs = FlowsheetBlock(default={"dynamic": False})
   m.fs.properties = swco2.SWCO2ParameterBlock()
   m.fs.unit = Compressor(default={"property_package": m.fs.properties})

--- a/docs/technical_specs/model_libraries/generic/property_models/swco2.rst
+++ b/docs/technical_specs/model_libraries/generic/property_models/swco2.rst
@@ -24,10 +24,10 @@ provides a simple example for using water properties.
   from idaes.generic_models.unit_models import Compressor
   from idaes.core import FlowsheetBlock
 
-  m = ConcreteModel()
-  m.fs = FlowsheetBlock(default={"dynamic": False})
-  m.fs.properties = swco2.SWCO2ParameterBlock()
-  m.fs.unit = Compressor(default={"property_package": m.fs.properties})
+  model = ConcreteModel()
+  model.fs = FlowsheetBlock(default={"dynamic": False})
+  model.fs.properties = swco2.SWCO2ParameterBlock()
+  model.fs.unit = Compressor(default={"property_package": model.fs.properties})
   F = 1000
   Tin = 500
   Pin = 10000

--- a/docs/technical_specs/model_libraries/power_generation/unit_models/turbine_inlet.rst
+++ b/docs/technical_specs/model_libraries/power_generation/unit_models/turbine_inlet.rst
@@ -22,7 +22,7 @@ Example
 
     from pyomo.environ import ConcreteModel, SolverFactory, TransformationFactory, units
     from idaes.core import FlowsheetBlock
-    from idaes.power_generation.unit_models.helm import TurbineInletStage
+    from idaes.power_generation.unit_models.helm import HelmTurbineInletStage
     from idaes.generic_models.properties import iapws95
 
     m = ConcreteModel()

--- a/docs/technical_specs/model_libraries/power_generation/unit_models/turbine_outlet.rst
+++ b/docs/technical_specs/model_libraries/power_generation/unit_models/turbine_outlet.rst
@@ -18,7 +18,7 @@ Example
 
     from pyomo.environ import ConcreteModel, SolverFactory
     from idaes.core import FlowsheetBlock
-    from idaes.power_generation.unit_models import HelmTurbineOutletStage
+    from idaes.power_generation.unit_models.helm import HelmTurbineOutletStage
     from idaes.generic_models.properties import iapws95
 
     m = ConcreteModel()

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ kwargs = dict(
         "pint",
         "psutil",
         "pyutilib>=6.0.0",
-        "pyomo>5.7.1,<6",
+        "pyomo>=5.7.3",
         "pytest",
         "pyyaml",
         "requests",  # for ui/fsvis


### PR DESCRIPTION
## Fixes
- Installation errors preventing Pyomo version 6 and up from being installed

## Changes proposed in this PR:
- Remove installation constraints requiring `pyomo<6` in `setup.py`
- Add `pytest-dev` job using dev dependencies (`requirements-dev.txt`) and Python 3.9
  - This uses a separate test job matrix without coverage report, and with "experimental mode", i.e. settings to prevent the entire workflow to be marked as failed if any job fails

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
