### PR TITLE
Reorganising tests of generic properties

### DIFF
--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
@@ -149,76 +149,7 @@ class TestStateBlock(object):
         for i in model.props[1].mole_frac_comp:
             assert value(model.props[1].mole_frac_comp[i]) == 1/3
 
-        # Check supporting variables
-        assert isinstance(model.props[1].flow_mol_phase, Var)
-        assert len(model.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.props[1].mole_frac_phase_comp, Var)
-        assert len(model.props[1].mole_frac_phase_comp) == 6
-
-        assert isinstance(model.props[1].phase_frac, Var)
-        assert len(model.props[1].phase_frac) == 2
-
-        assert isinstance(model.props[1].total_flow_balance, Constraint)
-        assert len(model.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.props[1].component_flow_balances, Constraint)
-        assert len(model.props[1].component_flow_balances) == 3
-
-        assert isinstance(model.props[1].sum_mole_frac, Constraint)
-        assert len(model.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.props[1].phase_fraction_constraint) == 2
-
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_flow_terms(p, j) == (
-                    model.props[1].flow_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
-                model.props[1].flow_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_density_terms(p, j) == (
-                    model.props[1].dens_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
-                model.props[1].dens_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):
@@ -253,9 +184,6 @@ class TestStateBlock(object):
                          "Temperature",
                          "Pressure"]
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, model):
         # Fix state
@@ -286,8 +214,6 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
         results = solver.solve(model)
@@ -297,9 +223,6 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):
         # Check phase equilibrium results
@@ -310,7 +233,6 @@ class TestStateBlock(object):
         assert model.props[1].phase_frac["Vap"].value == \
             pytest.approx(0.6422, abs=1e-4)
 
-    @pytest.mark.ui
     @pytest.mark.unit
     def test_report(self, model):
         model.props[1].report()

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
@@ -152,76 +152,7 @@ class TestStateBlock(object):
         for i in model.props[1].mole_frac_comp:
             assert value(model.props[1].mole_frac_comp[i]) == 1/3
 
-        # Check supporting variables
-        assert isinstance(model.props[1].flow_mol_phase, Var)
-        assert len(model.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.props[1].mole_frac_phase_comp, Var)
-        assert len(model.props[1].mole_frac_phase_comp) == 6
-
-        assert isinstance(model.props[1].phase_frac, Var)
-        assert len(model.props[1].phase_frac) == 2
-
-        assert isinstance(model.props[1].total_flow_balance, Constraint)
-        assert len(model.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.props[1].component_flow_balances, Constraint)
-        assert len(model.props[1].component_flow_balances) == 3
-
-        assert isinstance(model.props[1].sum_mole_frac, Constraint)
-        assert len(model.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.props[1].phase_fraction_constraint) == 2
-
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_flow_terms(p, j) == (
-                    model.props[1].flow_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
-                model.props[1].flow_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_density_terms(p, j) == (
-                    model.props[1].dens_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
-                model.props[1].dens_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):
@@ -256,9 +187,6 @@ class TestStateBlock(object):
                          "Temperature",
                          "Pressure"]
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, model):
         # Fix state
@@ -289,8 +217,6 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
         results = solver.solve(model)
@@ -300,9 +226,6 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):
         # Check phase equilibrium results
@@ -314,7 +237,7 @@ class TestStateBlock(object):
             pytest.approx(0.703, abs=1e-3)
         assert value(model.props[1].enth_mol_phase["Vap"]) == \
             pytest.approx(-6567, abs=1e1)
-    @pytest.mark.ui
+
     @pytest.mark.unit
     def test_report(self, model):
         model.props[1].report()

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -143,76 +143,7 @@ class TestStateBlock(object):
         for i in model.props[1].mole_frac_comp:
             assert value(model.props[1].mole_frac_comp[i]) == 0.5
 
-        # Check supporting variables
-        assert isinstance(model.props[1].flow_mol_phase, Var)
-        assert len(model.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.props[1].mole_frac_phase_comp, Var)
-        assert len(model.props[1].mole_frac_phase_comp) == 4
-
-        assert isinstance(model.props[1].phase_frac, Var)
-        assert len(model.props[1].phase_frac) == 2
-
-        assert isinstance(model.props[1].total_flow_balance, Constraint)
-        assert len(model.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.props[1].component_flow_balances, Constraint)
-        assert len(model.props[1].component_flow_balances) == 2
-
-        assert isinstance(model.props[1].sum_mole_frac, Constraint)
-        assert len(model.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.props[1].phase_fraction_constraint) == 2
-
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_flow_terms(p, j) == (
-                    model.props[1].flow_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
-                model.props[1].flow_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_density_terms(p, j) == (
-                    model.props[1].dens_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
-                model.props[1].dens_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):
@@ -246,13 +177,6 @@ class TestStateBlock(object):
                          "Total Mole Fraction",
                          "Temperature",
                          "Pressure"]
-
-    @pytest.mark.unit
-    def test_conc_mol(self, model):
-        assert isinstance(model.props[1].conc_mol_comp, Expression)
-        assert len(model.props[1].conc_mol_comp) == 2
-        assert isinstance(model.props[1].conc_mol_phase_comp, Expression)
-        assert len(model.props[1].conc_mol_phase_comp) == 4
 
     @pytest.mark.unit
     def test_dof(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -229,76 +229,7 @@ class TestStateBlock(object):
         for i in model.props[1].mole_frac_comp:
             assert value(model.props[1].mole_frac_comp[i]) == 0.5
 
-        # Check supporting variables
-        assert isinstance(model.props[1].flow_mol_phase, Var)
-        assert len(model.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.props[1].mole_frac_phase_comp, Var)
-        assert len(model.props[1].mole_frac_phase_comp) == 4
-
-        assert isinstance(model.props[1].phase_frac, Var)
-        assert len(model.props[1].phase_frac) == 2
-
-        assert isinstance(model.props[1].total_flow_balance, Constraint)
-        assert len(model.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.props[1].component_flow_balances, Constraint)
-        assert len(model.props[1].component_flow_balances) == 2
-
-        assert isinstance(model.props[1].sum_mole_frac, Constraint)
-        assert len(model.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.props[1].phase_fraction_constraint) == 2
-
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_flow_terms(p, j) == (
-                    model.props[1].flow_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
-                model.props[1].flow_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_density_terms(p, j) == (
-                    model.props[1].dens_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
-                model.props[1].dens_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
@@ -232,76 +232,7 @@ class TestStateBlock(object):
         for i in model.props[1].mole_frac_comp:
             assert value(model.props[1].mole_frac_comp[i]) == 0.5
 
-        # Check supporting variables
-        assert isinstance(model.props[1].flow_mol_phase, Var)
-        assert len(model.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.props[1].mole_frac_phase_comp, Var)
-        assert len(model.props[1].mole_frac_phase_comp) == 4
-
-        assert isinstance(model.props[1].phase_frac, Var)
-        assert len(model.props[1].phase_frac) == 2
-
-        assert isinstance(model.props[1].total_flow_balance, Constraint)
-        assert len(model.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.props[1].component_flow_balances, Constraint)
-        assert len(model.props[1].component_flow_balances) == 2
-
-        assert isinstance(model.props[1].sum_mole_frac, Constraint)
-        assert len(model.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.props[1].phase_fraction_constraint) == 2
-
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_flow_terms(p, j) == (
-                    model.props[1].flow_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
-                model.props[1].flow_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_density_terms(p, j) == (
-                    model.props[1].dens_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
-                model.props[1].dens_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):
@@ -342,9 +273,6 @@ class TestStateBlock(object):
 
         assert degrees_of_freedom(model.props[1]) == 0
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.unit
     def test_initialize(self, model):
         orig_fixed_vars = fixed_variables_set(model)
@@ -365,8 +293,6 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.unit
     def test_solve(self, model):
         results = solver.solve(model)
@@ -376,9 +302,6 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.unit
     def test_solution(self, model):
         # Check phase equilibrium results
@@ -389,7 +312,6 @@ class TestStateBlock(object):
         assert model.props[1].phase_frac["Vap"].value == \
             pytest.approx(0.3961, abs=1e-4)
 
-    @pytest.mark.ui
     @pytest.mark.unit
     def test_report(self, model):
         model.props[1].report()

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
@@ -224,76 +224,7 @@ class TestStateBlock(object):
         for i in model.props[1].mole_frac_comp:
             assert value(model.props[1].mole_frac_comp[i]) == 0.5
 
-        # Check supporting variables
-        assert isinstance(model.props[1].flow_mol_phase, Var)
-        assert len(model.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.props[1].mole_frac_phase_comp, Var)
-        assert len(model.props[1].mole_frac_phase_comp) == 4
-
-        assert isinstance(model.props[1].phase_frac, Var)
-        assert len(model.props[1].phase_frac) == 2
-
-        assert isinstance(model.props[1].total_flow_balance, Constraint)
-        assert len(model.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.props[1].component_flow_balances, Constraint)
-        assert len(model.props[1].component_flow_balances) == 2
-
-        assert isinstance(model.props[1].sum_mole_frac, Constraint)
-        assert len(model.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.props[1].phase_fraction_constraint) == 2
-
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_flow_terms(p, j) == (
-                    model.props[1].flow_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
-                model.props[1].flow_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                assert model.props[1].get_material_density_terms(p, j) == (
-                    model.props[1].dens_mol_phase[p] *
-                    model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
-                model.props[1].dens_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):
@@ -334,9 +265,6 @@ class TestStateBlock(object):
 
         assert degrees_of_freedom(model.props[1]) == 0
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.unit
     def test_initialize(self, model):
         orig_fixed_vars = fixed_variables_set(model)
@@ -357,8 +285,6 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.unit
     def test_solve(self, model):
         results = solver.solve(model)
@@ -368,9 +294,6 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.unit
     def test_solution(self, model):
         # Check phase equilibrium results
@@ -383,7 +306,6 @@ class TestStateBlock(object):
 
         assert value(model.props[1].enth_mol) == pytest.approx(48220.5, 1e-5)
 
-    @pytest.mark.ui
     @pytest.mark.unit
     def test_report(self, model):
         model.props[1].report()

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -49,10 +49,6 @@ solver = get_default_solver()
 
 # -----------------------------------------------------------------------------
 # Test robustness and some outputs
-@pytest.mark.solver
-@pytest.mark.skipif(solver is None, reason="Solver not available")
-@pytest.mark.skipif(not prop_available,
-                    reason="Cubic root finder not available")
 class TestBTExample(object):
     @pytest.fixture()
     def m(self):

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
@@ -15,8 +15,6 @@ Authors: Anuja Deshpande, Andrew Lee
 """
 import pytest
 import numpy as np
-import sys
-import os
 
 from pyomo.environ import (ConcreteModel,
                            Constraint,
@@ -56,6 +54,7 @@ from idaes.generic_models.properties.core.examples.CO2_H2O_Ideal_VLE import (
 # Get default solver for testing
 solver = get_default_solver()
 
+
 class TestParamBlock(object):
     @pytest.mark.unit
     def test_build(self):
@@ -88,7 +87,7 @@ class TestParamBlock(object):
             "flow_mol": (0, 10, 20, pyunits.mol/pyunits.s),
             "temperature": (273.15, 323.15, 1000, pyunits.K),
             "pressure": (5e4, 108900, 1e7, pyunits.Pa),
-            "mole_frac_comp": {"H2O":(0,0.5,1),"CO2":(0,0.5,1)}}
+            "mole_frac_comp": {"H2O": (0,0.5,1),"CO2": (0,0.5,1)}}
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): smooth_VLE}
@@ -156,78 +155,7 @@ class TestStateBlock(object):
         assert value(model.props[1].mole_frac_comp["H2O"]) == 0.5
         assert value(model.props[1].mole_frac_comp["CO2"]) == 0.5
 
-        # Check supporting variables
-        assert isinstance(model.props[1].flow_mol_phase, Var)
-        assert len(model.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.props[1].mole_frac_phase_comp, Var)
-        assert len(model.props[1].mole_frac_phase_comp) == 3
-
-        assert isinstance(model.props[1].phase_frac, Var)
-        assert len(model.props[1].phase_frac) == 2
-
-        assert isinstance(model.props[1].total_flow_balance, Constraint)
-        assert len(model.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.props[1].component_flow_balances, Constraint)
-        assert len(model.props[1].component_flow_balances) == 2
-
-        assert isinstance(model.props[1].sum_mole_frac, Constraint)
-        assert len(model.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.props[1].phase_fraction_constraint) == 2
-
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                if (p,j)!=("Liq","CO2"):
-                    assert model.props[1].get_material_flow_terms(p, j) == (
-                        model.props[1].flow_mol_phase[p] *
-                        model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
-                model.props[1].flow_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                if (p,j)!=("Liq","CO2"):
-                    assert model.props[1].get_material_density_terms(p, j) == (
-                        model.props[1].dens_mol_phase[p] *
-                        model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
-                model.props[1].dens_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):
@@ -266,9 +194,6 @@ class TestStateBlock(object):
     def test_dof(self, model):
         assert degrees_of_freedom(model.props[1]) == 0
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, model):
         orig_fixed_vars = fixed_variables_set(model)
@@ -289,8 +214,6 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
         results = solver.solve(model)
@@ -300,9 +223,6 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):
         # Check phase equilibrium results
@@ -314,7 +234,7 @@ class TestStateBlock(object):
             pytest.approx(0.88499, abs=1e-4)
         assert model.props[1].phase_frac["Vap"].value == \
             pytest.approx(0.56498, abs=1e-4)
-            
+
     @pytest.mark.integration
     def test_temp_swing(self):
         # Create a flash model with the CO2-H2O property package
@@ -322,55 +242,56 @@ class TestStateBlock(object):
         m.fs = FlowsheetBlock(default={"dynamic": False})
         m.fs.properties = GenericParameterBlock(default=configuration)
         m.fs.flash = Flash(default={"property_package": m.fs.properties})
-        
+
         # Fix inlet stream state variables
-        m.fs.flash.inlet.flow_mol.fix(9.89433124673833) # mol/s
+        m.fs.flash.inlet.flow_mol.fix(9.89433124673833)  # mol/s
         m.fs.flash.inlet.mole_frac_comp[0, 'CO2'].fix(0.13805801934749645)
         m.fs.flash.inlet.mole_frac_comp[0, 'H2O'].fix(0.8619419806525035)
-        m.fs.flash.inlet.pressure.fix(183430) # Pa
-        m.fs.flash.inlet.temperature.fix(396.79057912844183) # K
-        
+        m.fs.flash.inlet.pressure.fix(183430)  # Pa
+        m.fs.flash.inlet.temperature.fix(396.79057912844183)  # K
+
         # Fix flash and its outlet conditions
         m.fs.flash.deltaP.fix(0)
         m.fs.flash.vap_outlet.temperature.fix(313.15)
-        
-        #Initialize the flash model
-        initial = m.fs.flash.initialize(outlvl=0)
-        
-        # Create a dictionary of expected solution for flash outlet temperature 
-        #sweep
-        temp_range = list(np.linspace(313,396))
-        
-        expected_vapor_frac = [0.14388,0.14445,0.14508,0.14576,0.1465,0.14731,
-                               0.14818,0.14913,0.15017,0.15129,0.15251,0.15384,
-                               0.15528,0.15685,0.15856,0.16042,0.16245,0.16467,
-                               0.16709,0.16974,0.17265,0.17584,0.17935,0.18323,
-                               0.18751,0.19226,0.19755,0.20346,0.21008,0.21755,
-                               0.22601,0.23565,0.24673,0.25956,0.27456,0.29229,
-                               0.31354,0.33942,0.37157,0.4125,0.46628,0.53993,
-                               0.64678,0.81547,1.0,1.0,1.0,1.0,1.0,1.0]
-        
-        expected_heat_duty = [-319572.91269,-318207.35249,-316825.31456,
-                              -315425.46452,-314006.35514,-312566.41317,
-                              -311103.92414,-309617.01485,-308103.633,
-                              -306561.52359,-304988.20138,-303380.91855,
-                              -301736.62677,-300051.9324,-298323.04327,
-                              -296545.70535,-294715.12686,-292825.88683,
-                              -290871.8244,-288845.90382,-286740.04885,
-                              -284544.93807,-282249.74995,-279841.84278,
-                              -277306.349,-274625.65625,-271778.73623,
-                              -268740.26687,-265479.46928,-261958.54546,
-                              -258130.54709,-253936.4179,-249300.81058,
-                              -244126.04073,-238283.13381,-231598.19109,
-                              -223830.94744,-214639.75318,-203521.76902,
-                              -189705.16711,-171941.46564,-148070.35054,
-                              -114001.22402,-60937.07508,-3219.88715,
-                              -2631.66029,-2043.09203,-1454.17752,-864.91582,
-                              -275.30623]
-        
-        outvals = zip(expected_vapor_frac,expected_heat_duty)
-        expected_sol = dict(zip(temp_range,outvals))
-        
+
+        # Initialize the flash model
+        m.fs.flash.initialize()
+
+        # Create a dictionary of expected solution for flash outlet temperature
+        # sweep
+        temp_range = list(np.linspace(313, 396))
+
+        expected_vapor_frac = [
+            0.14388, 0.14445, 0.14508, 0.14576, 0.1465, 0.14731,
+            0.14818, 0.14913, 0.15017, 0.15129, 0.15251, 0.15384,
+            0.15528, 0.15685, 0.15856, 0.16042, 0.16245, 0.16467,
+            0.16709, 0.16974, 0.17265, 0.17584, 0.17935, 0.18323,
+            0.18751, 0.19226, 0.19755, 0.20346, 0.21008, 0.21755,
+            0.22601, 0.23565, 0.24673, 0.25956, 0.27456, 0.29229,
+            0.31354, 0.33942, 0.37157, 0.4125, 0.46628, 0.53993,
+            0.64678, 0.81547, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+        expected_heat_duty = [-319572.91269, -318207.35249, -316825.31456,
+                              -315425.46452, -314006.35514, -312566.41317,
+                              -311103.92414, -309617.01485, -308103.633,
+                              -306561.52359, -304988.20138, -303380.91855,
+                              -301736.62677, -300051.9324, -298323.04327,
+                              -296545.70535, -294715.12686, -292825.88683,
+                              -290871.8244, -288845.90382, -286740.04885,
+                              -284544.93807, -282249.74995, -279841.84278,
+                              -277306.349, -274625.65625, -271778.73623,
+                              -268740.26687, -265479.46928, -261958.54546,
+                              -258130.54709, -253936.4179, -249300.81058,
+                              -244126.04073, -238283.13381, -231598.19109,
+                              -223830.94744, -214639.75318, -203521.76902,
+                              -189705.16711, -171941.46564, -148070.35054,
+                              -114001.22402, -60937.07508, -3219.88715,
+                              -2631.66029, -2043.09203, -1454.17752,
+                              -864.91582, -275.30623]
+
+        outvals = zip(expected_vapor_frac, expected_heat_duty)
+        expected_sol = dict(zip(temp_range, outvals))
+
         # Solve the model for a range of flash outlet temperatures
         # Perform flash outlet temperature sweep and test the solution
         for t in temp_range:
@@ -378,12 +299,11 @@ class TestStateBlock(object):
             res = solver.solve(m)
             assert res.solver.termination_condition == "optimal"
             frac = value(m.fs.flash.vap_outlet.flow_mol[0]) \
-                /value(m.fs.flash.inlet.flow_mol[0])
-            assert frac == pytest.approx(expected_sol[t][0],abs=1e-4)
+                / value(m.fs.flash.inlet.flow_mol[0])
+            assert frac == pytest.approx(expected_sol[t][0], abs=1e-4)
             hduty = value(m.fs.flash.heat_duty[0])
-            assert hduty == pytest.approx(expected_sol[t][1],abs=1e-4)
+            assert hduty == pytest.approx(expected_sol[t][1], abs=1e-4)
 
-    @pytest.mark.ui
     @pytest.mark.unit
     def test_report(self, model):
         model.props[1].report()

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -15,7 +15,6 @@ Author: Andrew Lee, Alejandro Garciadiego
 """
 import pytest
 from pyomo.environ import (ConcreteModel,
-                           Constraint,
                            Set,
                            SolverStatus,
                            TerminationCondition,
@@ -24,16 +23,8 @@ from pyomo.environ import (ConcreteModel,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
 
-from idaes.core import (MaterialBalanceType,
-                        EnergyBalanceType,
-                        MaterialFlowBasis,
-                        FlowsheetBlock,
-                        declare_process_block_class,
-                        UnitModelBlockData,
-                        Component)
-from idaes.core.util.model_statistics import (degrees_of_freedom,
-                                              fixed_variables_set,
-                                              activated_constraints_set)
+from idaes.core import Component, FlowsheetBlock
+from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.testing import get_default_solver, initialization_tester
 
 from idaes.generic_models.properties.core.generic.generic_property import (
@@ -50,6 +41,7 @@ from idaes.generic_models.properties.core.examples.CO2_bmimPF6_PR \
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_default_solver()
+
 
 # Test for configuration dictionaries with parameters from Properties of Gases
 # and liquids 4th edition
@@ -111,6 +103,7 @@ class TestParamBlock(object):
 
         assert_units_consistent(model)
 
+
 class TestStateBlock(object):
     @pytest.fixture(scope="class")
     def model(self):
@@ -156,89 +149,9 @@ class TestStateBlock(object):
         assert isinstance(model.fs.props[1].mole_frac_comp, Var)
         assert len(model.fs.props[1].mole_frac_comp) == 2
         assert value(model.fs.props[1].mole_frac_comp["carbon_dioxide"]) == 0.2
-        assert value(model.fs.props[1].mole_frac_comp["bmimPF6"]) ==  0.8
-
-
-        # Check supporting variables
-        assert isinstance(model.fs.props[1].flow_mol_phase, Var)
-        assert len(model.fs.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.fs.props[1].mole_frac_phase_comp, Var)
-        assert len(model.fs.props[1].mole_frac_phase_comp) == 3
-
-        assert isinstance(model.fs.props[1].phase_frac, Var)
-        assert len(model.fs.props[1].phase_frac) == 2
-
-        assert isinstance(model.fs.props[1].total_flow_balance, Constraint)
-        assert len(model.fs.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.fs.props[1].component_flow_balances, Constraint)
-        assert len(model.fs.props[1].component_flow_balances) == 2
-
-        assert isinstance(model.fs.props[1].sum_mole_frac, Constraint)
-        assert len(model.fs.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.fs.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.fs.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.fs.props[1].phase_fraction_constraint) == 2
+        assert value(model.fs.props[1].mole_frac_comp["bmimPF6"]) == 0.8
 
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.fs.param.phase_list:
-            for j in model.fs.param.component_list:
-                if j == "bmimPF6":
-                    assert model.fs.props[1].get_material_flow_terms("Liq", j) == (
-                        model.fs.props[1].flow_mol_phase["Liq"] *
-                        model.fs.props[1].mole_frac_phase_comp["Liq", j])
-                else:
-                    assert model.fs.props[1].get_material_flow_terms(p, j) == (
-                        model.fs.props[1].flow_mol_phase[p] *
-                        model.fs.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.fs.param.phase_list:
-            assert model.fs.props[1].get_enthalpy_flow_terms(p) == (
-                model.fs.props[1].flow_mol_phase[p] *
-                model.fs.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.fs.param.phase_list:
-            for j in model.fs.param.component_list:
-                if j == "bmimPF6":
-                    assert model.fs.props[1].get_material_density_terms("Liq", j) == (
-                        model.fs.props[1].dens_mol_phase["Liq"] *
-                        model.fs.props[1].mole_frac_phase_comp["Liq", j])
-                else:
-                    assert model.fs.props[1].get_material_density_terms(p, j) == (
-                        model.fs.props[1].dens_mol_phase[p] *
-                        model.fs.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.fs.param.phase_list:
-            assert model.fs.props[1].get_energy_density_terms(p) == (
-                model.fs.props[1].dens_mol_phase[p] *
-                model.fs.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.fs.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.fs.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.fs.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):
@@ -276,27 +189,22 @@ class TestStateBlock(object):
     @pytest.mark.unit
     def test_unit_dof(self, model):
         model.fs.unit = Flash(default={"property_package": model.fs.param,
-                               "has_heat_transfer": False,
-                               "has_pressure_change": False})
+                                       "has_heat_transfer": False,
+                                       "has_pressure_change": False})
         # Fix state
         model.fs.unit.inlet.flow_mol.fix(1)
         model.fs.unit.inlet.temperature.fix(200.00)
         model.fs.unit.inlet.pressure.fix(101325)
-        model.fs.unit.inlet.mole_frac_comp[0,"carbon_dioxide"].fix(1/2)
-        model.fs.unit.inlet.mole_frac_comp[0,"bmimPF6"].fix(1/2)
+        model.fs.unit.inlet.mole_frac_comp[0, "carbon_dioxide"].fix(1/2)
+        model.fs.unit.inlet.mole_frac_comp[0, "bmimPF6"].fix(1/2)
 
         assert degrees_of_freedom(model.fs.unit) == 0
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, model):
 
         initialization_tester(model, dof=0)
 
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
         results = solver.solve(model)
@@ -306,19 +214,18 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):
         # Check phase equilibrium results
-        assert model.fs.unit.liq_outlet.mole_frac_comp[0, "carbon_dioxide"].value == \
+        assert model.fs.unit.liq_outlet.mole_frac_comp[
+            0, "carbon_dioxide"].value == \
             pytest.approx(0.3119, abs=1e-4)
-        assert model.fs.unit.vap_outlet.mole_frac_comp[0,"carbon_dioxide"].value == \
+        assert model.fs.unit.vap_outlet.mole_frac_comp[
+            0, "carbon_dioxide"].value == \
             pytest.approx(1.0000, abs=1e-4)
         assert (model.fs.unit.vap_outlet.flow_mol[0].value /
-                model.fs.unit.liq_outlet.flow_mol[0].value)  == \
-                pytest.approx(0.37619, abs=1e-4)
+                model.fs.unit.liq_outlet.flow_mol[0].value) == \
+            pytest.approx(0.37619, abs=1e-4)
 
     @pytest.mark.ui
     @pytest.mark.unit

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
@@ -240,94 +240,9 @@ class TestStateBlock(object):
             assert value(model.props[1].mole_frac_comp[i]) == \
                 pytest.approx(0.077, abs=1e-2)
 
-        # Check supporting variables
-        assert isinstance(model.props[1].flow_mol_phase, Var)
-        assert len(model.props[1].flow_mol_phase) == 2
-
-        assert isinstance(model.props[1].mole_frac_phase_comp, Var)
-        assert len(model.props[1].mole_frac_phase_comp) == 24
-
-        assert isinstance(model.props[1].phase_frac, Var)
-        assert len(model.props[1].phase_frac) == 2
-
-        assert isinstance(model.props[1].total_flow_balance, Constraint)
-        assert len(model.props[1].total_flow_balance) == 1
-
-        assert isinstance(model.props[1].component_flow_balances, Constraint)
-        assert len(model.props[1].component_flow_balances) == 13
-
-        assert isinstance(model.props[1].sum_mole_frac, Constraint)
-        assert len(model.props[1].sum_mole_frac) == 1
-
-        assert not hasattr(model.props[1], "sum_mole_frac_out")
-
-        assert isinstance(model.props[1].phase_fraction_constraint, Constraint)
-        assert len(model.props[1].phase_fraction_constraint) == 2
-
+    @pytest.mark.integration
+    def test_unit_consistency(self, model):
         assert_units_consistent(model)
-
-    @pytest.mark.unit
-    def test_get_material_flow_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                if j == "hydrogen":
-                    assert model.props[1].get_material_flow_terms("Vap", j) == (
-                        model.props[1].flow_mol_phase["Vap"] *
-                        model.props[1].mole_frac_phase_comp["Vap", j])
-                elif j == "methane":
-                    assert model.props[1].get_material_flow_terms("Vap", j) == (
-                        model.props[1].flow_mol_phase["Vap"] *
-                        model.props[1].mole_frac_phase_comp["Vap", j])
-                else:
-                    assert model.props[1].get_material_flow_terms(p, j) == (
-                        model.props[1].flow_mol_phase[p] *
-                        model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_enthalpy_flow_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
-                model.props[1].flow_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_get_material_density_terms(self, model):
-        for p in model.params.phase_list:
-            for j in model.params.component_list:
-                if j == "hydrogen":
-                    assert model.props[1].get_material_density_terms("Vap", j) == (
-                        model.props[1].dens_mol_phase["Vap"] *
-                        model.props[1].mole_frac_phase_comp["Vap", j])
-                elif j == "methane":
-                    assert model.props[1].get_material_density_terms("Vap", j) == (
-                        model.props[1].dens_mol_phase["Vap"] *
-                        model.props[1].mole_frac_phase_comp["Vap", j])
-                else:
-                    assert model.props[1].get_material_density_terms(p, j) == (
-                        model.props[1].dens_mol_phase[p] *
-                        model.props[1].mole_frac_phase_comp[p, j])
-
-    @pytest.mark.unit
-    def test_get_energy_density_terms(self, model):
-        for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
-                model.props[1].dens_mol_phase[p] *
-                model.props[1].enth_mol_phase[p])
-
-    @pytest.mark.unit
-    def test_default_material_balance_type(self, model):
-        assert model.props[1].default_material_balance_type() == \
-            MaterialBalanceType.componentTotal
-
-    @pytest.mark.unit
-    def test_default_energy_balance_type(self, model):
-        assert model.props[1].default_energy_balance_type() == \
-            EnergyBalanceType.enthalpyTotal
-
-    @pytest.mark.unit
-    def test_get_material_flow_basis(self, model):
-        assert model.props[1].get_material_flow_basis() == \
-            MaterialFlowBasis.molar
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):
@@ -362,10 +277,7 @@ class TestStateBlock(object):
                          "Temperature",
                          "Pressure"]
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.component
+    @pytest.mark.integration
     def test_initialize(self, model):
         # Fix state
         model.props[1].flow_mol.fix(1)
@@ -405,9 +317,7 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.component
+    @pytest.mark.integration
     def test_solve(self, model):
         results = solver.solve(model)
 
@@ -416,10 +326,7 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
-    @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.component
+    @pytest.mark.integration
     def test_solution(self, model):
         # Check phase equilibrium results
         assert model.props[1].mole_frac_phase_comp["Vap", "hydrogen"].value == \
@@ -431,7 +338,6 @@ class TestStateBlock(object):
         assert model.props[1].phase_frac["Vap"].value == \
             pytest.approx(0.77026, abs=1e-4)
 
-    @pytest.mark.ui
     @pytest.mark.unit
     def test_report(self, model):
         model.props[1].report()

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
@@ -983,6 +983,30 @@ class TestCommon(object):
         assert check_units_equivalent(frame.props[1].temperature,
                                       pyunits.K)
 
+        # Check supporting variables
+        assert isinstance(frame.props[1].flow_mol_phase, Var)
+        assert len(frame.props[1].flow_mol_phase) == 2
+
+        assert isinstance(frame.props[1].mole_frac_phase_comp, Var)
+        assert len(frame.props[1].mole_frac_phase_comp) == 6
+
+        assert isinstance(frame.props[1].phase_frac, Var)
+        assert len(frame.props[1].phase_frac) == 2
+
+        assert isinstance(frame.props[1].total_flow_balance, Constraint)
+        assert len(frame.props[1].total_flow_balance) == 1
+
+        assert isinstance(frame.props[1].component_flow_balances, Constraint)
+        assert len(frame.props[1].component_flow_balances) == 3
+
+        assert isinstance(frame.props[1].sum_mole_frac, Constraint)
+        assert len(frame.props[1].sum_mole_frac) == 1
+
+        assert isinstance(frame.props[1].sum_mole_frac_out, Constraint)
+
+        assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
+        assert len(frame.props[1].phase_fraction_constraint) == 2
+
     # Test General Methods
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
@@ -19,7 +19,8 @@ Authors: Andrew Lee
 import pytest
 from sys import modules
 
-from pyomo.environ import ConcreteModel, Constraint, Var, units as pyunits
+from pyomo.environ import (
+    ConcreteModel, Constraint, Expression, Var, units as pyunits)
 from pyomo.util.check_units import (
     check_units_equivalent, assert_units_consistent)
 
@@ -951,6 +952,32 @@ class TestCommon(object):
         assert check_units_equivalent(frame.props[1].temperature,
                                       pyunits.K)
 
+        # Check supporting variables
+        assert isinstance(frame.props[1].flow_mol_phase, Var)
+        assert len(frame.props[1].flow_mol_phase) == 2
+
+        assert isinstance(frame.props[1].mole_frac_phase_comp, Var)
+        assert len(frame.props[1].mole_frac_phase_comp) == 6
+
+        assert isinstance(frame.props[1].phase_frac, Var)
+        assert len(frame.props[1].phase_frac) == 2
+
+        assert isinstance(frame.props[1].total_flow_balance, Constraint)
+        assert len(frame.props[1].total_flow_balance) == 1
+
+        assert isinstance(frame.props[1].component_flow_balances, Constraint)
+        assert len(frame.props[1].component_flow_balances) == 3
+
+        assert isinstance(frame.props[1].sum_mole_frac, Constraint)
+        assert len(frame.props[1].sum_mole_frac) == 1
+
+        assert not hasattr(frame.props[1], "sum_mole_frac_out")
+
+        assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
+        assert len(frame.props[1].phase_fraction_constraint) == 2
+
+        assert_units_consistent(frame)
+
     # Test General Methods
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):
@@ -1012,3 +1039,10 @@ class TestCommon(object):
              "Total Mole Fraction": frame.props[1].mole_frac_comp,
              "Temperature": frame.props[1].temperature,
              "Pressure": frame.props[1].pressure}
+
+    @pytest.mark.unit
+    def test_conc_mol(self, frame):
+        assert isinstance(frame.props[1].conc_mol_comp, Expression)
+        assert len(frame.props[1].conc_mol_comp) == 3
+        assert isinstance(frame.props[1].conc_mol_phase_comp, Expression)
+        assert len(frame.props[1].conc_mol_phase_comp) == 6

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
@@ -1080,6 +1080,30 @@ class TestCommon(object):
         assert check_units_equivalent(frame.props[1].temperature,
                                       pyunits.K)
 
+        # Check supporting variables
+        assert isinstance(frame.props[1].flow_mol_phase, Var)
+        assert len(frame.props[1].flow_mol_phase) == 2
+
+        assert isinstance(frame.props[1].mole_frac_phase_comp, Var)
+        assert len(frame.props[1].mole_frac_phase_comp) == 6
+
+        assert isinstance(frame.props[1].phase_frac, Var)
+        assert len(frame.props[1].phase_frac) == 2
+
+        assert isinstance(frame.props[1].total_flow_balance, Constraint)
+        assert len(frame.props[1].total_flow_balance) == 1
+
+        assert isinstance(frame.props[1].component_flow_balances, Constraint)
+        assert len(frame.props[1].component_flow_balances) == 3
+
+        assert isinstance(frame.props[1].sum_mole_frac, Constraint)
+        assert len(frame.props[1].sum_mole_frac) == 1
+
+        assert not hasattr(frame.props[1], "sum_mole_frac_out")
+
+        assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
+        assert len(frame.props[1].phase_fraction_constraint) == 2
+
     # Test General Methods
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
@@ -1020,6 +1020,30 @@ class TestCommon(object):
         assert check_units_equivalent(frame.props[1].temperature,
                                       pyunits.K)
 
+        # Check supporting variables
+        assert isinstance(frame.props[1].flow_mol_phase, Var)
+        assert len(frame.props[1].flow_mol_phase) == 2
+
+        assert isinstance(frame.props[1].mole_frac_phase_comp, Var)
+        assert len(frame.props[1].mole_frac_phase_comp) == 6
+
+        assert isinstance(frame.props[1].phase_frac, Var)
+        assert len(frame.props[1].phase_frac) == 2
+
+        assert isinstance(frame.props[1].total_flow_balance, Constraint)
+        assert len(frame.props[1].total_flow_balance) == 1
+
+        assert isinstance(frame.props[1].component_flow_balances, Constraint)
+        assert len(frame.props[1].component_flow_balances) == 3
+
+        assert isinstance(frame.props[1].sum_mole_frac, Constraint)
+        assert len(frame.props[1].sum_mole_frac) == 1
+
+        assert not hasattr(frame.props[1], "sum_mole_frac_out")
+
+        assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
+        assert len(frame.props[1].phase_fraction_constraint) == 2
+
     # Test General Methods
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
@@ -939,6 +939,19 @@ class TestCommon(object):
         assert check_units_equivalent(frame.props[1].temperature,
                                       pyunits.K)
 
+        # Check supporting variables
+        assert isinstance(frame.props[1].flow_mol_phase, Expression)
+        assert len(frame.props[1].flow_mol_phase) == 2
+
+        assert isinstance(frame.props[1].mole_frac_phase_comp, Var)
+        assert len(frame.props[1].mole_frac_phase_comp) == 6
+
+        assert isinstance(frame.props[1].phase_frac, Expression)
+        assert len(frame.props[1].phase_frac) == 2
+
+        assert isinstance(frame.props[1].mole_frac_phase_comp_eq, Constraint)
+        assert len(frame.props[1].mole_frac_phase_comp_eq) == 6
+
     # Test General Methods
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Currently, testing of some core aspects of the generic properties framework is being done in the examples tests rathe than tests of the actual components responsible for creating the required features. This is not good for multiple reasons, not least being that making otherwise simple changes in these core components results in multiple example tests failing which then need to be fixed.

This PR reorganizes the tests so that these core features are tested in the tests for the associated components rather than in the examples.

## Changes proposed in this PR:
- Move all testing of components and methods created by the state definition classes to the tests for those modules, and removing them from the examples tests.
- Removing some redundant pytest mark` that should be deprecated.
- Linting of some affected some files.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
