### PR TITLE
Moving some slow tests to integration

### DIFF
--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
@@ -47,7 +47,7 @@ class TestColumn:
     -Pressure: Pa
     """
 
-    @pytest.mark.component
+    @pytest.mark.integration
     def test_steady_state_initialization(self):
         # Spacial domain finite elemets and finite element list
         x_nfe = 10
@@ -155,7 +155,6 @@ class TestColumn:
             m.fs.unit.liquid_inlet.mole_frac_comp[t, "MEA"].fix(0.11602)
         initialization_tester(m)
 
-
     @pytest.fixture(scope="module",
                     params=[ProcessType.absorber, ProcessType.stripper])
     def column_model_ss(self, request):
@@ -247,7 +246,6 @@ class TestColumn:
             m.fs.unit.initialize(
                 homotopy_steps_h=[0.1, 0.2, 0.4, 0.6, 0.8, 1])
         return m
-
 
     @pytest.fixture(scope="module",
                     params=[ProcessType.absorber, ProcessType.stripper])
@@ -345,10 +343,11 @@ class TestColumn:
 
             # Initialize column
             m.fs.unit.initialize(
-                homotopy_steps_h=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1])
+                homotopy_steps_h=[
+                    0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1])
         return m
 
-# ------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.integration
     def test_steady_state_column_build(self, column_model_ss):

--- a/idaes/power_generation/flowsheets/test/test_NGFC.py
+++ b/idaes/power_generation/flowsheets/test/test_NGFC.py
@@ -57,17 +57,19 @@ solver = get_default_solver()
 def m():
     m = pyo.ConcreteModel()
     m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    build_power_island(m)
+    build_reformer(m)
+    set_power_island_inputs(m)
+    set_reformer_inputs(m)
+    connect_reformer_to_power_island(m)
+
     return m
 
 
 @pytest.mark.component
 def test_build(m):
     """Build NGFC and check for unit ops"""
-    build_power_island(m)
-    build_reformer(m)
-    set_power_island_inputs(m)
-    set_reformer_inputs(m)
-    connect_reformer_to_power_island(m)
 
     assert degrees_of_freedom(m) == 0
 
@@ -82,7 +84,7 @@ def test_build(m):
     assert not m.fs.anode_mix.feed.flow_mol[0].fixed
 
 
-@pytest.mark.component
+@pytest.mark.integration
 def test_initialize(m):
     scale_flowsheet(m)
     initialize_power_island(m)
@@ -103,7 +105,7 @@ def test_initialize(m):
             pytest.approx(475.8, 1e-3))
 
 
-@pytest.mark.component
+@pytest.mark.integration
 def test_ROM(m):
     SOFC_ROM_setup(m)
     add_SOFC_energy_balance(m)
@@ -122,7 +124,7 @@ def test_ROM(m):
     assert hasattr(m.fs, 'CO2_emissions')
 
 
-@pytest.mark.component
+@pytest.mark.integration
 def test_json_load(m):
     fname = os.path.join(this_file_dir(), 'NGFC_flowsheet_init.json')
     ms.from_json(m, fname=fname)

--- a/idaes/power_generation/properties/tests/test_SOFC_ROM.py
+++ b/idaes/power_generation/properties/tests/test_SOFC_ROM.py
@@ -57,7 +57,7 @@ class TestSOFCROM(object):
         return m
 
     @pytest.mark.build
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_build(self, m):
         assert degrees_of_freedom(m) == 9
         assert number_variables(m) == 13562
@@ -90,13 +90,13 @@ class TestSOFCROM(object):
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.component
+    @pytest.mark.integration
     def test_initialize(self, m):
         initialize_SOFC_ROM(m.SOFC)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.component
+    @pytest.mark.integration
     def test_solve(self, m):
         m.SOFC.current_density.fix(4000)
         m.SOFC.fuel_temperature.fix(348.3)


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Changing the pytest marks on some slow tests to `integration` to speed up running of common tests.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
