### PR TITLE
Address issues with missing Codecov reports on some PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,8 @@ coverage:
       default:
         target: auto
         threshold: 1%
+codecov:
+  require_ci_to_pass: no
+  notify:
+    after_n_builds: 1
+    wait_for_ci: no


### PR DESCRIPTION
## Summary/Motivation
- Some PRs did not receive any report from Codecov
  - This search should show at least some of them: https://github.com/search?q=repo%3AIDAES%2Fidaes-pse+is%3Apr+-involves%3Acodecov-io+created%3A%3E2020-12-01

## Changes proposed in this PR:
- Add config to ensure codecov reports for all PRs

## Strategy
These config options look like they could be related to the issue, but I'm not 100% sure this is the case. I'm creating a parallel "null hypothesis" PR with the same lines commented out to see if there's any difference between the two.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
