### PR TITLE
Moving get_default_solver method

### DIFF
--- a/idaes/core/control_volume0d.py
+++ b/idaes/core/control_volume0d.py
@@ -1265,7 +1265,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                              'model_check method to the associated '
                              'ReactionBlock class.'.format(blk.name))
 
-    def initialize(blk, state_args=None, outlvl=idaeslog.NOTSET, optarg=None,
+    def initialize(blk, state_args=None, outlvl=idaeslog.NOTSET, optarg={},
                    solver=None, hold_state=True):
         '''
         Initialization routine for 0D control volume (default solver ipopt)
@@ -1276,7 +1276,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                          initialization (see documentation of the specific
                          property package) (default = {}).
             outlvl : sets output log level of initialization routine
-            optarg : solver options dictionary object (default=None)
+            optarg : solver options dictionary object (default={})
             solver : str indicating which solver to use during
                      initialization (default = None)
             hold_state : flag indicating whether the initialization routine

--- a/idaes/core/control_volume0d.py
+++ b/idaes/core/control_volume0d.py
@@ -1266,7 +1266,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                              'ReactionBlock class.'.format(blk.name))
 
     def initialize(blk, state_args=None, outlvl=idaeslog.NOTSET, optarg=None,
-                   solver='ipopt', hold_state=True):
+                   solver=None, hold_state=True):
         '''
         Initialization routine for 0D control volume (default solver ipopt)
 
@@ -1277,8 +1277,8 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                          property package) (default = {}).
             outlvl : sets output log level of initialization routine
             optarg : solver options dictionary object (default=None)
-            solver : str indicating whcih solver to use during
-                     initialization (default = 'ipopt')
+            solver : str indicating which solver to use during
+                     initialization (default = None)
             hold_state : flag indicating whether the initialization routine
                      should unfix any state variables fixed during
                      initialization, **default** - True. **Valid values:**
@@ -1293,7 +1293,8 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             states were fixed during initialization.
         '''
         # Get inlet state if not provided
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="control_volume")
+        init_log = idaeslog.getInitLogger(
+            blk.name, outlvl, tag="control_volume")
         if state_args is None:
             state_args = {}
             state_dict = (

--- a/idaes/core/control_volume1d.py
+++ b/idaes/core/control_volume1d.py
@@ -1567,7 +1567,7 @@ argument)."""))
                         'model_check method to the associated '
                         'ReactionBlock class.'.format(blk.name))
 
-    def initialize(blk, state_args=None, outlvl=idaeslog.NOTSET, optarg=None,
+    def initialize(blk, state_args=None, outlvl=idaeslog.NOTSET, optarg={},
                    solver=None, hold_state=True):
         '''
         Initialization routine for 1D control volume (default solver ipopt)
@@ -1578,7 +1578,7 @@ argument)."""))
                          initialization (see documentation of the specific
                          property package) (default = {}).
             outlvl : sets output level of initialization routine
-            optarg : solver options dictionary object (default=None)
+            optarg : solver options dictionary object (default={})
             solver : str indicating whcih solver to use during
                      initialization (default = None)
             hold_state : flag indicating whether the initialization routine

--- a/idaes/core/control_volume1d.py
+++ b/idaes/core/control_volume1d.py
@@ -1568,7 +1568,7 @@ argument)."""))
                         'ReactionBlock class.'.format(blk.name))
 
     def initialize(blk, state_args=None, outlvl=idaeslog.NOTSET, optarg=None,
-                   solver='ipopt', hold_state=True):
+                   solver=None, hold_state=True):
         '''
         Initialization routine for 1D control volume (default solver ipopt)
 
@@ -1580,7 +1580,7 @@ argument)."""))
             outlvl : sets output level of initialization routine
             optarg : solver options dictionary object (default=None)
             solver : str indicating whcih solver to use during
-                     initialization (default = 'ipopt')
+                     initialization (default = None)
             hold_state : flag indicating whether the initialization routine
                      should unfix any state variables fixed during
                      initialization, **default** - True. **Valid values:**
@@ -1596,7 +1596,8 @@ argument)."""))
             triggered.
         '''
         # Get inlet state if not provided
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="control_volume")
+        init_log = idaeslog.getInitLogger(
+            blk.name, outlvl, tag="control_volume")
 
         # Get source block
         if blk._flow_direction == FlowDirection.forward:

--- a/idaes/core/unit_model.py
+++ b/idaes/core/unit_model.py
@@ -32,6 +32,7 @@ from idaes.core.util.exceptions import (BurntToast,
 from idaes.core.util.tables import create_stream_table_dataframe
 import idaes.core.util.unit_costing
 import idaes.logger as idaeslog
+from idaes.core.util import get_default_solver
 
 __author__ = "John Eslick, Qi Chen, Andrew Lee"
 
@@ -610,7 +611,7 @@ Must be True if dynamic = True,
                     f"developer to develop a unit specific stream table.")
 
     def initialize(blk, state_args=None, outlvl=idaeslog.NOTSET,
-                   solver='ipopt', optarg={'tol': 1e-6}):
+                   solver=None, optarg={}):
         '''
         This is a general purpose initialization routine for simple unit
         models. This method assumes a single ControlVolume block called
@@ -626,9 +627,9 @@ Must be True if dynamic = True,
                            initialization (see documentation of the specific
                            property package) (default = {}).
             outlvl : sets output level of initialization routine
-            optarg : solver options dictionary object (default={'tol': 1e-6})
+            optarg : solver options dictionary object (default={})
             solver : str indicating which solver to use during
-                     initialization (default = 'ipopt')
+                     initialization (default = None, use default IDAES solver)
 
         Returns:
             None
@@ -637,8 +638,11 @@ Must be True if dynamic = True,
         init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
 
-        opt = SolverFactory(solver)
-        opt.options = optarg
+        if solver is None:
+            opt = get_default_solver()
+        else:
+            opt = SolverFactory(solver)
+            opt.options = optarg
 
         # ---------------------------------------------------------------------
         # Initialize control volume block

--- a/idaes/core/util/__init__.py
+++ b/idaes/core/util/__init__.py
@@ -1,2 +1,2 @@
 from .model_serializer import to_json, from_json, StoreSpec
-from .misc import svg_tag, copy_port_values, TagReference
+from .misc import svg_tag, copy_port_values, TagReference, get_default_solver

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -30,6 +30,22 @@ _log = idaeslog.getLogger(__name__)
 
 
 # Author: Andrew Lee
+def get_default_solver():
+    """
+    Tries to set-up the default solver for testing, and returns None if not
+    available
+    """
+    if pyo.SolverFactory('ipopt').available(exception_flag=False):
+        solver = pyo.SolverFactory('ipopt')
+        solver.options = {'tol': 1e-6,
+                          'linear_solver': 'ma27'}
+    else:
+        raise RuntimeError("Default solver unavailable.")
+
+    return solver
+
+
+# Author: Andrew Lee
 def add_object_reference(self, local_name, remote_object):
     """
     Method to create a reference in the local model to a remote Pyomo object.

--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -37,21 +37,20 @@ from idaes.core import (declare_process_block_class,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
+from idaes.core.util import get_default_solver as default_solver
+import idaes.logger as idaeslog
+
+_log = idaeslog.getLogger(__name__)
 
 
 def get_default_solver():
     """
-    Tries to set-up the default solver for testing, and returns None if not
-    available
+    Move to idaes.core.util.misc - leaving redirection method here for
+    deprecation warning
     """
-    if SolverFactory('ipopt').available(exception_flag=False):
-        solver = SolverFactory('ipopt')
-        solver.options = {'tol': 1e-6,
-                          'linear_solver': 'ma27'}
-    else:
-        solver = None
-
-    return solver
+    _log.warn("Deprecated: get_default_solve has been moved and can now be "
+              "imported from idaes.core.util")
+    return default_solver()
 
 
 def initialization_tester(m, dof=0, unit=None, **init_kwargs):

--- a/idaes/core/util/tests/test_homotopy.py
+++ b/idaes/core/util/tests/test_homotopy.py
@@ -29,7 +29,7 @@ from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VL
     import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.exceptions import ConfigurationError
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.core.util.homotopy import homotopy
 

--- a/idaes/core/util/tests/test_unit_costing.py
+++ b/idaes/core/util/tests/test_unit_costing.py
@@ -24,7 +24,7 @@ from idaes.core import FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 # Import Unit Model Modules
 from idaes.generic_models.properties import iapws95
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 import idaes.core.util.unit_costing as cs
 from idaes.power_generation.properties import FlueGasParameterBlock
 from idaes.generic_models.unit_models.pressure_changer import (

--- a/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_gas_prop.py
+++ b/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_gas_prop.py
@@ -23,8 +23,8 @@ from idaes.core import FlowsheetBlock
 
 from idaes.core.util.model_statistics import degrees_of_freedom
 
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 
 from idaes.gas_solid_contactors.properties.methane_iron_OC_reduction. \
     gas_phase_thermo import GasPhaseThermoParameterBlock

--- a/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_rxn_prop.py
+++ b/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_rxn_prop.py
@@ -24,8 +24,8 @@ from idaes.core import FlowsheetBlock
 
 from idaes.core.util.model_statistics import degrees_of_freedom
 
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 
 from idaes.gas_solid_contactors.properties.methane_iron_OC_reduction. \
     gas_phase_thermo import GasPhaseThermoParameterBlock

--- a/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_solid_prop.py
+++ b/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_solid_prop.py
@@ -24,8 +24,8 @@ from idaes.core import FlowsheetBlock
 
 from idaes.core.util.model_statistics import degrees_of_freedom
 
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 
 from idaes.gas_solid_contactors.properties.methane_iron_OC_reduction. \
     solid_phase_thermo import SolidPhaseThermoParameterBlock

--- a/idaes/gas_solid_contactors/unit_models/tests/test_BFB.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_BFB.py
@@ -36,8 +36,8 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_total_constraints,
                                               number_unused_variables,
                                               unused_variables_set)
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 
 from idaes.gas_solid_contactors.unit_models. \
     bubbling_fluidized_bed import BubblingFluidizedBed

--- a/idaes/gas_solid_contactors/unit_models/tests/test_MB.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_MB.py
@@ -35,8 +35,8 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_total_constraints,
                                               number_unused_variables,
                                               unused_variables_set)
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 
 # Import MBR unit model
 from idaes.gas_solid_contactors.unit_models.moving_bed import MBR

--- a/idaes/generic_models/flowsheets/demo_flowsheet.py
+++ b/idaes/generic_models/flowsheets/demo_flowsheet.py
@@ -21,7 +21,7 @@ from pyomo.environ import ConcreteModel, TransformationFactory
 from pyomo.network import Arc
 
 from idaes.core import FlowsheetBlock
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 from idaes.core.util.initialization import propagate_state
 from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VLE \
     import BTXParameterBlock

--- a/idaes/generic_models/properties/core/examples/reactions/tests/test_reaction_example.py
+++ b/idaes/generic_models/properties/core/examples/reactions/tests/test_reaction_example.py
@@ -25,7 +25,7 @@ from pyomo.util.check_units import assert_units_consistent
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
@@ -31,7 +31,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
@@ -31,7 +31,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -32,7 +32,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -31,7 +31,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.core import LiquidPhase, VaporPhase
 

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
@@ -32,7 +32,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.core import LiquidPhase, VaporPhase
 

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
@@ -32,7 +32,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.core import LiquidPhase, VaporPhase
 

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -32,7 +32,7 @@ from pyomo.environ import (ConcreteModel,
                            TerminationCondition,
                            value)
 
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 import idaes.logger as idaeslog
 SOUT = idaeslog.INFO

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
@@ -40,7 +40,7 @@ from idaes.generic_models.unit_models import Flash
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -34,7 +34,8 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
@@ -32,7 +32,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
@@ -32,7 +32,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)

--- a/idaes/generic_models/properties/core/generic/tests/test_noncondense.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_noncondense.py
@@ -36,7 +36,7 @@ from idaes.core.phases import PhaseType as PT
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.state_definitions import FTPx
 from idaes.generic_models.properties.core.eos.ideal import Ideal

--- a/idaes/generic_models/properties/core/generic/tests/test_noncondense_PR.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_noncondense_PR.py
@@ -36,7 +36,7 @@ from idaes.core.phases import PhaseType as PT
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.state_definitions import FTPx
 from idaes.generic_models.properties.core.eos.ceos import Cubic, CubicType

--- a/idaes/generic_models/properties/core/generic/tests/test_nonvap.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_nonvap.py
@@ -36,7 +36,7 @@ from idaes.core.phases import PhaseType as PT
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.state_definitions import FTPx
 from idaes.generic_models.properties.core.eos.ideal import Ideal

--- a/idaes/generic_models/properties/core/generic/tests/test_nonvap_PR.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_nonvap_PR.py
@@ -36,7 +36,7 @@ from idaes.core.phases import PhaseType as PT
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.state_definitions import FTPx
 from idaes.generic_models.properties.core.eos.ceos import Cubic, CubicType

--- a/idaes/generic_models/properties/cubic_eos/tests/test_BT_example.py
+++ b/idaes/generic_models/properties/cubic_eos/tests/test_BT_example.py
@@ -27,7 +27,7 @@ from pyomo.util.check_units import (assert_units_consistent,
 
 from idaes.generic_models.properties.tests.test_harness import \
     PropertyTestHarness
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 
 # Set module level pyest marker

--- a/idaes/generic_models/properties/examples/tests/test_saponification_reaction.py
+++ b/idaes/generic_models/properties/examples/tests/test_saponification_reaction.py
@@ -29,7 +29,7 @@ from idaes.generic_models.properties.examples.saponification_reactions import (
 from idaes.generic_models.properties.examples.saponification_thermo import (
     SaponificationParameterBlock)
 
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/properties/examples/tests/test_saponification_thermo.py
+++ b/idaes/generic_models/properties/examples/tests/test_saponification_thermo.py
@@ -29,7 +29,7 @@ from idaes.core import (MaterialBalanceType,
 from idaes.generic_models.properties.examples.saponification_thermo import (
     SaponificationParameterBlock, SaponificationStateBlock)
 
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/properties/tests/test_harness.py
+++ b/idaes/generic_models/properties/tests/test_harness.py
@@ -27,7 +27,7 @@ from idaes.core import (ControlVolume0DBlock,
                         EnergyBalanceType,
                         MaterialFlowBasis)
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 import idaes.core.util.scaling as iscale
 
 

--- a/idaes/generic_models/unit_models/distillation/condenser.py
+++ b/idaes/generic_models/unit_models/distillation/condenser.py
@@ -41,7 +41,7 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import PropertyPackageError, \
     ConfigurationError, PropertyNotSupportedError
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 _log = idaeslog.getLogger(__name__)
 

--- a/idaes/generic_models/unit_models/distillation/reboiler.py
+++ b/idaes/generic_models/unit_models/distillation/reboiler.py
@@ -40,7 +40,7 @@ from idaes.core import (ControlVolume0DBlock,
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import PropertyPackageError, \
     PropertyNotSupportedError, ConfigurationError
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 
 

--- a/idaes/generic_models/unit_models/distillation/tests/test_conventional_tray.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_conventional_tray.py
@@ -27,8 +27,9 @@ from idaes.generic_models.properties.activity_coeff_models.\
 from idaes.core.util.model_statistics import degrees_of_freedom, \
     number_variables, number_total_constraints, number_unused_variables, \
     fixed_variables_set, activated_constraints_set
-from idaes.core.util.testing import get_default_solver, \
+from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/distillation/tests/test_feed_tray.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_feed_tray.py
@@ -27,8 +27,9 @@ from idaes.generic_models.properties.activity_coeff_models.\
 from idaes.core.util.model_statistics import degrees_of_freedom, \
     number_variables, number_total_constraints, number_unused_variables, \
     fixed_variables_set, activated_constraints_set
-from idaes.core.util.testing import get_default_solver, \
+from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/distillation/tests/test_partial_condenser.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_partial_condenser.py
@@ -29,8 +29,9 @@ from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VL
     import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom, \
     number_variables, number_total_constraints, number_unused_variables
-from idaes.core.util.testing import get_default_solver, \
+from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
+from idaes.core.util import get_default_solver
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing

--- a/idaes/generic_models/unit_models/distillation/tests/test_reboiler.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_reboiler.py
@@ -27,8 +27,9 @@ from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VL
     import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom, \
     number_variables, number_total_constraints, number_unused_variables
-from idaes.core.util.testing import get_default_solver, \
+from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
+from idaes.core.util import get_default_solver
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing

--- a/idaes/generic_models/unit_models/distillation/tests/test_total_condenser.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_total_condenser.py
@@ -29,8 +29,9 @@ from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VL
     import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom, \
     number_variables, number_total_constraints, number_unused_variables
-from idaes.core.util.testing import get_default_solver, \
+from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
+from idaes.core.util import get_default_solver
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_default_solver()

--- a/idaes/generic_models/unit_models/distillation/tests/test_tray_column.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_tray_column.py
@@ -26,8 +26,9 @@ from idaes.generic_models.unit_models.distillation.condenser \
 from idaes.generic_models.properties.activity_coeff_models.\
     BTX_activity_coeff_VLE import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.util.testing import get_default_solver, \
+from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
+from idaes.core.util import get_default_solver
 
 from idaes.generic_models.properties.core.generic.generic_property \
     import GenericParameterBlock

--- a/idaes/generic_models/unit_models/distillation/tests/test_tray_side_liq_draw.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_tray_side_liq_draw.py
@@ -27,9 +27,9 @@ from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VL
 from idaes.core.util.model_statistics import degrees_of_freedom, \
     number_variables, number_total_constraints, number_unused_variables, \
     fixed_variables_set, activated_constraints_set
-from idaes.core.util.testing import get_default_solver, \
+from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
-
+from idaes.core.util import get_default_solver
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing

--- a/idaes/generic_models/unit_models/distillation/tests/test_tray_side_vap_draw.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_tray_side_vap_draw.py
@@ -27,8 +27,9 @@ from idaes.generic_models.properties.activity_coeff_models.\
 from idaes.core.util.model_statistics import degrees_of_freedom, \
     number_variables, number_total_constraints, number_unused_variables, \
     fixed_variables_set, activated_constraints_set
-from idaes.core.util.testing import get_default_solver, \
+from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/distillation/tray.py
+++ b/idaes/generic_models/unit_models/distillation/tray.py
@@ -38,7 +38,7 @@ from idaes.core import (declare_process_block_class,
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError, \
     PropertyPackageError, PropertyNotSupportedError
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 
 _log = idaeslog.getLogger(__name__)

--- a/idaes/generic_models/unit_models/distillation/tray_column.py
+++ b/idaes/generic_models/unit_models/distillation/tray_column.py
@@ -35,7 +35,7 @@ from idaes.core import (declare_process_block_class,
                         useDefault)
 from idaes.core.util.exceptions import ConfigurationError
 from idaes.core.util.config import is_physical_parameter_block
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 _log = idaeslog.getLogger(__name__)
 

--- a/idaes/generic_models/unit_models/tests/test_cstr.py
+++ b/idaes/generic_models/unit_models/tests/test_cstr.py
@@ -35,10 +35,10 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      ReactionParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from pyomo.util.check_units import (assert_units_consistent,
                                     assert_units_equivalent)
 

--- a/idaes/generic_models/unit_models/tests/test_equilibrium_reactor.py
+++ b/idaes/generic_models/unit_models/tests/test_equilibrium_reactor.py
@@ -36,10 +36,10 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      ReactionParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from pyomo.util.check_units import (assert_units_consistent,
                                     assert_units_equivalent)
 

--- a/idaes/generic_models/unit_models/tests/test_feed.py
+++ b/idaes/generic_models/unit_models/tests/test_feed.py
@@ -28,9 +28,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_feed_flash.py
+++ b/idaes/generic_models/unit_models/tests/test_feed_flash.py
@@ -31,9 +31,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from pyomo.util.check_units import assert_units_consistent
 
 

--- a/idaes/generic_models/unit_models/tests/test_flash.py
+++ b/idaes/generic_models/unit_models/tests/test_flash.py
@@ -34,9 +34,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing

--- a/idaes/generic_models/unit_models/tests/test_gibbs.py
+++ b/idaes/generic_models/unit_models/tests/test_gibbs.py
@@ -36,9 +36,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from idaes.core.util.exceptions import ConfigurationError
 
 

--- a/idaes/generic_models/unit_models/tests/test_heat_exchanger.py
+++ b/idaes/generic_models/unit_models/tests/test_heat_exchanger.py
@@ -53,9 +53,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 
 

--- a/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
@@ -43,9 +43,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from idaes.core.util import scaling as iscale
 
 

--- a/idaes/generic_models/unit_models/tests/test_heater.py
+++ b/idaes/generic_models/unit_models/tests/test_heater.py
@@ -45,9 +45,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_unused_variables)
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_mixer.py
+++ b/idaes/generic_models/unit_models/tests/test_mixer.py
@@ -57,10 +57,10 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      TestStateBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_pfr.py
+++ b/idaes/generic_models/unit_models/tests/test_pfr.py
@@ -40,10 +40,10 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_total_constraints,
                                               number_unused_variables,
                                               number_derivative_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      ReactionParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/generic_models/unit_models/tests/test_pressure_changer.py
@@ -52,9 +52,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from idaes.core.util.exceptions import BalanceTypeNotSupportedError
 from idaes.core.util import scaling as iscale
 

--- a/idaes/generic_models/unit_models/tests/test_product.py
+++ b/idaes/generic_models/unit_models/tests/test_product.py
@@ -35,9 +35,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_rstoic.py
+++ b/idaes/generic_models/unit_models/tests/test_rstoic.py
@@ -39,12 +39,12 @@ from idaes.generic_models.properties.examples.saponification_thermo import (
 from idaes.generic_models.properties.examples.saponification_reactions import (
     SaponificationReactionParameterBlock)
 
+from idaes.core.util import get_default_solver
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      ReactionParameterTestBlock,
                                      initialization_tester)
 

--- a/idaes/generic_models/unit_models/tests/test_separator.py
+++ b/idaes/generic_models/unit_models/tests/test_separator.py
@@ -53,10 +53,10 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      TestStateBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_statejunction.py
+++ b/idaes/generic_models/unit_models/tests/test_statejunction.py
@@ -36,9 +36,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_translator.py
+++ b/idaes/generic_models/unit_models/tests/test_translator.py
@@ -32,9 +32,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_valve.py
+++ b/idaes/generic_models/unit_models/tests/test_valve.py
@@ -31,10 +31,10 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      ReactionParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from pyomo.util.check_units import (assert_units_consistent,
                                     assert_units_equivalent)
 

--- a/idaes/power_generation/flowsheets/test/test_subcritical_boiler.py
+++ b/idaes/power_generation/flowsheets/test/test_subcritical_boiler.py
@@ -25,7 +25,7 @@ from idaes.power_generation.flowsheets.subcritical_power_plant.\
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               activated_equalities_generator)
 from idaes.generic_models.properties import iapws95
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 import idaes.core.util.scaling as iscale
 
 solver_available = pyo.SolverFactory('ipopt').available()

--- a/idaes/power_generation/unit_models/helm/tests/test_condenser_ntu.py
+++ b/idaes/power_generation/unit_models/helm/tests/test_condenser_ntu.py
@@ -18,7 +18,7 @@ import pyomo.environ as pyo
 import idaes.core
 from idaes.power_generation.unit_models.helm import HelmNtuCondenser
 from idaes.generic_models.properties import iapws95
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_default_solver
 
 solver = get_default_solver()
 

--- a/idaes/power_generation/unit_models/helm/tests/test_phase_separator.py
+++ b/idaes/power_generation/unit_models/helm/tests/test_phase_separator.py
@@ -32,7 +32,8 @@ from idaes.generic_models.properties import iapws95
 
 from idaes.power_generation.unit_models.helm.phase_separator import \
     HelmPhaseSeparator
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing

--- a/idaes/power_generation/unit_models/tests/test_boiler_heat_exchanger.py
+++ b/idaes/power_generation/unit_models/tests/test_boiler_heat_exchanger.py
@@ -36,8 +36,8 @@ from idaes.power_generation.unit_models.boiler_heat_exchanger import (
         BoilerHeatExchanger, TubeArrangement, DeltaTMethod)
 
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock)
+from idaes.core.util.testing import PhysicalParameterTestBlock
+from idaes.core.util import get_default_solver
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing

--- a/idaes/power_generation/unit_models/tests/test_boilerfireside.py
+++ b/idaes/power_generation/unit_models/tests/test_boilerfireside.py
@@ -32,7 +32,8 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 # Import Unit Model Modules
 from idaes.generic_models.properties import iapws95
 
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 from idaes.power_generation.properties import FlueGasParameterBlock
 from idaes.power_generation.unit_models.boiler_fireside import BoilerFireside
 import datadictionary as dat

--- a/idaes/power_generation/unit_models/tests/test_downcomer.py
+++ b/idaes/power_generation/unit_models/tests/test_downcomer.py
@@ -31,7 +31,8 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 # Import Unit Model Modules
 from idaes.generic_models.properties import iapws95
 
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 from idaes.power_generation.unit_models.downcomer import Downcomer
 
 # -----------------------------------------------------------------------------

--- a/idaes/power_generation/unit_models/tests/test_drum.py
+++ b/idaes/power_generation/unit_models/tests/test_drum.py
@@ -50,7 +50,8 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.generic_models.properties import iapws95
 from idaes.power_generation.unit_models.drum import Drum
 
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_default_solver()

--- a/idaes/power_generation/unit_models/tests/test_drum1D.py
+++ b/idaes/power_generation/unit_models/tests/test_drum1D.py
@@ -49,7 +49,8 @@ from idaes.generic_models.properties import iapws95
 # from idaes.power_generation.unit_models.drum_1D import Drum1D
 from idaes.power_generation.unit_models.drum1D import Drum1D
 import idaes.core.util.scaling as iscale
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_default_solver()

--- a/idaes/power_generation/unit_models/tests/test_feedwater_heater_dynamic.py
+++ b/idaes/power_generation/unit_models/tests/test_feedwater_heater_dynamic.py
@@ -18,7 +18,8 @@ from idaes.core import FlowsheetBlock
 from idaes.generic_models.properties import iapws95
 from idaes.power_generation.unit_models import FWH0DDynamic
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 prop_available = iapws95.iapws95_available()
 
 # See if ipopt is available and set up solver

--- a/idaes/power_generation/unit_models/tests/test_heat_exchanger2D.py
+++ b/idaes/power_generation/unit_models/tests/test_heat_exchanger2D.py
@@ -36,7 +36,8 @@ from idaes.generic_models.properties import iapws95
 from idaes.power_generation.properties import FlueGasParameterBlock
 from idaes.power_generation.unit_models.boiler_heat_exchanger_2D import \
     HeatExchangerCrossFlow2D_Header
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_default_solver()

--- a/idaes/power_generation/unit_models/tests/test_heat_exchanger_3streams.py
+++ b/idaes/power_generation/unit_models/tests/test_heat_exchanger_3streams.py
@@ -29,9 +29,9 @@ from idaes.core import FlowsheetBlock
 from idaes.power_generation.properties import FlueGasParameterBlock
 
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.util.testing import (get_default_solver,
-                                     PhysicalParameterTestBlock,
+from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
+from idaes.core.util import get_default_solver
 from idaes.power_generation.unit_models.heat_exchanger_3streams import \
     HeatExchangerWith3Streams
 import idaes.core.util.scaling as iscale

--- a/idaes/power_generation/unit_models/tests/test_steamheater.py
+++ b/idaes/power_generation/unit_models/tests/test_steamheater.py
@@ -32,7 +32,8 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 # Import Unit Model Modules
 from idaes.generic_models.properties import iapws95
 
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 from idaes.power_generation.unit_models.steamheater import SteamHeater
 
 # -----------------------------------------------------------------------------

--- a/idaes/power_generation/unit_models/tests/test_waterpipe.py
+++ b/idaes/power_generation/unit_models/tests/test_waterpipe.py
@@ -26,7 +26,8 @@ from idaes.power_generation.unit_models.waterpipe import WaterPipe
 # Import Unit Model Modules
 from idaes.generic_models.properties import iapws95
 
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing

--- a/idaes/power_generation/unit_models/tests/test_watertank.py
+++ b/idaes/power_generation/unit_models/tests/test_watertank.py
@@ -39,7 +39,8 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.generic_models.properties import iapws95
 from idaes.power_generation.unit_models.watertank import WaterTank
 
-from idaes.core.util.testing import get_default_solver, initialization_tester
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_default_solver
 # -----------------------------------------------------------------------------
 # Get default solver for testing
 solver = get_default_solver()

--- a/idaes/power_generation/unit_models/tests/test_waterwall.py
+++ b/idaes/power_generation/unit_models/tests/test_waterwall.py
@@ -39,7 +39,7 @@ from idaes.generic_models.properties import iapws95
 
 from idaes.power_generation.unit_models.waterwall_section import \
     WaterwallSection
-from idaes.core.util.testing import (get_default_solver)
+from idaes.core.util import get_default_solver
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing


### PR DESCRIPTION
## Part of #202


## Summary/Motivation:
This is the first part of addressing #202. This moves the existing `get_default_solver` method from util.testing to util.misc to avoid a potential recursive import loop and updates all existing models and tests that rely on the method. This will provide a centralized method for creating a default solver object in the absence of user input. For now, the solver options are hard-coded, but we can look at moving to using the IDAES config file in future (and all models/tests that use the method will automatically be updated0.

## Changes proposed in this PR:
- Moved the `get_default_solver` method to `util.misc`, with a wrapper method left in `util.testing` with a deprecation warning for backwards compatibility.
- Updated the default initialize methods in `UnitBlockData` to use the new `get_default_solver` method in place of a hard-coded iopt instance.
- Changed the default values of the `solver` and `optarg` arguments in the `ControlVolume0D` and `ControlVolume1D` initialize methods to not presume any settings.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
