### PR TITLE
Adding scaling support to generic properties framework

### DIFF
--- a/idaes/core/property_meta.py
+++ b/idaes/core/property_meta.py
@@ -290,6 +290,8 @@ class PropertyClassMetadata(object):
                                  self.default_units["length"]**-3),
                 "density_mole": (self.default_units["amount"] *
                                  self.default_units["length"]**-3),
+                "molecular_weight": (self.default_units["mass"] /
+                                     self.default_units["amount"]),
                 "energy": (self.default_units["mass"] *
                            self.default_units["length"]**2 *
                            self.default_units["time"]**-2),

--- a/idaes/core/util/phase_equilibria.py
+++ b/idaes/core/util/phase_equilibria.py
@@ -123,6 +123,7 @@ def Txy_data(model, component_1, component_2, pressure, num_points = 20, tempera
     model.props[1].pressure.fix(pressure)
 
     # Initialize flash unit model
+    model.props[1].calculate_scaling_factors()
     model.props.initialize(optarg=solver_op, outlvl=print_level)
 
     solver = SolverFactory('ipopt')

--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -243,8 +243,8 @@ def populate_default_scaling_factors(c):
                 "fug_phase_comp": (1e4*pyo.units.Pa, "pressure"),
                 "fug_coeff_phase_comp": (1*pyo.units.dimensionless, None),
                 "gibbs_mol": (1e4*pyo.units.J/pyo.units.mol, "energy_mole"),
-                "mole_frac_comp": (0.01*pyo.units.dimensionless, None),
-                "mole_frac_phase_comp": (0.01*pyo.units.dimensionless, None),
+                "mole_frac_comp": (0.001*pyo.units.dimensionless, None),
+                "mole_frac_phase_comp": (0.001*pyo.units.dimensionless, None),
                 "mw": (1e-3*pyo.units.kg/pyo.units.mol, "molecular_weight"),
                 "mw_phase": (1e-3*pyo.units.kg/pyo.units.mol,
                              "molecular_weight")}

--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -103,7 +103,7 @@ def min_scaling_factor(iter, default=1, warning=True):
     minimum scaling factor.
 
     Args:
-        iter: Iterable yeilding Pyomo componentes
+        iter: Iterable yeilding Pyomo components
         default: The default value used when a scaling factor is missing.  If
             None, this will raise an exception when scaling factors are missing.
             The default is default=1.

--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -229,7 +229,7 @@ def populate_default_scaling_factors(c):
     """
     Method to set default scaling factors for a number of common quantities
     based of typical values expressed in SI units. Values are converted to
-    those used by the proeprty package using Pyomo's unit conversion tools.
+    those used by the property package using Pyomo's unit conversion tools.
     """
     units = c.get_metadata().derived_units
 

--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -27,6 +27,8 @@ variables to calculate additional scaling factors.
 
 __author__ = "John Eslick, Tim Bartholomew"
 
+from math import log10
+
 import pyomo.environ as pyo
 from pyomo.core.expr import current as EXPR
 from pyomo.core.expr.visitor import identify_variables
@@ -98,7 +100,7 @@ def map_scaling_factor(iter, default=1, warning=False, func=min):
 
 def min_scaling_factor(iter, default=1, warning=True):
     """Map get_scaling_factor to an iterable of Pyomo components, and get the
-    minimum caling factor.
+    minimum scaling factor.
 
     Args:
         iter: Iterable yeilding Pyomo componentes
@@ -221,6 +223,43 @@ def unset_scaling_factor(c, data_objects=True):
                 del cdat.parent_block().scaling_factor[cdat]
     except (AttributeError, KeyError):
         pass # no scaling factor suffix, is fine
+
+
+def populate_default_scaling_factors(c):
+    """
+    Method to set default scaling factors for a number of common quantities
+    based of typical values expressed in SI units. Values are converted to
+    those used by the proeprty package using Pyomo's unit conversion tools.
+    """
+    units = c.get_metadata().derived_units
+
+    si_scale = {"temperature": (100*pyo.units.K, "temperature"),
+                "pressure": (1e5*pyo.units.Pa, "pressure"),
+                "dens_mol_phase": (100*pyo.units.mol/pyo.units.m**3,
+                                   "density_mole"),
+                "enth_mol": (1e4*pyo.units.J/pyo.units.mol, "energy_mole"),
+                "entr_mol": (100*pyo.units.J/pyo.units.mol/pyo.units.K,
+                             "entropy_mole"),
+                "fug_phase_comp": (1e4*pyo.units.Pa, "pressure"),
+                "fug_coeff_phase_comp": (1*pyo.units.dimensionless, None),
+                "gibbs_mol": (1e4*pyo.units.J/pyo.units.mol, "energy_mole"),
+                "mole_frac_comp": (0.01*pyo.units.dimensionless, None),
+                "mole_frac_phase_comp": (0.01*pyo.units.dimensionless, None),
+                "mw": (1e-3*pyo.units.kg/pyo.units.mol, "molecular_weight"),
+                "mw_phase": (1e-3*pyo.units.kg/pyo.units.mol,
+                             "molecular_weight")}
+
+    for p, f in si_scale.items():
+        # If a defautl scaling factor exists, do not over write it
+        if p not in c.default_scaling_factor.keys():
+            if f[1] is not None:
+                v = pyo.units.convert(f[0], to_units=units[f[1]])
+            else:
+                v = f[0]
+
+            sf = 1/(10**round(log10(pyo.value(v))))
+
+            c.set_default_scaling(p, sf)
 
 
 def __set_constraint_transform_applied_scaling_factor(c, v):

--- a/idaes/generic_models/properties/core/eos/ceos.py
+++ b/idaes/generic_models/properties/core/eos/ceos.py
@@ -298,6 +298,10 @@ class Cubic(EoSBase):
                                          function="ceos_z_vap"))
 
     @staticmethod
+    def calculate_scaling_factors(b, pobj):
+        pass
+
+    @staticmethod
     def build_parameters(b):
         b._cubic_type = b.config.equation_of_state_options["type"]
         cname = b._cubic_type.name

--- a/idaes/generic_models/properties/core/eos/enrtl.py
+++ b/idaes/generic_models/properties/core/eos/enrtl.py
@@ -42,5 +42,9 @@ class ENRTL(EoSBase):
         #             .format(b.name))
         # b._return_component_list = types.MethodType(_return_component_list, b)
 
+    @staticmethod
+    def calculate_scaling_factors(b, pobj):
+        pass
+
     def build_parameters(b):
         pass

--- a/idaes/generic_models/properties/core/eos/eos_base.py
+++ b/idaes/generic_models/properties/core/eos/eos_base.py
@@ -40,6 +40,10 @@ class EoSBase():
         raise NotImplementedError(_msg(b, "common"))
 
     @staticmethod
+    def calculate_scaling_factors(b, pobj):
+        raise NotImplementedError(_msg(b, "calculate_scaling_factors"))
+
+    @staticmethod
     def build_parameters(b):
         raise NotImplementedError(_msg(b, "build_parameters"))
 

--- a/idaes/generic_models/properties/core/eos/ideal.py
+++ b/idaes/generic_models/properties/core/eos/ideal.py
@@ -32,6 +32,10 @@ class Ideal(EoSBase):
         pass
 
     @staticmethod
+    def calculate_scaling_factors(b, pobj):
+        pass
+
+    @staticmethod
     def build_parameters(b):
         # No EoS specific parameters required
         pass

--- a/idaes/generic_models/properties/core/eos/tests/test_ceos_PR.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_ceos_PR.py
@@ -50,9 +50,10 @@ def set_metadata(b):
 
 
 # Dummy methods for dummied submodules
-def dummy_pe(b, *args):
-    # Return a dummy expression for the constraint
-    return b.temperature == 100
+class dummy_pe():
+    def return_expression(b, *args):
+        # Return a dummy expression for the constraint
+        return b.temperature == 100
 
 
 def phase_equil(b, *args):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -118,6 +118,8 @@ class TestStateBlock(object):
                 [1],
                 default={"defined_state": True})
 
+        model.props[1].calculate_scaling_factors()
+
         return model
 
     @pytest.mark.unit
@@ -188,6 +190,57 @@ class TestStateBlock(object):
         model.props[1].mole_frac_comp["toluene"].fix(0.5)
 
         assert degrees_of_freedom(model.props[1]) == 0
+
+    @pytest.mark.unit
+    def test_basic_scaling(self, model):
+
+        assert len(model.props[1].scaling_factor) == 24
+        assert model.props[1].scaling_factor[model.props[1].flow_mol] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_phase["Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_phase["Vap"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_comp["benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_comp["toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Vap", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Vap", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[model.props[1].pressure] == 1e-5
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature] == 1e-2
+        assert model.props[1].scaling_factor[model.props[1]._teq] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1]._teq["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1]._t1_Vap_Liq] == 1e-2
+
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub["Vap", "Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub["Vap", "Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew["Vap", "Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew["Vap", "Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_bubble] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_bubble["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_dew] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_dew["Vap", "Liq"]] == 1e-2
 
     @pytest.mark.initialize
     @pytest.mark.solver

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -199,6 +199,8 @@ class TestStateBlock(object):
                 default={"parameters": model.params,
                          "defined_state": True})
 
+        model.props[1].calculate_scaling_factors()
+
         return model
 
     @pytest.mark.unit
@@ -230,6 +232,58 @@ class TestStateBlock(object):
             assert value(model.props[1].mole_frac_comp[i]) == 0.5
 
         assert_units_consistent(model)
+
+    @pytest.mark.unit
+    def test_basic_scaling(self, model):
+
+        assert len(model.props[1].scaling_factor) == 25
+        assert model.props[1].scaling_factor[model.props[1].enth_mol] == 1e-4
+        assert model.props[1].scaling_factor[model.props[1].flow_mol] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_phase["Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_phase["Vap"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_comp["benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_comp["toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Vap", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Vap", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[model.props[1].pressure] == 1e-5
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature] == 1e-2
+        assert model.props[1].scaling_factor[model.props[1]._teq] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1]._teq["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1]._t1_Vap_Liq] == 1e-2
+
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub["Vap", "Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub["Vap", "Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew["Vap", "Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew["Vap", "Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_bubble] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_bubble["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_dew] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_dew["Vap", "Liq"]] == 1e-2
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
@@ -200,6 +200,8 @@ class TestStateBlock(object):
                 default={"parameters": model.params,
                          "defined_state": True})
 
+        model.props[1].calculate_scaling_factors()
+
         return model
 
     @pytest.mark.unit
@@ -233,6 +235,62 @@ class TestStateBlock(object):
             assert value(model.props[1].mole_frac_comp[i]) == 0.5
 
         assert_units_consistent(model)
+
+    @pytest.mark.unit
+    def test_basic_scaling(self, model):
+
+        assert len(model.props[1].scaling_factor) == 27
+        assert model.props[1].scaling_factor[model.props[1].enth_mol] == 1e-4
+        assert model.props[1].scaling_factor[model.props[1].flow_mol] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_phase["Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_phase["Vap"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_comp["benzene"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_comp["toluene"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_comp["benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_comp["toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Vap", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Vap", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[model.props[1].pressure] == 1e-5
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature] == 1e-2
+        assert model.props[1].scaling_factor[model.props[1]._teq] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1]._teq["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1]._t1_Vap_Liq] == 1e-2
+
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub["Vap", "Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub["Vap", "Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew["Vap", "Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew["Vap", "Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_bubble] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_bubble["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_dew] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_dew["Vap", "Liq"]] == 1e-2
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
@@ -197,6 +197,8 @@ class TestStateBlock(object):
                 default={"parameters": model.params,
                          "defined_state": True})
 
+        model.props[1].calculate_scaling_factors()
+
         return model
 
     @pytest.mark.unit
@@ -225,6 +227,61 @@ class TestStateBlock(object):
             assert value(model.props[1].mole_frac_comp[i]) == 0.5
 
         assert_units_consistent(model)
+
+    @pytest.mark.unit
+    def test_basic_scaling(self, model):
+
+        assert len(model.props[1].scaling_factor) == 26
+        assert model.props[1].scaling_factor[model.props[1].flow_mol] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_phase["Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_phase["Vap"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_comp["benzene"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].flow_mol_comp["toluene"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_comp["benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_comp["toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Vap", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].mole_frac_phase_comp["Vap", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[model.props[1].pressure] == 1e-5
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature] == 1e-2
+        assert model.props[1].scaling_factor[model.props[1]._teq] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1]._teq["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1]._t1_Vap_Liq] == 1e-2
+
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub["Vap", "Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tbub["Vap", "Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew["Vap", "Liq", "benzene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1]._mole_frac_tdew["Vap", "Liq", "toluene"]] == 1000
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_bubble] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_bubble["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_dew] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].temperature_dew["Vap", "Liq"]] == 1e-2
 
     @pytest.mark.unit
     def test_define_state_vars(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -62,6 +62,8 @@ class TestBTExample(object):
                 [1],
                 default={"defined_state": True})
 
+        m.fs.state[1].calculate_scaling_factors()
+
         return m
 
     @pytest.mark.integration
@@ -500,9 +502,8 @@ class TestBTExample(object):
 
     @pytest.mark.unit
     def test_basic_scaling(self, m):
-        m.fs.state[1].calculate_scaling_factors()
 
-        assert len(m.fs.state[1].scaling_factor) == 14
+        assert len(m.fs.state[1].scaling_factor) == 24
         assert m.fs.state[1].scaling_factor[m.fs.state[1].flow_mol] == 1e-2
         assert m.fs.state[1].scaling_factor[
             m.fs.state[1].flow_mol_phase["Liq"]] == 1e-2
@@ -526,3 +527,24 @@ class TestBTExample(object):
         assert m.fs.state[1].scaling_factor[
             m.fs.state[1]._teq["Vap", "Liq"]] == 1e-2
         assert m.fs.state[1].scaling_factor[m.fs.state[1]._t1_Vap_Liq] == 1e-2
+
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1]._mole_frac_tbub] == 1000
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1]._mole_frac_tbub["Vap", "Liq", "benzene"]] == 1000
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1]._mole_frac_tbub["Vap", "Liq", "toluene"]] == 1000
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1]._mole_frac_tdew] == 1000
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1]._mole_frac_tdew["Vap", "Liq", "benzene"]] == 1000
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1]._mole_frac_tdew["Vap", "Liq", "toluene"]] == 1000
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].temperature_bubble] == 1e-2
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].temperature_bubble["Vap", "Liq"]] == 1e-2
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].temperature_dew] == 1e-2
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].temperature_dew["Vap", "Liq"]] == 1e-2

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -505,7 +505,7 @@ class TestBTExample(object):
         print(m.fs.props.default_scaling_factor)
         m.fs.state[1].scaling_factor.display()
 
-        assert len(m.fs.state[1].scaling_factor) == 13
+        assert len(m.fs.state[1].scaling_factor) == 14
         assert m.fs.state[1].scaling_factor[m.fs.state[1].flow_mol] == 1e-2
         assert m.fs.state[1].scaling_factor[
             m.fs.state[1].flow_mol_phase["Liq"]] == 1e-2
@@ -528,3 +528,4 @@ class TestBTExample(object):
         assert m.fs.state[1].scaling_factor[m.fs.state[1]._teq] == 1e-2
         assert m.fs.state[1].scaling_factor[
             m.fs.state[1]._teq["Vap", "Liq"]] == 1e-2
+        assert m.fs.state[1].scaling_factor[m.fs.state[1]._t1_Vap_Liq] == 1e-2

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -505,7 +505,7 @@ class TestBTExample(object):
         print(m.fs.props.default_scaling_factor)
         m.fs.state[1].scaling_factor.display()
 
-        assert len(m.fs.state[1].scaling_factor) == 11
+        assert len(m.fs.state[1].scaling_factor) == 13
         assert m.fs.state[1].scaling_factor[m.fs.state[1].flow_mol] == 1e-2
         assert m.fs.state[1].scaling_factor[
             m.fs.state[1].flow_mol_phase["Liq"]] == 1e-2
@@ -525,3 +525,6 @@ class TestBTExample(object):
             m.fs.state[1].mole_frac_phase_comp["Vap", "toluene"]] == 100
         assert m.fs.state[1].scaling_factor[m.fs.state[1].pressure] == 1e-5
         assert m.fs.state[1].scaling_factor[m.fs.state[1].temperature] == 1e-2
+        assert m.fs.state[1].scaling_factor[m.fs.state[1]._teq] == 1e-2
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1]._teq["Vap", "Liq"]] == 1e-2

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -502,9 +502,6 @@ class TestBTExample(object):
     def test_basic_scaling(self, m):
         m.fs.state[1].calculate_scaling_factors()
 
-        print(m.fs.props.default_scaling_factor)
-        m.fs.state[1].scaling_factor.display()
-
         assert len(m.fs.state[1].scaling_factor) == 14
         assert m.fs.state[1].scaling_factor[m.fs.state[1].flow_mol] == 1e-2
         assert m.fs.state[1].scaling_factor[
@@ -512,17 +509,17 @@ class TestBTExample(object):
         assert m.fs.state[1].scaling_factor[
             m.fs.state[1].flow_mol_phase["Vap"]] == 1e-2
         assert m.fs.state[1].scaling_factor[
-            m.fs.state[1].mole_frac_comp["benzene"]] == 100
+            m.fs.state[1].mole_frac_comp["benzene"]] == 1000
         assert m.fs.state[1].scaling_factor[
-            m.fs.state[1].mole_frac_comp["toluene"]] == 100
+            m.fs.state[1].mole_frac_comp["toluene"]] == 1000
         assert m.fs.state[1].scaling_factor[
-            m.fs.state[1].mole_frac_phase_comp["Liq", "benzene"]] == 100
+            m.fs.state[1].mole_frac_phase_comp["Liq", "benzene"]] == 1000
         assert m.fs.state[1].scaling_factor[
-            m.fs.state[1].mole_frac_phase_comp["Liq", "toluene"]] == 100
+            m.fs.state[1].mole_frac_phase_comp["Liq", "toluene"]] == 1000
         assert m.fs.state[1].scaling_factor[
-            m.fs.state[1].mole_frac_phase_comp["Vap", "benzene"]] == 100
+            m.fs.state[1].mole_frac_phase_comp["Vap", "benzene"]] == 1000
         assert m.fs.state[1].scaling_factor[
-            m.fs.state[1].mole_frac_phase_comp["Vap", "toluene"]] == 100
+            m.fs.state[1].mole_frac_phase_comp["Vap", "toluene"]] == 1000
         assert m.fs.state[1].scaling_factor[m.fs.state[1].pressure] == 1e-5
         assert m.fs.state[1].scaling_factor[m.fs.state[1].temperature] == 1e-2
         assert m.fs.state[1].scaling_factor[m.fs.state[1]._teq] == 1e-2

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -506,11 +506,11 @@ class TestBTExample(object):
         m.fs.state[1].scaling_factor.display()
 
         assert len(m.fs.state[1].scaling_factor) == 11
-        assert m.fs.state[1].scaling_factor[m.fs.state[1].flow_mol] == 1.0
+        assert m.fs.state[1].scaling_factor[m.fs.state[1].flow_mol] == 1e-2
         assert m.fs.state[1].scaling_factor[
-            m.fs.state[1].flow_mol_phase["Liq"]] == 1.0
+            m.fs.state[1].flow_mol_phase["Liq"]] == 1e-2
         assert m.fs.state[1].scaling_factor[
-            m.fs.state[1].flow_mol_phase["Vap"]] == 1.0
+            m.fs.state[1].flow_mol_phase["Vap"]] == 1e-2
         assert m.fs.state[1].scaling_factor[
             m.fs.state[1].mole_frac_comp["benzene"]] == 100
         assert m.fs.state[1].scaling_factor[

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -497,3 +497,31 @@ class TestBTExample(object):
                 value(m.fs.state[1].entr_mol_phase["Liq"]), 1e-5) == -372.869
         assert pytest.approx(
                 value(m.fs.state[1].entr_mol_phase["Vap"]), 1e-5) == -278.766
+
+    @pytest.mark.unit
+    def test_basic_scaling(self, m):
+        m.fs.state[1].calculate_scaling_factors()
+
+        print(m.fs.props.default_scaling_factor)
+        m.fs.state[1].scaling_factor.display()
+
+        assert len(m.fs.state[1].scaling_factor) == 11
+        assert m.fs.state[1].scaling_factor[m.fs.state[1].flow_mol] == 1.0
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].flow_mol_phase["Liq"]] == 1.0
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].flow_mol_phase["Vap"]] == 1.0
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].mole_frac_comp["benzene"]] == 100
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].mole_frac_comp["toluene"]] == 100
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].mole_frac_phase_comp["Liq", "benzene"]] == 100
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].mole_frac_phase_comp["Liq", "toluene"]] == 100
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].mole_frac_phase_comp["Vap", "benzene"]] == 100
+        assert m.fs.state[1].scaling_factor[
+            m.fs.state[1].mole_frac_phase_comp["Vap", "toluene"]] == 100
+        assert m.fs.state[1].scaling_factor[m.fs.state[1].pressure] == 1e-5
+        assert m.fs.state[1].scaling_factor[m.fs.state[1].temperature] == 1e-2

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -156,6 +156,53 @@ class TestStateBlock(object):
         assert_units_consistent(model)
 
     @pytest.mark.unit
+    def test_basic_scaling(self, model):
+        model.fs.props[1].calculate_scaling_factors()
+        model.fs.props[1].scaling_factor.display()
+
+        assert len(model.fs.props[1].scaling_factor) == 18
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].flow_mol] == 1e-2
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].flow_mol_phase["Liq"]] == 1e-2
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].flow_mol_phase["Vap"]] == 1e-2
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].mole_frac_comp["bmimPF6"]] == 1000
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].mole_frac_comp["carbon_dioxide"]] == 1000
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].mole_frac_phase_comp["Liq", "bmimPF6"]] == 1000
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].mole_frac_phase_comp[
+                "Liq", "carbon_dioxide"]] == 1000
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].mole_frac_phase_comp[
+                "Vap", "carbon_dioxide"]] == 1000
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].pressure] == 1e-5
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].temperature] == 1e-2
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1]._teq] == 1e-2
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1]._teq["Vap", "Liq"]] == 1e-2
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1]._t1_Vap_Liq] == 1e-2
+
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1]._mole_frac_tbub] == 1000
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1]._mole_frac_tbub["Vap", "Liq", "bmimPF6"]] == 1000
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1]._mole_frac_tbub[
+                "Vap", "Liq", "carbon_dioxide"]] == 1000
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].temperature_bubble] == 1e-2
+        assert model.fs.props[1].scaling_factor[
+            model.fs.props[1].temperature_bubble["Vap", "Liq"]] == 1e-2
+
+    @pytest.mark.unit
     def test_define_state_vars(self, model):
         sv = model.fs.props[1].define_state_vars()
 
@@ -215,14 +262,13 @@ class TestFlashIntegration(object):
 
         assert degrees_of_freedom(model.fs) == 0
 
+        # Apply scaling - model will not solver without this
+        model.fs.unit.control_volume.properties_in[
+            0].calculate_scaling_factors()
+        model.fs.unit.control_volume.properties_out[
+            0].calculate_scaling_factors()
+
         return model
-
-    @pytest.mark.component
-    def test_scaling(self, model):
-        model.fs.unit.control_volume.properties_in[0].calculate_scaling_factors()
-        model.fs.unit.control_volume.properties_out[0].calculate_scaling_factors()
-
-        assert False
 
     @pytest.mark.component
     def test_initialize(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -203,6 +203,20 @@ class TestStateBlock(object):
         assert degrees_of_freedom(model.fs.unit) == 0
 
     @pytest.mark.component
+    def test_scaling(self, model):
+
+        # model.fs.unit.control_volume.properties_in[0].calculate_scaling_factors()
+        # model.fs.unit.control_volume.properties_out[0].calculate_scaling_factors()
+        import idaes.core.util.scaling as iscale
+        iscale.constraint_scaling_transform(
+                model.fs.unit.control_volume.properties_in[0].eq_mole_frac_tbub["Vap", "Liq"], 1e3)
+        iscale.constraint_scaling_transform(
+                model.fs.unit.control_volume.properties_out[0].eq_mole_frac_tbub["Vap", "Liq"], 1e3)
+        
+        model.fs.unit.control_volume.properties_out[0].eq_mole_frac_tbub.pprint()
+        assert False
+
+    @pytest.mark.component
     def test_initialize(self, model):
 
         initialization_tester(model, dof=0)

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -772,7 +772,6 @@ class GenericParameterData(PhysicalParameterBlock):
         # Set default scaling factors
         # First, call set_dfault_scaling_factors method from state definiton
         try:
-            print("In try")
             self.config.state_definition.define_default_scaling_factors(self)
         except AttributeError:
             pass

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -190,7 +190,7 @@ class GenericParameterData(PhysicalParameterBlock):
     CONFIG.declare("default_scaling_factors", ConfigValue(
         domain=dict,
         description="User-defined default scaling factors",
-        doc="Dict of user-defined proeprties and associated default "
+        doc="Dict of user-defined properties and associated default "
         "scaling factors"))
 
     def build(self):

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1414,6 +1414,10 @@ class GenericStateBlockData(StateBlockData):
                 doc="Inherent reaction equilibrium constraint",
                 rule=equil_rule)
 
+    def calculate_scaling_factors(self):
+        # Get default scale factors and do calculations from base classes
+        super().calculate_scaling_factors()
+
     def components_in_phase(self, phase):
         """
         Generator method which yields components present in a given phase.

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1418,7 +1418,7 @@ class GenericStateBlockData(StateBlockData):
 
     def calculate_scaling_factors(self):
         # Get default scale factors and do calculations from base classes
-        # super().calculate_scaling_factors()
+        super().calculate_scaling_factors()
 
         sf_T = iscale.get_scaling_factor(
             self.temperature, default=1, warning=True)
@@ -1427,65 +1427,65 @@ class GenericStateBlockData(StateBlockData):
         sf_mf = iscale.get_scaling_factor(
             self.mole_frac_phase_comp, default=1e3, warning=True)
 
-        # # Add scaling for components in build method
-        # # Phase equilibrium temperature
-        # if hasattr(self, "_teq"):
-        #     iscale.set_scaling_factor(self._teq, sf_T)
+        # Add scaling for components in build method
+        # Phase equilibrium temperature
+        if hasattr(self, "_teq"):
+            iscale.set_scaling_factor(self._teq, sf_T)
 
-        # # Other EoS variables and constraints
-        # for p in self.params.phase_list:
-        #     pobj = self.params.get_phase(p)
-        #     pobj.config.equation_of_state.calculate_scaling_factors(self, pobj)
+        # Other EoS variables and constraints
+        for p in self.params.phase_list:
+            pobj = self.params.get_phase(p)
+            pobj.config.equation_of_state.calculate_scaling_factors(self, pobj)
 
-        # # Phase equilibrium constraint
-        # if hasattr(self, "equilibrium_constraint"):
-        #     pe_form_config = self.params.config.phase_equilibrium_state
-        #     for pp in self.params._pe_pairs:
-        #         pe_form_config[pp].calculate_scaling_factors(self, pp)
+        # Phase equilibrium constraint
+        if hasattr(self, "equilibrium_constraint"):
+            pe_form_config = self.params.config.phase_equilibrium_state
+            for pp in self.params._pe_pairs:
+                pe_form_config[pp].calculate_scaling_factors(self, pp)
 
-        #     for k in self.equilibrium_constraint:
-        #         sf_fug = self.params.get_component(
-        #             k[2]).config.phase_equilibrium_form[
-        #                 (k[0], k[1])].calculate_scaling_factors(
-        #                     self, k[0], k[1], k[2])
+            for k in self.equilibrium_constraint:
+                sf_fug = self.params.get_component(
+                    k[2]).config.phase_equilibrium_form[
+                        (k[0], k[1])].calculate_scaling_factors(
+                            self, k[0], k[1], k[2])
 
-        #         iscale.constraint_scaling_transform(
-        #             self.equilibrium_constraint[k], sf_fug)
+                iscale.constraint_scaling_transform(
+                    self.equilibrium_constraint[k], sf_fug)
 
-        # # Inherent reactions
-        # if hasattr(self, "k_eq"):
-        #     for r in self.params.inherent_reaction_idx:
-        #         rblock = getattr(self.params, "reaction_"+r)
-        #         carg = self.params.config.inherent_reactions[r]
-        #         sf_keq = carg[
-        #             "equilibrium_constant"].calculate_scaling_factors(
-        #                 self, rblock)
+        # Inherent reactions
+        if hasattr(self, "k_eq"):
+            for r in self.params.inherent_reaction_idx:
+                rblock = getattr(self.params, "reaction_"+r)
+                carg = self.params.config.inherent_reactions[r]
+                sf_keq = carg[
+                    "equilibrium_constant"].calculate_scaling_factors(
+                        self, rblock)
 
-        #         iscale.set_scaling_factor(self.k_eq, sf_keq)
-        #         iscale.constraint_scaling_transform(
-        #             self.inherent_equilibrium_constraint[r], sf_keq)
+                iscale.set_scaling_factor(self.k_eq, sf_keq)
+                iscale.constraint_scaling_transform(
+                    self.inherent_equilibrium_constraint[r], sf_keq)
 
         # Add scaling for additional Vars and Constraints
         # Bubble and dew points
         if hasattr(self, "_mole_frac_tbub"):
-            # iscale.set_scaling_factor(self.temperature_bubble, sf_T)
-            # iscale.set_scaling_factor(self._mole_frac_tbub, sf_mf)
+            iscale.set_scaling_factor(self.temperature_bubble, sf_T)
+            iscale.set_scaling_factor(self._mole_frac_tbub, sf_mf)
             self.params.config.bubble_dew_method.scale_temperature_bubble(self)
 
-        # if hasattr(self, "_mole_frac_tdew"):
-        #     iscale.set_scaling_factor(self.temperature_dew, sf_T)
-        #     iscale.set_scaling_factor(self._mole_frac_tdew, sf_mf)
-        #     self.params.config.bubble_dew_method.scale_temperature_dew(self)
+        if hasattr(self, "_mole_frac_tdew"):
+            iscale.set_scaling_factor(self.temperature_dew, sf_T)
+            iscale.set_scaling_factor(self._mole_frac_tdew, sf_mf)
+            self.params.config.bubble_dew_method.scale_temperature_dew(self)
 
-        # if hasattr(self, "_mole_frac_pbub"):
-        #     iscale.set_scaling_factor(self.pressure_bubble, sf_P)
-        #     iscale.set_scaling_factor(self._mole_frac_pbub, sf_mf)
-        #     self.params.config.bubble_dew_method.scale_pressure_bubble(self)
+        if hasattr(self, "_mole_frac_pbub"):
+            iscale.set_scaling_factor(self.pressure_bubble, sf_P)
+            iscale.set_scaling_factor(self._mole_frac_pbub, sf_mf)
+            self.params.config.bubble_dew_method.scale_pressure_bubble(self)
 
-        # if hasattr(self, "_mole_frac_pdew"):
-        #     iscale.set_scaling_factor(self.pressure_dew, sf_P)
-        #     iscale.set_scaling_factor(self._mole_frac_pdew, sf_mf)
-        #     self.params.config.bubble_dew_method.scale_pressure_dew(self)
+        if hasattr(self, "_mole_frac_pdew"):
+            iscale.set_scaling_factor(self.pressure_dew, sf_P)
+            iscale.set_scaling_factor(self._mole_frac_pdew, sf_mf)
+            self.params.config.bubble_dew_method.scale_pressure_dew(self)
 
     def components_in_phase(self, phase):
         """

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -772,7 +772,8 @@ class GenericParameterData(PhysicalParameterBlock):
         # Set default scaling factors
         # First, call set_dfault_scaling_factors method from state definiton
         try:
-            self.config.state_definition.set_default_scaling_factors(self)
+            print("In try")
+            self.config.state_definition.define_default_scaling_factors(self)
         except AttributeError:
             pass
         # Next, apply any user-defined scaling factors

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1420,6 +1420,9 @@ class GenericStateBlockData(StateBlockData):
         # Get default scale factors and do calculations from base classes
         super().calculate_scaling_factors()
 
+        # Sclae state variables and associated constraints
+        self.params.config.state_definition.calculate_scaling_factors(self)
+
         sf_T = iscale.get_scaling_factor(
             self.temperature, default=1, warning=True)
         sf_P = iscale.get_scaling_factor(

--- a/idaes/generic_models/properties/core/generic/tests/dummy_eos.py
+++ b/idaes/generic_models/properties/core/generic/tests/dummy_eos.py
@@ -31,6 +31,10 @@ def common(b, pobj):
         b.eos_common = 1
 
 
+def calculate_scaling_factors(b, pobj):
+    pass
+
+
 def build_parameters(b):
     if not hasattr(b, "dummy_param"):
         b.dummy_param = Var(initialize=42)

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -915,8 +915,8 @@ class TestGenericParameterBlock(object):
         assert dsf[("fug_phase_comp", None)] == 1e-4
         assert dsf[("fug_coeff_phase_comp", None)] == 1
         assert dsf[("gibbs_mol", None)] == 1e-4
-        assert dsf[("mole_frac_comp", None)] == 1e2
-        assert dsf[("mole_frac_phase_comp", None)] == 1e2
+        assert dsf[("mole_frac_comp", None)] == 1e3
+        assert dsf[("mole_frac_phase_comp", None)] == 1e3
         assert dsf[("mw", None)] == 1e3
         assert dsf[("mw_phase", None)] == 1e3
 
@@ -949,8 +949,8 @@ class TestGenericParameterBlock(object):
         assert dsf[("fug_phase_comp", None)] == 1e-7
         assert dsf[("fug_coeff_phase_comp", None)] == 1
         assert dsf[("gibbs_mol", None)] == 1e-9
-        assert dsf[("mole_frac_comp", None)] == 1e2
-        assert dsf[("mole_frac_phase_comp", None)] == 1e2
+        assert dsf[("mole_frac_comp", None)] == 1e3
+        assert dsf[("mole_frac_phase_comp", None)] == 1e3
         assert dsf[("mw", None)] == 1e3
         assert dsf[("mw_phase", None)] == 1e3
 
@@ -1007,14 +1007,14 @@ class TestGenericStateBlock(object):
         assert frame.props[1].scaling_factor[
             frame.props[1].pressure] == 1e-5
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["p1", "a"]] == 100
+            frame.props[1].mole_frac_phase_comp["p1", "a"]] == 1000
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["p1", "b"]] == 100
+            frame.props[1].mole_frac_phase_comp["p1", "b"]] == 1000
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["p1", "c"]] == 100
+            frame.props[1].mole_frac_phase_comp["p1", "c"]] == 1000
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["p2", "a"]] == 100
+            frame.props[1].mole_frac_phase_comp["p2", "a"]] == 1000
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["p2", "b"]] == 100
+            frame.props[1].mole_frac_phase_comp["p2", "b"]] == 1000
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["p2", "c"]] == 100
+            frame.props[1].mole_frac_phase_comp["p2", "c"]] == 1000

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -890,6 +890,71 @@ class TestGenericParameterBlock(object):
                     "e1": {"stoichiometry": {("p1", "a"): -3,
                                              ("p1", "b"): 4}}}})
 
+    @pytest.mark.unit
+    def test_default_scaling(self):
+        m = ConcreteModel()
+        m.params = DummyParameterBlock(default={
+                "components": {"a": {}, "b": {}, "c": {}},
+                "phases": {
+                    "p1": {"type": LiquidPhase,
+                           "component_list": ["a", "b"],
+                           "equation_of_state": dummy_eos},
+                    "p2": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": base_units})
+
+        dsf = m.params.default_scaling_factor
+
+        assert dsf[("temperature", None)] == 1e-2
+        assert dsf[("pressure", None)] == 1e-5
+        assert dsf[("dens_mol_phase", None)] == 1e-2
+        assert dsf[("enth_mol", None)] == 1e-4
+        assert dsf[("entr_mol", None)] == 1e-2
+        assert dsf[("fug_phase_comp", None)] == 1e-4
+        assert dsf[("fug_coeff_phase_comp", None)] == 1
+        assert dsf[("gibbs_mol", None)] == 1e-4
+        assert dsf[("mole_frac_comp", None)] == 1e2
+        assert dsf[("mole_frac_phase_comp", None)] == 1e2
+        assert dsf[("mw", None)] == 1e3
+        assert dsf[("mw_phase", None)] == 1e3
+
+
+    @pytest.mark.unit
+    def test_default_scaling_convert(self):
+        m = ConcreteModel()
+        m.params = DummyParameterBlock(default={
+                "components": {"a": {}, "b": {}, "c": {}},
+                "phases": {
+                    "p1": {"type": LiquidPhase,
+                           "component_list": ["a", "b"],
+                           "equation_of_state": dummy_eos},
+                    "p2": {"equation_of_state": dummy_eos}},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300,
+                "base_units": {"time": pyunits.minutes,
+                               "length": pyunits.foot,
+                               "mass": pyunits.pound,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.degR}})
+
+        dsf = m.params.default_scaling_factor
+
+        assert dsf[("temperature", None)] == 1e-2
+        assert dsf[("pressure", None)] == 1e-8
+        assert dsf[("dens_mol_phase", None)] == 1
+        assert dsf[("enth_mol", None)] == 1e-9
+        assert dsf[("entr_mol", None)] == 1e-7
+        assert dsf[("fug_phase_comp", None)] == 1e-7
+        assert dsf[("fug_coeff_phase_comp", None)] == 1
+        assert dsf[("gibbs_mol", None)] == 1e-9
+        assert dsf[("mole_frac_comp", None)] == 1e2
+        assert dsf[("mole_frac_phase_comp", None)] == 1e2
+        assert dsf[("mw", None)] == 1e3
+        assert dsf[("mw_phase", None)] == 1e3
+
 
 # -----------------------------------------------------------------------------
 # Dummy methods for testing build calls to sub-modules

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -920,7 +920,6 @@ class TestGenericParameterBlock(object):
         assert dsf[("mw", None)] == 1e3
         assert dsf[("mw_phase", None)] == 1e3
 
-
     @pytest.mark.unit
     def test_default_scaling_convert(self):
         m = ConcreteModel()
@@ -997,3 +996,25 @@ class TestGenericStateBlock(object):
         assert frame.props[1].state_defined
         assert isinstance(frame.props[1].dummy_var, Var)
         assert frame.props[1].eos_common == 2
+
+    @pytest.mark.unit
+    def test_basic_scaling(self, frame):
+        frame.props[1].calculate_scaling_factors()
+
+        assert len(frame.props[1].scaling_factor) == 8
+        assert frame.props[1].scaling_factor[
+            frame.props[1].temperature] == 0.01
+        assert frame.props[1].scaling_factor[
+            frame.props[1].pressure] == 1e-5
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["p1", "a"]] == 100
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["p1", "b"]] == 100
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["p1", "c"]] == 100
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["p2", "a"]] == 100
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["p2", "b"]] == 100
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["p2", "c"]] == 100

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -39,6 +39,10 @@ def set_metadata(b):
     pass
 
 
+def calculate_scaling_factors(b):
+    b.scaling_check = True
+
+
 # Dummy build_parameter methods for tests
 def build_parameters(cobj, p):
     cobj.add_component("test_param_"+p, Var(initialize=42))
@@ -1000,6 +1004,8 @@ class TestGenericStateBlock(object):
     @pytest.mark.unit
     def test_basic_scaling(self, frame):
         frame.props[1].calculate_scaling_factors()
+
+        assert frame.props[1].scaling_check
 
         assert len(frame.props[1].scaling_factor) == 8
         assert frame.props[1].scaling_factor[

--- a/idaes/generic_models/properties/core/generic/utility.py
+++ b/idaes/generic_models/properties/core/generic/utility.py
@@ -16,8 +16,6 @@ Common methods used by generic framework
 Author: A Lee
 """
 
-import types
-
 from pyomo.environ import units as pyunits
 
 from idaes.core.util.exceptions import ConfigurationError, PropertyPackageError

--- a/idaes/generic_models/properties/core/phase_equil/forms.py
+++ b/idaes/generic_models/properties/core/phase_equil/forms.py
@@ -13,6 +13,7 @@
 """
 Library of common forms for phase equilibrium constraints
 """
+import idaes.core.util.scaling as iscale
 
 
 class fugacity():
@@ -25,6 +26,15 @@ class fugacity():
                 b.params.get_phase(phase2).config.equation_of_state
                 .fug_phase_comp_eq(b, phase2, comp, pp))
 
+    @staticmethod
+    def calculate_scaling_factors(b, phase1, phase2, comp):
+        sf_1 = iscale.get_scaling_factor(
+            b.fug_phase_comp[phase1, comp], default=1, warning=True)
+        sf_2 = iscale.get_scaling_factor(
+            b.fug_phase_comp[phase2, comp], default=1, warning=True)
+
+        return min(sf_1, sf_2)
+
 
 class log_fugacity():
 
@@ -35,3 +45,8 @@ class log_fugacity():
                 .log_fug_phase_comp_eq(b, phase1, comp, pp) ==
                 b.params.get_phase(phase2).config.equation_of_state
                 .log_fug_phase_comp_eq(b, phase2, comp, pp))
+
+    @staticmethod
+    def calculate_scaling_factors(b, phase1, phase2, comp):
+        # For log fugacity, assume already well scaled
+        return 1

--- a/idaes/generic_models/properties/core/phase_equil/forms.py
+++ b/idaes/generic_models/properties/core/phase_equil/forms.py
@@ -15,17 +15,23 @@ Library of common forms for phase equilibrium constraints
 """
 
 
-def fugacity(b, phase1, phase2, comp):
-    pp = (phase1, phase2)
-    return (b.params.get_phase(phase1)
-            .config.equation_of_state.fug_phase_comp_eq(b, phase1, comp, pp) ==
-            b.params.get_phase(phase2)
-            .config.equation_of_state.fug_phase_comp_eq(b, phase2, comp, pp))
+class fugacity():
+
+    @staticmethod
+    def return_expression(b, phase1, phase2, comp):
+        pp = (phase1, phase2)
+        return (b.params.get_phase(phase1).config.equation_of_state
+                .fug_phase_comp_eq(b, phase1, comp, pp) ==
+                b.params.get_phase(phase2).config.equation_of_state
+                .fug_phase_comp_eq(b, phase2, comp, pp))
 
 
-def log_fugacity(b, phase1, phase2, comp):
-    pp = (phase1, phase2)
-    return (b.params.get_phase(phase1).config.equation_of_state
-            .log_fug_phase_comp_eq(b, phase1, comp, pp) ==
-            b.params.get_phase(phase2).config.equation_of_state
-            .log_fug_phase_comp_eq(b, phase2, comp, pp))
+class log_fugacity():
+
+    @staticmethod
+    def return_expression(b, phase1, phase2, comp):
+        pp = (phase1, phase2)
+        return (b.params.get_phase(phase1).config.equation_of_state
+                .log_fug_phase_comp_eq(b, phase1, comp, pp) ==
+                b.params.get_phase(phase2).config.equation_of_state
+                .log_fug_phase_comp_eq(b, phase2, comp, pp))

--- a/idaes/generic_models/properties/core/phase_equil/smooth_VLE.py
+++ b/idaes/generic_models/properties/core/phase_equil/smooth_VLE.py
@@ -23,6 +23,7 @@ from idaes.core.util.exceptions import ConfigurationError
 from idaes.core.util.math import smooth_max, smooth_min
 from idaes.generic_models.properties.core.phase_equil.bubble_dew import (
     _valid_VL_component_list)
+import idaes.core.util.scaling as iscale
 
 
 def phase_equil(b, phase_pair):
@@ -88,6 +89,23 @@ def phase_equil(b, phase_pair):
     b.add_component("_teq_constraint"+suffix, Constraint(rule=rule_teq))
 
 
+def calculate_scaling_factors(b, phase_pair):
+    suffix = "_"+phase_pair[0]+"_"+phase_pair[1]
+    sf_T = iscale.get_scaling_factor(
+            b.temperature, default=1, warning=True)
+
+    try:
+        _t1 = getattr(b, "_t1"+suffix)
+        _t1_cons = getattr(b, "_t1_constraint"+suffix)
+        iscale.set_scaling_factor(_t1, sf_T)
+        iscale.constraint_scaling_transform(_t1_cons, sf_T)
+    except AttributeError:
+        pass
+
+    _teq_cons = getattr(b, "_teq_constraint"+suffix)
+    iscale.constraint_scaling_transform(_teq_cons, sf_T)
+
+
 def phase_equil_initialization(b, phase_pair):
     suffix = "_"+phase_pair[0]+"_"+phase_pair[1]
 
@@ -121,3 +139,4 @@ class SmoothVLE(object):
     phase_equil = phase_equil
     phase_equil_initialization = phase_equil_initialization
     calculate_teq = calculate_teq
+    calculate_scaling_factors = calculate_scaling_factors

--- a/idaes/generic_models/properties/core/phase_equil/tests/test_forms.py
+++ b/idaes/generic_models/properties/core/phase_equil/tests/test_forms.py
@@ -63,7 +63,7 @@ def test_fugacity():
                        "amount": pyunits.mol,
                        "temperature": pyunits.K}})
 
-    assert str(fugacity(m, "Vap", "Liq", "H2O")) == str(
+    assert str(fugacity.return_expression(m, "Vap", "Liq", "H2O")) == str(
         m.x["Vap", "H2O"] == m.x["Liq", "H2O"])
 
 
@@ -92,5 +92,5 @@ def test_log_fugacity():
                        "amount": pyunits.mol,
                        "temperature": pyunits.K}})
 
-    assert str(log_fugacity(m, "Vap", "Liq", "H2O")) == str(
+    assert str(log_fugacity.return_expression(m, "Vap", "Liq", "H2O")) == str(
         42*m.x["Vap", "H2O"] == 42*m.x["Liq", "H2O"])

--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -13,7 +13,7 @@
 """
 Methods for calculating equilibrium constants
 """
-from pyomo.environ import exp, Var, units as pyunits
+from pyomo.environ import exp, Var, units as pyunits, value
 
 from idaes.generic_models.properties.core.generic.generic_reaction import \
     ConcentrationForm
@@ -80,3 +80,7 @@ class van_t_hoff():
               pyunits.convert(c.gas_constant,
                               to_units=units["gas_constant"])) *
             (1/T - 1/rblock.T_eq_ref))
+
+    @staticmethod
+    def calculate_scaling_factors(b, rblock):
+        return 1/value(rblock.k_eq_ref)

--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -14,7 +14,7 @@
 Methods for setting up FPhx as the state variables in a generic property
 package
 """
-from pyomo.environ import Constraint, NonNegativeReals, Var
+from pyomo.environ import Constraint, NonNegativeReals, Var, units as pyunits
 
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
@@ -268,16 +268,55 @@ def define_state(b):
 
 def define_default_scaling_factors(b):
     # Get bounds and initial values from config args
-    units = b.params.get_metadata().derived_units
+    units = b.get_metadata().derived_units
+    state_bounds = b.config.state_bounds
 
-    f_bounds, f_init = get_bounds_from_config(
-        b, "flow_mol_comp", units["flow_mole"])
-    h_bounds, h_init = get_bounds_from_config(
-        b, "enth_mol", units["energy_mole"])
-    p_bounds, p_init = get_bounds_from_config(
-        b, "pressure", units["pressure"])
-    t_bounds, t_init = get_bounds_from_config(
-        b, "temperature", units["temperature"])
+    if state_bounds is None:
+        return
+
+    try:
+        f_bounds = state_bounds["flow_mol_comp"]
+        if len(f_bounds) == 4:
+            f_init = pyunits.convert_value(f_bounds[1],
+                                           from_units=f_bounds[3],
+                                           to_units=units["flow_mole"])
+        else:
+            f_init = f_bounds[1]
+    except KeyError:
+        f_init = 1
+
+    try:
+        p_bounds = state_bounds["pressure"]
+        if len(p_bounds) == 4:
+            p_init = pyunits.convert_value(p_bounds[1],
+                                           from_units=p_bounds[3],
+                                           to_units=units["pressure"])
+        else:
+            p_init = p_bounds[1]
+    except KeyError:
+        p_init = 1
+
+    try:
+        h_bounds = state_bounds["enth_mol"]
+        if len(h_bounds) == 4:
+            h_init = pyunits.convert_value(h_bounds[1],
+                                           from_units=h_bounds[3],
+                                           to_units=units["energy_mole"])
+        else:
+            h_init = h_bounds[1]
+    except KeyError:
+        h_init = 1
+
+    try:
+        t_bounds = state_bounds["temperature"]
+        if len(t_bounds) == 4:
+            t_init = pyunits.convert_value(t_bounds[1],
+                                           from_units=t_bounds[3],
+                                           to_units=units["temperature"])
+        else:
+            t_init = t_bounds[1]
+    except KeyError:
+        t_init = 1
 
     # Set default scaling factors
     b.set_default_scaling("flow_mol", 1/f_init)
@@ -300,4 +339,4 @@ class FPhx(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
-    define_default_Scaling_factors = define_default_scaling_factors
+    define_default_scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -275,7 +275,7 @@ def define_default_scaling_factors(b):
         return
 
     try:
-        f_bounds = state_bounds["flow_mol_comp"]
+        f_bounds = state_bounds["flow_mol"]
         if len(f_bounds) == 4:
             f_init = pyunits.convert_value(f_bounds[1],
                                            from_units=f_bounds[3],

--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -266,6 +266,29 @@ def define_state(b):
     b.define_display_vars = define_display_vars_FPhx
 
 
+def define_default_scaling_factors(b):
+    # Get bounds and initial values from config args
+    units = b.params.get_metadata().derived_units
+
+    f_bounds, f_init = get_bounds_from_config(
+        b, "flow_mol_comp", units["flow_mole"])
+    h_bounds, h_init = get_bounds_from_config(
+        b, "enth_mol", units["energy_mole"])
+    p_bounds, p_init = get_bounds_from_config(
+        b, "pressure", units["pressure"])
+    t_bounds, t_init = get_bounds_from_config(
+        b, "temperature", units["temperature"])
+
+    # Set default scaling factors
+    b.set_default_scaling("flow_mol", 1/f_init)
+    b.set_default_scaling("flow_mol_phase", 1/f_init)
+    b.set_default_scaling("flow_mol_comp", 1/f_init)
+    b.set_default_scaling("flow_mol_phase_comp", 1/f_init)
+    b.set_default_scaling("pressure", 1/p_init)
+    b.set_default_scaling("temperature", 1/t_init)
+    b.set_default_scaling("enth_mol", 1/h_init)
+
+
 # Inherit state_initialization from FTPX form, as the process is the same
 
 
@@ -277,3 +300,4 @@ class FPhx(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
+    define_default_Scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -267,6 +267,11 @@ def define_state(b):
 
 
 def define_default_scaling_factors(b):
+    """
+    Method to set default scaling factors for the property package. Scaling
+    factors are based on the default initial value for each variable provided
+    in the state_bounds config argument.
+    """
     # Get bounds and initial values from config args
     units = b.get_metadata().derived_units
     state_bounds = b.config.state_bounds
@@ -328,6 +333,10 @@ def define_default_scaling_factors(b):
     b.set_default_scaling("enth_mol", 1/h_init)
 
 
+def calculate_scaling_factors(b):
+    pass
+
+
 # Inherit state_initialization from FTPX form, as the process is the same
 
 
@@ -340,3 +349,4 @@ class FPhx(object):
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
     define_default_scaling_factors = define_default_scaling_factors
+    calculate_scaling_factors = calculate_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -131,8 +131,8 @@ def define_state(b):
     if b.config.defined_state is False:
         # applied at outlet only
         b.sum_mole_frac_out = Constraint(
-            expr=1e3 == 1e3*sum(b.mole_frac_comp[i]
-                                for i in b.component_list))
+            expr=1 == sum(b.mole_frac_comp[i]
+                          for i in b.component_list))
 
     def rule_enth_mol(b):
         return b.enth_mol == sum(b.enth_mol_phase[p]*b.phase_frac[p]
@@ -146,8 +146,8 @@ def define_state(b):
         b.total_flow_balance = Constraint(rule=rule_total_mass_balance)
 
         def rule_comp_mass_balance(b, i):
-            return 1e3*b.mole_frac_comp[i] == \
-                1e3*b.mole_frac_phase_comp[b.phase_list[1], i]
+            return b.mole_frac_comp[i] == \
+                b.mole_frac_phase_comp[b.phase_list[1], i]
         b.component_flow_balances = Constraint(b.component_list,
                                                rule=rule_comp_mass_balance)
 
@@ -172,14 +172,12 @@ def define_state(b):
                                                rule=rule_comp_mass_balance)
 
         def rule_mole_frac(b):
-            return 1e3*sum(b.mole_frac_phase_comp[b.phase_list[1], i]
-                           for i in b.component_list
-                           if (b.phase_list[1], i)
-                           in b.phase_component_set) -\
-                1e3*sum(b.mole_frac_phase_comp[b.phase_list[2], i]
-                        for i in b.component_list
-                        if (b.phase_list[2], i)
-                        in b.phase_component_set) == 0
+            return sum(b.mole_frac_phase_comp[b.phase_list[1], i]
+                       for i in b.component_list
+                       if (b.phase_list[1], i) in b.phase_component_set) -\
+                sum(b.mole_frac_phase_comp[b.phase_list[2], i]
+                    for i in b.component_list
+                    if (b.phase_list[2], i) in b.phase_component_set) == 0
         b.sum_mole_frac = Constraint(rule=rule_mole_frac)
 
         def rule_phase_frac(b, p):
@@ -198,9 +196,9 @@ def define_state(b):
                                                rule=rule_comp_mass_balance)
 
         def rule_mole_frac(b, p):
-            return 1e3*sum(b.mole_frac_phase_comp[p, i]
-                           for i in b.component_list
-                           if (p, i) in b.phase_component_set) == 1e3
+            return sum(b.mole_frac_phase_comp[p, i]
+                       for i in b.component_list
+                       if (p, i) in b.phase_component_set) == 1
         b.sum_mole_frac = Constraint(b.phase_list,
                                      rule=rule_mole_frac)
 

--- a/idaes/generic_models/properties/core/state_definitions/FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FTPx.py
@@ -24,6 +24,7 @@ from idaes.generic_models.properties.core.generic.utility import \
     get_bounds_from_config, get_method, GenericPropertyPackageError
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
+import idaes.core.util.scaling as iscale
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)
@@ -120,8 +121,7 @@ def define_state(b):
     if b.config.defined_state is False:
         # applied at outlet only
         b.sum_mole_frac_out = Constraint(
-            expr=1e3 == 1e3*sum(b.mole_frac_comp[i]
-                                for i in b.component_list))
+            expr=1 == sum(b.mole_frac_comp[i] for i in b.component_list))
 
     if len(b.phase_list) == 1:
         def rule_total_mass_balance(b):
@@ -129,8 +129,8 @@ def define_state(b):
         b.total_flow_balance = Constraint(rule=rule_total_mass_balance)
 
         def rule_comp_mass_balance(b, i):
-            return 1e3*b.mole_frac_comp[i] == \
-                1e3*b.mole_frac_phase_comp[b.phase_list[1], i]
+            return b.mole_frac_comp[i] == \
+                b.mole_frac_phase_comp[b.phase_list[1], i]
         b.component_flow_balances = Constraint(b.component_list,
                                                rule=rule_comp_mass_balance)
 
@@ -155,14 +155,12 @@ def define_state(b):
                                                rule=rule_comp_mass_balance)
 
         def rule_mole_frac(b):
-            return 1e3*sum(b.mole_frac_phase_comp[b.phase_list[1], i]
-                           for i in b.component_list
-                           if (b.phase_list[1], i)
-                           in b.phase_component_set) -\
-                1e3*sum(b.mole_frac_phase_comp[b.phase_list[2], i]
-                        for i in b.component_list
-                        if (b.phase_list[2], i)
-                        in b.phase_component_set) == 0
+            return sum(b.mole_frac_phase_comp[b.phase_list[1], i]
+                       for i in b.component_list
+                       if (b.phase_list[1], i) in b.phase_component_set) -\
+                sum(b.mole_frac_phase_comp[b.phase_list[2], i]
+                    for i in b.component_list
+                    if (b.phase_list[2], i) in b.phase_component_set) == 0
         b.sum_mole_frac = Constraint(rule=rule_mole_frac)
 
         def rule_phase_frac(b, p):
@@ -181,9 +179,9 @@ def define_state(b):
                                                rule=rule_comp_mass_balance)
 
         def rule_mole_frac(b, p):
-            return 1e3*sum(b.mole_frac_phase_comp[p, i]
-                           for i in b.component_list
-                           if (p, i) in b.phase_component_set) == 1e3
+            return sum(b.mole_frac_phase_comp[p, i]
+                       for i in b.component_list
+                       if (p, i) in b.phase_component_set) == 1
         b.sum_mole_frac = Constraint(b.phase_list,
                                      rule=rule_mole_frac)
 
@@ -407,6 +405,11 @@ def state_initialization(b):
 
 
 def define_default_scaling_factors(b):
+    """
+    Method to set default scaling factors for the property package. Scaling
+    factors are based on the default initial value for each variable provided
+    in the state_bounds config argument.
+    """
     # Get bounds and initial values from config args
     units = b.get_metadata().derived_units
     state_bounds = b.config.state_bounds
@@ -456,6 +459,57 @@ def define_default_scaling_factors(b):
     b.set_default_scaling("temperature", 1/t_init)
 
 
+def calculate_scaling_factors(b):
+    sf_flow = iscale.get_scaling_factor(
+        b.flow_mol, default=1, warning=True)
+    sf_mf = iscale.get_scaling_factor(
+        b.mole_frac_phase_comp, default=1e3, warning=True)
+
+    if b.config.defined_state is False:
+        iscale.constraint_scaling_transform(b.sum_mole_frac_out, sf_mf)
+
+    if len(b.phase_list) == 1:
+        iscale.constraint_scaling_transform(b.total_flow_balance, sf_flow)
+
+        for j in b.component_list:
+            sf_j = sf_mf = iscale.get_scaling_factor(
+                b.mole_frac_phase_comp[j], default=1e3, warning=True)
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_j)
+
+        # b.phase_fraction_constraint is well scaled
+
+    elif len(b.phase_list) == 2:
+        iscale.constraint_scaling_transform(b.total_flow_balance, sf_flow)
+
+        for j in b.component_list:
+            sf_j = sf_mf = iscale.get_scaling_factor(
+                b.mole_frac_comp[j], default=1e3, warning=True)
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_j*sf_flow)
+
+        iscale.constraint_scaling_transform(b.sum_mole_frac, sf_mf)
+
+        for p in b.phase_list:
+            iscale.constraint_scaling_transform(
+                b.phase_fraction_constraint[p], sf_flow)
+
+    else:
+        iscale.constraint_scaling_transform(b.total_flow_balance, sf_flow)
+
+        for j in b.component_list:
+            sf_j = sf_mf = iscale.get_scaling_factor(
+                b.mole_frac_comp[j], default=1e3, warning=True)
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_j*sf_flow)
+
+        for p in b.phase_list:
+            iscale.constraint_scaling_transform(
+                b.sum_mole_frac[p], sf_mf)
+            iscale.constraint_scaling_transform(
+                b.phase_fraction_constraint[p], sf_flow)
+
+
 do_not_initialize = ["sum_mole_frac_out"]
 
 
@@ -465,3 +519,4 @@ class FTPx(object):
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
     define_default_scaling_factors = define_default_scaling_factors
+    calculate_scaling_factors = calculate_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FTPx.py
@@ -405,6 +405,26 @@ def state_initialization(b):
                 pass
 
 
+def define_default_scaling_factors(b):
+    # Get bounds and initial values from config args
+    units = b.params.get_metadata().derived_units
+
+    f_bounds, f_init = get_bounds_from_config(
+        b, "flow_mol_comp", units["flow_mole"])
+    p_bounds, p_init = get_bounds_from_config(
+        b, "pressure", units["pressure"])
+    t_bounds, t_init = get_bounds_from_config(
+        b, "temperature", units["temperature"])
+
+    # Set default scaling factors
+    b.set_default_scaling("flow_mol", 1/f_init)
+    b.set_default_scaling("flow_mol_phase", 1/f_init)
+    b.set_default_scaling("flow_mol_comp", 1/f_init)
+    b.set_default_scaling("flow_mol_phase_comp", 1/f_init)
+    b.set_default_scaling("pressure", 1/p_init)
+    b.set_default_scaling("temperature", 1/t_init)
+
+
 do_not_initialize = ["sum_mole_frac_out"]
 
 
@@ -413,3 +433,4 @@ class FTPx(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
+    define_default_Scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FTPx.py
@@ -417,14 +417,12 @@ def define_default_scaling_factors(b):
     try:
         f_bounds = state_bounds["flow_mol"]
         if len(f_bounds) == 4:
-            print("Should see this")
             f_init = pyunits.convert_value(f_bounds[1],
                                            from_units=f_bounds[3],
                                            to_units=units["flow_mole"])
         else:
             f_init = f_bounds[1]
     except KeyError:
-        print("Don't want to see this")
         f_init = 1
 
     try:

--- a/idaes/generic_models/properties/core/state_definitions/FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FTPx.py
@@ -415,14 +415,16 @@ def define_default_scaling_factors(b):
         return
 
     try:
-        f_bounds = state_bounds["flow_mol_comp"]
+        f_bounds = state_bounds["flow_mol"]
         if len(f_bounds) == 4:
+            print("Should see this")
             f_init = pyunits.convert_value(f_bounds[1],
                                            from_units=f_bounds[3],
                                            to_units=units["flow_mole"])
         else:
             f_init = f_bounds[1]
     except KeyError:
+        print("Don't want to see this")
         f_init = 1
 
     try:

--- a/idaes/generic_models/properties/core/state_definitions/FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcPh.py
@@ -14,7 +14,8 @@
 Methods for setting up FcPh as the state variables in a generic property
 package
 """
-from pyomo.environ import Constraint, Expression, NonNegativeReals, Var
+from pyomo.environ import \
+    Constraint, Expression, NonNegativeReals, Var, units as pyunits
 
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
@@ -271,16 +272,55 @@ def define_state(b):
 
 def define_default_scaling_factors(b):
     # Get bounds and initial values from config args
-    units = b.params.get_metadata().derived_units
+    units = b.get_metadata().derived_units
+    state_bounds = b.config.state_bounds
 
-    f_bounds, f_init = get_bounds_from_config(
-        b, "flow_mol_comp", units["flow_mole"])
-    h_bounds, h_init = get_bounds_from_config(
-        b, "enth_mol", units["energy_mole"])
-    p_bounds, p_init = get_bounds_from_config(
-        b, "pressure", units["pressure"])
-    t_bounds, t_init = get_bounds_from_config(
-        b, "temperature", units["temperature"])
+    if state_bounds is None:
+        return
+
+    try:
+        f_bounds = state_bounds["flow_mol_comp"]
+        if len(f_bounds) == 4:
+            f_init = pyunits.convert_value(f_bounds[1],
+                                           from_units=f_bounds[3],
+                                           to_units=units["flow_mole"])
+        else:
+            f_init = f_bounds[1]
+    except KeyError:
+        f_init = 1
+
+    try:
+        p_bounds = state_bounds["pressure"]
+        if len(p_bounds) == 4:
+            p_init = pyunits.convert_value(p_bounds[1],
+                                           from_units=p_bounds[3],
+                                           to_units=units["pressure"])
+        else:
+            p_init = p_bounds[1]
+    except KeyError:
+        p_init = 1
+
+    try:
+        h_bounds = state_bounds["enth_mol"]
+        if len(h_bounds) == 4:
+            h_init = pyunits.convert_value(h_bounds[1],
+                                           from_units=h_bounds[3],
+                                           to_units=units["energy_mole"])
+        else:
+            h_init = h_bounds[1]
+    except KeyError:
+        h_init = 1
+
+    try:
+        t_bounds = state_bounds["temperature"]
+        if len(t_bounds) == 4:
+            t_init = pyunits.convert_value(t_bounds[1],
+                                           from_units=t_bounds[3],
+                                           to_units=units["temperature"])
+        else:
+            t_init = t_bounds[1]
+    except KeyError:
+        t_init = 1
 
     # Set default scaling factors
     b.set_default_scaling("flow_mol", 1/f_init)
@@ -303,4 +343,4 @@ class FcPh(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
-    define_default_Scaling_factors = define_default_scaling_factors
+    define_default_scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcPh.py
@@ -269,6 +269,29 @@ def define_state(b):
     b.define_display_vars = define_display_vars_FcPh
 
 
+def define_default_scaling_factors(b):
+    # Get bounds and initial values from config args
+    units = b.params.get_metadata().derived_units
+
+    f_bounds, f_init = get_bounds_from_config(
+        b, "flow_mol_comp", units["flow_mole"])
+    h_bounds, h_init = get_bounds_from_config(
+        b, "enth_mol", units["energy_mole"])
+    p_bounds, p_init = get_bounds_from_config(
+        b, "pressure", units["pressure"])
+    t_bounds, t_init = get_bounds_from_config(
+        b, "temperature", units["temperature"])
+
+    # Set default scaling factors
+    b.set_default_scaling("flow_mol", 1/f_init)
+    b.set_default_scaling("flow_mol_phase", 1/f_init)
+    b.set_default_scaling("flow_mol_comp", 1/f_init)
+    b.set_default_scaling("flow_mol_phase_comp", 1/f_init)
+    b.set_default_scaling("pressure", 1/p_init)
+    b.set_default_scaling("temperature", 1/t_init)
+    b.set_default_scaling("enth_mol", 1/h_init)
+
+
 # Inherit state_initialization from FTPX form, as the process is the same
 
 
@@ -280,3 +303,4 @@ class FcPh(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
+    define_default_Scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcPh.py
@@ -27,6 +27,7 @@ from idaes.generic_models.properties.core.generic.utility import \
     get_bounds_from_config
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
+import idaes.core.util.scaling as iscale
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)
@@ -152,8 +153,8 @@ def define_state(b):
         b.total_flow_balance = Constraint(rule=rule_total_mass_balance)
 
         def rule_comp_mass_balance(b, i):
-            return 1e3*b.mole_frac_comp[i] == \
-                1e3*b.mole_frac_phase_comp[b.phase_list[1], i]
+            return b.mole_frac_comp[i] == \
+                b.mole_frac_phase_comp[b.phase_list[1], i]
         b.component_flow_balances = Constraint(b.component_list,
                                                rule=rule_comp_mass_balance)
 
@@ -178,14 +179,12 @@ def define_state(b):
                                                rule=rule_comp_mass_balance)
 
         def rule_mole_frac(b):
-            return 1e3*sum(b.mole_frac_phase_comp[b.phase_list[1], i]
-                           for i in b.component_list
-                           if (b.phase_list[1], i)
-                           in b.phase_component_set) -\
-                1e3*sum(b.mole_frac_phase_comp[b.phase_list[2], i]
-                        for i in b.component_list
-                        if (b.phase_list[2], i)
-                        in b.phase_component_set) == 0
+            return sum(b.mole_frac_phase_comp[b.phase_list[1], i]
+                       for i in b.component_list
+                       if (b.phase_list[1], i) in b.phase_component_set) -\
+                sum(b.mole_frac_phase_comp[b.phase_list[2], i]
+                    for i in b.component_list
+                    if (b.phase_list[2], i) in b.phase_component_set) == 0
         b.sum_mole_frac = Constraint(rule=rule_mole_frac)
 
         def rule_phase_frac(b, p):
@@ -199,14 +198,14 @@ def define_state(b):
             return b.flow_mol_comp[i] == sum(
                 b.flow_mol_phase[p]*b.mole_frac_phase_comp[p, i]
                 for p in b.phase_list
-                if (p, i)in b.phase_component_set)
+                if (p, i) in b.phase_component_set)
         b.component_flow_balances = Constraint(b.component_list,
                                                rule=rule_comp_mass_balance)
 
         def rule_mole_frac(b, p):
-            return 1e3*sum(b.mole_frac_phase_comp[p, i]
-                           for i in b.component_list
-                           if (p, i)in b.phase_component_set) == 1e3
+            return sum(b.mole_frac_phase_comp[p, i]
+                       for i in b.component_list
+                       if (p, i) in b.phase_component_set) == 1
         b.sum_mole_frac = Constraint(b.phase_list,
                                      rule=rule_mole_frac)
 
@@ -271,6 +270,11 @@ def define_state(b):
 
 
 def define_default_scaling_factors(b):
+    """
+    Method to set default scaling factors for the property package. Scaling
+    factors are based on the default initial value for each variable provided
+    in the state_bounds config argument.
+    """
     # Get bounds and initial values from config args
     units = b.get_metadata().derived_units
     state_bounds = b.config.state_bounds
@@ -332,6 +336,61 @@ def define_default_scaling_factors(b):
     b.set_default_scaling("enth_mol", 1/h_init)
 
 
+def calculate_scaling_factors(b):
+    sf_flow = iscale.get_scaling_factor(b.flow_mol, default=1, warning=True)
+    sf_h = iscale.get_scaling_factor(b.enth_mol, default=1, warning=True)
+    sf_mf = iscale.get_scaling_factor(
+        b.mole_frac_phase_comp, default=1e3, warning=True)
+
+    for j in b.component_list:
+        sf_j = iscale.get_scaling_factor(
+            b.mole_frac_comp[j], default=1e3, warning=True)
+        iscale.constraint_scaling_transform(b.mole_frac_comp_eq[j], sf_j)
+
+    iscale.constraint_scaling_transform(b.enth_mol_eq, sf_h)
+
+    if len(b.phase_list) == 1:
+        iscale.constraint_scaling_transform(b.total_flow_balance, sf_flow)
+
+        for j in b.component_list:
+            sf_j = iscale.get_scaling_factor(
+                b.mole_frac_comp[j], default=1e3, warning=True)
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_j)
+
+        # b.phase_fraction_constraint is well scaled
+
+    elif len(b.phase_list) == 2:
+        iscale.constraint_scaling_transform(b.total_flow_balance, sf_flow)
+
+        for j in b.component_list:
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_flow)
+
+        iscale.constraint_scaling_transform(b.sum_mole_frac, sf_mf)
+
+        for p in b.phase_list:
+            sf_p = iscale.get_scaling_factor(
+                b.phase_frac[p], default=1, warning=True)
+            iscale.constraint_scaling_transform(
+                b.phase_fraction_constraint[p], sf_p*sf_flow)
+
+    else:
+        for j in b.component_list:
+            sf_fc = iscale.get_scaling_factor(
+                b.flow_mol_comp[j], default=1, warning=True)
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_fc)
+
+        for p in b.phase_list:
+            sf_fp = iscale.get_scaling_factor(
+                b.flow_mol_phase[p], default=1, warning=True)
+            iscale.constraint_scaling_transform(
+                b.sum_mole_frac[p], sf_mf)
+            iscale.constraint_scaling_transform(
+                b.phase_fraction_constraint[p], sf_fp)
+
+
 # Inherit state_initialization from FTPX form, as the process is the same
 
 
@@ -344,3 +403,4 @@ class FcPh(object):
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
     define_default_scaling_factors = define_default_scaling_factors
+    calculate_scaling_factors = calculate_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcTP.py
@@ -14,7 +14,8 @@
 Methods for setting up FcTP as the state variables in a generic property
 package
 """
-from pyomo.environ import Constraint, Expression, NonNegativeReals, Var
+from pyomo.environ import \
+    Constraint, Expression, NonNegativeReals, Var, units as pyunits
 
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
@@ -253,14 +254,44 @@ def define_state(b):
 
 def define_default_scaling_factors(b):
     # Get bounds and initial values from config args
-    units = b.params.get_metadata().derived_units
+    units = b.get_metadata().derived_units
+    state_bounds = b.config.state_bounds
 
-    f_bounds, f_init = get_bounds_from_config(
-        b, "flow_mol_comp", units["flow_mole"])
-    p_bounds, p_init = get_bounds_from_config(
-        b, "pressure", units["pressure"])
-    t_bounds, t_init = get_bounds_from_config(
-        b, "temperature", units["temperature"])
+    if state_bounds is None:
+        return
+
+    try:
+        f_bounds = state_bounds["flow_mol_comp"]
+        if len(f_bounds) == 4:
+            f_init = pyunits.convert_value(f_bounds[1],
+                                           from_units=f_bounds[3],
+                                           to_units=units["flow_mole"])
+        else:
+            f_init = f_bounds[1]
+    except KeyError:
+        f_init = 1
+
+    try:
+        p_bounds = state_bounds["pressure"]
+        if len(p_bounds) == 4:
+            p_init = pyunits.convert_value(p_bounds[1],
+                                           from_units=p_bounds[3],
+                                           to_units=units["pressure"])
+        else:
+            p_init = p_bounds[1]
+    except KeyError:
+        p_init = 1
+
+    try:
+        t_bounds = state_bounds["temperature"]
+        if len(t_bounds) == 4:
+            t_init = pyunits.convert_value(t_bounds[1],
+                                           from_units=t_bounds[3],
+                                           to_units=units["temperature"])
+        else:
+            t_init = t_bounds[1]
+    except KeyError:
+        t_init = 1
 
     # Set default scaling factors
     b.set_default_scaling("flow_mol", 1/f_init)
@@ -282,4 +313,4 @@ class FcTP(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
-    define_default_Scaling_factors = define_default_scaling_factors
+    define_default_scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcTP.py
@@ -27,6 +27,7 @@ from idaes.generic_models.properties.core.generic.utility import \
     get_bounds_from_config
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
+import idaes.core.util.scaling as iscale
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)
@@ -134,8 +135,8 @@ def define_state(b):
         b.total_flow_balance = Constraint(rule=rule_total_mass_balance)
 
         def rule_comp_mass_balance(b, i):
-            return b.mole_frac_comp[i]*1e3 == \
-                1e3*b.mole_frac_phase_comp[b.phase_list[1], i]
+            return b.mole_frac_comp[i] == \
+                b.mole_frac_phase_comp[b.phase_list[1], i]
         b.component_flow_balances = Constraint(b.component_list,
                                                rule=rule_comp_mass_balance)
 
@@ -160,14 +161,12 @@ def define_state(b):
                                                rule=rule_comp_mass_balance)
 
         def rule_mole_frac(b):
-            return 1e3*sum(b.mole_frac_phase_comp[b.phase_list[1], i]
-                           for i in b.component_list
-                           if (b.phase_list[1], i)
-                           in b.phase_component_set) -\
-                1e3*sum(b.mole_frac_phase_comp[b.phase_list[2], i]
-                        for i in b.component_list
-                        if (b.phase_list[2], i)
-                        in b.phase_component_set) == 0
+            return sum(b.mole_frac_phase_comp[b.phase_list[1], i]
+                       for i in b.component_list
+                       if (b.phase_list[1], i) in b.phase_component_set) -\
+                sum(b.mole_frac_phase_comp[b.phase_list[2], i]
+                    for i in b.component_list
+                    if (b.phase_list[2], i) in b.phase_component_set) == 0
         b.sum_mole_frac = Constraint(rule=rule_mole_frac)
 
         def rule_phase_frac(b, p):
@@ -186,9 +185,9 @@ def define_state(b):
                                                rule=rule_comp_mass_balance)
 
         def rule_mole_frac(b, p):
-            return 1e3*sum(b.mole_frac_phase_comp[p, i]
-                           for i in b.component_list
-                           if (p, i) in b.phase_component_set) == 1e3
+            return sum(b.mole_frac_phase_comp[p, i]
+                       for i in b.component_list
+                       if (p, i) in b.phase_component_set) == 1
         b.sum_mole_frac = Constraint(b.phase_list,
                                      rule=rule_mole_frac)
 
@@ -253,6 +252,11 @@ def define_state(b):
 
 
 def define_default_scaling_factors(b):
+    """
+    Method to set default scaling factors for the property package. Scaling
+    factors are based on the default initial value for each variable provided
+    in the state_bounds config argument.
+    """
     # Get bounds and initial values from config args
     units = b.get_metadata().derived_units
     state_bounds = b.config.state_bounds
@@ -302,6 +306,60 @@ def define_default_scaling_factors(b):
     b.set_default_scaling("temperature", 1/t_init)
 
 
+def calculate_scaling_factors(b):
+    sf_flow = iscale.get_scaling_factor(b.flow_mol, default=1, warning=True)
+    sf_mf = iscale.get_scaling_factor(
+        b.mole_frac_phase_comp, default=1e3, warning=True)
+
+    for j in b.component_list:
+        sf_j = iscale.get_scaling_factor(
+            b.mole_frac_comp[j], default=1e3, warning=True)
+        iscale.constraint_scaling_transform(b.mole_frac_comp_eq[j], sf_j)
+
+    if len(b.phase_list) == 1:
+        iscale.constraint_scaling_transform(b.total_flow_balance, sf_flow)
+
+        for j in b.component_list:
+            sf_j = iscale.get_scaling_factor(
+                b.mole_frac_comp[j], default=1e3, warning=True)
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_j)
+
+        # b.phase_fraction_constraint is well scaled
+
+    elif len(b.phase_list) == 2:
+        iscale.constraint_scaling_transform(b.total_flow_balance, sf_flow)
+
+        for j in b.component_list:
+            sf_fc = iscale.get_scaling_factor(
+                b.flow_mol_comp[j], default=1, warning=True)
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_fc)
+
+        iscale.constraint_scaling_transform(b.sum_mole_frac, sf_mf)
+
+        for p in b.phase_list:
+            sf_p = iscale.get_scaling_factor(
+                b.flow_mol_phase[p], default=1, warning=True)
+            iscale.constraint_scaling_transform(
+                b.phase_fraction_constraint[p], sf_p)
+
+    else:
+        for j in b.component_list:
+            sf_fc = iscale.get_scaling_factor(
+                b.flow_mol_comp[j], default=1, warning=True)
+            iscale.constraint_scaling_transform(
+                b.component_flow_balances[j], sf_fc)
+
+        for p in b.phase_list:
+            sf_p = iscale.get_scaling_factor(
+                b.flow_mol_phase[p], default=1, warning=True)
+            iscale.constraint_scaling_transform(
+                b.sum_mole_frac[p], sf_mf)
+            iscale.constraint_scaling_transform(
+                b.phase_fraction_constraint[p], sf_p)
+
+
 # Inherit state_initialization from FTPX form, as the process is the same
 
 
@@ -314,3 +372,4 @@ class FcTP(object):
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
     define_default_scaling_factors = define_default_scaling_factors
+    calculate_scaling_factors = calculate_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcTP.py
@@ -251,6 +251,26 @@ def define_state(b):
     b.define_display_vars = define_display_vars_FTPx
 
 
+def define_default_scaling_factors(b):
+    # Get bounds and initial values from config args
+    units = b.params.get_metadata().derived_units
+
+    f_bounds, f_init = get_bounds_from_config(
+        b, "flow_mol_comp", units["flow_mole"])
+    p_bounds, p_init = get_bounds_from_config(
+        b, "pressure", units["pressure"])
+    t_bounds, t_init = get_bounds_from_config(
+        b, "temperature", units["temperature"])
+
+    # Set default scaling factors
+    b.set_default_scaling("flow_mol", 1/f_init)
+    b.set_default_scaling("flow_mol_phase", 1/f_init)
+    b.set_default_scaling("flow_mol_comp", 1/f_init)
+    b.set_default_scaling("flow_mol_phase_comp", 1/f_init)
+    b.set_default_scaling("pressure", 1/p_init)
+    b.set_default_scaling("temperature", 1/t_init)
+
+
 # Inherit state_initialization from FTPX form, as the process is the same
 
 
@@ -262,3 +282,4 @@ class FcTP(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
+    define_default_Scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FpcTP.py
@@ -14,7 +14,8 @@
 Methods for setting up FpcTP as the state variables in a generic property
 package
 """
-from pyomo.environ import Constraint, Expression, NonNegativeReals, Var, value
+from pyomo.environ import \
+    Constraint, Expression, NonNegativeReals, Var, value, units as pyunits
 
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
@@ -190,14 +191,44 @@ def state_initialization(b):
 
 def define_default_scaling_factors(b):
     # Get bounds and initial values from config args
-    units = b.params.get_metadata().derived_units
+    units = b.get_metadata().derived_units
+    state_bounds = b.config.state_bounds
 
-    f_bounds, f_init = get_bounds_from_config(
-        b, "flow_mol_comp", units["flow_mole"])
-    p_bounds, p_init = get_bounds_from_config(
-        b, "pressure", units["pressure"])
-    t_bounds, t_init = get_bounds_from_config(
-        b, "temperature", units["temperature"])
+    if state_bounds is None:
+        return
+
+    try:
+        f_bounds = state_bounds["flow_mol_comp"]
+        if len(f_bounds) == 4:
+            f_init = pyunits.convert_value(f_bounds[1],
+                                           from_units=f_bounds[3],
+                                           to_units=units["flow_mole"])
+        else:
+            f_init = f_bounds[1]
+    except KeyError:
+        f_init = 1
+
+    try:
+        p_bounds = state_bounds["pressure"]
+        if len(p_bounds) == 4:
+            p_init = pyunits.convert_value(p_bounds[1],
+                                           from_units=p_bounds[3],
+                                           to_units=units["pressure"])
+        else:
+            p_init = p_bounds[1]
+    except KeyError:
+        p_init = 1
+
+    try:
+        t_bounds = state_bounds["temperature"]
+        if len(t_bounds) == 4:
+            t_init = pyunits.convert_value(t_bounds[1],
+                                           from_units=t_bounds[3],
+                                           to_units=units["temperature"])
+        else:
+            t_init = t_bounds[1]
+    except KeyError:
+        t_init = 1
 
     # Set default scaling factors
     b.set_default_scaling("flow_mol", 1/f_init)
@@ -216,4 +247,4 @@ class FpcTP(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
-    define_default_Scaling_factors = define_default_scaling_factors
+    define_default_scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FpcTP.py
@@ -190,6 +190,11 @@ def state_initialization(b):
 
 
 def define_default_scaling_factors(b):
+    """
+    Method to set default scaling factors for the property package. Scaling
+    factors are based on the default initial value for each variable provided
+    in the state_bounds config argument.
+    """
     # Get bounds and initial values from config args
     units = b.get_metadata().derived_units
     state_bounds = b.config.state_bounds
@@ -239,6 +244,10 @@ def define_default_scaling_factors(b):
     b.set_default_scaling("temperature", 1/t_init)
 
 
+def calculate_scaling_factors(b):
+    pass
+
+
 do_not_initialize = []
 
 
@@ -248,3 +257,4 @@ class FpcTP(object):
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
     define_default_scaling_factors = define_default_scaling_factors
+    calculate_scaling_factors = calculate_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FpcTP.py
@@ -198,7 +198,7 @@ def define_default_scaling_factors(b):
         return
 
     try:
-        f_bounds = state_bounds["flow_mol_comp"]
+        f_bounds = state_bounds["flow_mol_phase_comp"]
         if len(f_bounds) == 4:
             f_init = pyunits.convert_value(f_bounds[1],
                                            from_units=f_bounds[3],

--- a/idaes/generic_models/properties/core/state_definitions/FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FpcTP.py
@@ -24,6 +24,7 @@ from idaes.generic_models.properties.core.generic.utility import \
     get_bounds_from_config
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
+import idaes.core.util.scaling as iscale
 
 # Set up logger
 _log = idaeslog.getLogger(__name__)
@@ -245,7 +246,11 @@ def define_default_scaling_factors(b):
 
 
 def calculate_scaling_factors(b):
-    pass
+    for p, j in b.phase_component_set:
+        sf = iscale.get_scaling_factor(b.flow_mol_phase_comp[
+            p, j], default=1, warning=True)
+        iscale.constraint_scaling_transform(
+            b.mole_frac_phase_comp_eq[p, j], sf)
 
 
 do_not_initialize = []

--- a/idaes/generic_models/properties/core/state_definitions/FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FpcTP.py
@@ -188,6 +188,26 @@ def state_initialization(b):
             b.flow_mol_phase_comp[i] / b.flow_mol_phase[i[0]])
 
 
+def define_default_scaling_factors(b):
+    # Get bounds and initial values from config args
+    units = b.params.get_metadata().derived_units
+
+    f_bounds, f_init = get_bounds_from_config(
+        b, "flow_mol_comp", units["flow_mole"])
+    p_bounds, p_init = get_bounds_from_config(
+        b, "pressure", units["pressure"])
+    t_bounds, t_init = get_bounds_from_config(
+        b, "temperature", units["temperature"])
+
+    # Set default scaling factors
+    b.set_default_scaling("flow_mol", 1/f_init)
+    b.set_default_scaling("flow_mol_phase", 1/f_init)
+    b.set_default_scaling("flow_mol_comp", 1/f_init)
+    b.set_default_scaling("flow_mol_phase_comp", 1/f_init)
+    b.set_default_scaling("pressure", 1/p_init)
+    b.set_default_scaling("temperature", 1/t_init)
+
+
 do_not_initialize = []
 
 
@@ -196,3 +216,4 @@ class FpcTP(object):
     define_state = define_state
     state_initialization = state_initialization
     do_not_initialize = do_not_initialize
+    define_default_Scaling_factors = define_default_scaling_factors

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
@@ -1024,23 +1024,23 @@ class TestCommon(object):
         assert frame.props[1].scaling_factor[
             frame.props[1].dens_mol_phase["b"]] == 1e-2
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c1"]] == 1e2
+            frame.props[1].mole_frac_comp["c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c2"]] == 1e2
+            frame.props[1].mole_frac_comp["c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c3"]] == 1e2
+            frame.props[1].mole_frac_comp["c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
         assert frame.props[1].scaling_factor[
             frame.props[1].temperature] == 1e-2

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
@@ -24,7 +24,7 @@ from pyomo.util.check_units import (
 
 # Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FPhx import \
-    define_state, set_metadata, define_default_scaling_factors
+    FPhx, define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -931,7 +931,7 @@ class TestCommon(object):
                 "phases": {
                     "a": {"equation_of_state": dummy_eos},
                     "b": {"equation_of_state": dummy_eos}},
-                "state_definition": modules[__name__],
+                "state_definition": FPhx,
                 "pressure_ref": 1e5,
                 "temperature_ref": 300,
                 "state_bounds": {
@@ -952,8 +952,6 @@ class TestCommon(object):
         # Add necessary variables that would be built by other methods
         m.props[1].dens_mol_phase = Var(m.params.phase_list, initialize=1)
         m.props[1].enth_mol_phase = Var(m.params.phase_list, initialize=1)
-
-        define_state(m.props[1])
 
         return m
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
@@ -22,8 +22,9 @@ from pyomo.environ import ConcreteModel, Constraint, Var, units as pyunits
 from pyomo.util.check_units import (
     check_units_equivalent, assert_units_consistent)
 
+# Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FPhx import \
-    define_state, set_metadata
+    define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -1006,6 +1007,43 @@ class TestCommon(object):
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
+
+    @pytest.mark.unit
+    def test_calculate_scaling_factors(self, frame):
+        frame.props[1].calculate_scaling_factors()
+
+        assert len(frame.props[1].scaling_factor) == 17
+        assert frame.props[1].scaling_factor[frame.props[1].enth_mol] == 1e-4
+        assert frame.props[1].scaling_factor[frame.props[1].flow_mol] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
+        assert frame.props[1].scaling_factor[
+            frame.props[1].temperature] == 1e-2
 
     # Test General Methods
     @pytest.mark.unit

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
@@ -225,15 +225,15 @@ class Test1PhaseDefinedStateFalseNoBounds(object):
         for i in frame.props[1].component_flow_balances:
             assert i in frame.props[1].params.component_list
             assert str(frame.props[1].component_flow_balances[i].body) == str(
-                1e3*frame.props[1].mole_frac_comp[i] -
-                1e3*frame.props[1].mole_frac_phase_comp[
-                        frame.params.phase_list[1], i])
+                frame.props[1].mole_frac_comp[i] -
+                frame.props[1].mole_frac_phase_comp[
+                    frame.params.phase_list[1], i])
 
         assert isinstance(frame.props[1].sum_mole_frac_out, Constraint)
         assert len(frame.props[1].sum_mole_frac_out) == 1
         assert str(frame.props[1].sum_mole_frac_out.body) == str(
-                1e3*sum(frame.props[1].mole_frac_comp[i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_comp[i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 1
@@ -350,9 +350,9 @@ class Test1PhaseDefinedStateTrueWithBounds(object):
         for i in frame.props[1].component_flow_balances:
             assert i in frame.props[1].params.component_list
             assert str(frame.props[1].component_flow_balances[i].body) == str(
-                1e3*frame.props[1].mole_frac_comp[i] -
-                1e3*frame.props[1].mole_frac_phase_comp[
-                        frame.params.phase_list[1], i])
+                frame.props[1].mole_frac_comp[i] -
+                frame.props[1].mole_frac_phase_comp[
+                    frame.params.phase_list[1], i])
 
         assert not hasattr(frame.props[1], "sum_mole_frac_out")
 
@@ -483,18 +483,18 @@ class Test2PhaseDefinedStateFalseNoBounds(object):
         assert isinstance(frame.props[1].sum_mole_frac, Constraint)
         assert len(frame.props[1].sum_mole_frac) == 1
         assert str(frame.props[1].sum_mole_frac.body) == str(
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[1], i]
-                        for i in frame.props[1].params.component_list) -
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[2], i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[1], i]
+                    for i in frame.props[1].params.component_list) -
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[2], i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].sum_mole_frac_out, Constraint)
         assert len(frame.props[1].sum_mole_frac_out) == 1
         assert str(frame.props[1].sum_mole_frac_out.body) == str(
-                1e3*sum(frame.props[1].mole_frac_comp[i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_comp[i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
@@ -623,12 +623,12 @@ class Test2PhaseDefinedStateTrueWithBounds(object):
         assert isinstance(frame.props[1].sum_mole_frac, Constraint)
         assert len(frame.props[1].sum_mole_frac) == 1
         assert str(frame.props[1].sum_mole_frac.body) == str(
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[1], i]
-                        for i in frame.props[1].params.component_list) -
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[2], i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[1], i]
+                    for i in frame.props[1].params.component_list) -
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[2], i]
+                    for i in frame.props[1].params.component_list))
 
         assert not hasattr(frame.props[1], "sum_mole_frac_out")
 
@@ -757,14 +757,14 @@ class Test3PhaseDefinedStateFalseNoBounds(object):
         for p in frame.props[1].sum_mole_frac:
             assert p in frame.params.phase_list
             assert str(frame.props[1].sum_mole_frac[p].body) == str(
-                    1e3*sum(frame.props[1].mole_frac_phase_comp[p, i]
-                            for i in frame.props[1].params.component_list))
+                    sum(frame.props[1].mole_frac_phase_comp[p, i]
+                        for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].sum_mole_frac_out, Constraint)
         assert len(frame.props[1].sum_mole_frac_out) == 1
         assert str(frame.props[1].sum_mole_frac_out.body) == str(
-                1e3*sum(frame.props[1].mole_frac_comp[i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_comp[i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 3
@@ -905,8 +905,8 @@ class Test3PhaseDefinedStateTrueWithBounds(object):
         for p in frame.props[1].sum_mole_frac:
             assert p in frame.params.phase_list
             assert str(frame.props[1].sum_mole_frac[p].body) == str(
-                    1e3*sum(frame.props[1].mole_frac_phase_comp[p, i]
-                            for i in frame.props[1].params.component_list))
+                    sum(frame.props[1].mole_frac_phase_comp[p, i]
+                        for i in frame.props[1].params.component_list))
 
         assert not hasattr(frame.props[1], "sum_mole_frac_out")
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
@@ -994,23 +994,23 @@ class TestCommon(object):
         assert frame.props[1].scaling_factor[
             frame.props[1].dens_mol_phase["b"]] == 1e-2
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c1"]] == 1e2
+            frame.props[1].mole_frac_comp["c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c2"]] == 1e2
+            frame.props[1].mole_frac_comp["c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c3"]] == 1e2
+            frame.props[1].mole_frac_comp["c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
         assert frame.props[1].scaling_factor[
             frame.props[1].temperature] == 1e-2

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
@@ -24,8 +24,9 @@ from pyomo.environ import (
 from pyomo.util.check_units import (
     check_units_equivalent, assert_units_consistent)
 
+# Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FTPx import \
-    define_state, set_metadata
+    define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -977,6 +978,42 @@ class TestCommon(object):
         assert len(frame.props[1].phase_fraction_constraint) == 2
 
         assert_units_consistent(frame)
+
+    @pytest.mark.unit
+    def test_calculate_scaling_factors(self, frame):
+        frame.props[1].calculate_scaling_factors()
+
+        assert len(frame.props[1].scaling_factor) == 16
+        assert frame.props[1].scaling_factor[frame.props[1].flow_mol] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
+        assert frame.props[1].scaling_factor[
+            frame.props[1].temperature] == 1e-2
 
     # Test General Methods
     @pytest.mark.unit

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
@@ -26,7 +26,7 @@ from pyomo.util.check_units import (
 
 # Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FTPx import \
-    define_state, set_metadata, define_default_scaling_factors
+    FTPx, define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -205,15 +205,15 @@ class Test1PhaseDefinedStateFalseNoBounds(object):
         for i in frame.props[1].component_flow_balances:
             assert i in frame.props[1].params.component_list
             assert str(frame.props[1].component_flow_balances[i].body) == str(
-                1e3*frame.props[1].mole_frac_comp[i] -
-                1e3*frame.props[1].mole_frac_phase_comp[
+                frame.props[1].mole_frac_comp[i] -
+                frame.props[1].mole_frac_phase_comp[
                         frame.params.phase_list[1], i])
 
         assert isinstance(frame.props[1].sum_mole_frac_out, Constraint)
         assert len(frame.props[1].sum_mole_frac_out) == 1
         assert str(frame.props[1].sum_mole_frac_out.body) == str(
-                1e3*sum(frame.props[1].mole_frac_comp[i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_comp[i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 1
@@ -337,9 +337,9 @@ class Test1PhaseDefinedStateTrueWithBounds(object):
         for i in frame.props[1].component_flow_balances:
             assert i in frame.props[1].params.component_list
             assert str(frame.props[1].component_flow_balances[i].body) == str(
-                1e3*frame.props[1].mole_frac_comp[i] -
-                1e3*frame.props[1].mole_frac_phase_comp[
-                        frame.params.phase_list[1], i])
+                frame.props[1].mole_frac_comp[i] -
+                frame.props[1].mole_frac_phase_comp[
+                    frame.params.phase_list[1], i])
 
         assert not hasattr(frame.props[1], "sum_mole_frac_out")
 
@@ -465,18 +465,18 @@ class Test2PhaseDefinedStateFalseNoBounds(object):
         assert isinstance(frame.props[1].sum_mole_frac, Constraint)
         assert len(frame.props[1].sum_mole_frac) == 1
         assert str(frame.props[1].sum_mole_frac.body) == str(
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[1], i]
-                        for i in frame.props[1].params.component_list) -
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[2], i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[1], i]
+                    for i in frame.props[1].params.component_list) -
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[2], i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].sum_mole_frac_out, Constraint)
         assert len(frame.props[1].sum_mole_frac_out) == 1
         assert str(frame.props[1].sum_mole_frac_out.body) == str(
-                1e3*sum(frame.props[1].mole_frac_comp[i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_comp[i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
@@ -612,12 +612,12 @@ class Test2PhaseDefinedStateTrueWithBounds(object):
         assert isinstance(frame.props[1].sum_mole_frac, Constraint)
         assert len(frame.props[1].sum_mole_frac) == 1
         assert str(frame.props[1].sum_mole_frac.body) == str(
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[1], i]
-                        for i in frame.props[1].params.component_list) -
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[2], i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[1], i]
+                    for i in frame.props[1].params.component_list) -
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[2], i]
+                    for i in frame.props[1].params.component_list))
 
         assert not hasattr(frame.props[1], "sum_mole_frac_out")
 
@@ -741,14 +741,14 @@ class Test3PhaseDefinedStateFalseNoBounds(object):
         for p in frame.props[1].sum_mole_frac:
             assert p in frame.params.phase_list
             assert str(frame.props[1].sum_mole_frac[p].body) == str(
-                    1e3*sum(frame.props[1].mole_frac_phase_comp[p, i]
-                            for i in frame.props[1].params.component_list))
+                    sum(frame.props[1].mole_frac_phase_comp[p, i]
+                        for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].sum_mole_frac_out, Constraint)
         assert len(frame.props[1].sum_mole_frac_out) == 1
         assert str(frame.props[1].sum_mole_frac_out.body) == str(
-                1e3*sum(frame.props[1].mole_frac_comp[i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_comp[i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 3
@@ -881,8 +881,8 @@ class Test3PhaseDefinedStateTrueWithBounds(object):
         for p in frame.props[1].sum_mole_frac:
             assert p in frame.params.phase_list
             assert str(frame.props[1].sum_mole_frac[p].body) == str(
-                    1e3*sum(frame.props[1].mole_frac_phase_comp[p, i]
-                            for i in frame.props[1].params.component_list))
+                    sum(frame.props[1].mole_frac_phase_comp[p, i]
+                        for i in frame.props[1].params.component_list))
 
         assert not hasattr(frame.props[1], "sum_mole_frac_out")
 
@@ -907,7 +907,7 @@ class TestCommon(object):
                 "phases": {
                     "a": {"equation_of_state": dummy_eos},
                     "b": {"equation_of_state": dummy_eos}},
-                "state_definition": modules[__name__],
+                "state_definition": FTPx,
                 "pressure_ref": 1e5,
                 "temperature_ref": 300,
                 "state_bounds": {
@@ -927,8 +927,6 @@ class TestCommon(object):
         # Add necessary variables that would be built by other methods
         m.props[1].dens_mol_phase = Var(m.params.phase_list, initialize=1)
         m.props[1].enth_mol_phase = Var(m.params.phase_list, initialize=1)
-
-        define_state(m.props[1])
 
         return m
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
@@ -1127,23 +1127,23 @@ class TestCommon(object):
         assert frame.props[1].scaling_factor[
             frame.props[1].dens_mol_phase["b"]] == 1e-2
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c1"]] == 1e2
+            frame.props[1].mole_frac_comp["c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c2"]] == 1e2
+            frame.props[1].mole_frac_comp["c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c3"]] == 1e2
+            frame.props[1].mole_frac_comp["c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
         assert frame.props[1].scaling_factor[
             frame.props[1].temperature] == 1e-2

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
@@ -26,7 +26,7 @@ from pyomo.util.check_units import (
 
 # Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FcPh import \
-    define_state, set_metadata, define_default_scaling_factors
+    FcPh, define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -237,9 +237,9 @@ class Test1PhaseDefinedStateFalseNoBounds(object):
         for i in frame.props[1].component_flow_balances:
             assert i in frame.props[1].params.component_list
             assert str(frame.props[1].component_flow_balances[i].body) == str(
-                1e3*frame.props[1].mole_frac_comp[i] -
-                1e3*frame.props[1].mole_frac_phase_comp[
-                        frame.params.phase_list[1], i])
+                frame.props[1].mole_frac_comp[i] -
+                frame.props[1].mole_frac_phase_comp[
+                    frame.params.phase_list[1], i])
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 1
@@ -387,9 +387,9 @@ class Test1PhaseDefinedStateTrueWithBounds(object):
         for i in frame.props[1].component_flow_balances:
             assert i in frame.props[1].params.component_list
             assert str(frame.props[1].component_flow_balances[i].body) == str(
-                1e3*frame.props[1].mole_frac_comp[i] -
-                1e3*frame.props[1].mole_frac_phase_comp[
-                        frame.params.phase_list[1], i])
+                frame.props[1].mole_frac_comp[i] -
+                frame.props[1].mole_frac_phase_comp[
+                    frame.params.phase_list[1], i])
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 1
@@ -533,12 +533,12 @@ class Test2PhaseDefinedStateFalseNoBounds(object):
         assert isinstance(frame.props[1].sum_mole_frac, Constraint)
         assert len(frame.props[1].sum_mole_frac) == 1
         assert str(frame.props[1].sum_mole_frac.body) == str(
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[1], i]
-                        for i in frame.props[1].params.component_list) -
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[2], i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[1], i]
+                    for i in frame.props[1].params.component_list) -
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[2], i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
@@ -698,12 +698,12 @@ class Test2PhaseDefinedStateTrueWithBounds(object):
         assert isinstance(frame.props[1].sum_mole_frac, Constraint)
         assert len(frame.props[1].sum_mole_frac) == 1
         assert str(frame.props[1].sum_mole_frac.body) == str(
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[1], i]
-                        for i in frame.props[1].params.component_list) -
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[2], i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[1], i]
+                    for i in frame.props[1].params.component_list) -
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[2], i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
@@ -845,8 +845,8 @@ class Test3PhaseDefinedStateFalseNoBounds(object):
         for p in frame.props[1].sum_mole_frac:
             assert p in frame.params.phase_list
             assert str(frame.props[1].sum_mole_frac[p].body) == str(
-                    1e3*sum(frame.props[1].mole_frac_phase_comp[p, i]
-                            for i in frame.props[1].params.component_list))
+                    sum(frame.props[1].mole_frac_phase_comp[p, i]
+                        for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 3
@@ -1002,8 +1002,8 @@ class Test3PhaseDefinedStateTrueWithBounds(object):
         for p in frame.props[1].sum_mole_frac:
             assert p in frame.params.phase_list
             assert str(frame.props[1].sum_mole_frac[p].body) == str(
-                    1e3*sum(frame.props[1].mole_frac_phase_comp[p, i]
-                            for i in frame.props[1].params.component_list))
+                    sum(frame.props[1].mole_frac_phase_comp[p, i]
+                        for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 3
@@ -1026,7 +1026,7 @@ class TestCommon(object):
                 "phases": {
                     "a": {"equation_of_state": dummy_eos},
                     "b": {"equation_of_state": dummy_eos}},
-                "state_definition": modules[__name__],
+                "state_definition": FcPh,
                 "pressure_ref": 1e5,
                 "temperature_ref": 300,
                 "state_bounds": {
@@ -1047,8 +1047,6 @@ class TestCommon(object):
         # Add necessary variables that would be built by other methods
         m.props[1].dens_mol_phase = Var(m.params.phase_list, initialize=1)
         m.props[1].enth_mol_phase = Var(m.params.phase_list, initialize=1)
-
-        define_state(m.props[1])
 
         return m
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
@@ -24,8 +24,9 @@ from pyomo.environ import (ConcreteModel, Constraint,
 from pyomo.util.check_units import (
     check_units_equivalent, assert_units_consistent)
 
+# Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FcPh import \
-    define_state, set_metadata
+    define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -1103,6 +1104,49 @@ class TestCommon(object):
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
+
+    @pytest.mark.unit
+    def test_calculate_scaling_factors(self, frame):
+        frame.props[1].calculate_scaling_factors()
+
+        assert len(frame.props[1].scaling_factor) == 20
+        assert frame.props[1].scaling_factor[frame.props[1].enth_mol] == 1e-4
+        assert frame.props[1].scaling_factor[frame.props[1].flow_mol] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c1"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c2"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c3"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
+        assert frame.props[1].scaling_factor[
+            frame.props[1].temperature] == 1e-2
 
     # Test General Methods
     @pytest.mark.unit

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
@@ -24,8 +24,9 @@ from pyomo.environ import (ConcreteModel, Constraint,
 from pyomo.util.check_units import (
     check_units_equivalent, assert_units_consistent)
 
+# Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FcTP import \
-    define_state, set_metadata
+    define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -1043,6 +1044,48 @@ class TestCommon(object):
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
+
+    @pytest.mark.unit
+    def test_calculate_scaling_factors(self, frame):
+        frame.props[1].calculate_scaling_factors()
+
+        assert len(frame.props[1].scaling_factor) == 19
+        assert frame.props[1].scaling_factor[frame.props[1].flow_mol] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c1"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c2"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c3"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
+        assert frame.props[1].scaling_factor[
+            frame.props[1].temperature] == 1e-2
 
     # Test General Methods
     @pytest.mark.unit

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
@@ -26,7 +26,7 @@ from pyomo.util.check_units import (
 
 # Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FcTP import \
-    define_state, set_metadata, define_default_scaling_factors
+    FcTP, define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -222,9 +222,9 @@ class Test1PhaseDefinedStateFalseNoBounds(object):
         for i in frame.props[1].component_flow_balances:
             assert i in frame.props[1].params.component_list
             assert str(frame.props[1].component_flow_balances[i].body) == str(
-                1e3*frame.props[1].mole_frac_comp[i] -
-                1e3*frame.props[1].mole_frac_phase_comp[
-                        frame.params.phase_list[1], i])
+                frame.props[1].mole_frac_comp[i] -
+                frame.props[1].mole_frac_phase_comp[
+                    frame.params.phase_list[1], i])
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 1
@@ -362,9 +362,9 @@ class Test1PhaseDefinedStateTrueWithBounds(object):
         for i in frame.props[1].component_flow_balances:
             assert i in frame.props[1].params.component_list
             assert str(frame.props[1].component_flow_balances[i].body) == str(
-                1e3*frame.props[1].mole_frac_comp[i] -
-                1e3*frame.props[1].mole_frac_phase_comp[
-                        frame.params.phase_list[1], i])
+                frame.props[1].mole_frac_comp[i] -
+                frame.props[1].mole_frac_phase_comp[
+                    frame.params.phase_list[1], i])
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 1
@@ -502,12 +502,12 @@ class Test2PhaseDefinedStateFalseNoBounds(object):
         assert isinstance(frame.props[1].sum_mole_frac, Constraint)
         assert len(frame.props[1].sum_mole_frac) == 1
         assert str(frame.props[1].sum_mole_frac.body) == str(
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[1], i]
-                        for i in frame.props[1].params.component_list) -
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[2], i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[1], i]
+                    for i in frame.props[1].params.component_list) -
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[2], i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
@@ -658,12 +658,12 @@ class Test2PhaseDefinedStateTrueWithBounds(object):
         assert isinstance(frame.props[1].sum_mole_frac, Constraint)
         assert len(frame.props[1].sum_mole_frac) == 1
         assert str(frame.props[1].sum_mole_frac.body) == str(
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[1], i]
-                        for i in frame.props[1].params.component_list) -
-                1e3*sum(frame.props[1].mole_frac_phase_comp[
-                        frame.props[1].params.phase_list[2], i]
-                        for i in frame.props[1].params.component_list))
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[1], i]
+                    for i in frame.props[1].params.component_list) -
+                sum(frame.props[1].mole_frac_phase_comp[
+                    frame.props[1].params.phase_list[2], i]
+                    for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 2
@@ -799,8 +799,8 @@ class Test3PhaseDefinedStateFalseNoBounds(object):
         for p in frame.props[1].sum_mole_frac:
             assert p in frame.params.phase_list
             assert str(frame.props[1].sum_mole_frac[p].body) == str(
-                    1e3*sum(frame.props[1].mole_frac_phase_comp[p, i]
-                            for i in frame.props[1].params.component_list))
+                    sum(frame.props[1].mole_frac_phase_comp[p, i]
+                        for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 3
@@ -948,8 +948,8 @@ class Test3PhaseDefinedStateTrueWithBounds(object):
         for p in frame.props[1].sum_mole_frac:
             assert p in frame.params.phase_list
             assert str(frame.props[1].sum_mole_frac[p].body) == str(
-                    1e3*sum(frame.props[1].mole_frac_phase_comp[p, i]
-                            for i in frame.props[1].params.component_list))
+                    sum(frame.props[1].mole_frac_phase_comp[p, i]
+                        for i in frame.props[1].params.component_list))
 
         assert isinstance(frame.props[1].phase_fraction_constraint, Constraint)
         assert len(frame.props[1].phase_fraction_constraint) == 3
@@ -972,7 +972,7 @@ class TestCommon(object):
                 "phases": {
                     "a": {"equation_of_state": dummy_eos},
                     "b": {"equation_of_state": dummy_eos}},
-                "state_definition": modules[__name__],
+                "state_definition": FcTP,
                 "pressure_ref": 1e5,
                 "temperature_ref": 300,
                 "state_bounds": {
@@ -992,8 +992,6 @@ class TestCommon(object):
         # Add necessary variables that would be built by other methods
         m.props[1].dens_mol_phase = Var(m.params.phase_list, initialize=1)
         m.props[1].enth_mol_phase = Var(m.params.phase_list, initialize=1)
-
-        define_state(m.props[1])
 
         return m
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
@@ -1066,23 +1066,23 @@ class TestCommon(object):
         assert frame.props[1].scaling_factor[
             frame.props[1].dens_mol_phase["b"]] == 1e-2
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c1"]] == 1e2
+            frame.props[1].mole_frac_comp["c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c2"]] == 1e2
+            frame.props[1].mole_frac_comp["c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c3"]] == 1e2
+            frame.props[1].mole_frac_comp["c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
         assert frame.props[1].scaling_factor[
             frame.props[1].temperature] == 1e-2

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
@@ -986,23 +986,23 @@ class TestCommon(object):
         assert frame.props[1].scaling_factor[
             frame.props[1].dens_mol_phase["b"]] == 1e-2
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c1"]] == 1e2
+            frame.props[1].mole_frac_comp["c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c2"]] == 1e2
+            frame.props[1].mole_frac_comp["c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_comp["c3"]] == 1e2
+            frame.props[1].mole_frac_comp["c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e3
         assert frame.props[1].scaling_factor[
-            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e3
         assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
         assert frame.props[1].scaling_factor[
             frame.props[1].temperature] == 1e-2

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
@@ -26,7 +26,7 @@ from pyomo.util.check_units import (
 
 # Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FpcTP import \
-    define_state, set_metadata, define_default_scaling_factors
+    FpcTP, define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -892,7 +892,7 @@ class TestCommon(object):
                 "phases": {
                     "a": {"equation_of_state": dummy_eos},
                     "b": {"equation_of_state": dummy_eos}},
-                "state_definition": modules[__name__],
+                "state_definition": FpcTP,
                 "pressure_ref": 1e5,
                 "temperature_ref": 300,
                 "state_bounds": {
@@ -913,8 +913,6 @@ class TestCommon(object):
         # Add necessary variables that would be built by other methods
         m.props[1].dens_mol_phase = Var(m.params.phase_list, initialize=1)
         m.props[1].enth_mol_phase = Var(m.params.phase_list, initialize=1)
-
-        define_state(m.props[1])
 
         return m
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
@@ -24,8 +24,9 @@ from pyomo.environ import (ConcreteModel, Constraint,
 from pyomo.util.check_units import (
     check_units_equivalent, assert_units_consistent)
 
+# Need define_default_scaling_factors, even though it is not used directly
 from idaes.generic_models.properties.core.state_definitions.FpcTP import \
-    define_state, set_metadata
+    define_state, set_metadata, define_default_scaling_factors
 from idaes.core import (MaterialFlowBasis,
                         MaterialBalanceType,
                         EnergyBalanceType,
@@ -951,6 +952,60 @@ class TestCommon(object):
 
         assert isinstance(frame.props[1].mole_frac_phase_comp_eq, Constraint)
         assert len(frame.props[1].mole_frac_phase_comp_eq) == 6
+
+    @pytest.mark.unit
+    def test_calculate_scaling_factors(self, frame):
+        frame.props[1].calculate_scaling_factors()
+
+        assert len(frame.props[1].scaling_factor) == 25
+        assert frame.props[1].scaling_factor[frame.props[1].flow_mol] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c1"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c2"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_comp["c3"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase_comp["a", "c1"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase_comp["a", "c2"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase_comp["a", "c3"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase_comp["b", "c1"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase_comp["b", "c2"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].flow_mol_phase_comp["b", "c3"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["a"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].dens_mol_phase["b"]] == 1e-2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_comp["c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["a", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c1"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c2"]] == 1e2
+        assert frame.props[1].scaling_factor[
+            frame.props[1].mole_frac_phase_comp["b", "c3"]] == 1e2
+        assert frame.props[1].scaling_factor[frame.props[1].pressure] == 1e-5
+        assert frame.props[1].scaling_factor[
+            frame.props[1].temperature] == 1e-2
 
     # Test General Methods
     @pytest.mark.unit

--- a/idaes/generic_models/properties/cubic_eos/cubic_prop_pack.py
+++ b/idaes/generic_models/properties/cubic_eos/cubic_prop_pack.py
@@ -1639,7 +1639,7 @@ class CubicStateBlockData(StateBlockData):
                 log(b.temperature/b.params.temperature_ref))
 
     def calculate_scaling_factors(self):
-        # Get default scale factors and do caclulations from base classes
+        # Get default scale factors and do calculations from base classes
         super().calculate_scaling_factors()
 
         phases = self.params.config.valid_phase


### PR DESCRIPTION
## Partly addresses #76 


## Summary/Motivation:
Generic property packages do not yet support the IDAES scaling tools. This PR adds scaling methods to the generic properties framework (but not generic reactions).

## Changes proposed in this PR:
- Lots.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
