### PR TITLE
Add utility workflow to remove labels used to trigger CI workflows

### DIFF
--- a/.github/workflows/util-cleanup.yml
+++ b/.github/workflows/util-cleanup.yml
@@ -1,0 +1,19 @@
+name: (util) Cleanup
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  clean-labels:
+    name: (util) Remove workflow trigger labels
+    runs-on: ubuntu-latest
+    if: contains(github.event.label.description, 'triggers_workflow')
+    env:
+      GITHUB_TOKEN: ${{ secrets.IDAES_BUILD_TOKEN }}
+      pull_number: ${{ github.event.pull_request.number }}
+      label_name: ${{ github.event.label.name }}
+    steps:
+      - name: Issue API call to remove label
+        run:
+          gh api --method DELETE "repos/$GITHUB_REPOSITORY/issues/$pull_number/labels/$label_name"


### PR DESCRIPTION
## Summary/Motivation
- Because of security contraints built into GitHub Actions, there is no direct way to manually dispatch a workflow so that it runs on a PR branch coming from a fork of the main repository
- To work around this limitation without bypassing the security measures, one of the event types allowed for PRs can be used as a makeshift trigger, as long as the workflow is set up to include this event type among its triggers
- An example of this is the integration tests workflow, that is set up to trigger when a specific label is added to the PR
- This current approach works, but has a few shortcomings:
  - The actual triggering event is emitted when the label is added, so if the trigger label is already present on the PR, it must be removed and then added again, which is cumbersome and not very intuitive
  - Additionally, if the label is not manually removed immediately after being applied, it will stay on the PR together with the actual (non-trigger) labels, contributing to visual noise

## Changes proposed in this PR:
- Add utility GitHub Actions workflow containing a job to remove labels used to trigger CI workflows

## Implementation details

- The workflow is triggered when a label is added to a PR
- If the label that was added is not identified as a trigger label, the workflow will be skipped
- Otherwise, the label will be removed
  - The label removal event will be associated with the account corresponding to the access token specified 
- This workflow uses the secure [`pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event, which isolates the CI environment from the (potentially arbitrary) code contained in the PR branch
- Both the workflow and the label removal job have their name prefixed by "(util)" to make it easier to distinguish them from the actual workflows in the various GitHub interfaces where workflow runs and checks are displayed

## For reviewers
- The `pull_request_target` event only triggers workflows defined on a repository's default branch, so this will need to be merged into `main` to verify whether it works properly in this repository
  - The workflow has been tested extensively in the separate repository that I'm using for GitHub Actions development
- In any case, this is a standalone workflow that doesn't affect any of the other workflows, so it shouldn't require particular extra precautions before being merged in
- Taking this into account, I've marked this as high priority. This is not particularly urgent per se, but having it available before cutting the release (together with #221) would reduce some of the manual work related to reviewing and merging PRs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
