### PR TITLE
Add section on installing IDAES using Conda to installation docs

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -179,6 +179,37 @@ Powershell Prompt.  Regardless of OS and shell, the following steps are the same
    output. You can report problems on the |github-issues|
    (Please try to be specific about the command and the offending output.)
 
+**Install IDAES using Conda**
+
+As an alternative to the ``pip install`` method described above, IDAES can also be installed using the Conda package manager.
+
+1. Create a new Conda environment with a name of your choice (in this example, ``my-idaes-env``)::
+
+    conda create --yes --name my-idaes-env python=3.8
+
+..
+
+    .. note:: The ``--yes`` optional flag can be used to perform the installation without having it pausing to ask for confirmation.
+
+2. Activate the ``my-idaes-env`` Conda environment::
+
+    conda activate my-idaes-env
+
+..
+
+    .. note:: This step is needed when starting a new session or a new console tab/window.
+
+3. Install the IDAES Conda package using the ``conda install`` subcommand::
+
+    conda install --yes -c IDAES-PSE -c conda-forge idaes-pse
+
+..
+
+    .. note:: The most recent stable release will be selected by default.
+              To instead select a particular version, specify the version tag using an ``=`` after the package name, e.g. ``idaes-pse=1.9.0rc0``.
+
+4. To complete the installation, follow the instructions described in the previous section from Step 2 ("Run the ``idaes get-extensions`` command...") onward.
+
 Optional Dependencies
 ---------------------
 Some tools in IDAES may require additional dependencies. Instructions for installing these dependencies


### PR DESCRIPTION
## Summary/Motivation
- Now that a Conda package is available for `idaes-pse`, add instructions on how to install it to the general installation docs (issue #233)

## Changes proposed in this PR:
- Add "Install IDAES using Conda" section to installation docs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
