### PR TITLE
Minor update to copy_port_values(), now can take and arc

### DIFF
--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -213,18 +213,25 @@ def svg_tag(
 
 
 # Author: John Eslick
-def copy_port_values(destination, source):
+def copy_port_values(destination=None, source=None, arc=None):
     """
     Copy the variable values in the source port to the destination port. The
     ports must containt the same variables.
 
     Args:
-        (pyomo.Port): Copy values from this port
-        (pyomo.Port): Copy values to this port
+        destination (Port): Copy values from this port
+        source (Port): Copy values to this port
+        arc (Arc): If arc is provided, use it to get default values of source
+            and destination
 
     Returns:
         None
     """
+    if arc is not None:
+        if source is None:
+            source = arc.source
+        if destination is None:
+            destination = arc.dest
     for k, v in destination.vars.items():
         if isinstance(v, pyo.Var):
             for i in v:

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -23,6 +23,7 @@ from pyomo.core.base.indexed_component import (
     UnindexedComponent_set, )
 from pyomo.core.base.util import disable_methods
 from pyomo.common.config import ConfigBlock
+from pyomo.network import Port, Arc
 
 import idaes.logger as idaeslog
 
@@ -219,19 +220,42 @@ def copy_port_values(destination=None, source=None, arc=None):
     ports must containt the same variables.
 
     Args:
-        destination (Port): Copy values from this port
-        source (Port): Copy values to this port
-        arc (Arc): If arc is provided, use it to get default values of source
-            and destination
+        destination (Port): Port to copy values to or None if specifying arc
+        source (Port): Port to copy values from or None if specifying arc
+        arc (Arc): If arc is provided, use arc to define source and destination
 
     Returns:
         None
     """
+    # Allow an arc to be passed as a positional arg
+    if destination is not None and source is None and isinstance(destination, Arc):
+        arc = destination
+        destination = None
+    # Check that only arc or source and destination are passed
+    if arc is None and (destination is None or source is None):
+        raise RuntimeError(
+            "In copy_port_values(), must provide source and destination or arc")
     if arc is not None:
-        if source is None:
-            source = arc.source
-        if destination is None:
-            destination = arc.dest
+        if not isinstance(arc, Arc):
+            raise RuntimeError(
+                "In copy_port_values(), arc argument is not an instance of an Arc")
+        if destination is not None or source is not None:
+            raise RuntimeError(
+                "In copy_port_values(), provide only arc or source and destination")
+    if destination is not None:
+        if not isinstance(destination, Port):
+            raise RuntimeError(
+                "In copy_port_values(), destination is not an instance of Port")
+        if not isinstance(source, Port):
+            raise RuntimeError(
+                "In copy_port_values(), source is not an instance of Port")
+
+    # Arc provided so get source and destination from arc
+    if arc is not None:
+        source = arc.source
+        destination = arc.dest
+
+    # Copy values
     for k, v in destination.vars.items():
         if isinstance(v, pyo.Var):
             for i in v:

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -70,33 +70,55 @@ def test_port_copy():
     m.b2.port.add(m.b2.x, "x")
     m.b2.port.add(m.b2.y, "y")
     m.b2.port.add(m.b2.z, "z")
-    copy_port_values(m.b2.port, m.b1.port)
-    assert(m.b2.x == 3)
-    assert(m.b2.y[0] == 4)
-    assert(m.b2.y[1] == 5)
-    assert(m.b2.z[0, "A"] == 6)
-    assert(m.b2.z[0, "B"] == 7)
-    assert(m.b2.z[1, "A"] == 8)
-    assert(m.b2.z[1, "B"] == 9)
+    def assert_copied_right():
+        assert(m.b2.x == 3)
+        assert(m.b2.y[0] == 4)
+        assert(m.b2.y[1] == 5)
+        assert(m.b2.z[0, "A"] == 6)
+        assert(m.b2.z[0, "B"] == 7)
+        assert(m.b2.z[1, "A"] == 8)
+        assert(m.b2.z[1, "B"] == 9)
 
-    m.b2.x = 0
-    m.b2.y[0] = 0
-    m.b2.y[1] = 0
-    m.b2.z[0, "A"] = 0
-    m.b2.z[0, "B"] = 0
-    m.b2.z[1, "A"] = 0
-    m.b2.z[1, "B"] = 0
-
+    def reset():
+        m.b2.x = 0
+        m.b2.y[0] = 0
+        m.b2.y[1] = 0
+        m.b2.z[0, "A"] = 0
+        m.b2.z[0, "B"] = 0
+        m.b2.z[1, "A"] = 0
+        m.b2.z[1, "B"] = 0
     m.arc = Arc(source=m.b1.port, dest=m.b2.port)
-    copy_port_values(arc=m.arc)
 
-    assert(m.b2.x == 3)
-    assert(m.b2.y[0] == 4)
-    assert(m.b2.y[1] == 5)
-    assert(m.b2.z[0, "A"] == 6)
-    assert(m.b2.z[0, "B"] == 7)
-    assert(m.b2.z[1, "A"] == 8)
-    assert(m.b2.z[1, "B"] == 9)
+    copy_port_values(m.b2.port, m.b1.port)
+    assert_copied_right()
+    reset()
+
+
+    copy_port_values(source=m.b1.port, destination=m.b2.port)
+    assert_copied_right()
+    reset()
+
+    copy_port_values(m.arc)
+    assert_copied_right()
+    reset()
+
+    copy_port_values(arc=m.arc)
+    assert_copied_right()
+    reset()
+
+    with pytest.raises(RuntimeError):
+        copy_port_values(arc=m.b1.port)
+
+    with pytest.raises(RuntimeError):
+        copy_port_values(source=m.b1.port, destination=m.b2.port, arc=m.arc)
+
+    with pytest.raises(RuntimeError):
+        copy_port_values(source=m.b1.port, arc=m.arc)
+
+    with pytest.raises(RuntimeError):
+        copy_port_values(source=m.b1.port, destination=m.arc)
+
+
 
 
 

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -17,7 +17,7 @@ This module contains miscalaneous utility functions for use in IDAES models.
 import pytest
 
 from pyomo.environ import ConcreteModel, Expression, Set, Block, Var, units
-from pyomo.network import Port
+from pyomo.network import Port, Arc
 from pyomo.common.config import ConfigBlock
 from pyomo.core.base.units_container import UnitsError
 
@@ -78,6 +78,26 @@ def test_port_copy():
     assert(m.b2.z[0, "B"] == 7)
     assert(m.b2.z[1, "A"] == 8)
     assert(m.b2.z[1, "B"] == 9)
+
+    m.b2.x = 0
+    m.b2.y[0] = 0
+    m.b2.y[1] = 0
+    m.b2.z[0, "A"] = 0
+    m.b2.z[0, "B"] = 0
+    m.b2.z[1, "A"] = 0
+    m.b2.z[1, "B"] = 0
+
+    m.arc = Arc(source=m.b1.port, dest=m.b2.port)
+    copy_port_values(arc=m.arc)
+
+    assert(m.b2.x == 3)
+    assert(m.b2.y[0] == 4)
+    assert(m.b2.y[1] == 5)
+    assert(m.b2.z[0, "A"] == 6)
+    assert(m.b2.z[0, "B"] == 7)
+    assert(m.b2.z[1, "A"] == 8)
+    assert(m.b2.z[1, "B"] == 9)
+
 
 
 # Author: John Eslick


### PR DESCRIPTION
This makes it possible to specify an arc for the ```copy_port_values()``` function.  Just saves some typing and make it a little easier to use.  It still works the way it did, just provides an extra option. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
