### PR TITLE
Mark bin download test as integration

### DIFF
--- a/idaes/util/tests/test_download_bin.py
+++ b/idaes/util/tests/test_download_bin.py
@@ -12,7 +12,7 @@ def _del_data_file(path):
     except OSError:
         pass
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_dl_bin():
     idaes._create_testing_dir()
     _del_data_file(os.path.join(idaes.testing_directory, "version_lib.txt"))


### PR DESCRIPTION
## Fixes
Mark bin download test as integration.  That makes it run less often and random network-type errors that causes the download to fail will happen less often.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
