### PR TITLE
Enable integration tests to run automatically on approved PRs

### DIFF
--- a/.github/actions/check-pr-approval/action.yml
+++ b/.github/actions/check-pr-approval/action.yml
@@ -1,0 +1,38 @@
+name: Check PR approval
+description: Determines if a PR is approved by reviewers
+inputs:
+  number:
+    description: Number of the PR to check
+    required: true
+  query-result-path:
+    description: File where the result of the API query will be saved
+    required: false
+    default: query-result.json
+outputs:
+  is-approved:
+    description: Set to 'true' if PR is approved, 'false' otherwise
+    value: ${{ steps.check-approval.outputs.is-approved }}
+runs:
+  using: composite
+  steps:
+    - id: run-query
+      run: |
+        # This step uses `curl` instead of the higher-level `hub` or `gh` tools available on the runner
+        # because these have authentication issues running API queries,
+        # probably due to the limited permissions available for pull_request events from forks
+        url="$GITHUB_API_URL/search/issues?q=repo:$GITHUB_REPOSITORY+is:pr+is:open+review:approved"
+        curl "$url" > "${{ inputs.query-result-path }}"
+        echo "::group::Query results"
+        jq . "${{ inputs.query-result-path }}"
+        echo "::endgroup"
+      shell: bash
+    - id: check-approval
+      shell: bash
+      run: |
+        # the "items" field of the JSON response is an array of PRs that are open and approved
+        # the jq query checks the "number" field of each PR object
+        # returning "true" if any of them matches the PR number specified as an input parameter
+        # or "false" otherwise
+        jq_query=".items | any(.number == ${{ inputs.number }})"
+        is_approved=$(jq "$jq_query" "${{ inputs.query-result-path }}")
+        echo "::set-output name=is-approved::$is_approved"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -106,43 +106,7 @@ jobs:
           msg = f'{workflow_trigger=}    event/action={event_name}/{event_action or "N/A"}    is_pr_approved={is_pr_approved or "N/A"}'
           _display_on_run_dashboard(msg)
           _set_output('workflow-trigger', workflow_trigger)
-  # TODO to be removed later once we see that everything works properly
-  debug_precheck:
-    name: (util) Debug precheck job
-    runs-on: ubuntu-latest
-    needs: precheck
-    steps:
-      - name: Show precheck output
-        run: |
-          jq . <<EOF
-          ${{ toJSON(needs.precheck.outputs) }}
-          EOF
-          echo "precheck.outputs.is-pr-approved=${{ needs.precheck.outputs.is-pr-approved }}"
-          echo "precheck.outputs.workflow-trigger=${{ needs.precheck.outputs.workflow-trigger }}"
-      - name: Test if condition
-        if: >-
-          (
-            needs.precheck.outputs.workflow-trigger == 'user_dispatch'
-            || needs.precheck.outputs.workflow-trigger == 'not_pr'
-            || needs.precheck.outputs.workflow-trigger == 'approved_pr'
-          )
-        run: echo "If I'm running, the main job should be running as well"
-  # TODO to be removed later once we see that everything works properly
-  debug_label:
-    name: (util) Debug label triggers
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/display-debug-info
-      - name: Test label condition
-        if: >-
-          (
-            github.event.action == 'labeled'
-            && contains(github.event.label.description, 'triggers_workflow')
-            && contains(github.event.label.description, github.workflow)
-          )
-        run: echo "${{ github.event.label.description }}"
-#
+
   pytest:
     name: pytest (py${{ matrix.python-version }}/${{ matrix.os }}/integration)
     runs-on: ${{ matrix.os }}
@@ -157,10 +121,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
+          # - '3.6'
           - '3.7'
-          - '3.8'
-          - '3.9'
+          # - '3.8'
+          # - '3.9'
         os:
           - ubuntu-18.04
           - windows-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -106,7 +106,43 @@ jobs:
           msg = f'{workflow_trigger=}    event/action={event_name}/{event_action or "N/A"}    is_pr_approved={is_pr_approved or "N/A"}'
           _display_on_run_dashboard(msg)
           _set_output('workflow-trigger', workflow_trigger)
-
+  # TODO to be removed later once we see that everything works properly
+  debug_precheck:
+    name: (util) Debug precheck job
+    runs-on: ubuntu-latest
+    needs: precheck
+    steps:
+      - name: Show precheck output
+        run: |
+          jq . <<EOF
+          ${{ toJSON(needs.precheck.outputs) }}
+          EOF
+          echo "precheck.outputs.is-pr-approved=${{ needs.precheck.outputs.is-pr-approved }}"
+          echo "precheck.outputs.workflow-trigger=${{ needs.precheck.outputs.workflow-trigger }}"
+      - name: Test if condition
+        if: >-
+          (
+            needs.precheck.outputs.workflow-trigger == 'user_dispatch'
+            || needs.precheck.outputs.workflow-trigger == 'not_pr'
+            || needs.precheck.outputs.workflow-trigger == 'approved_pr'
+          )
+        run: echo "If I'm running, the main job should be running as well"
+  # TODO to be removed later once we see that everything works properly
+  debug_label:
+    name: (util) Debug label triggers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/display-debug-info
+      - name: Test label condition
+        if: >-
+          (
+            github.event.action == 'labeled'
+            && contains(github.event.label.description, 'triggers_workflow')
+            && contains(github.event.label.description, github.workflow)
+          )
+        run: echo "${{ github.event.label.description }}"
+#
   pytest:
     name: pytest (py${{ matrix.python-version }}/${{ matrix.os }}/integration)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,10 +121,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          # - '3.6'
+          - '3.6'
           - '3.7'
-          # - '3.8'
-          # - '3.9'
+          - '3.8'
+          - '3.9'
         os:
           - ubuntu-18.04
           - windows-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/display-debug-info
       - id: check-pr-approval
-        uses: ./.github/actions/check-pr-approved
+        uses: ./.github/actions/check-pr-approval
         if: contains(github.event_name, 'pull_request')
         with:
           number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,26 +19,104 @@ on:
   pull_request:
     types:
       - labeled
+      - synchronize
+  pull_request_review:
+    types:
+      - submitted
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  check-skip:
-    name: Check if integration tests should run
-    # NOTE: the name of the special label is hardcoded here
-    # it would be better to extract it to a more global location, e.g. the workflow-level env context,
-    # but the env context is not available in job-level if expressions (only step-level ones)
-    if: (github.event.action != 'labeled') || (github.event.label.name == 'CI:run-integration')
-    runs-on: ubuntu-latest
+  precheck:
+    name: (util) Check if should run
+    runs-on: ubuntu-20.04
+    # the ">-" YAML syntax will result in a single string without terminating newline
+    # it is used here to make the relatively complex if clause more readable by adding line breaks
+    if: >-
+      (
+        (
+          github.event.action == 'labeled'
+          && contains(github.event.label.description, 'triggers_workflow')
+          && contains(github.event.label.description, github.workflow)
+        )
+        || (
+          github.event.action == 'submitted'
+          && github.event.review.state == 'APPROVED'
+        )
+        || github.event.action == 'synchronize'
+        || !contains(github.event_name, 'pull_request')
+      )
+    outputs:
+      is-pr-approved: ${{ steps.check-pr-approval.outputs.is-approved }}
+      workflow-trigger: ${{ steps.determine-trigger.outputs.workflow-trigger }}
     steps:
-      - name: Notify
-        run: echo "The integration tests will run"
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/display-debug-info
+      - id: check-pr-approval
+        uses: ./.github/actions/check-pr-approved
+        if: contains(github.event_name, 'pull_request')
+        with:
+          number: ${{ github.event.pull_request.number }}
+      - name: Process intermediate steps outputs
+        run: |
+          jq . <<EOF
+          ${{ toJSON(steps) }}
+          EOF
+          echo "steps.check-pr-approval.outputs.is-approved=${{ steps.check-pr-approval.outputs.is-approved }}"
+          # make "is_pr_approved" available to next steps as an env variable
+          echo "is_pr_approved=${{ steps.check-pr-approval.outputs.is-approved }}" >> $GITHUB_ENV
+      - id: determine-trigger
+        name: Determine workflow trigger
+        env:
+          _GITHUB_EVENT_ACTION: ${{ github.event.action }}
+        shell: python {0}
+        run: |
+          import json
+          from os import environ as env
+
+          def _display_on_run_dashboard(msg):
+              # workflow warnings are displayed on the workflow run dashboard,
+              # so we use this as a way to display a short summary of why this workflow is being run
+              # without having to dig in each job's log output
+              print(f'::warning ::{msg}')
+          def _set_output(name, val):
+              print(f'::set-output name={name}::{val}')
+
+          event_name = env["GITHUB_EVENT_NAME"]
+          event_action = env["_GITHUB_EVENT_ACTION"]
+          is_pr = 'pull_request' in event_name.lower()
+          # if the event is not a PR event, the "is_pr_approved" env var will be set to an empty string,
+          # which cannot be parsed as valid json
+          is_pr_approved = json.loads(env.get("is_pr_approved") or "null")
+
+          workflow_trigger = 'undetermined'
+
+          if is_pr:
+              if event_action == 'labeled':
+                  workflow_trigger = 'user_dispatch'
+              elif is_pr_approved is True:
+                  workflow_trigger = 'approved_pr'
+              elif is_pr_approved is False:
+                  workflow_trigger = 'unapproved_pr'
+          else:
+              workflow_trigger = 'not_pr'
+
+          msg = f'{workflow_trigger=}    event/action={event_name}/{event_action or "N/A"}    is_pr_approved={is_pr_approved or "N/A"}'
+          _display_on_run_dashboard(msg)
+          _set_output('workflow-trigger', workflow_trigger)
+
   pytest:
     name: pytest (py${{ matrix.python-version }}/${{ matrix.os }}/integration)
     runs-on: ${{ matrix.os }}
-    needs: [check-skip]
+    needs: [precheck]
+    if: >-
+      (
+        needs.precheck.outputs.workflow-trigger == 'user_dispatch'
+        || needs.precheck.outputs.workflow-trigger == 'not_pr'
+        || needs.precheck.outputs.workflow-trigger == 'approved_pr'
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary/Motivation
- Currently, running integration tests on a PR requires manually adding a label to the PR, which is cumbersome and not intuitive
- This PR enables integration tests to be dispatched automatically for approved PRs
- More specifically, integration tests will run:
  - As soon as the second approving review is submitted on a PR
  - When a commit is pushed to the branch of an approved PR without affecting the reviewed code (this is common when merging back changes from `main`, which required repetitive manual intervention)
  - (same as before) When the target branch is not a PR (e.g. when integration tests are run on the `main` branch as part of nightlies)
  - (same as before) When a special trigger label is added on a PR
    - This functionality is being kept, even though the vast majority of cases should be covered by the automatic triggers
    - The criteria used to identify the trigger label have been tweaked, so that it's easier to manipulate in other workflows, such as e.g. automatically removing the label (and thus "resetting" the trigger) as implemented in #222

## Changes proposed in this PR:
- Add functionality to programmatically determine a PR's review approval status
- Improve clarity and robustness when deciding whether integration tests should run or be skipped
- Improve distinguishing between actual CI jobs and utility jobs by prefixing utility jobs names with "(util)"

## Implementation details

- GitHub does not offer a direct way to determine a PR's overall approval status (as opposed to a single review's), so this required a bit of trial and error to get right
- The solution in this PR is relatively straightforward, using (documented) functionality of the issue/PR search API to get a list of approved open PRs, and then searching if the PR from where the workflow was triggered is among them
  - This does not require authentication or particular permissions, and therefore can be run directly on `pull_request` events triggered from forks (which run in CI environment with very limited permissions for security reasons)
  - Using only tools that are already available on the CI runners means that utility jobs to determine whether all trigger conditions are set can be run very quickly (< 5 s)


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
