### PR TITLE
Correcting equation in documentation

### DIFF
--- a/docs/user_guide/components/property_package/general/pure/NIST.rst
+++ b/docs/user_guide/components/property_package/general/pure/NIST.rst
@@ -41,7 +41,7 @@ Ideal Gas Molar Enthalpy
 
 The correlation for the ideal gas molar enthalpy is derived from the correlation for the molar heat capacity and is given below:
 
-.. math:: \frac{h_{\text{ig}} - h_{\text{ig ref}}}{1000} = A \times (t-t_{ref}) + \frac{B}{2} \times (t^2 - t_{ref}^2) + \frac{C}{3} \times (t^3 - t_{ref}^3) + \frac{D}{4} \times (t^4 - t_{ref}^4) + E \times (\frac{1}{t} - \frac{1}{t_{ref}}) + F - H
+.. math:: \frac{h_{\text{ig}} - h_{\text{ig ref}}}{1000} = A \times t + \frac{B}{2} \times t^2 + \frac{C}{3} \times t^3 + \frac{D}{4} \times t^4 + E \times \frac{1}{t} + F - H
 
 Units are :math:`\text{J/mol}`.
 


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
The documentation for calculating specific enthalpy using the NIST Shomate equation was not updated when fixing the bugs in PR #223.

## Changes proposed in this PR:
- Removed `t_ref` from Shomate equation in docs
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
