### PR TITLE
Add performace curve structure to isentropic pressure changers.

### DIFF
--- a/docs/technical_specs/model_libraries/generic/unit_models/pressure_changer.rst
+++ b/docs/technical_specs/model_libraries/generic/unit_models/pressure_changer.rst
@@ -185,7 +185,7 @@ The next example shows how to use a callback to add performance curves.
   m.fs.properties = iapws95.Iapws95ParameterBlock()
 
   def perf_callback(blk):
-      # This callback adds constriants to the performance_cruve block.  blk is the
+      # This callback adds constraints to the performance_cruve block. blk is the
       # performance_curve block, but we also want to use quantities from the main
       # pressure changer model, which is the parent block.
       prnt = blk.parent_block()

--- a/docs/technical_specs/model_libraries/generic/unit_models/pressure_changer.rst
+++ b/docs/technical_specs/model_libraries/generic/unit_models/pressure_changer.rst
@@ -92,6 +92,132 @@ If compressor is True, :math:`W_{fluid,t} = W_{mechanical,t} \times \eta_t`
 
 If compressor is False, :math:`W_{fluid,t} \times \eta_t = W_{mechanical,t}`
 
+Performance Curves
+------------------
+Isentropic pressure changers support optional performance curve constraints.
+The exact form of these constraints is left to the user, but generally the
+constraints take the form of one or two equations which provide a correlation
+between head, efficiency, or pressure ratio and mass or volumetric flow.
+Additional variables such as compressor or turbine speed can be added if needed.
+
+Performance curves should be added to the ``perfomance_curve`` sub-block rather
+than adding them elsewhere because it allows them to be integrated into the
+unit model initialization. It also provides standardization for users and
+provides a convenient way to turn the performance equations on and off by
+activating and deactivating the block.
+
+Usually there are one or two performance curve constraints. Either directly or
+indirectly, these curves specify an efficiency and pressure drop, so in adding
+performance curves the efficiency and/or pressure drop should be freed as
+appropriate.
+
+Performance equations generally are in a simple form (e.g. efficiency = f(flow)),
+where no special initialization is needed. Performance curves also are specific
+to a particular property package selection and pressure changer, which allows
+the performance curve equations to be written in a well-scaled way since units
+of measure and magnitudes are known.
+
+To add performance curves to an isentropic pressure changer, simply supply the
+``"support_isentropic_performance_curves": True`` options in the pressure
+changer config dict.  This will create a ``performance_curve`` sub-block of
+the pressure changer model. By default this block will have the expressions
+``head`` and ``heat_isentropic`` for convenience, as these quantities often
+appear in performance curves.
+
+Two examples are provided below that demonstrate two ways to add performance
+curves. The first does not use a callback the second does.
+
+.. testcode::
+
+  from pyomo.environ import ConcreteModel, SolverFactory, units, value
+  from idaes.core import FlowsheetBlock
+  from idaes.generic_models.unit_models.pressure_changer import Turbine
+  from idaes.generic_models.properties import iapws95
+  import pytest
+
+  solver = SolverFactory('ipopt')
+  m = ConcreteModel()
+  m.fs = FlowsheetBlock(default={"dynamic": False})
+  m.fs.properties = iapws95.Iapws95ParameterBlock()
+  m.fs.unit = Turbine(default={
+      "property_package": m.fs.properties,
+      "support_isentropic_performance_curves":True})
+
+  # Add performance curves
+  @m.fs.unit.performance_curve.Constraint(m.fs.config.time)
+  def pc_isen_eff_eqn(b, t):
+      # main pressure changer block parent of performance_curve
+      prnt = b.parent_block()
+      return prnt.efficiency_isentropic[t] == 0.9
+  @m.fs.unit.performance_curve.Constraint(m.fs.config.time)
+  def pc_isen_head_eqn(b, t):
+      # divide both sides by 1000 for scaling
+      return b.head_isentropic[t]/1000 == -75530.8/1000*units.J/units.kg
+
+  # set inputs
+  m.fs.unit.inlet.flow_mol[0].fix(1000)  # mol/s
+  Tin = 500  # K
+  Pin = 1000000  # Pa
+  Pout = 700000  # Pa
+  hin = iapws95.htpx(Tin*units.K, Pin*units.Pa)
+  m.fs.unit.inlet.enth_mol[0].fix(hin)
+  m.fs.unit.inlet.pressure[0].fix(Pin)
+
+  m.fs.unit.initialize()
+  solver.solve(m, tee=True)
+
+  assert value(m.fs.unit.efficiency_isentropic[0]) == pytest.approx(0.9, rel=1e-3)
+  assert value(m.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)
+
+The next example shows how to use a callback to add performance curves.
+
+.. testcode::
+
+  from pyomo.environ import ConcreteModel, SolverFactory, units, value
+  from idaes.core import FlowsheetBlock
+  from idaes.generic_models.unit_models.pressure_changer import Turbine
+  from idaes.generic_models.properties import iapws95
+  import pytest
+
+  solver = SolverFactory('ipopt')
+  m = ConcreteModel()
+  m.fs = FlowsheetBlock(default={"dynamic": False})
+  m.fs.properties = iapws95.Iapws95ParameterBlock()
+
+  def perf_callback(blk):
+      # This callback adds constriants to the perfomance_cruve block.  blk is the
+      # performance_curve block, but we also want to use quantities from the main
+      # pressure changer model, which is the parent block.
+      prnt = blk.parent_block()
+      # this is the pressure changer model block
+      @blk.Constraint(m.fs.config.time)
+      def pc_isen_eff_eqn(b, t):
+          return prnt.efficiency_isentropic[t] == 0.9
+      @blk.Constraint(m.fs.config.time)
+      def pc_isen_head_eqn(b, t):
+          return b.head_isentropic[t]/1000 == -75530.8/1000*units.J/units.kg
+
+  m.fs.unit = Turbine(default={
+      "property_package": m.fs.properties,
+      "support_isentropic_performance_curves":True,
+      "isentropic_performance_curves": {"build_callback": perf_callback}})
+
+  # set inputs
+  m.fs.unit.inlet.flow_mol[0].fix(1000)  # mol/s
+  Tin = 500  # K
+  Pin = 1000000  # Pa
+  Pout = 700000  # Pa
+  hin = iapws95.htpx(Tin*units.K, Pin*units.Pa)
+  m.fs.unit.inlet.enth_mol[0].fix(hin)
+  m.fs.unit.inlet.pressure[0].fix(Pin)
+
+  m.fs.unit.initialize()
+  solver.solve(m, tee=True)
+
+  assert value(m.fs.unit.efficiency_isentropic[0]) == pytest.approx(0.9, rel=1e-3)
+  assert value(m.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)
+
+
 PressureChanger Class
 ----------------------
 

--- a/docs/technical_specs/model_libraries/generic/unit_models/pressure_changer.rst
+++ b/docs/technical_specs/model_libraries/generic/unit_models/pressure_changer.rst
@@ -164,7 +164,7 @@ curves. The first does not use a callback the second does.
   m.fs.unit.inlet.pressure[0].fix(Pin)
 
   m.fs.unit.initialize()
-  solver.solve(m, tee=True)
+  solver.solve(m, tee=False)
 
   assert value(m.fs.unit.efficiency_isentropic[0]) == pytest.approx(0.9, rel=1e-3)
   assert value(m.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)
@@ -212,7 +212,7 @@ The next example shows how to use a callback to add performance curves.
   m.fs.unit.inlet.pressure[0].fix(Pin)
 
   m.fs.unit.initialize()
-  solver.solve(m, tee=True)
+  solver.solve(m, tee=False)
 
   assert value(m.fs.unit.efficiency_isentropic[0]) == pytest.approx(0.9, rel=1e-3)
   assert value(m.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)

--- a/docs/technical_specs/model_libraries/generic/unit_models/pressure_changer.rst
+++ b/docs/technical_specs/model_libraries/generic/unit_models/pressure_changer.rst
@@ -100,7 +100,7 @@ constraints take the form of one or two equations which provide a correlation
 between head, efficiency, or pressure ratio and mass or volumetric flow.
 Additional variables such as compressor or turbine speed can be added if needed.
 
-Performance curves should be added to the ``perfomance_curve`` sub-block rather
+Performance curves should be added to the ``performance_curve`` sub-block rather
 than adding them elsewhere because it allows them to be integrated into the
 unit model initialization. It also provides standardization for users and
 provides a convenient way to turn the performance equations on and off by
@@ -185,7 +185,7 @@ The next example shows how to use a callback to add performance curves.
   m.fs.properties = iapws95.Iapws95ParameterBlock()
 
   def perf_callback(blk):
-      # This callback adds constriants to the perfomance_cruve block.  blk is the
+      # This callback adds constriants to the performance_cruve block.  blk is the
       # performance_curve block, but we also want to use quantities from the main
       # pressure changer model, which is the parent block.
       prnt = blk.parent_block()

--- a/idaes/generic_models/unit_models/pressure_changer.py
+++ b/idaes/generic_models/unit_models/pressure_changer.py
@@ -54,16 +54,16 @@ class ThermodynamicAssumption(Enum):
 
 @declare_process_block_class("IsentropicPerformanceCurve")
 class IsentropicPerformanceCurveData(ProcessBlockData):
-    """Block that holds perfomance curves. Typically these are in the form of
+    """Block that holds performance curves. Typically these are in the form of
     constraints that relate head, efficiency, or pressure ratio to volumetric
     or mass flow.  Additional varaibles can be included if needed, such as
     speed. For convenience an option is provided to add head expressions to the
-    block. Perfomance curves, and any additional variables, constraints, or
+    block. performance curves, and any additional variables, constraints, or
     expressions can be added to this block either via callback provided to the
     configuration, or after the model is constructued."""
 
     CONFIG = ProcessBlockData.CONFIG(
-        doc="Configuration dictionary for the performace curve block.")
+        doc="Configuration dictionary for the performance curve block.")
     CONFIG.declare("build_callback", ConfigValue(
         default=None,
         doc="Optional callback to add performance curve constraints"))
@@ -71,7 +71,7 @@ class IsentropicPerformanceCurveData(ProcessBlockData):
         default=True,
         domain=bool,
         doc="If true add expressions for 'head' and 'head_isentropic'."
-            " These expressions can be used in perfomance curve constraints."))
+            " These expressions can be used in performance curve constraints."))
 
     def has_constraints(self):
         for o in self.component_data_objects(Constraint):
@@ -238,16 +238,16 @@ see property package for documentation.}""",
         ),
     )
     CONFIG.declare(
-        "support_isentropic_perfomance_curves",
+        "support_isentropic_performance_curves",
         ConfigValue(
             default=False,
             domain=In([True, False]),
-            doc="Include a block for perfomance curves, configure via"
-                " isentropic_perfomance_curves.",
+            doc="Include a block for performance curves, configure via"
+                " isentropic_performance_curves.",
         ),
     )
     CONFIG.declare(
-        "isentropic_perfomance_curves",
+        "isentropic_performance_curves",
         IsentropicPerformanceCurveData.CONFIG(),
         # doc included in IsentropicPerformanceCurveData
     )
@@ -534,9 +534,9 @@ see property package for documentation.}""",
                     b.work_isentropic[t] * b.efficiency_isentropic[t]
                 )
 
-        if self.config.support_isentropic_perfomance_curves:
+        if self.config.support_isentropic_performance_curves:
             self.performance_curve = IsentropicPerformanceCurve(
-                default=self.config.isentropic_perfomance_curves)
+                default=self.config.isentropic_performance_curves)
 
     def model_check(blk):
         """
@@ -728,19 +728,19 @@ see property package for documentation.}""",
         t0 = blk.flowsheet().config.time.first()
         state_args_out = {}
 
-        # perfomance curves exist and are active so initialize with them
+        # performance curves exist and are active so initialize with them
         activate_performance_curves = (
             hasattr(blk, "performance_curve") and
             blk.performance_curve.has_constraints() and
             blk.performance_curve.active)
         if activate_performance_curves:
             blk.performance_curve.deactivate()
-            # The performace curves will provide (maybe indirectly) efficency
+            # The performance curves will provide (maybe indirectly) efficency
             # and/or pressure ratio. To get through the standard isentropic
             # pressure changer init, we'll see if the user provided a guess for
             # pressure ratio or isentropic efficency and fix them if need. If
             # not fixed and no guess provided, fill in something reasonable
-            # until the performace curves are turned on.
+            # until the performance curves are turned on.
             unfix_eff = {}
             unfix_ratioP = {}
             for t in blk.flowsheet().config.time:

--- a/idaes/generic_models/unit_models/pressure_changer.py
+++ b/idaes/generic_models/unit_models/pressure_changer.py
@@ -853,10 +853,6 @@ see property package for documentation.}""",
         init_log.info_high("Initialization Step 4 {}."
                            .format(idaeslog.condition(res)))
 
-        # ---------------------------------------------------------------------
-        # Release Inlet state
-        blk.control_volume.release_state(flags, outlvl)
-
         if blk.performance_curve.has_constraints():
             blk.performance_curve.activate()
             for t, v in unfix_eff.items():
@@ -869,6 +865,9 @@ see property package for documentation.}""",
                 res = opt.solve(blk, tee=slc.tee)
             init_log.info_high(f"Initialization Step 5 {idaeslog.condition(res)}.")
 
+        # ---------------------------------------------------------------------
+        # Release Inlet state
+        blk.control_volume.release_state(flags, outlvl)
         init_log.info(f"Initialization Complete: {idaeslog.condition(res)}")
 
     def _get_performance_contents(self, time_point=0):

--- a/idaes/generic_models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/generic_models/unit_models/tests/test_pressure_changer.py
@@ -82,7 +82,7 @@ class TestPressureChanger(object):
                 "property_package": m.fs.properties})
 
         # Check unit config arguments
-        assert len(m.fs.unit.config) == 11
+        assert len(m.fs.unit.config) == 12
 
         assert m.fs.unit.config.material_balance_type == \
             MaterialBalanceType.useDefault
@@ -676,7 +676,7 @@ class TestTurbine(object):
 
         assert isinstance(m.fs.unit, PressureChangerData)
         # Check unit config arguments
-        assert len(m.fs.unit.config) == 11
+        assert len(m.fs.unit.config) == 12
 
         assert m.fs.unit.config.material_balance_type == \
             MaterialBalanceType.useDefault
@@ -707,7 +707,7 @@ class TestCompressor(object):
 
         assert isinstance(m.fs.unit, PressureChangerData)
         # Check unit config arguments
-        assert len(m.fs.unit.config) == 11
+        assert len(m.fs.unit.config) == 12
 
         assert m.fs.unit.config.material_balance_type == \
             MaterialBalanceType.useDefault
@@ -738,7 +738,7 @@ class TestPump(object):
 
         assert isinstance(m.fs.unit, PressureChangerData)
         # Check unit config arguments
-        assert len(m.fs.unit.config) == 11
+        assert len(m.fs.unit.config) == 12
 
         assert m.fs.unit.config.material_balance_type == \
             MaterialBalanceType.useDefault
@@ -886,9 +886,8 @@ class Test_costing(object):
 
         m.fs.unit = Turbine(default={
             "property_package": m.fs.properties,
-            "isentropic_perfomance_curves": {
-                "build_callback": perf_callback,
-                "build_head_expressions": True}})
+            "support_isentropic_perfomance_curves":True,
+            "isentropic_perfomance_curves": {"build_callback": perf_callback}})
 
         # set inputs
         m.fs.unit.inlet.flow_mol[0].fix(1000)  # mol/s
@@ -915,7 +914,7 @@ class Test_costing(object):
         m.fs.properties = iapws95.Iapws95ParameterBlock()
         m.fs.unit = Turbine(default={
             "property_package": m.fs.properties,
-            "isentropic_perfomance_curves":{"build_head_expressions":True}})
+            "support_isentropic_perfomance_curves":True})
         unit_hd = units.J/units.kg
         unit_vflw = units.m**3/units.s
         @m.fs.unit.performance_curve.Constraint(m.fs.config.time)

--- a/idaes/generic_models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/generic_models/unit_models/tests/test_pressure_changer.py
@@ -82,7 +82,7 @@ class TestPressureChanger(object):
                 "property_package": m.fs.properties})
 
         # Check unit config arguments
-        assert len(m.fs.unit.config) == 10
+        assert len(m.fs.unit.config) == 11
 
         assert m.fs.unit.config.material_balance_type == \
             MaterialBalanceType.useDefault
@@ -676,7 +676,7 @@ class TestTurbine(object):
 
         assert isinstance(m.fs.unit, PressureChangerData)
         # Check unit config arguments
-        assert len(m.fs.unit.config) == 10
+        assert len(m.fs.unit.config) == 11
 
         assert m.fs.unit.config.material_balance_type == \
             MaterialBalanceType.useDefault
@@ -707,7 +707,7 @@ class TestCompressor(object):
 
         assert isinstance(m.fs.unit, PressureChangerData)
         # Check unit config arguments
-        assert len(m.fs.unit.config) == 10
+        assert len(m.fs.unit.config) == 11
 
         assert m.fs.unit.config.material_balance_type == \
             MaterialBalanceType.useDefault
@@ -738,7 +738,7 @@ class TestPump(object):
 
         assert isinstance(m.fs.unit, PressureChangerData)
         # Check unit config arguments
-        assert len(m.fs.unit.config) == 10
+        assert len(m.fs.unit.config) == 11
 
         assert m.fs.unit.config.material_balance_type == \
             MaterialBalanceType.useDefault
@@ -862,3 +862,85 @@ class Test_costing(object):
         solver.solve(m, tee=True)
         assert m.fs.unit.costing.purchase_cost.value ==\
             pytest.approx(213199, 1e-5)
+
+    @pytest.mark.component
+    def test_turbine_performace_way1(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+        m.fs.properties = iapws95.Iapws95ParameterBlock()
+
+        def perf_callback(b):
+            unit_hd = units.J/units.kg
+            unit_vflw = units.m**3/units.s
+            @b.Constraint(m.fs.config.time)
+            def pc_isen_eff_eqn(b, t):
+                prnt = b.parent_block()
+                vflw = prnt.control_volume.properties_in[t].flow_vol
+                return prnt.efficiency_isentropic[t] == 0.9/3.975*vflw/unit_vflw
+            @b.Constraint(m.fs.config.time)
+            def pc_isen_head_eqn(b, t):
+                prnt = b.parent_block()
+                vflw = prnt.control_volume.properties_in[t].flow_vol
+                return prnt.head_isentropic[t]/1000 == \
+                    -75530.8/3.975/1000*vflw/unit_vflw*unit_hd
+
+        m.fs.unit = Turbine(default={
+            "property_package": m.fs.properties,
+            "isentropic_perfomance_curves": {
+                "build_callback": perf_callback}})
+
+        # set inputs
+        m.fs.unit.inlet.flow_mol[0].fix(1000)  # mol/s
+        Tin = 500  # K
+        Pin = 1000000  # Pa
+        Pout = 700000  # Pa
+        hin = iapws95.htpx(Tin*units.K, Pin*units.Pa)
+        m.fs.unit.inlet.enth_mol[0].fix(hin)
+        m.fs.unit.inlet.pressure[0].fix(Pin)
+
+        m.fs.unit.initialize()
+        assert degrees_of_freedom(m) == 0
+        assert_units_consistent(m.fs.unit)
+        solver.solve(m, tee=True)
+
+        assert value(m.fs.unit.efficiency_isentropic[0]) \
+            == pytest.approx(0.9, rel=1e-3)
+        assert value(m.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)
+
+    @pytest.mark.component
+    def test_turbine_performace_way2(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+        m.fs.properties = iapws95.Iapws95ParameterBlock()
+        m.fs.unit = Turbine(default={"property_package": m.fs.properties})
+        unit_hd = units.J/units.kg
+        unit_vflw = units.m**3/units.s
+        @m.fs.unit.performance_curve.Constraint(m.fs.config.time)
+        def pc_isen_eff_eqn(b, t):
+            prnt = b.parent_block()
+            vflw = prnt.control_volume.properties_in[t].flow_vol
+            return prnt.efficiency_isentropic[t] == 0.9/3.975*vflw/unit_vflw
+        @m.fs.unit.performance_curve.Constraint(m.fs.config.time)
+        def pc_isen_head_eqn(b, t):
+            prnt = b.parent_block()
+            vflw = prnt.control_volume.properties_in[t].flow_vol
+            return prnt.head_isentropic[t]/1000 == \
+                -75530.8/3.975/1000*vflw/unit_vflw*unit_hd
+
+        # set inputs
+        m.fs.unit.inlet.flow_mol[0].fix(1000)  # mol/s
+        Tin = 500  # K
+        Pin = 1000000  # Pa
+        Pout = 700000  # Pa
+        hin = iapws95.htpx(Tin*units.K, Pin*units.Pa)
+        m.fs.unit.inlet.enth_mol[0].fix(hin)
+        m.fs.unit.inlet.pressure[0].fix(Pin)
+
+        m.fs.unit.initialize()
+        assert degrees_of_freedom(m) == 0
+        assert_units_consistent(m.fs.unit)
+        solver.solve(m, tee=True)
+
+        assert value(m.fs.unit.efficiency_isentropic[0]) \
+            == pytest.approx(0.9, rel=1e-3)
+        assert value(m.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)

--- a/idaes/generic_models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/generic_models/unit_models/tests/test_pressure_changer.py
@@ -864,7 +864,7 @@ class Test_costing(object):
             pytest.approx(213199, 1e-5)
 
     @pytest.mark.component
-    def test_turbine_performace_way1(self):
+    def test_turbine_performance_way1(self):
         m = ConcreteModel()
         m.fs = FlowsheetBlock(default={"dynamic": False})
         m.fs.properties = iapws95.Iapws95ParameterBlock()
@@ -886,8 +886,8 @@ class Test_costing(object):
 
         m.fs.unit = Turbine(default={
             "property_package": m.fs.properties,
-            "support_isentropic_perfomance_curves":True,
-            "isentropic_perfomance_curves": {"build_callback": perf_callback}})
+            "support_isentropic_performance_curves":True,
+            "isentropic_performance_curves": {"build_callback": perf_callback}})
 
         # set inputs
         m.fs.unit.inlet.flow_mol[0].fix(1000)  # mol/s
@@ -908,13 +908,13 @@ class Test_costing(object):
         assert value(m.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)
 
     @pytest.mark.component
-    def test_turbine_performace_way2(self):
+    def test_turbine_performance_way2(self):
         m = ConcreteModel()
         m.fs = FlowsheetBlock(default={"dynamic": False})
         m.fs.properties = iapws95.Iapws95ParameterBlock()
         m.fs.unit = Turbine(default={
             "property_package": m.fs.properties,
-            "support_isentropic_perfomance_curves":True})
+            "support_isentropic_performance_curves":True})
         unit_hd = units.J/units.kg
         unit_vflw = units.m**3/units.s
         @m.fs.unit.performance_curve.Constraint(m.fs.config.time)

--- a/idaes/generic_models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/generic_models/unit_models/tests/test_pressure_changer.py
@@ -881,13 +881,14 @@ class Test_costing(object):
             def pc_isen_head_eqn(b, t):
                 prnt = b.parent_block()
                 vflw = prnt.control_volume.properties_in[t].flow_vol
-                return prnt.head_isentropic[t]/1000 == \
+                return b.head_isentropic[t]/1000 == \
                     -75530.8/3.975/1000*vflw/unit_vflw*unit_hd
 
         m.fs.unit = Turbine(default={
             "property_package": m.fs.properties,
             "isentropic_perfomance_curves": {
-                "build_callback": perf_callback}})
+                "build_callback": perf_callback,
+                "build_head_expressions": True}})
 
         # set inputs
         m.fs.unit.inlet.flow_mol[0].fix(1000)  # mol/s
@@ -912,7 +913,9 @@ class Test_costing(object):
         m = ConcreteModel()
         m.fs = FlowsheetBlock(default={"dynamic": False})
         m.fs.properties = iapws95.Iapws95ParameterBlock()
-        m.fs.unit = Turbine(default={"property_package": m.fs.properties})
+        m.fs.unit = Turbine(default={
+            "property_package": m.fs.properties,
+            "isentropic_perfomance_curves":{"build_head_expressions":True}})
         unit_hd = units.J/units.kg
         unit_vflw = units.m**3/units.s
         @m.fs.unit.performance_curve.Constraint(m.fs.config.time)
@@ -924,7 +927,7 @@ class Test_costing(object):
         def pc_isen_head_eqn(b, t):
             prnt = b.parent_block()
             vflw = prnt.control_volume.properties_in[t].flow_vol
-            return prnt.head_isentropic[t]/1000 == \
+            return b.head_isentropic[t]/1000 == \
                 -75530.8/3.975/1000*vflw/unit_vflw*unit_hd
 
         # set inputs


### PR DESCRIPTION
Adding some support for performance curves in pressure changers.  Need these for gas turbines among other things.  This seems to work, but we can have some discussion around the design of it.  The main reason I used a sub-block for performance curves is that I didn't put any restriction on the form of the performance curves, so it gives me an easy way to deactivate and activate them.  The bad thing about it is that the variables and expressions that go into the performance cruves are defined in the parent block, so writing the performance curves is a little convoluted.  I can add some docs if everyone agrees to the implementation.  There are two ways to add curves, as seen in the tests.  Either a callback or just adding constraints after constructing the pressure changer.  Either way ends up the same. 

The main reason for adding this and not just slapping a few extra constraints into the existing turbine model is that I want to integrate with the pressure changer initialization, so people don't need to create some custom initialization if they want to use performance curves. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
