### PR TITLE
Matopt upgrade

### DIFF
--- a/docs/user_guide/modeling_extensions/matopt/index.rst
+++ b/docs/user_guide/modeling_extensions/matopt/index.rst
@@ -14,7 +14,7 @@ Thank you for your interest in MatOpt. We would love to hear your feedback! Plea
 
 If you are using MatOpt, please consider citing:
 
-* Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. `MatOpt: A Python package for nanomaterials discete optimization. <http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf>`_
+* Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. `MatOpt: A Python package for nanomaterials discrete optimization. <http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf>`_
 
 
 Basic Usage
@@ -154,4 +154,4 @@ References
 * Hanselman, C.L., Zhong, W., Tran, K., Ulissi, Z.W. and Gounaris, C.E., 2019. `Optimization-based design of active and stable nanostructured surfaces. <https://pubs.acs.org/doi/abs/10.1021/acs.jpcc.9b08431>`_ *The Journal of Physical Chemistry C*, 123(48), pp.29209-29218.
 * Isenberg, N.M., Taylor, M.G., Yan, Z., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2020. `Identification of optimally stable nanocluster geometries via mathematical optimization and density-functional theory. <https://pubs.rsc.org/en/content/articlelanding/2019/me/c9me00108e#!divAbstract>`_ *Molecular Systems Design & Engineering*.
 * Yin, X., Isenberg, N.M., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2021. A mathematical optimization-based design framework for identifying stable bimetallic nanoclusters. *In preparation*.
-* Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. `MatOpt: A Python package for nanomaterials discete optimization. <http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf>`_
+* Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. `MatOpt: A Python package for nanomaterials discrete optimization. <http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf>`_

--- a/docs/user_guide/modeling_extensions/matopt/index.rst
+++ b/docs/user_guide/modeling_extensions/matopt/index.rst
@@ -14,7 +14,7 @@ Thank you for your interest in MatOpt. We would love to hear your feedback! Plea
 
 If you are using MatOpt, please consider citing:
 
-* Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2020. MatOpt: A Python package for nanomaterials design using discrete optimization. *In preparation*.
+* Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. `MatOpt: A Python package for nanomaterials discete optimization. <http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf>`_
 
 
 Basic Usage
@@ -144,8 +144,8 @@ The results of the optimization process will be loaded into ``Design`` objects a
 
 MatOpt Examples
 ---------------
-Five `case studies
-<https://github.com/IDAES/examples-pse/tree/main/src/matopt>`_ are provided to illustrate the detailed usage of MatOpt. In each case, a Jupyter notebook with explanations as well as an equivalent Python script is provided.
+Several `case studies
+<https://idaes.github.io/examples-pse/latest/Examples/MatOpt/index.html>`_ are provided to illustrate the detailed usage of MatOpt. In each case, a Jupyter notebook with explanations as well as an equivalent Python script is provided.
 
 References
 ----------
@@ -153,5 +153,5 @@ References
 * Hanselman, C.L., Alfonso, D.R., Lekse, J.W., Matranga, C., Miller, D.C. and Gounaris, C.E., 2019. `A framework for optimizing oxygen vacancy formation in doped perovskites. <https://www.sciencedirect.com/science/article/pii/S0098135418310998>`_ *Computers & Chemical Engineering*, 126, pp.168-177.
 * Hanselman, C.L., Zhong, W., Tran, K., Ulissi, Z.W. and Gounaris, C.E., 2019. `Optimization-based design of active and stable nanostructured surfaces. <https://pubs.acs.org/doi/abs/10.1021/acs.jpcc.9b08431>`_ *The Journal of Physical Chemistry C*, 123(48), pp.29209-29218.
 * Isenberg, N.M., Taylor, M.G., Yan, Z., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2020. `Identification of optimally stable nanocluster geometries via mathematical optimization and density-functional theory. <https://pubs.rsc.org/en/content/articlelanding/2019/me/c9me00108e#!divAbstract>`_ *Molecular Systems Design & Engineering*.
-* Yin, X., Isenberg, N.M., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2020. A mathematical optimization-based design framework for identifying stable bimetallic nanoclusters. *In preparation*.
-* Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2020. MatOpt: A Python package for nanomaterials design using discrete optimization. *In preparation*.
+* Yin, X., Isenberg, N.M., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2021. A mathematical optimization-based design framework for identifying stable bimetallic nanoclusters. *In preparation*.
+* Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. `MatOpt: A Python package for nanomaterials discete optimization. <http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf>`_

--- a/idaes/apps/matopt/README.md
+++ b/idaes/apps/matopt/README.md
@@ -13,7 +13,7 @@ Thank you for your interest in MatOpt. We would love to hear your feedback! Plea
 
 If you are using MatOpt, please consider citing:
 
--   Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2020. MatOpt: A Python package for nanomaterials design using discrete optimization. *In preparation*.
+-   Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. MatOpt: A Python package for nanomaterials discete optimization *[Preprint available](http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf)*.
 
 Basic Usage
 -----------
@@ -203,8 +203,7 @@ The results of the optimization process will be loaded into `Design` objects aut
 
 MatOpt Examples
 ---------------
-
-Five [case studies](https://github.com/IDAES/examples-pse/tree/main/src/matopt) are provided to illustrate the detailed usage of MatOpt. In each case, a Jupyter notebook with explanations as well as an equivalent Python script is provided.
+Several [case studies](https://idaes.github.io/examples-pse/latest/Examples/MatOpt/index.html) are provided to illustrate the detailed usage of MatOpt. In each case, a Jupyter notebook with explanations as well as an equivalent Python script is provided.
 
 References
 ----------
@@ -214,5 +213,4 @@ References
 -   Hanselman, C.L., Zhong, W., Tran, K., Ulissi, Z.W. and Gounaris, C.E., 2019. [Optimization-based design of active and stable nanostructured surfaces.](https://pubs.acs.org/doi/abs/10.1021/acs.jpcc.9b08431) *The Journal of Physical Chemistry C*, 123(48), pp.29209-29218.
 -   Isenberg, N.M., Taylor, M.G., Yan, Z., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2020. [Identification of optimally stable nanocluster geometries via mathematical optimization and density-functional theory.](https://pubs.rsc.org/en/content/articlelanding/2019/me/c9me00108e#!divAbstract) *Molecular Systems Design & Engineering*.
 -   Yin, X., Isenberg, N.M., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2020. A mathematical optimization-based design framework for identifying stable bimetallic nanoclusters. *In preparation*.
--   Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2020. MatOpt: A Python package for nanomaterials design using discrete optimization. *In preparation*.
-
+-   Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. MatOpt: A Python package for nanomaterials discete optimization *[Preprint available](http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf)*.

--- a/idaes/apps/matopt/README.md
+++ b/idaes/apps/matopt/README.md
@@ -13,7 +13,7 @@ Thank you for your interest in MatOpt. We would love to hear your feedback! Plea
 
 If you are using MatOpt, please consider citing:
 
--   Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. MatOpt: A Python package for nanomaterials discete optimization *[Preprint available](http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf)*.
+-   Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. MatOpt: A Python package for nanomaterials discrete optimization *[Preprint available](http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf)*.
 
 Basic Usage
 -----------
@@ -213,4 +213,4 @@ References
 -   Hanselman, C.L., Zhong, W., Tran, K., Ulissi, Z.W. and Gounaris, C.E., 2019. [Optimization-based design of active and stable nanostructured surfaces.](https://pubs.acs.org/doi/abs/10.1021/acs.jpcc.9b08431) *The Journal of Physical Chemistry C*, 123(48), pp.29209-29218.
 -   Isenberg, N.M., Taylor, M.G., Yan, Z., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2020. [Identification of optimally stable nanocluster geometries via mathematical optimization and density-functional theory.](https://pubs.rsc.org/en/content/articlelanding/2019/me/c9me00108e#!divAbstract) *Molecular Systems Design & Engineering*.
 -   Yin, X., Isenberg, N.M., Hanselman, C.L., Mpourmpakis, G. and Gounaris, C.E., 2020. A mathematical optimization-based design framework for identifying stable bimetallic nanoclusters. *In preparation*.
--   Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. MatOpt: A Python package for nanomaterials discete optimization *[Preprint available](http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf)*.
+-   Hanselman, C.L., Yin, X., Miller, D.C. and Gounaris, C.E., 2021. MatOpt: A Python package for nanomaterials discrete optimization *[Preprint available](http://gounaris.cheme.cmu.edu/drafts/Draft_MATOPT.pdf)*.

--- a/idaes/apps/matopt/materials/__init__.py
+++ b/idaes/apps/matopt/materials/__init__.py
@@ -4,6 +4,6 @@ from matopt.materials.parsers import *
 from .atom import Atom
 from .canvas import Canvas
 from .design import Design, loadFromPDBs, loadFromCFGs
-from .tiling import CubicTiling, PlanarTiling
+from .tiling import LinearTiling, CubicTiling, PlanarTiling
 from .geometry import *
 from .motifs import areMotifViaTransF, areMotifViaTransFs, getEnumConfs

--- a/idaes/apps/matopt/materials/lattices/__init__.py
+++ b/idaes/apps/matopt/materials/lattices/__init__.py
@@ -1,3 +1,5 @@
 from .fcc_lattice import FCCLattice
 from .perovskite_lattice import PerovskiteLattice
 from .cubic_lattice import CubicLattice
+from .diamond_lattice import DiamondLattice
+from .wurtzite_lattice import WurtziteLattice

--- a/idaes/apps/matopt/materials/lattices/cubic_lattice.py
+++ b/idaes/apps/matopt/materials/lattices/cubic_lattice.py
@@ -17,6 +17,7 @@ from ..geometry import Parallelepiped
 from ..transform_func import ScaleFunc
 from .unit_cell_lattice import UnitCell, UnitCellLattice
 from ..tiling import CubicTiling
+from ...util.util import ListHasPoint
 
 
 class CubicLattice(UnitCellLattice):
@@ -34,13 +35,13 @@ class CubicLattice(UnitCellLattice):
         RefUnitCell = UnitCell(RefUnitCellTiling, RefFracPositions)
         UnitCellLattice.__init__(self, RefUnitCell)
         self._IAD = IAD
-        self._RefNeighborsPattern = [np.array([1.0, 0.0, 0.0]),
-                                     np.array([0.0, 1.0, 0.0]),
-                                     np.array([0.0, 0.0, 1.0]),
-                                     np.array([-1.0, 0.0, 0.0]),
-                                     np.array([0.0, -1.0, 0.0]),
-                                     np.array([0.0, 0.0, -1.0])]
         self.applyTransF(ScaleFunc(IAD / CubicLattice.RefIAD))
+        self._NthNeighbors = [[np.array([1.0, 0.0, 0.0]),
+                               np.array([0.0, 1.0, 0.0]),
+                               np.array([0.0, 0.0, 1.0]),
+                               np.array([-1.0, 0.0, 0.0]),
+                               np.array([0.0, -1.0, 0.0]),
+                               np.array([0.0, 0.0, -1.0])]]
 
     # === MANIPULATION METHODS
     def applyTransF(self, TransF):
@@ -55,13 +56,29 @@ class CubicLattice(UnitCellLattice):
     def areNeighbors(self, P1, P2):
         return np.linalg.norm(P2 - P1) <= self.IAD
 
-    def getNeighbors(self, P):
+    def getNeighbors(self, P, layer=1):
         RefP = self._getConvertToReference(P)
-        result = deepcopy(self._RefNeighborsPattern)
-        for NeighP in result:
+        if layer > len(self._NthNeighbors):
+            self._calculateNeighbors(layer)
+        NBs = deepcopy(self._NthNeighbors[layer - 1])
+        for NeighP in NBs:
             NeighP += RefP
             self._convertFromReference(NeighP)
-        return result
+        return NBs
+
+    def _calculateNeighbors(self, layer):
+        NList = [np.array([0, 0, 0], dtype=float)]
+        for nb in self._NthNeighbors:
+            NList.extend(nb)
+        for _ in range(layer - len(self._NthNeighbors)):
+            tmp = []
+            for P in self._NthNeighbors[len(self._NthNeighbors) - 1]:
+                for Q in self._NthNeighbors[0]:
+                    N = P + Q
+                    if not ListHasPoint(NList, N, 0.001 * CubicLattice.RefIAD):
+                        tmp.append(N)
+                        NList.append(N)
+            self._NthNeighbors.append(tmp)
 
     # === BASIC QUERY METHODS
     @property

--- a/idaes/apps/matopt/materials/lattices/cubic_lattice.py
+++ b/idaes/apps/matopt/materials/lattices/cubic_lattice.py
@@ -34,7 +34,7 @@ class CubicLattice(UnitCellLattice):
         RefFracPositions = [np.array([0.0, 0.0, 0.0])]
         RefUnitCell = UnitCell(RefUnitCellTiling, RefFracPositions)
         UnitCellLattice.__init__(self, RefUnitCell)
-        self._IAD = IAD
+        self._IAD = CubicLattice.RefIAD
         self.applyTransF(ScaleFunc(IAD / CubicLattice.RefIAD))
         self._NthNeighbors = [[np.array([1.0, 0.0, 0.0]),
                                np.array([0.0, 1.0, 0.0]),
@@ -46,7 +46,10 @@ class CubicLattice(UnitCellLattice):
     # === MANIPULATION METHODS
     def applyTransF(self, TransF):
         if isinstance(TransF, ScaleFunc):
-            self._IAD *= TransF.Scale
+            if TransF.isIsometric:
+                self._IAD *= TransF.Scale[0]
+            else:
+                raise ValueError('CubicLattice applyTransF: Can only scale isometrically')
         UnitCellLattice.applyTransF(self, TransF)
 
     # === PROPERTY EVALUATION METHODS

--- a/idaes/apps/matopt/materials/lattices/diamond_lattice.py
+++ b/idaes/apps/matopt/materials/lattices/diamond_lattice.py
@@ -1,0 +1,252 @@
+##############################################################################
+# Institute for the Design of Advanced Energy Systems Process Systems
+# Engineering Framework (IDAES PSE Framework) Copyright (c) 2018-2020, by the
+# software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
+# University Research Corporation, et al. All rights reserved.
+#
+# Please see the files COPYRIGHT.txt and LICENSE.txt for full copyright and
+# license information, respectively. Both files are also available online
+# at the URL "https://github.com/IDAES/idaes-pse".
+##############################################################################
+from copy import deepcopy
+from math import sqrt
+
+import numpy as np
+
+from .unit_cell_lattice import UnitCell, UnitCellLattice
+from ..geometry import Cube
+from ..tiling import CubicTiling
+from ..transform_func import ScaleFunc, RotateFunc
+from ...util.util import ListHasPoint
+
+
+class DiamondLattice(UnitCellLattice):
+    RefIAD = sqrt(3) / 4
+
+    # === STANDARD CONSTRUCTOR
+    def __init__(self, IAD):
+        RefUnitCellShape = Cube(1, BotBackLeftCorner=np.array([0, 0, 0], dtype=float))
+        RefUnitCellTiling = CubicTiling(RefUnitCellShape)
+        RefFracPositions = [np.array([0.0, 0.0, 0.0]),
+                            np.array([0.5, 0.5, 0.0]),
+                            np.array([0.0, 0.5, 0.5]),
+                            np.array([0.5, 0.0, 0.5]),
+                            np.array([0.25, 0.25, 0.25]),
+                            np.array([0.25, 0.75, 0.75]),
+                            np.array([0.75, 0.25, 0.75]),
+                            np.array([0.75, 0.75, 0.25])]
+        RefUnitCell = UnitCell(RefUnitCellTiling, RefFracPositions)
+        UnitCellLattice.__init__(self, RefUnitCell)
+        self._IAD = DiamondLattice.RefIAD  # IAD is set correctly after calling applyTransF
+        self.applyTransF(ScaleFunc(IAD / DiamondLattice.RefIAD))
+        self._NthNeighbors = [[[np.array([0.25, 0.25, 0.25]),
+                                np.array([-0.25, -0.25, 0.25]),
+                                np.array([-0.25, 0.25, -0.25]),
+                                np.array([0.25, -0.25, -0.25])],
+                               [np.array([-0.25, -0.25, -0.25]),
+                                np.array([0.25, 0.25, -0.25]),
+                                np.array([0.25, -0.25, 0.25]),
+                                np.array([-0.25, 0.25, 0.25])]],
+                              [[np.array([0.0, 0.5, 0.5]),
+                                np.array([0.0, 0.5, -0.5]),
+                                np.array([0.0, -0.5, 0.5]),
+                                np.array([0.0, -0.5, -0.5]),
+                                np.array([0.5, 0.5, 0.0]),
+                                np.array([0.5, 0.0, 0.5]),
+                                np.array([0.5, -0.5, 0.0]),
+                                np.array([0.5, 0.0, -0.5]),
+                                np.array([-0.5, 0.5, 0.0]),
+                                np.array([-0.5, 0.0, 0.5]),
+                                np.array([-0.5, -0.5, 0.0]),
+                                np.array([-0.5, 0.0, -0.5])],
+                               [np.array([0.0, 0.5, 0.5]),
+                                np.array([0.0, 0.5, -0.5]),
+                                np.array([0.0, -0.5, 0.5]),
+                                np.array([0.0, -0.5, -0.5]),
+                                np.array([0.5, 0.5, 0.0]),
+                                np.array([0.5, 0.0, 0.5]),
+                                np.array([0.5, -0.5, 0.0]),
+                                np.array([0.5, 0.0, -0.5]),
+                                np.array([-0.5, 0.5, 0.0]),
+                                np.array([-0.5, 0.0, 0.5]),
+                                np.array([-0.5, -0.5, 0.0]),
+                                np.array([-0.5, 0.0, -0.5])]]]
+        self._typeDict = {0: 0, 3: 1}
+        self._relativePositions = {0: np.array([0.0, 0.0, 0.0]), 3: np.array([0.25, 0.25, 0.25])}
+
+    # === CONSTRUCTOR - Aligned with {100}
+    @classmethod
+    def alignedWith100(cls, IAD):
+        return cls(IAD)  # Default implementation
+
+    # === CONSTRUCTOR - Aligned with {110}
+    @classmethod
+    def aligndWith110(cls, IAD):
+        result = cls(IAD)
+        thetaX = 0
+        thetaY = np.pi * 0.25
+        thetaZ = 0
+        result.applyTransF(RotateFunc.fromXYZAngles(thetaX, thetaY, thetaZ))
+        return result
+
+    # === CONSTRUCTOR - Aligned with {111}
+    @classmethod
+    def alignedWith111(cls, IAD, blnTrianglesAlignedWithX=True):
+        result = cls(IAD)
+        thetaX = -np.pi * 0.25
+        thetaY = -np.arctan2(-sqrt(2), 2)
+        thetaZ = (np.pi * 0.5 if blnTrianglesAlignedWithX else 0)
+        result.applyTransF(RotateFunc.fromXYZAngles(thetaX, thetaY, thetaZ))
+        return result
+
+    # === CONSTRUCTOR - Aligned with {xyz}
+    @classmethod
+    def alignedWith(cls, IAD, MI):
+        if (type(MI) is str) and (len(MI) == 3) and all(x.isdigit() for x in MI):
+            if MI in ['100', '010', '001']:
+                return cls(IAD)
+            elif MI in ['110', '101', '011']:
+                return cls.aligndWith110(IAD)
+            elif MI == '111':
+                return cls.alignedWith111(IAD)
+            else:
+                result = cls(IAD)
+                a = np.array([0.0, 0.0, 1.0])
+                b = np.array([float(MI[0]), float(MI[1]), float(MI[2])])
+                axis = np.cross(a, b)
+                angle = np.arccos(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+                result.applyTransF(RotateFunc.fromAxisAngle(axis, angle))
+                return result
+        return ValueError('DiamondLattice.alignedWith: Input direction is not correct.')
+
+    # === MANIPULATION METHODS
+    def applyTransF(self, TransF):
+        if isinstance(TransF, ScaleFunc):
+            if TransF.isIsometric:
+                self._IAD *= TransF.Scale[0]
+            else:
+                raise ValueError('DiamondLattice.applyTransF: Can only scale isometrically')
+        UnitCellLattice.applyTransF(self, TransF)
+
+    # === AUXILIARY METHODS
+    def _getPointType(self, P):
+        return (int(round(P[0] * 4)) + int(round(P[1] * 4)) + int(round(P[2] * 4))) % 4
+
+    # === PROPERTY EVALUATION METHODS
+    # NOTE: inherited from UnitCellLattice
+    # def isOnLattice(self,P):
+
+    def areNeighbors(self, P1, P2):
+        return np.linalg.norm(P2 - P1) <= self.IAD
+
+    def getNeighbors(self, P, layer=1):
+        RefP = self._getConvertToReference(P)
+        PType = self._getPointType(RefP)
+        if PType not in self._typeDict.keys():
+            raise ValueError('DiamondLattice.getNeighbors Should never reach here!')
+        if layer > len(self._NthNeighbors):
+            self._calculateNeighbors(layer)
+        NBs = deepcopy(self._NthNeighbors[layer - 1][self._typeDict[PType]])
+        for NeighP in NBs:
+            NeighP += RefP
+            self._convertFromReference(NeighP)
+        return NBs
+
+    def _calculateNeighbors(self, layer):
+        NList = []
+        for k, v in self._typeDict.items():
+            tmp = [np.array([0, 0, 0], dtype=float)]
+            for nb in self._NthNeighbors:
+                tmp.extend(nb[v])
+            NList.append(tmp)
+        for _ in range(layer - len(self._NthNeighbors)):
+            tmp = [[] for _ in self._typeDict.keys()]
+            for k, v in self._typeDict.items():
+                for P in self._NthNeighbors[len(self._NthNeighbors) - 1][v]:
+                    PType = self._getPointType(P + self._relativePositions[k])
+                    for Q in self._NthNeighbors[0][self._typeDict[PType]]:
+                        N = P + Q
+                        if not ListHasPoint(NList[v], N, 0.001 * DiamondLattice.RefIAD):
+                            tmp[v].append(N)
+                            NList[v].append(N)
+            self._NthNeighbors.append(tmp)
+
+    def isASite(self, P):
+        RefP = self._getConvertToReference(P)
+        PType = self._getPointType(RefP)
+        return PType == 0
+
+    def isBSite(self, P):
+        RefP = self._getConvertToReference(P)
+        PType = self._getPointType(RefP)
+        return PType == 3
+
+    def setDesign(self, D, AType, BType):
+        for i, P in enumerate(D.Canvas.Points):
+            if self.isASite(P):
+                D.setContent(i, AType)
+            elif self.isBSite(P):
+                D.setContent(i, BType)
+            else:
+                raise ValueError('setDesign can not set site not on lattice')
+
+    # === BASIC QUERY METHODS
+    @property
+    def IAD(self):
+        return self._IAD
+
+    @property
+    def Diamond100LayerSpacing(self):
+        return self.IAD / sqrt(3)
+
+    @property
+    def Diamond110LayerSpacing(self):
+        return self.IAD * sqrt(2) / sqrt(3)
+
+    @property
+    def Diamond111LayerSpacing(self):
+        return self.IAD * 4 / 3
+
+    @property
+    def Diamond112LayerSpacing(self):
+        return self.IAD * sqrt(2) / 3
+
+    def getLayerSpacing(self, MI):
+        if (type(MI) is str) and (len(MI) == 3) and all(x.isdigit() for x in MI):
+            if MI in ['100', '010', '001']:
+                return self.Diamond100LayerSpacing
+            elif MI in ['110', '101', '011']:
+                return self.Diamond110LayerSpacing
+            elif MI == '111':
+                return self.Diamond111LayerSpacing
+            elif MI in ['112', '121', '211']:
+                return self.Diamond112LayerSpacing
+            else:
+                raise NotImplementedError('DiamondLattice.getLayerSpacing: Input direction is not supported.')
+        return ValueError('DiamondLattice.getLayerSpacing: Input direction is not correct.')
+
+    def getShellSpacing(self, MI):
+        if (type(MI) is str) and (len(MI) == 3) and all(x.isdigit() for x in MI):
+            if MI in ['100', '010', '001', '110', '101', '011', '111']:
+                return self.IAD * sqrt(8) / sqrt(3)
+            elif MI in ['112', '121', '211']:
+                return self.IAD * sqrt(2) / sqrt(3)
+            else:
+                raise NotImplementedError('DiamondLattice.getShellSpacing: Input direction is not supported.')
+        return ValueError('The input direction is not correct.')
+
+    def getUniqueLayerCount(self, MI):
+        if (type(MI) is str) and (len(MI) == 3) and all(x.isdigit() for x in MI):
+            if MI in ['100', '010', '001']:
+                return 4
+            elif MI in ['110', '101', '011']:
+                return 2
+            elif MI == '111':
+                return 3
+            elif MI in ['112', '121', '211']:
+                return 6
+            else:
+                raise NotImplementedError('DiamondLattice.getUniqueLayerCount: Input direction is not supported.')
+        return ValueError('The input direction is not correct.')

--- a/idaes/apps/matopt/materials/lattices/lattice.py
+++ b/idaes/apps/matopt/materials/lattices/lattice.py
@@ -79,7 +79,7 @@ class Lattice(object):
         raise NotImplementedError
 
     @abstractmethod
-    def getNeighbors(self, P):
+    def getNeighbors(self, P, layer):
         raise NotImplementedError
 
     def _convertFromReference(self, P):

--- a/idaes/apps/matopt/materials/lattices/perovskite_lattice.py
+++ b/idaes/apps/matopt/materials/lattices/perovskite_lattice.py
@@ -58,9 +58,11 @@ class PerovskiteLattice(UnitCellLattice):
     # def isOnLattice(self,P):
 
     def areNeighbors(self, P1, P2):
-        raise NotImplementedError('Decide what this means for PerovskiteLattice...')
+        raise NotImplementedError('PerovskiteLattice: there is no universal definition of nearest neighbors.')
 
-    def getNeighbors(self, P):
+    def getNeighbors(self, P, layer=1):
+        if layer > 2:
+            raise ValueError('PerovskiteLattice: there is no universal definition of N-th nearest neighbors.')
         RefP = self._getConvertToReference(P)
         if self.isASite(P):
             return []

--- a/idaes/apps/matopt/materials/lattices/unit_cell_lattice.py
+++ b/idaes/apps/matopt/materials/lattices/unit_cell_lattice.py
@@ -113,7 +113,7 @@ class UnitCellLattice(Lattice):
         raise NotImplementedError
 
     @abstractmethod
-    def getNeighbors(self, P):
+    def getNeighbors(self, P, layer):
         raise NotImplementedError
 
     # === BASIC QUERY METHODS

--- a/idaes/apps/matopt/materials/lattices/wurtzite_lattice.py
+++ b/idaes/apps/matopt/materials/lattices/wurtzite_lattice.py
@@ -19,6 +19,7 @@ from .unit_cell_lattice import UnitCell, UnitCellLattice
 from ..geometry import Parallelepiped
 from ..tiling import CubicTiling
 from ..transform_func import ScaleFunc, RotateFunc
+from ...opt import DBL_TOL
 from ...util.util import ListHasPoint
 
 
@@ -99,7 +100,7 @@ class WurtziteLattice(UnitCellLattice):
     # def isOnLattice(self,P):
 
     def areNeighbors(self, P1, P2):
-        return np.linalg.norm(P2 - P1) <= self.IAD
+        return np.linalg.norm(P2 - P1) <= self.IAD + DBL_TOL
 
     def getNeighbors(self, P, layer=1):
         RefP = self._getConvertToReference(P)

--- a/idaes/apps/matopt/materials/lattices/wurtzite_lattice.py
+++ b/idaes/apps/matopt/materials/lattices/wurtzite_lattice.py
@@ -1,0 +1,188 @@
+##############################################################################
+# Institute for the Design of Advanced Energy Systems Process Systems
+# Engineering Framework (IDAES PSE Framework) Copyright (c) 2018-2020, by the
+# software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
+# University Research Corporation, et al. All rights reserved.
+#
+# Please see the files COPYRIGHT.txt and LICENSE.txt for full copyright and
+# license information, respectively. Both files are also available online
+# at the URL "https://github.com/IDAES/idaes-pse".
+##############################################################################
+from copy import deepcopy
+from math import sqrt
+
+import numpy as np
+
+from .unit_cell_lattice import UnitCell, UnitCellLattice
+from ..geometry import Parallelepiped
+from ..tiling import CubicTiling
+from ..transform_func import ScaleFunc, RotateFunc
+from ...util.util import ListHasPoint
+
+
+class WurtziteLattice(UnitCellLattice):
+    RefIAD = sqrt(3 / 8)
+
+    # === STANDARD CONSTRUCTOR
+    def __init__(self, IAD):
+        RefUnitCellShape = Parallelepiped(np.array([1, 0, 0], dtype=float),
+                                          np.array([0.5, sqrt(3) / 2, 0], dtype=float),
+                                          np.array([0, 0, sqrt(8) / sqrt(3)], dtype=float),
+                                          BotBackLeftCorner=np.array([0, 0, 0], dtype=float))
+        RefUnitCellTiling = CubicTiling(RefUnitCellShape)
+        RefFracPositions = [np.array([0.0, 0.0, 0.0]),
+                            np.array([0.5, sqrt(3) / 6.0, 1.0 / sqrt(24)]),
+                            np.array([0.5, sqrt(3) / 6.0, 4.0 / sqrt(24)]),
+                            np.array([0.0, 0.0, 5.0 / sqrt(24)])]
+        RefUnitCell = UnitCell(RefUnitCellTiling, RefFracPositions)
+        UnitCellLattice.__init__(self, RefUnitCell)
+        self._IAD = WurtziteLattice.RefIAD  # IAD is set correctly after calling applyTransF
+        self.applyTransF(ScaleFunc(IAD / WurtziteLattice.RefIAD))
+        self._NthNeighbors = [[[np.array([0.0, 0.0, -3 / sqrt(24)]),
+                                np.array([0.0, -sqrt(3) / 3, 1 / sqrt(24)]),
+                                np.array([0.5, sqrt(3) / 6, 1 / sqrt(24)]),
+                                np.array([-0.5, sqrt(3) / 6, 1 / sqrt(24)])],
+                               [np.array([0.0, 0.0, 3 / sqrt(24)]),
+                                np.array([0.0, sqrt(3) / 3, -1 / sqrt(24)]),
+                                np.array([0.5, -sqrt(3) / 6, -1 / sqrt(24)]),
+                                np.array([-0.5, -sqrt(3) / 6, -1 / sqrt(24)])],
+                               [np.array([0.0, 0.0, -3 / sqrt(24)]),
+                                np.array([0.0, sqrt(3) / 3, 1 / sqrt(24)]),
+                                np.array([0.5, -sqrt(3) / 6, 1 / sqrt(24)]),
+                                np.array([-0.5, -sqrt(3) / 6, 1 / sqrt(24)])],
+                               [np.array([0.0, 0.0, 3 / sqrt(24)]),
+                                np.array([0.0, -sqrt(3) / 3, -1 / sqrt(24)]),
+                                np.array([0.5, sqrt(3) / 6, -1 / sqrt(24)]),
+                                np.array([-0.5, sqrt(3) / 6, -1 / sqrt(24)])]]]
+        self._typeDict = {0: 0, 1: 1, 4: 2, 5: 3}
+        self._relativePositions = {0: np.array([0.0, 0.0, 0.0]),
+                                   1: np.array([0.5, sqrt(3) / 6.0, 1.0 / sqrt(24)]),
+                                   4: np.array([0.5, sqrt(3) / 6.0, 4.0 / sqrt(24)]),
+                                   5: np.array([0.0, 0.0, 5.0 / sqrt(24)])}
+
+    @classmethod
+    def alignedWith(cls, IAD, MI):
+        if MI == '0001':
+            return cls(IAD)
+        elif MI == '1100':
+            result = cls(IAD)
+            axis = np.array([1, 0, 0], dtype=float)
+            angle = np.pi / 2
+            result.applyTransF(RotateFunc.fromAxisAngle(axis, angle))
+            return result
+        elif MI == '1120':
+            result = cls(IAD)
+            axis = np.array([0, 1, 0], dtype=float)
+            angle = np.pi / 2
+            result.applyTransF(RotateFunc.fromAxisAngle(axis, angle))
+            return result
+        else:
+            raise ValueError('WurtziteLattice.alignedWith: Input direction is not supported.')
+
+    # === MANIPULATION METHODS
+    def applyTransF(self, TransF):
+        if isinstance(TransF, ScaleFunc):
+            if TransF.isIsometric:
+                self._IAD *= TransF.Scale[0]
+            else:
+                raise ValueError('WurtziteLattice.applyTransF: Can only scale isometrically')
+        UnitCellLattice.applyTransF(self, TransF)
+
+    # === AUXILIARY METHODS
+    def _getPointType(self, P):
+        return int(round(P[2] * sqrt(24))) % 8
+
+    # === PROPERTY EVALUATION METHODS
+    # NOTE: inherited from UnitCellLattice
+    # def isOnLattice(self,P):
+
+    def areNeighbors(self, P1, P2):
+        return np.linalg.norm(P2 - P1) <= self.IAD
+
+    def getNeighbors(self, P, layer=1):
+        RefP = self._getConvertToReference(P)
+        PType = self._getPointType(RefP)
+        if PType not in self._typeDict.keys():
+            raise ValueError('WurtziteLattice.getNeighbors Should never reach here!')
+        if layer > len(self._NthNeighbors):
+            self._calculateNeighbors(layer)
+        NBs = deepcopy(self._NthNeighbors[layer - 1][self._typeDict[PType]])
+        for NeighP in NBs:
+            NeighP += RefP
+            self._convertFromReference(NeighP)
+        return NBs
+
+    def _calculateNeighbors(self, layer):
+        NList = []
+        for k, v in self._typeDict.items():
+            tmp = [np.array([0, 0, 0], dtype=float)]
+            for nb in self._NthNeighbors:
+                tmp.extend(nb[v])
+            NList.append(tmp)
+        for _ in range(layer - len(self._NthNeighbors)):
+            tmp = [[] for _ in self._typeDict.keys()]
+            for k, v in self._typeDict.items():
+                for P in self._NthNeighbors[len(self._NthNeighbors) - 1][v]:
+                    PType = self._getPointType(P + self._relativePositions[k])
+                    for Q in self._NthNeighbors[0][self._typeDict[PType]]:
+                        N = P + Q
+                        if not ListHasPoint(NList[v], N, 0.001 * WurtziteLattice.RefIAD):
+                            tmp[v].append(N)
+                            NList[v].append(N)
+            self._NthNeighbors.append(tmp)
+
+    def isASite(self, P):
+        RefP = self._getConvertToReference(P)
+        PType = self._getPointType(RefP)
+        return PType == 0 or PType == 4
+
+    def isBSite(self, P):
+        RefP = self._getConvertToReference(P)
+        PType = self._getPointType(RefP)
+        return PType == 1 or PType == 5
+
+    def setDesign(self, D, AType, BType):
+        for i, P in enumerate(D.Canvas.Points):
+            if self.isASite(P):
+                D.setContent(i, AType)
+            elif self.isBSite(P):
+                D.setContent(i, BType)
+            else:
+                raise ValueError('setDesign can not set site not on lattice')
+
+    # === BASIC QUERY METHODS
+    @property
+    def IAD(self):
+        return self._IAD
+
+    def getLayerSpacing(self, MI):
+        if MI == '0001':
+            return self._IAD * 4 / 3
+        elif MI == '1100':
+            return self._IAD * sqrt(2)
+        elif MI == '1120':
+            return self._IAD * sqrt(8 / 3)
+        else:
+            raise NotImplementedError('WurtziteLattice.getLayerSpacing: Input direction is not supported.')
+
+    def getShellSpacing(self, MI):
+        if MI == '0001':
+            return self._IAD * sqrt(2)
+        elif MI == '1100':
+            return self._IAD * sqrt(8 / 3)
+        elif MI == '1120':
+            return self._IAD * sqrt(8 / 3)
+        else:
+            raise NotImplementedError('WurtziteLattice.getShellSpacing: Input direction is not supported.')
+
+    def getUniqueLayerCount(self, MI):
+        if MI == '0001':
+            return 2
+        elif MI == '1100':
+            return 2
+        elif MI == '1120':
+            return 1
+        else:
+            raise NotImplementedError('WurtziteLattice.getUniqueLayerCount: Input direction is not supported.')

--- a/idaes/apps/matopt/materials/tiling.py
+++ b/idaes/apps/matopt/materials/tiling.py
@@ -10,10 +10,10 @@
 # license information, respectively. Both files are also available online
 # at the URL "https://github.com/IDAES/idaes-pse".
 ##############################################################################
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 import numpy as np
 
-from .geometry import Parallelepiped
+from .geometry import Parallelepiped, Cylinder, CylindricalSector
 from .design import Design
 
 
@@ -59,6 +59,49 @@ class Tiling(object):
 
         """
         raise NotImplementedError
+
+
+class LinearTiling(Tiling, ABC):
+    """ Class to manage linear periodicity. """
+    DBL_TOL = 1e-5
+
+    # === STANDARD CONSTRUCTOR
+    def __init__(self, TilingDirections_, argShape=None):
+        super().__init__()
+        self._TileShape = argShape
+        self._TilingDirections = TilingDirections_
+
+    # === CONSTRUCTOR - From Parallelepiped
+    @classmethod
+    def fromParallelepiped(cls, argShape):
+        assert (type(argShape) == Parallelepiped), 'The input shape is not an instance of Parallelepiped.'
+        TilingDirections_ = [argShape.Vz, -argShape.Vz]
+        return cls(TilingDirections_, argShape)
+
+    # === CONSTRUCTOR - From Cylinder or CylindricalSector
+    @classmethod
+    def fromCylindricalShape(cls, argShape):
+        assert (type(argShape) == Cylinder or CylindricalSector), 'The input shape is not an instance of Cylinder or CylindricalSector.'
+        TilingDirections_ = [argShape.Vh, -argShape.Vh]
+        return cls(TilingDirections_, argShape)
+
+    # === CONSTRUCTOR - From POSCAR files
+    @classmethod
+    def fromPOSCAR(cls, filename):
+        return cls.fromParallelepiped(Parallelepiped.fromPOSCAR(filename))
+
+    # === BASIC QUERY METHODS
+    @property
+    def TileShape(self):
+        return self._TileShape
+
+    @property
+    def TilingDirections(self):
+        return self._TilingDirections
+
+    @property
+    def V(self):
+        return self._TilingDirections[0]
 
 
 class PlanarTiling(Tiling):

--- a/idaes/apps/matopt/tests/test_matopt_objects_construction.py
+++ b/idaes/apps/matopt/tests/test_matopt_objects_construction.py
@@ -26,21 +26,23 @@ import pytest
 
 @pytest.mark.unit
 def test_construct_FCCLattice():
-    IAD = 2.77
+    IAD = sqrt(2) / 2
+    lattice = FCCLattice.alignedWith100(IAD)
+    lattice = FCCLattice.alignedWith111(IAD)
     lattice = FCCLattice(IAD)
     return lattice
 
 
 @pytest.mark.unit
 def test_construct_CubicLattice():
-    IAD = 2.77
+    IAD = 1.0
     lattice = CubicLattice(IAD)
     return lattice
 
 
 @pytest.mark.unit
 def test_construct_PerovskiteLattice():
-    A, B, C = 4, 4, 4
+    A, B, C = 1.0, 1.0, 1.0
     lattice = PerovskiteLattice(A, B, C)
     return lattice
 
@@ -48,6 +50,9 @@ def test_construct_PerovskiteLattice():
 @pytest.mark.unit
 def test_construct_DiamondLattice():
     IAD = sqrt(3) / 4
+    lattice = DiamondLattice.alignedWith(IAD, '100')
+    lattice = DiamondLattice.alignedWith(IAD, '110')
+    lattice = DiamondLattice.alignedWith(IAD, '111')
     lattice = DiamondLattice(IAD)
     return lattice
 
@@ -55,6 +60,7 @@ def test_construct_DiamondLattice():
 @pytest.mark.unit
 def test_construct_WurtziteLattice():
     IAD = sqrt(3 / 8)
+    lattice = WurtziteLattice.alignedWith(IAD, '0001')
     lattice = WurtziteLattice(IAD)
     return lattice
 

--- a/idaes/apps/matopt/tests/test_matopt_objects_construction.py
+++ b/idaes/apps/matopt/tests/test_matopt_objects_construction.py
@@ -12,8 +12,9 @@
 ##############################################################################
 import numpy as np
 from math import sqrt
-from idaes.apps.matopt.materials import Atom, Canvas, Design, PlanarTiling, CubicTiling
-from idaes.apps.matopt.materials.geometry import Shape, Cuboctahedron, Parallelepiped, Rhombohedron, RectPrism, Cube
+from idaes.apps.matopt.materials import Atom, Canvas, Design, LinearTiling, PlanarTiling, CubicTiling
+from idaes.apps.matopt.materials.geometry import Shape, Cuboctahedron, Parallelepiped, Rhombohedron, RectPrism, Cube, \
+    Cylinder, CylindricalSector
 from idaes.apps.matopt.materials.lattices import FCCLattice, CubicLattice, PerovskiteLattice, DiamondLattice, \
     WurtziteLattice
 from idaes.apps.matopt.materials.transform_func import ShiftFunc, ScaleFunc, RotateFunc, ReflectFunc
@@ -121,6 +122,30 @@ def test_construct_RectPrism():
 def test_construct_Cube():
     shape = Cube(1.0)
     return shape
+
+
+@pytest.mark.unit
+def test_construct_Cylinder():
+    shape = Cylinder(np.zeros(3, dtype=float), 1.0, 1.0)
+    return shape
+
+
+@pytest.mark.unit
+def test_construct_CylindricalSector():
+    shape = CylindricalSector(np.zeros(3, dtype=float), 1.0, 1.0,
+                              np.array([1, 0, 0], dtype=float),
+                              np.array([0, 1, 0], dtype=float),
+                              np.array([0, 0, 1], dtype=float))
+    return shape
+
+
+@pytest.mark.unit
+def test_construct_LinearTiling():
+    parallelepiped = test_construct_Parallelepiped()
+    cylinder = test_construct_Cylinder()
+    tiling = LinearTiling.fromParallelepiped(parallelepiped)
+    tiling = LinearTiling.fromCylindricalShape(cylinder)
+    return tiling
 
 
 @pytest.mark.unit

--- a/idaes/apps/matopt/tests/test_matopt_objects_construction.py
+++ b/idaes/apps/matopt/tests/test_matopt_objects_construction.py
@@ -11,15 +11,17 @@
 # at the URL "https://github.com/IDAES/idaes-pse".
 ##############################################################################
 import numpy as np
-
+from math import sqrt
 from idaes.apps.matopt.materials import Atom, Canvas, Design, PlanarTiling, CubicTiling
 from idaes.apps.matopt.materials.geometry import Shape, Cuboctahedron, Parallelepiped, Rhombohedron, RectPrism, Cube
-from idaes.apps.matopt.materials.lattices import FCCLattice, CubicLattice, PerovskiteLattice
+from idaes.apps.matopt.materials.lattices import FCCLattice, CubicLattice, PerovskiteLattice, DiamondLattice, \
+    WurtziteLattice
 from idaes.apps.matopt.materials.transform_func import ShiftFunc, ScaleFunc, RotateFunc, ReflectFunc
 from idaes.apps.matopt.opt import Coef, LinearExpr, MatOptModel, SumNeighborSites, SumNeighborBonds, SumSites, SumBonds, \
     SumSiteTypes, SumBondTypes, SumSitesAndTypes, SumBondsAndTypes, SumConfs, SumSitesAndConfs, LessThan, EqualTo, \
     GreaterThan, FixedTo, Disallow, PiecewiseLinear, Implies, NegImplies, ImpliesSiteCombination, ImpliesNeighbors
 import pytest
+
 
 @pytest.mark.unit
 def test_construct_FCCLattice():
@@ -39,6 +41,20 @@ def test_construct_CubicLattice():
 def test_construct_PerovskiteLattice():
     A, B, C = 4, 4, 4
     lattice = PerovskiteLattice(A, B, C)
+    return lattice
+
+
+@pytest.mark.unit
+def test_construct_DiamondLattice():
+    IAD = sqrt(3) / 4
+    lattice = DiamondLattice(IAD)
+    return lattice
+
+
+@pytest.mark.unit
+def test_construct_WurtziteLattice():
+    IAD = sqrt(3 / 8)
+    lattice = WurtziteLattice(IAD)
     return lattice
 
 
@@ -277,7 +293,7 @@ def test_construct_Disallow():
 @pytest.mark.unit
 def test_construct_PiecewiseLinear():
     m = test_construct_MatOptModel()
-    rule = PiecewiseLinear([x**2 for x in range(3)],
+    rule = PiecewiseLinear([x ** 2 for x in range(3)],
                            [x for x in range(3)],
                            m.Ci)
     return rule

--- a/idaes/apps/matopt/tests/test_matopt_objects_functionality.py
+++ b/idaes/apps/matopt/tests/test_matopt_objects_functionality.py
@@ -1,0 +1,92 @@
+##############################################################################
+# Institute for the Design of Advanced Energy Systems Process Systems
+# Engineering Framework (IDAES PSE Framework) Copyright (c) 2018-2020, by the
+# software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
+# University Research Corporation, et al. All rights reserved.
+#
+# Please see the files COPYRIGHT.txt and LICENSE.txt for full copyright and
+# license information, respectively. Both files are also available online
+# at the URL "https://github.com/IDAES/idaes-pse".
+##############################################################################
+import numpy as np
+from math import sqrt
+from idaes.apps.matopt.materials import Atom, Canvas, Design, LinearTiling, PlanarTiling, CubicTiling
+from idaes.apps.matopt.materials.geometry import Shape, Cuboctahedron, Parallelepiped, Rhombohedron, RectPrism, Cube, \
+    Cylinder, CylindricalSector
+from idaes.apps.matopt.materials.lattices import FCCLattice, CubicLattice, PerovskiteLattice, DiamondLattice, \
+    WurtziteLattice
+from idaes.apps.matopt.materials.transform_func import ShiftFunc, ScaleFunc, RotateFunc, ReflectFunc
+from idaes.apps.matopt.opt import Coef, LinearExpr, MatOptModel, SumNeighborSites, SumNeighborBonds, SumSites, SumBonds, \
+    SumSiteTypes, SumBondTypes, SumSitesAndTypes, SumBondsAndTypes, SumConfs, SumSitesAndConfs, LessThan, EqualTo, \
+    GreaterThan, FixedTo, Disallow, PiecewiseLinear, Implies, NegImplies, ImpliesSiteCombination, ImpliesNeighbors
+from idaes.apps.matopt.util.util import areEqual
+import pytest
+from test_matopt_objects_construction import *
+
+
+@pytest.mark.unit
+def test_functionality_FCCLattice():
+    lattice = test_construct_FCCLattice()
+    assert lattice.areNeighbors(np.zeros(3, dtype=float), np.array([0.0, -0.5, 0.5]))
+    nbs = lattice.getNeighbors(np.zeros(3, dtype=float))
+    for p in nbs:
+        assert lattice.areNeighbors(np.zeros(3, dtype=float), p)
+    assert areEqual(lattice.IAD, sqrt(2) / 2, 1e-4)
+    assert areEqual(lattice.FCC111LayerSpacing, 1 / sqrt(3), 1e-4)
+    assert areEqual(lattice.FCC100LayerSpacing, 1 / 2, 1e-4)
+    assert areEqual(lattice.FCC110LayerSpacing, sqrt(2) / 2, 1e-4)
+
+
+@pytest.mark.units
+def test_functionality_CubicLattice():
+    lattice = test_construct_CubicLattice()
+    assert lattice.areNeighbors(np.zeros(3, dtype=float), np.array([1.0, 0.0, 0.0]))
+    nbs = lattice.getNeighbors(np.zeros(3, dtype=float))
+    for p in nbs:
+        assert lattice.areNeighbors(np.zeros(3, dtype=float), p)
+    assert areEqual(lattice.IAD, 1.0, 1e-4)
+
+
+@pytest.mark.unit
+def test_functionality_DiamondLattice():
+    lattice = test_construct_DiamondLattice()
+    assert lattice.areNeighbors(np.zeros(3, dtype=float), np.array([0.25, 0.25, 0.25]))
+    nbs = lattice.getNeighbors(np.zeros(3, dtype=float))
+    for p in nbs:
+        assert lattice.areNeighbors(np.zeros(3, dtype=float), p)
+    assert lattice.isASite(np.zeros(3, dtype=float))
+    assert lattice.isBSite(np.array([0.25, 0.25, 0.25]))
+    assert areEqual(lattice.IAD, sqrt(3) / 4, 1e-4)
+    assert areEqual(lattice.getLayerSpacing('100'), 1 / 4, 1e-4)
+    assert areEqual(lattice.getLayerSpacing('110'), sqrt(2) / 4, 1e-4)
+    assert areEqual(lattice.getLayerSpacing('111'), sqrt(3) / 3, 1e-4)
+    assert areEqual(lattice.getLayerSpacing('112'), sqrt(6) / 12, 1e-4)
+    assert areEqual(lattice.getShellSpacing('100'), sqrt(8) / 4, 1e-4)
+    assert areEqual(lattice.getShellSpacing('112'), sqrt(2) / 4, 1e-4)
+    assert areEqual(lattice.getUniqueLayerCount('100'), 4, 1e-4)
+    assert areEqual(lattice.getUniqueLayerCount('110'), 2, 1e-4)
+    assert areEqual(lattice.getUniqueLayerCount('111'), 3, 1e-4)
+    assert areEqual(lattice.getUniqueLayerCount('112'), 6, 1e-4)
+
+
+@pytest.mark.unit
+def test_functionality_WurtziteLattice():
+    lattice = test_construct_WurtziteLattice()
+    assert lattice.areNeighbors(np.zeros(3, dtype=float), np.array([0.0, 0.0, -3 / sqrt(24)]))
+    nbs = lattice.getNeighbors(np.zeros(3, dtype=float))
+    for p in nbs:
+        assert lattice.areNeighbors(np.zeros(3, dtype=float), p)
+    assert lattice.isASite(np.zeros(3, dtype=float))
+    assert lattice.isBSite(np.array([0.0, 0.0, -3 / sqrt(24)]))
+    assert areEqual(lattice.IAD, sqrt(3 / 8), 1e-4)
+    assert areEqual(lattice.getLayerSpacing('0001'), sqrt(2 / 3), 1e-4)
+    assert areEqual(lattice.getLayerSpacing('1100'), sqrt(3) / 2, 1e-4)
+    assert areEqual(lattice.getLayerSpacing('1120'), 1, 1e-4)
+    assert areEqual(lattice.getShellSpacing('0001'), sqrt(3) / 2, 1e-4)
+    assert areEqual(lattice.getShellSpacing('1100'), 1, 1e-4)
+    assert areEqual(lattice.getShellSpacing('1120'), 1, 1e-4)
+    assert areEqual(lattice.getUniqueLayerCount('0001'), 2, 1e-4)
+    assert areEqual(lattice.getUniqueLayerCount('1100'), 2, 1e-4)
+    assert areEqual(lattice.getUniqueLayerCount('1120'), 1, 1e-4)

--- a/idaes/apps/matopt/util/util.py
+++ b/idaes/apps/matopt/util/util.py
@@ -51,7 +51,8 @@ def myArrayEq(x, y, atol):
     Returns:
     (bool) true if the two arrays are equal
     """
-    return (np.abs(x - y) < atol).all()
+    return (x[0] - y[0] < atol) and (x[0] - y[0] > -atol) and (x[1] - y[1] < atol) and (x[1] - y[1] > -atol) and (
+            x[2] - y[2] < atol) and (x[2] - y[2] > -atol)
 
 
 myPointEq = myArrayEq


### PR DESCRIPTION
## Fixes
N/A

## Summary/Motivation:
We have developed new objects and capabilities of MatOpt for designing semiconductor nanowire materials. This PR is the code contribution as promised in the IDAES FWP. We have tested the code and examples in the example-pse repository locally. There are some unit tests for constructing new objects in the tests subfolder. We will also provide an example illustrating designing nanowires via a PR to the example-pse repository soon.

## Changes proposed in this PR:
- New `LinearTiling` class for 1d periodicity
- New `Cylinder` and `CylindricalSector` classes for the shape of the design canvas
- New `DiamondLattice` and `WurtziteLattice` classes to support a broader range of materials
- New capability of `Canvas` class to return n-th layer neighbor indices
- Modification of `util.myArrayEq` function for faster geometric calculations
- Updated URLs in the documentation
- Unit tests for new classes

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
