### PR TITLE
Final (hopefully) steps in setting up infrastructure for electrolytes

### DIFF
--- a/docs/user_guide/components/property_package/general_reactions/equil_constant.rst
+++ b/docs/user_guide/components/property_package/general_reactions/equil_constant.rst
@@ -19,3 +19,20 @@ The method uses the van 't Hoff equation to calculate the equilibrium constant.
    ":math:`k_{eq, ref}`", "k_eq_ref", "Varies, depends on equilibrium form", "Equlibrium constant at reference temperature"
    ":math:`T_{ref, eq}`", "temperature_eq_ref", "Base units", "Reference temperature for calculating equilibrium constant"
 
+Gibbs Energy (gibbs_energy)
+---------------------------
+
+The method uses the thermodynamic relationship with Gibbs energy to calculate the equilibrium constant.
+
+.. math:: k_{eq} = e^{-\frac{\Delta H_{rxn, ref}}{R T} + \frac{\Delta S_{rxn, ref}}{R}}
+
+**Parameters**
+
+.. csv-table::
+   :header: "Symbol", "Parameter Name", "Units", "Description"
+
+   ":math:`\Delta H_{rxn, ref}`", "dh_rxn_ref", "Base units", "Heat of reaction at reference temperature"
+   ":math:`\Delta S_{rxn, ref}`", "ds_rxn_ref", "Base units", "Entropy of reaction at reference temperature"
+   ":math:`T_{ref, eq}`", "temperature_eq_ref", "Base units", "Reference temperature, used for calculating scaling factors"
+
+Note that the above form is strictly unitless - units for the equilibrium constant are calculated separately and appended to the expression.

--- a/docs/user_guide/components/property_package/general_reactions/equil_form.rst
+++ b/docs/user_guide/components/property_package/general_reactions/equil_form.rst
@@ -19,3 +19,19 @@ The method uses a power law form using the concentration form provided  to calcu
    ":math:`O`", "reaction_order", "phase, component", "Reaction order"
 
 Providing a `reaction_order` dict is optional. If one is not provided, it will be assumed that this is an elementary reaction and that the reaction order is equal to the stoichiometric coefficient for all component in non-solid phases (the contribution of solid phases is assumed to be constant and included in the equilibrium constant, thus an order of zero is assumed).
+
+Log Power Law (log_power_law_equil)
+-----------------------------------
+
+The method uses a log form of a power law using the concentration form provided  to calculate the reaction rate.
+
+.. math:: log(k_{eq}) = \sum_{(p, j)}{O_{(p,j)}*log(x_{(p,j))}
+
+**Parameters**
+
+.. csv-table::
+   :header: "Symbol", "Parameter Name", "Indices", "Description"
+
+   ":math:`O`", "reaction_order", "phase, component", "Reaction order"
+
+Providing a `reaction_order` dict is optional. If one is not provided, it will be assumed that this is an elementary reaction and that the reaction order is equal to the stoichiometric coefficient for all component in non-solid phases (the contribution of solid phases is assumed to be constant and included in the equilibrium constant, thus an order of zero is assumed).

--- a/idaes/generic_models/properties/core/eos/ideal.py
+++ b/idaes/generic_models/properties/core/eos/ideal.py
@@ -25,6 +25,8 @@ from .eos_base import EoSBase
 
 # TODO: Add support for ideal solids
 class Ideal(EoSBase):
+    # Add attribute indicating support for electrolyte systems
+    electrolyte_support = True
 
     @staticmethod
     def common(b, pobj):
@@ -58,7 +60,7 @@ class Ideal(EoSBase):
         if pobj.is_vapor_phase():
             return b.pressure/(Ideal.gas_constant(b)*b.temperature)
         elif pobj.is_liquid_phase():
-            return sum(b.mole_frac_phase_comp[p, j] *
+            return sum(b.get_mole_frac()[p, j] *
                        get_method(b, "dens_mol_liq_comp", j)(
                            b, cobj(b, j), b.temperature)
                        for j in b.components_in_phase(p))
@@ -67,7 +69,7 @@ class Ideal(EoSBase):
 
     @staticmethod
     def cp_mol_phase(b, p):
-        return sum(b.mole_frac_phase_comp[p, j]*b.cp_mol_phase_comp[p, j]
+        return sum(b.get_mole_frac()[p, j]*b.cp_mol_phase_comp[p, j]
                    for j in b.components_in_phase(p))
 
     @staticmethod
@@ -84,7 +86,7 @@ class Ideal(EoSBase):
 
     @staticmethod
     def enth_mol_phase(b, p):
-        return sum(b.mole_frac_phase_comp[p, j]*b.enth_mol_phase_comp[p, j]
+        return sum(b.get_mole_frac()[p, j]*b.enth_mol_phase_comp[p, j]
                    for j in b.components_in_phase(p))
 
     @staticmethod
@@ -101,7 +103,7 @@ class Ideal(EoSBase):
 
     @staticmethod
     def entr_mol_phase(b, p):
-        return sum(b.mole_frac_phase_comp[p, j]*b.entr_mol_phase_comp[p, j]
+        return sum(b.get_mole_frac()[p, j]*b.entr_mol_phase_comp[p, j]
                    for j in b.components_in_phase(p))
 
     @staticmethod
@@ -111,7 +113,7 @@ class Ideal(EoSBase):
             return (get_method(b, "entr_mol_ig_comp", j)(
                 b, cobj(b, j), b.temperature) -
                 Ideal.gas_constant(b)*log(
-                    b.mole_frac_phase_comp[p, j]*b.pressure /
+                    b.get_mole_frac()[p, j]*b.pressure /
                     b.params.pressure_ref))
         elif pobj.is_liquid_phase():
             # Assume no pressure/volume dependecy of entropy for ideal liquids
@@ -132,9 +134,9 @@ class Ideal(EoSBase):
     def log_fug_phase_comp_eq(b, p, j, pp):
         pobj = b.params.get_phase(p)
         if pobj.is_vapor_phase():
-            return log(b.mole_frac_phase_comp[p, j]) + log(b.pressure)
+            return log(b.get_mole_frac()[p, j]) + log(b.pressure)
         elif pobj.is_liquid_phase():
-            return (log(b.mole_frac_phase_comp[p, j]) +
+            return (log(b.get_mole_frac()[p, j]) +
                     log(get_method(b, "pressure_sat_comp", j)(
                         b, cobj(b, j), b.temperature)))
         else:
@@ -184,7 +186,7 @@ class Ideal(EoSBase):
 
     @staticmethod
     def gibbs_mol_phase(b, p):
-        return sum(b.mole_frac_phase_comp[p, j]*b.gibbs_mol_phase_comp[p, j]
+        return sum(b.get_mole_frac()[p, j]*b.gibbs_mol_phase_comp[p, j]
                    for j in b.components_in_phase(p))
 
     @staticmethod
@@ -203,9 +205,9 @@ def _invalid_phase_msg(name, phase):
 def _fug_phase_comp(b, p, j, T):
     pobj = b.params.get_phase(p)
     if pobj.is_vapor_phase():
-        return b.mole_frac_phase_comp[p, j] * b.pressure
+        return b.get_mole_frac()[p, j] * b.pressure
     elif pobj.is_liquid_phase():
-        return (b.mole_frac_phase_comp[p, j] *
+        return (b.get_mole_frac()[p, j] *
                 get_method(b, "pressure_sat_comp", j)(
                     b, cobj(b, j), T))
     else:

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1574,14 +1574,40 @@ class GenericStateBlockData(StateBlockData):
     def components_in_phase(self, phase):
         """
         Generator method which yields components present in a given phase.
+        As this methid is used only for property calcuations, it should use the
+        true species sset if one exists.
+
         Args:
             phase - phase for which to yield components
+
         Yields:
             components present in phase.
         """
-        for j in self.component_list:
-            if (phase, j) in self.phase_component_set:
+        if not self.params._electrolyte:
+            component_list = self.component_list
+            pc_set = self.phase_component_set
+        else:
+            component_list = self.params.true_species_set
+            pc_set = self.params.true_phase_component_set
+
+        for j in component_list:
+            if (phase, j) in pc_set:
                 yield j
+
+    def get_mole_frac(self):
+        """
+        Property calcuations generally depend on phase_component mole fractions
+        for mixing rules, but in some cases there are multiple component lists
+        to work from. This method is used to return the correct phase-component
+        indexed mole fraction component for the given circumstances.
+
+        Returns:
+            mole fraction object
+        """
+        if not self.params._electrolyte:
+            return self.mole_frac_phase_comp
+        else:
+            return self.mole_frac_phase_comp_true
 
     # -------------------------------------------------------------------------
     # Bubble and Dew Points

--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -116,7 +116,7 @@ class gibbs_energy():
                 "configuration dict.".format(rblock.name))
         elif (c_form == ConcentrationForm.moleFraction or
               c_form == ConcentrationForm.massFraction):
-            e_units = None
+            e_units = pyunits.dimensionless
         else:
             order = 0
 

--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -52,7 +52,7 @@ class van_t_hoff():
                     # In most cases ,should have _phase_component_set
                     pc_set = parent._phase_component_set
                 else:
-                    # However, for electrolytes need ture species set
+                    # However, for electrolytes need true species set
                     pc_set = parent.true_phase_component_set
 
             for p, j in pc_set:
@@ -97,3 +97,92 @@ class van_t_hoff():
     @staticmethod
     def calculate_scaling_factors(b, rblock):
         return 1/value(rblock.k_eq_ref)
+
+
+# -----------------------------------------------------------------------------
+# Constant dh_rxn and ds_rxn
+class gibbs_energy():
+
+    @staticmethod
+    def build_parameters(rblock, config):
+        parent = rblock.parent_block()
+        units = parent.get_metadata().derived_units
+
+        c_form = config.concentration_form
+        if c_form is None:
+            raise ConfigurationError(
+                "{} concentration_form configuration argument was not set. "
+                "Please ensure that this argument is included in your "
+                "configuration dict.".format(rblock.name))
+        elif (c_form == ConcentrationForm.moleFraction or
+              c_form == ConcentrationForm.massFraction):
+            e_units = None
+        else:
+            order = 0
+
+            try:
+                # This will work for Reaction Packages
+                pc_set = parent.config.property_package._phase_component_set
+            except AttributeError:
+                # Need to allow for inherent reactions in Property Packages
+                if not parent._electrolyte:
+                    # In most cases ,should have _phase_component_set
+                    pc_set = parent._phase_component_set
+                else:
+                    # However, for electrolytes need true species set
+                    pc_set = parent.true_phase_component_set
+
+            for p, j in pc_set:
+                order += rblock.reaction_order[p, j].value
+
+            if (c_form == ConcentrationForm.molarity or
+                    c_form == ConcentrationForm.activity):
+                c_units = units["density_mole"]
+            elif c_form == ConcentrationForm.molality:
+                c_units = units["amount"]*units["mass"]**-1
+            elif c_form == ConcentrationForm.partialPressure:
+                c_units = units["pressure"]
+            else:
+                raise BurntToast(
+                    "{} get_concentration_term received unrecognised "
+                    "ConcentrationForm ({}). This should not happen - please "
+                    "contact the IDAES developers with this bug."
+                    .format(rblock.name, c_form))
+
+            e_units = c_units**order
+
+        rblock._keq_units = e_units
+
+        rblock.dh_rxn_ref = Var(
+                doc="Specific molar heat of reaction at reference state",
+                units=units["energy_mole"])
+        set_param_from_config(rblock, param="dh_rxn_ref", config=config)
+
+        rblock.ds_rxn_ref = Var(
+                doc="Specific molar entropy of reaction at reference state",
+                units=units["entropy_mole"])
+        set_param_from_config(rblock, param="ds_rxn_ref", config=config)
+
+        rblock.T_eq_ref = Var(
+                doc="Reference temperature for equilibrium constant",
+                units=units["temperature"])
+        set_param_from_config(rblock, param="T_eq_ref", config=config)
+
+    @staticmethod
+    def return_expression(b, rblock, r_idx, T):
+        units = rblock.parent_block().get_metadata().derived_units
+
+        R = pyunits.convert(c.gas_constant, to_units=units["gas_constant"])
+
+        return (exp(
+            (-rblock.dh_rxn_ref / (R*T)) +
+            (rblock.ds_rxn_ref / R)) * rblock._keq_units)
+
+    @staticmethod
+    def calculate_scaling_factors(b, rblock):
+        units = rblock.parent_block().get_metadata().derived_units
+        R = pyunits.convert(c.gas_constant, to_units=units["gas_constant"])
+
+        keq_val = value(exp(-rblock.dh_rxn_ref/(R*rblock.T_eq_ref) +
+                            rblock.ds_rxn_ref/R))
+        return 1/keq_val

--- a/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
@@ -63,19 +63,33 @@ class log_power_law_equil():
     def return_expression(b, rblock, r_idx, T):
         e = None
 
+        print("Electrolyte:", b._params._electrolyte)
         if hasattr(b.params, "_electrolyte") and b.params._electrolyte:
+            print("Should see this")
             pc_set = b.params.true_phase_component_set
         else:
+            print("Should not see this")
             pc_set = b.phase_component_set
 
+        print("Starting")
         # Get reaction orders and construct power law expression
         for p, j in pc_set:
             o = rblock.reaction_order[p, j]
+            print(p, j, o.value)
 
             if e is None and o != 0:
+                print("None", o.value)
+                print(safe_log(get_concentration_term(b, r_idx)[p, j], eps=EPS))
+                print()
                 e = o*safe_log(get_concentration_term(b, r_idx)[p, j], eps=EPS)
             elif e is not None and o != 0:
+                print("Building", o.value)
+                print()
+                print(safe_log(get_concentration_term(b, r_idx)[p, j], eps=EPS))
+                print()
                 e = e + o*safe_log(
                     get_concentration_term(b, r_idx)[p, j], eps=EPS)
+        print("Finish")
+        print()
 
         return safe_log(b.k_eq[r_idx], eps=EPS) == e

--- a/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
@@ -63,33 +63,19 @@ class log_power_law_equil():
     def return_expression(b, rblock, r_idx, T):
         e = None
 
-        print("Electrolyte:", b._params._electrolyte)
         if hasattr(b.params, "_electrolyte") and b.params._electrolyte:
-            print("Should see this")
             pc_set = b.params.true_phase_component_set
         else:
-            print("Should not see this")
             pc_set = b.phase_component_set
 
-        print("Starting")
         # Get reaction orders and construct power law expression
         for p, j in pc_set:
             o = rblock.reaction_order[p, j]
-            print(p, j, o.value)
 
             if e is None and o != 0:
-                print("None", o.value)
-                print(safe_log(get_concentration_term(b, r_idx)[p, j], eps=EPS))
-                print()
                 e = o*safe_log(get_concentration_term(b, r_idx)[p, j], eps=EPS)
             elif e is not None and o != 0:
-                print("Building", o.value)
-                print()
-                print(safe_log(get_concentration_term(b, r_idx)[p, j], eps=EPS))
-                print()
                 e = e + o*safe_log(
                     get_concentration_term(b, r_idx)[p, j], eps=EPS)
-        print("Finish")
-        print()
 
         return safe_log(b.k_eq[r_idx], eps=EPS) == e

--- a/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
@@ -58,213 +58,509 @@ def model():
     return m
 
 
-@pytest.mark.unit
-def test_van_t_hoff_mole_frac(model):
-    model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-        "k_eq_ref": 1,
-        "T_eq_ref": 500}
+class TestVanTHoff(object):
+    @pytest.mark.unit
+    def test_van_t_hoff_mole_frac(self, model):
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "k_eq_ref": 1,
+            "T_eq_ref": 500}
 
-    van_t_hoff.build_parameters(
-        model.rparams.reaction_r1,
-        model.rparams.config.equilibrium_reactions["r1"])
+        van_t_hoff.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
 
-    # Check parameter construction
-    assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
-    assert model.rparams.reaction_r1.k_eq_ref.value == 1
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
+        assert model.rparams.reaction_r1.k_eq_ref.value == 1
 
-    assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-    assert model.rparams.reaction_r1.T_eq_ref.value == 500
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
-    # Check expression
-    rform = van_t_hoff.return_expression(
-        model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        # Check expression
+        rform = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
 
-    assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-    assert_units_equivalent(rform, None)
+        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
+        assert_units_equivalent(rform, None)
+
+    @pytest.mark.unit
+    def test_van_t_hoff_mole_frac_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "k_eq_ref": (1, None),
+            "T_eq_ref": (900, pyunits.degR)}
+
+        van_t_hoff.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
+        assert model.rparams.reaction_r1.k_eq_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        # Check expression
+        rform = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
+        assert_units_equivalent(rform, None)
+
+    @pytest.mark.unit
+    def test_van_t_hoff_molarity(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.molarity
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "k_eq_ref": 1,
+            "T_eq_ref": 500}
+
+        van_t_hoff.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
+        assert model.rparams.reaction_r1.k_eq_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        # Check expression
+        rform = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.mol/pyunits.m**3)
+
+    @pytest.mark.unit
+    def test_van_t_hoff_molarity_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.molarity
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "k_eq_ref": (1e-3, pyunits.kmol/pyunits.m**3),
+            "T_eq_ref": (900, pyunits.degR)}
+
+        van_t_hoff.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
+        assert model.rparams.reaction_r1.k_eq_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        # Check expression
+        rform = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.mol/pyunits.m**3)
+
+    @pytest.mark.unit
+    def test_van_t_hoff_molality(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.molality
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "k_eq_ref": 1,
+            "T_eq_ref": 500}
+
+        van_t_hoff.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
+        assert model.rparams.reaction_r1.k_eq_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        # Check expression
+        rform = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.mol/pyunits.kg)
+
+    @pytest.mark.unit
+    def test_van_t_hoff_molality_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.molality
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "k_eq_ref": (1e-3, pyunits.kmol/pyunits.kg),
+            "T_eq_ref": (900, pyunits.degR)}
+
+        van_t_hoff.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
+        assert model.rparams.reaction_r1.k_eq_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        # Check expression
+        rform = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.mol/pyunits.kg)
+
+    @pytest.mark.unit
+    def test_van_t_hoff_partial_pressure(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.partialPressure
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "k_eq_ref": 1,
+            "T_eq_ref": 500}
+
+        van_t_hoff.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
+        assert model.rparams.reaction_r1.k_eq_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        # Check expression
+        rform = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.Pa)
+
+    @pytest.mark.unit
+    def test_van_t_hoff_partial_pressure_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.partialPressure
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "k_eq_ref": (1e-3, pyunits.kPa),
+            "T_eq_ref": (900, pyunits.degR)}
+
+        van_t_hoff.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
+        assert model.rparams.reaction_r1.k_eq_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        # Check expression
+        rform = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.Pa)
 
 
-@pytest.mark.unit
-def test_van_t_hoff_mole_frac_convert(model):
-    model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-        "k_eq_ref": (1, None),
-        "T_eq_ref": (900, pyunits.degR)}
+class TestGibbsEnergy(object):
+    @pytest.mark.unit
+    def test_gibbs_energy_mole_frac(self, model):
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "dh_rxn_ref": 2,
+            "ds_rxn_ref": 1,
+            "T_eq_ref": 500}
 
-    van_t_hoff.build_parameters(
-        model.rparams.reaction_r1,
-        model.rparams.config.equilibrium_reactions["r1"])
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
 
-    # Check parameter construction
-    assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
-    assert model.rparams.reaction_r1.k_eq_ref.value == 1
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
+        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
 
-    assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-    assert model.rparams.reaction_r1.T_eq_ref.value == 500
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
-    # Check expression
-    rform = van_t_hoff.return_expression(
-        model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
-    assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-    assert_units_equivalent(rform, None)
+        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
+                                pyunits.dimensionless)
 
+        # Check expression
+        rform = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
 
-@pytest.mark.unit
-def test_van_t_hoff_molarity(model):
-    model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-        ConcentrationForm.molarity
-    model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-        "k_eq_ref": 1,
-        "T_eq_ref": 500}
+        assert str(rform) == (
+            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
+            'rparams.reaction_r1.ds_rxn_ref)*dimensionless')
+        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+        assert_units_equivalent(rform, None)
 
-    van_t_hoff.build_parameters(
-        model.rparams.reaction_r1,
-        model.rparams.config.equilibrium_reactions["r1"])
+    @pytest.mark.unit
+    def test_gibbs_energy_mole_frac_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
+            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
+            "T_eq_ref": (900, pyunits.degR)}
 
-    # Check parameter construction
-    assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
-    assert model.rparams.reaction_r1.k_eq_ref.value == 1
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
 
-    assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-    assert model.rparams.reaction_r1.T_eq_ref.value == 500
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
+        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
 
-    # Check expression
-    rform = van_t_hoff.return_expression(
-        model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
-    assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-    assert_units_equivalent(rform, pyunits.mol/pyunits.m**3)
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
+        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
+                                pyunits.dimensionless)
 
-@pytest.mark.unit
-def test_van_t_hoff_molarity_convert(model):
-    model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-        ConcentrationForm.molarity
-    model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-        "k_eq_ref": (1e-3, pyunits.kmol/pyunits.m**3),
-        "T_eq_ref": (900, pyunits.degR)}
+        # Check expression
+        rform = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
 
-    van_t_hoff.build_parameters(
-        model.rparams.reaction_r1,
-        model.rparams.config.equilibrium_reactions["r1"])
+        assert str(rform) == (
+            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
+            'rparams.reaction_r1.ds_rxn_ref)*dimensionless')
+        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+        assert_units_equivalent(rform, None)
 
-    # Check parameter construction
-    assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
-    assert model.rparams.reaction_r1.k_eq_ref.value == 1
+    @pytest.mark.unit
+    def test_gibbs_energy_molarity(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.molarity
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "dh_rxn_ref": 2,
+            "ds_rxn_ref": 1,
+            "T_eq_ref": 500}
 
-    assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-    assert model.rparams.reaction_r1.T_eq_ref.value == 500
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
 
-    # Check expression
-    rform = van_t_hoff.return_expression(
-        model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
+        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
 
-    assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-    assert_units_equivalent(rform, pyunits.mol/pyunits.m**3)
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
-@pytest.mark.unit
-def test_van_t_hoff_molality(model):
-    model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-        ConcentrationForm.molality
-    model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-        "k_eq_ref": 1,
-        "T_eq_ref": 500}
+        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
+                                pyunits.mol*pyunits.m**-3)
 
-    van_t_hoff.build_parameters(
-        model.rparams.reaction_r1,
-        model.rparams.config.equilibrium_reactions["r1"])
+        # Check expression
+        rform = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
 
-    # Check parameter construction
-    assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
-    assert model.rparams.reaction_r1.k_eq_ref.value == 1
+        assert str(rform) == (
+            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
+            'rparams.reaction_r1.ds_rxn_ref)*(mol*m**-3)')
+        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.mol*pyunits.m**-3)
 
-    assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-    assert model.rparams.reaction_r1.T_eq_ref.value == 500
+    @pytest.mark.unit
+    def test_gibbs_energy_molarity_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.molarity
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
+            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
+            "T_eq_ref": (900, pyunits.degR)}
 
-    # Check expression
-    rform = van_t_hoff.return_expression(
-        model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
 
-    assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-    assert_units_equivalent(rform, pyunits.mol/pyunits.kg)
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
+        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
 
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
-@pytest.mark.unit
-def test_van_t_hoff_molality_convert(model):
-    model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-        ConcentrationForm.molality
-    model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-        "k_eq_ref": (1e-3, pyunits.kmol/pyunits.kg),
-        "T_eq_ref": (900, pyunits.degR)}
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
-    van_t_hoff.build_parameters(
-        model.rparams.reaction_r1,
-        model.rparams.config.equilibrium_reactions["r1"])
+        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
+                                pyunits.mol/pyunits.m**3)
 
-    # Check parameter construction
-    assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
-    assert model.rparams.reaction_r1.k_eq_ref.value == 1
+        # Check expression
+        rform = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
 
-    assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-    assert model.rparams.reaction_r1.T_eq_ref.value == 500
+        assert str(rform) == (
+            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
+            'rparams.reaction_r1.ds_rxn_ref)*(mol*m**-3)')
+        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.mol*pyunits.m**-3)
 
-    # Check expression
-    rform = van_t_hoff.return_expression(
-        model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+    @pytest.mark.unit
+    def test_gibss_energy_molality(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.molality
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "dh_rxn_ref": 2,
+            "ds_rxn_ref": 1,
+            "T_eq_ref": 500}
 
-    assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-    assert_units_equivalent(rform, pyunits.mol/pyunits.kg)
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
 
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
+        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
 
-@pytest.mark.unit
-def test_van_t_hoff_partial_pressure(model):
-    model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-        ConcentrationForm.partialPressure
-    model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-        "k_eq_ref": 1,
-        "T_eq_ref": 500}
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
-    van_t_hoff.build_parameters(
-        model.rparams.reaction_r1,
-        model.rparams.config.equilibrium_reactions["r1"])
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
-    # Check parameter construction
-    assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
-    assert model.rparams.reaction_r1.k_eq_ref.value == 1
+        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
+                                pyunits.mol/pyunits.kg)
 
-    assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-    assert model.rparams.reaction_r1.T_eq_ref.value == 500
+        # Check expression
+        rform = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
 
-    # Check expression
-    rform = van_t_hoff.return_expression(
-        model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform) == (
+            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
+            'rparams.reaction_r1.ds_rxn_ref)*(mol*kg**-1)')
+        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.mol/pyunits.kg)
 
-    assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-    assert_units_equivalent(rform, pyunits.Pa)
+    @pytest.mark.unit
+    def test_gibbs_energy_molality_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.molality
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
+            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
+            "T_eq_ref": (900, pyunits.degR)}
 
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
 
-@pytest.mark.unit
-def test_van_t_hoff_partial_pressure_convert(model):
-    model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-        ConcentrationForm.partialPressure
-    model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-        "k_eq_ref": (1e-3, pyunits.kPa),
-        "T_eq_ref": (900, pyunits.degR)}
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
+        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
 
-    van_t_hoff.build_parameters(
-        model.rparams.reaction_r1,
-        model.rparams.config.equilibrium_reactions["r1"])
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
-    # Check parameter construction
-    assert isinstance(model.rparams.reaction_r1.k_eq_ref, Var)
-    assert model.rparams.reaction_r1.k_eq_ref.value == 1
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
-    assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-    assert model.rparams.reaction_r1.T_eq_ref.value == 500
+        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
+                                pyunits.mol/pyunits.kg)
 
-    # Check expression
-    rform = van_t_hoff.return_expression(
-        model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        # Check expression
+        rform = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
 
-    assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-    assert_units_equivalent(rform, pyunits.Pa)
+        assert str(rform) == (
+            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
+            'rparams.reaction_r1.ds_rxn_ref)*(mol*kg**-1)')
+        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.mol*pyunits.kg**-1)
+
+    @pytest.mark.unit
+    def test_gibbs_energy_partial_pressure(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.partialPressure
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "dh_rxn_ref": 2,
+            "ds_rxn_ref": 1,
+            "T_eq_ref": 500}
+
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
+        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
+
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
+                                pyunits.Pa)
+
+        # Check expression
+        rform = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert str(rform) == (
+            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
+            'rparams.reaction_r1.ds_rxn_ref)*(kg*m**-1*s**-2)')
+        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.Pa)
+
+    @pytest.mark.unit
+    def test_gibbs_energy_partial_pressure_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
+            ConcentrationForm.partialPressure
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
+            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
+            "T_eq_ref": (900, pyunits.degR)}
+
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
+        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
+
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
+                                pyunits.Pa)
+
+        # Check expression
+        rform = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert str(rform) == (
+            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
+            'rparams.reaction_r1.ds_rxn_ref)*(kg*m**-1*s**-2)')
+        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+        assert_units_equivalent(rform, pyunits.Pa)

--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -138,7 +138,7 @@ def define_state(b):
 
     # Add electrolye state vars if required
     # This must occur before adding the enthalpy constraint, as it needs true
-    # spcies mole fractions
+    # species mole fractions
     if b.params._electrolyte:
         define_electrolyte_state(b)
 

--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -136,6 +136,12 @@ def define_state(b):
         doc='Phase fractions',
         units=None)
 
+    # Add electrolye state vars if required
+    # This must occur before adding the enthalpy constraint, as it needs true
+    # spcies mole fractions
+    if b.params._electrolyte:
+        define_electrolyte_state(b)
+
     # Add supporting constraints
     if b.config.defined_state is False:
         # applied at outlet only
@@ -215,9 +221,6 @@ def define_state(b):
             return b.phase_frac[p]*b.flow_mol == b.flow_mol_phase[p]
         b.phase_fraction_constraint = Constraint(b.phase_list,
                                                  rule=rule_phase_frac)
-
-    if b.params._electrolyte:
-        define_electrolyte_state(b)
 
     # -------------------------------------------------------------------------
     # General Methods

--- a/idaes/generic_models/properties/core/state_definitions/FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FTPx.py
@@ -128,6 +128,10 @@ def define_state(b):
         doc='Phase fractions',
         units=None)
 
+    # Add electrolye state vars if required
+    if b.params._electrolyte:
+        define_electrolyte_state(b)
+
     # Add supporting constraints
     if b.config.defined_state is False:
         # applied at outlet only
@@ -201,9 +205,6 @@ def define_state(b):
         b.phase_fraction_constraint = Constraint(b.phase_list,
                                                  rule=rule_phase_frac)
 
-    if b.params._electrolyte:
-        define_electrolyte_state(b)
-
     # -------------------------------------------------------------------------
     # General Methods
     def get_material_flow_terms_FTPx(p, j):
@@ -258,8 +259,9 @@ def define_state(b):
 def state_initialization(b):
     for p in b.phase_list:
         # Start with phase mole fractions equal to total mole fractions
-        for j in b.components_in_phase(p):
-            b.mole_frac_phase_comp[p, j].value = b.mole_frac_comp[j].value
+        for j in b.component_list:
+            if (p, j) in b.phase_component_set:
+                b.mole_frac_phase_comp[p, j].value = b.mole_frac_comp[j].value
 
         b.flow_mol_phase[p].value = value(
                         b.flow_mol / len(b.phase_list))

--- a/idaes/generic_models/properties/core/state_definitions/FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcPh.py
@@ -140,6 +140,12 @@ def define_state(b):
         doc='Phase fractions',
         units=None)
 
+    # Add electrolye state vars if required
+    # This must occur before adding the enthalpy constraint, as it needs true
+    # spcies mole fractions
+    if b.params._electrolyte:
+        define_electrolyte_state(b)
+
     # Add supporting constraints
     def rule_mole_frac_comp(b, j):
         if len(b.component_list) > 1:
@@ -222,9 +228,6 @@ def define_state(b):
             return b.phase_frac[p]*b.flow_mol == b.flow_mol_phase[p]
         b.phase_fraction_constraint = Constraint(b.phase_list,
                                                  rule=rule_phase_frac)
-
-    if b.params._electrolyte:
-        define_electrolyte_state(b)
 
     # -------------------------------------------------------------------------
     # General Methods

--- a/idaes/generic_models/properties/core/state_definitions/FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcPh.py
@@ -142,7 +142,7 @@ def define_state(b):
 
     # Add electrolye state vars if required
     # This must occur before adding the enthalpy constraint, as it needs true
-    # spcies mole fractions
+    # species mole fractions
     if b.params._electrolyte:
         define_electrolyte_state(b)
 

--- a/idaes/generic_models/properties/core/state_definitions/FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcTP.py
@@ -126,6 +126,10 @@ def define_state(b):
         doc='Phase fractions',
         units=None)
 
+    # Add electrolye state vars if required
+    if b.params._electrolyte:
+        define_electrolyte_state(b)
+
     # Add supporting constraints
     def rule_mole_frac_comp(b, j):
         if len(b.component_list) > 1:
@@ -202,9 +206,6 @@ def define_state(b):
             return b.phase_frac[p]*b.flow_mol == b.flow_mol_phase[p]
         b.phase_fraction_constraint = Constraint(b.phase_list,
                                                  rule=rule_phase_frac)
-
-    if b.params._electrolyte:
-        define_electrolyte_state(b)
 
     # -------------------------------------------------------------------------
     # General Methods

--- a/idaes/generic_models/properties/core/state_definitions/FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FpcTP.py
@@ -134,6 +134,7 @@ def define_state(b):
         rule=rule_phase_frac,
         doc='Phase fractions')
 
+    # Add electrolye state vars if required
     if b.params._electrolyte:
         define_electrolyte_state(b)
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx_electrolyte.py
@@ -242,12 +242,8 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h20(*args, **kwargs):
+def dens_mol_h2o(*args, **kwargs):
     return 55e3
-
-
-def dens_mol_other(*args, **kwargs):
-    return 0
 
 
 class TestApparentSpeciesBasisInherent():
@@ -255,47 +251,44 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
-                    "charge": +1,
-                    "dens_mol_liq_comp": dens_mol_other,
-                    "parameter_data": {
-                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
+                   "charge": +1,
+                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "parameter_data": {
+                       "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
-                    "charge": +1,
-                    "dens_mol_liq_comp": dens_mol_other,
-                    "parameter_data": {
-                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
+                   "charge": +1,
+                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "parameter_data": {
+                       "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                           "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                             "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                             "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -688,47 +681,44 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx_electrolyte.py
@@ -242,7 +242,7 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h2o(*args, **kwargs):
+def dens_mol_H2O(*args, **kwargs):
     return 55e3
 
 
@@ -251,7 +251,7 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
@@ -268,27 +268,27 @@ class TestApparentSpeciesBasisInherent():
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                           "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                             "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                             "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -316,7 +316,7 @@ class TestApparentSpeciesBasisInherent():
         "temperature_ref": (298.15, pyunits.K),
 
         "inherent_reactions": {
-            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+            "H2O_si": {"stoichiometry": {("Liq", "H2O"): -1,
                                          ("Liq", "H+"): 1,
                                          ("Liq", "OH-"): 1},
                        "heat_of_reaction": constant_dh_rxn,
@@ -438,7 +438,7 @@ class TestApparentSpeciesBasisInherent():
         assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
         assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
         for i in m.fs.state[1].params.inherent_reaction_idx:
-            assert i in ["h2o_si", "co3_hco3"]
+            assert i in ["H2O_si", "co3_hco3"]
 
         assert isinstance(m.fs.state[1].apparent_inherent_reaction_extent, Var)
         assert len(m.fs.state[1].apparent_inherent_reaction_extent) == 2
@@ -681,7 +681,7 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
@@ -698,27 +698,27 @@ class TestTrueSpeciesBasisInherent():
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -746,7 +746,7 @@ class TestTrueSpeciesBasisInherent():
         "temperature_ref": (298.15, pyunits.K),
 
         "inherent_reactions": {
-            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+            "H2O_si": {"stoichiometry": {("Liq", "H2O"): -1,
                                          ("Liq", "H+"): 1,
                                          ("Liq", "OH-"): 1},
                        "heat_of_reaction": constant_dh_rxn,
@@ -872,7 +872,7 @@ class TestTrueSpeciesBasisInherent():
         assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
         assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
         for i in m.fs.state[1].params.inherent_reaction_idx:
-            assert i in ["h2o_si", "co3_hco3"]
+            assert i in ["H2O_si", "co3_hco3"]
 
         assert not hasattr(m.fs.state[1], "apparent_inherent_reaction_extent")
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx_electrolyte.py
@@ -49,7 +49,6 @@ from idaes.generic_models.properties.core.generic.generic_property import (
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util import get_default_solver
 
-import idaes.logger as idaeslog
 
 # -----------------------------------------------------------------------------
 class TestApparentSpeciesBasisNoInherent():
@@ -234,12 +233,8 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h20(*args, **kwargs):
+def dens_mol_h2o(*args, **kwargs):
     return 55e3
-
-
-def dens_mol_other(*args, **kwargs):
-    return 0
 
 
 class TestApparentSpeciesBasisInherent():
@@ -247,47 +242,44 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                         "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                         "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                          "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                            "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                            "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -673,47 +665,44 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                         "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                         "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                          "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                            "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                            "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -780,6 +769,581 @@ class TestTrueSpeciesBasisInherent():
 
         m.fs.props = GenericParameterBlock(
             default=TestTrueSpeciesBasisInherent.config)
+
+        m.fs.state = m.fs.props.build_state_block(
+                [1],
+                default={"defined_state": True})
+
+        m.fs.state[1].calculate_scaling_factors()
+
+        return m
+
+    @pytest.mark.unit
+    def test_vars_and_constraints(self, frame):
+        m = frame
+
+        assert m.fs.state[1].component_list is m.fs.props.true_species_set
+
+        assert m.fs.state[1].phase_component_set is \
+            m.fs.props.true_phase_component_set
+
+        assert isinstance(m.fs.state[1].flow_mol, Var)
+        assert len(m.fs.state[1].flow_mol) == 1
+        assert isinstance(m.fs.state[1].pressure, Var)
+        assert len(m.fs.state[1].pressure) == 1
+        assert isinstance(m.fs.state[1].temperature, Var)
+        assert len(m.fs.state[1].temperature) == 1
+
+        assert isinstance(m.fs.state[1].flow_mol_phase, Var)
+        assert len(m.fs.state[1].flow_mol_phase) == 1
+        for p in m.fs.state[1].flow_mol_phase:
+            assert p in ["Liq"]
+        assert isinstance(m.fs.state[1].phase_frac, Var)
+        assert len(m.fs.state[1].phase_frac) == 1
+        for p in m.fs.state[1].phase_frac:
+            assert p in ["Liq"]
+
+        assert isinstance(m.fs.state[1].mole_frac_comp, Var)
+        assert len(m.fs.state[1].mole_frac_comp) == 6
+        for j in m.fs.state[1].mole_frac_comp:
+            assert j in ["H+", "K+", "HCO3-", "CO3--", "OH-", "H2O"]
+
+        assert isinstance(m.fs.state[1].total_flow_balance, Constraint)
+        assert len(m.fs.state[1].total_flow_balance) == 1
+        assert isinstance(m.fs.state[1].phase_fraction_constraint, Constraint)
+        assert len(m.fs.state[1].phase_fraction_constraint) == 1
+        assert isinstance(m.fs.state[1].component_flow_balances, Constraint)
+        assert len(m.fs.state[1].component_flow_balances) == 6
+        for j in m.fs.state[1].component_flow_balances:
+            assert j in ["H+", "K+", "HCO3-", "CO3--", "OH-", "H2O"]
+
+        assert isinstance(m.fs.state[1].mole_frac_phase_comp, Var)
+        assert len(m.fs.state[1].mole_frac_phase_comp) == 6
+        for j in m.fs.state[1].mole_frac_phase_comp:
+            assert j in [("Liq", "H+"), ("Liq", "K+"), ("Liq", "HCO3-"),
+                         ("Liq", "CO3--"), ("Liq", "OH-"), ("Liq", "H2O")]
+
+        # Check references to base state variables
+        assert m.fs.state[1].flow_mol_true is m.fs.state[1].flow_mol
+        for i in m.fs.state[1].flow_mol_phase_true:
+            assert m.fs.state[1].flow_mol_phase_true[i] is \
+                m.fs.state[1].flow_mol_phase[i]
+            assert i in m.fs.props.phase_list
+        for i in m.fs.state[1].flow_mol_phase_comp_true:
+            assert m.fs.state[1].flow_mol_phase_comp_true[i] is \
+                m.fs.state[1].flow_mol_phase_comp[i]
+            assert i in m.fs.props.true_phase_component_set
+        for i in m.fs.state[1].mole_frac_phase_comp_true:
+            assert m.fs.state[1].mole_frac_phase_comp_true[i] is \
+                m.fs.state[1].mole_frac_phase_comp[i]
+            assert i in m.fs.props.true_phase_component_set
+
+        # Check for apparent species components
+        assert isinstance(m.fs.state[1].flow_mol_phase_comp_apparent, Var)
+        assert len(m.fs.state[1].flow_mol_phase_comp_apparent) == 4
+        assert isinstance(m.fs.state[1].mole_frac_phase_comp_apparent, Var)
+        assert len(m.fs.state[1].mole_frac_phase_comp_apparent) == 4
+        assert isinstance(m.fs.state[1].true_to_appr_species, Constraint)
+        assert len(m.fs.state[1].true_to_appr_species) == 4
+        assert isinstance(m.fs.state[1].appr_mole_frac_constraint,
+                          Constraint)
+        assert len(m.fs.state[1].appr_mole_frac_constraint) == 4
+
+        # Check for inherent reactions
+        assert m.fs.state[1].has_inherent_reactions
+        assert m.fs.state[1].include_inherent_reactions
+        assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
+        assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
+        for i in m.fs.state[1].params.inherent_reaction_idx:
+            assert i in ["h2o_si", "co3_hco3"]
+
+        assert not hasattr(m.fs.state[1], "apparent_inherent_reaction_extent")
+
+    @pytest.mark.component
+    def test_solve_for_true_species(self, frame):
+        m = frame
+
+        m.fs.state[1].flow_mol.fix(2)
+        m.fs.state[1].temperature.fix(350)
+        m.fs.state[1].pressure.fix(1e5)
+
+        m.fs.state[1].mole_frac_comp["H2O"].fix(0.5716)
+        m.fs.state[1].mole_frac_comp["K+"].fix(0.2858)
+        m.fs.state[1].mole_frac_comp["H+"].fix(2.9e-16)
+        m.fs.state[1].mole_frac_comp["HCO3-"].fix(1.14e-8)
+        m.fs.state[1].mole_frac_comp["CO3--"].fix(0.1429)
+        m.fs.state[1].mole_frac_comp["OH-"].fix(1.14e-8)
+
+        assert degrees_of_freedom(m.fs) == 0
+
+        m.fs.state.initialize()
+
+        solver = get_default_solver()
+        res = solver.solve(m.fs)
+
+        # Check for optimal solution
+        assert res.solver.termination_condition == \
+            TerminationCondition.optimal
+        assert res.solver.status == SolverStatus.ok
+
+        # Check true species flowrates
+        for j in m.fs.state[1].mole_frac_comp:
+            assert (
+                value(m.fs.state[1].flow_mol_phase_comp_true["Liq", j]) ==
+                pytest.approx(value(m.fs.state[1].flow_mol *
+                                    m.fs.state[1].mole_frac_comp[j]),
+                              rel=1e-5))
+
+        # Check element balances
+        assert(value(
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "K2CO3"]*2 +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KHCO3"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KOH"]) ==
+            pytest.approx(value(
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "K+"]),
+                rel=1e-5))
+        assert(value(
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "K2CO3"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KHCO3"]) ==
+            pytest.approx(value(
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "CO3--"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "HCO3-"]),
+                rel=1e-5))
+        assert(value(
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "K2CO3"]*3 +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KHCO3"]*3 +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KOH"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "H2O"]) ==
+            pytest.approx(value(
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "CO3--"]*3 +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "HCO3-"]*3 +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "OH-"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "H2O"]),
+                rel=1e-5))
+        assert(value(
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KHCO3"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KOH"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "H2O"]*2) ==
+            pytest.approx(value(
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "HCO3-"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "OH-"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "H+"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "H2O"]*2),
+                rel=1e-5))
+
+        # Check apparent species mole fractions
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_apparent["Liq", "K2CO3"]) ==
+            pytest.approx(0.2, rel=1e-5))
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_apparent["Liq", "H2O"]) ==
+            pytest.approx(0.8, rel=1e-5))
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_apparent["Liq", "KHCO3"]) ==
+            pytest.approx(1.6e-8, abs=1e-9))
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_apparent["Liq", "KHCO3"]) ==
+            pytest.approx(1.6e-8, abs=1e-9))
+
+
+# -----------------------------------------------------------------------------
+class TestApparentSpeciesBasisInherentIdeal():
+    config = {
+        # Specifying components
+        "components": {
+            'H2O': {"type": Solvent,
+                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "parameter_data": {
+                        "mw": (18E-3, pyunits.kg/pyunits.mol)}},
+            'KHCO3': {"type": Apparent,
+                      "dissociation_species": {"K+": 1, "HCO3-": 1},
+                      "parameter_data": {
+                          "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
+            'K2CO3': {"type": Apparent,
+                      "dissociation_species": {"K+": 2, "CO3--": 1},
+                      "parameter_data": {
+                          "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
+            'KOH': {"type": Apparent,
+                    "dissociation_species": {"K+": 1, "OH-": 1},
+                    "parameter_data": {
+                        "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
+            'H+': {"type": Cation,
+                   "charge": +1,
+                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "parameter_data": {
+                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
+            'K+': {"type": Cation,
+                   "charge": +1,
+                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "parameter_data": {
+                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
+            'OH-': {"type": Anion,
+                    "charge": -1,
+                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "parameter_data": {
+                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
+            'HCO3-': {"type": Anion,
+                      "charge": -1,
+                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "parameter_data": {
+                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
+            'CO3--': {"type": Anion,
+                      "charge": -2,
+                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "parameter_data": {
+                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
+
+        # Specifying phases
+        "phases":  {'Liq': {"type": AqueousPhase,
+                            "equation_of_state": Ideal,
+                            "equation_of_state_options": {
+                                "pH_range": "basic"}}},
+
+        # Set base units of measurement
+        "base_units": {"time": pyunits.s,
+                       "length": pyunits.m,
+                       "mass": pyunits.kg,
+                       "amount": pyunits.mol,
+                       "temperature": pyunits.K},
+
+        # Specifying state definition
+        "state_definition": FTPx,
+        "state_bounds": {"flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+                         "temperature": (273.15, 300, 500, pyunits.K),
+                         "pressure": (5e4, 1e5, 1e6, pyunits.Pa)},
+        "state_components": StateIndex.apparent,
+        "pressure_ref": (101325, pyunits.Pa),
+        "temperature_ref": (298.15, pyunits.K),
+
+        "inherent_reactions": {
+            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+                                         ("Liq", "H+"): 1,
+                                         ("Liq", "OH-"): 1},
+                       "heat_of_reaction": constant_dh_rxn,
+                       "equilibrium_constant": van_t_hoff,
+                       "equilibrium_form": power_law_equil,
+                       "concentration_form": ConcentrationForm.molarity,
+                       "parameter_data": {
+                           "reaction_order": {("Liq", "H+"): 1,
+                                              ("Liq", "OH-"): 1},
+                           "dh_rxn_ref": 1,
+                           "k_eq_ref": 1e-14,
+                           "T_eq_ref": 350}},
+            "co3_hco3": {"stoichiometry": {("Liq", "CO3--"): -1,
+                                           ("Liq", "H2O"): -1,
+                                           ("Liq", "HCO3-"): 1,
+                                           ("Liq", "OH-"): 1},
+                         "heat_of_reaction": constant_dh_rxn,
+                         "equilibrium_constant": van_t_hoff,
+                         "equilibrium_form": power_law_equil,
+                         "concentration_form": ConcentrationForm.molarity,
+                         "parameter_data": {
+                             "reaction_order": {("Liq", "CO3--"): -1,
+                                                ("Liq", "HCO3-"): 1,
+                                                ("Liq", "OH-"): 1},
+                             "dh_rxn_ref": 1,
+                             "k_eq_ref": 5e-11,
+                             "T_eq_ref": 350}}}}
+
+    @pytest.fixture(scope="class")
+    def frame(self):
+        m = ConcreteModel()
+
+        m.fs = FlowsheetBlock(default={'dynamic': False})
+
+        m.fs.props = GenericParameterBlock(
+            default=TestApparentSpeciesBasisInherentIdeal.config)
+
+        m.fs.state = m.fs.props.build_state_block(
+                [1],
+                default={"defined_state": True})
+
+        m.fs.state[1].calculate_scaling_factors()
+
+        return m
+
+    @pytest.mark.unit
+    def test_vars_and_constraints(self, frame):
+        m = frame
+
+        assert m.fs.state[1].component_list is m.fs.props.apparent_species_set
+
+        assert m.fs.state[1].phase_component_set is \
+            m.fs.props.apparent_phase_component_set
+
+        assert isinstance(m.fs.state[1].flow_mol, Var)
+        assert len(m.fs.state[1].flow_mol) == 1
+        assert isinstance(m.fs.state[1].pressure, Var)
+        assert len(m.fs.state[1].pressure) == 1
+        assert isinstance(m.fs.state[1].temperature, Var)
+        assert len(m.fs.state[1].temperature) == 1
+
+        assert isinstance(m.fs.state[1].flow_mol_phase, Var)
+        assert len(m.fs.state[1].flow_mol_phase) == 1
+        for p in m.fs.state[1].flow_mol_phase:
+            assert p in ["Liq"]
+        assert isinstance(m.fs.state[1].phase_frac, Var)
+        assert len(m.fs.state[1].phase_frac) == 1
+        for p in m.fs.state[1].phase_frac:
+            assert p in ["Liq"]
+
+        assert isinstance(m.fs.state[1].mole_frac_comp, Var)
+        assert len(m.fs.state[1].mole_frac_comp) == 4
+        for j in m.fs.state[1].mole_frac_comp:
+            assert j in ["KHCO3", "H2O", "K2CO3", "KOH"]
+
+        assert isinstance(m.fs.state[1].total_flow_balance, Constraint)
+        assert len(m.fs.state[1].total_flow_balance) == 1
+        assert isinstance(m.fs.state[1].phase_fraction_constraint, Constraint)
+        assert len(m.fs.state[1].phase_fraction_constraint) == 1
+        assert isinstance(m.fs.state[1].component_flow_balances, Constraint)
+        assert len(m.fs.state[1].component_flow_balances) == 4
+        for j in m.fs.state[1].component_flow_balances:
+            assert j in ["KHCO3", "H2O", "K2CO3", "KOH"]
+
+        assert isinstance(m.fs.state[1].mole_frac_phase_comp, Var)
+        assert len(m.fs.state[1].mole_frac_phase_comp) == 4
+        for j in m.fs.state[1].mole_frac_phase_comp:
+            assert j in [("Liq", "H2O"), ("Liq", "K2CO3"),
+                         ("Liq", "KHCO3"), ("Liq", "KOH")]
+
+        # Check references to base state variables
+        assert m.fs.state[1].flow_mol_apparent is m.fs.state[1].flow_mol
+        for i in m.fs.state[1].flow_mol_phase_apparent:
+            assert m.fs.state[1].flow_mol_phase_apparent[i] is \
+                m.fs.state[1].flow_mol_phase[i]
+            assert i in m.fs.props.phase_list
+        for i in m.fs.state[1].flow_mol_phase_comp_apparent:
+            assert m.fs.state[1].flow_mol_phase_comp_apparent[i] is \
+                m.fs.state[1].flow_mol_phase_comp[i]
+            assert i in m.fs.props.apparent_phase_component_set
+        for i in m.fs.state[1].mole_frac_phase_comp_apparent:
+            assert m.fs.state[1].mole_frac_phase_comp_apparent[i] is \
+                m.fs.state[1].mole_frac_phase_comp[i]
+            assert i in m.fs.props.apparent_phase_component_set
+
+        # Check for true species components
+        assert isinstance(m.fs.state[1].flow_mol_phase_comp_true, Var)
+        assert len(m.fs.state[1].flow_mol_phase_comp_true) == 6
+        assert isinstance(m.fs.state[1].mole_frac_phase_comp_true, Var)
+        assert len(m.fs.state[1].mole_frac_phase_comp_true) == 6
+        assert isinstance(m.fs.state[1].appr_to_true_species, Constraint)
+        assert len(m.fs.state[1].appr_to_true_species) == 6
+        assert isinstance(m.fs.state[1].true_mole_frac_constraint, Constraint)
+        assert len(m.fs.state[1].true_mole_frac_constraint) == 6
+
+        # Check for inherent reactions
+        assert m.fs.state[1].has_inherent_reactions
+        assert not m.fs.state[1].include_inherent_reactions
+        assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
+        assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
+        for i in m.fs.state[1].params.inherent_reaction_idx:
+            assert i in ["h2o_si", "co3_hco3"]
+
+        assert isinstance(m.fs.state[1].apparent_inherent_reaction_extent, Var)
+        assert len(m.fs.state[1].apparent_inherent_reaction_extent) == 2
+
+    @pytest.mark.component
+    def test_solve_for_true_species(self, frame):
+        m = frame
+
+        m.fs.state[1].flow_mol.fix(2)
+        m.fs.state[1].temperature.fix(350)
+        m.fs.state[1].pressure.fix(1e5)
+
+        m.fs.state[1].mole_frac_comp["H2O"].fix(0.8)
+        m.fs.state[1].mole_frac_comp["K2CO3"].fix(0.2)
+        m.fs.state[1].mole_frac_comp["KHCO3"].fix(0)
+        m.fs.state[1].mole_frac_comp["KOH"].fix(0)
+
+        assert degrees_of_freedom(m.fs) == 0
+
+        m.fs.state.initialize()
+
+        solver = get_default_solver()
+        res = solver.solve(m.fs)
+
+        # Check for optimal solution
+        assert res.solver.termination_condition == \
+            TerminationCondition.optimal
+        assert res.solver.status == SolverStatus.ok
+
+        # Check apparent species flowrates
+        for j in m.fs.state[1].mole_frac_comp:
+            assert (
+                value(m.fs.state[1].flow_mol_phase_comp_apparent["Liq", j]) ==
+                pytest.approx(value(m.fs.state[1].flow_mol *
+                                    m.fs.state[1].mole_frac_comp[j]),
+                              rel=1e-5))
+
+        # Check element balances
+        assert(value(
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "K2CO3"]*2 +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KHCO3"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KOH"]) ==
+            pytest.approx(value(
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "K+"]),
+                rel=1e-5))
+        assert(value(
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "K2CO3"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KHCO3"]) ==
+            pytest.approx(value(
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "CO3--"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "HCO3-"]),
+                rel=1e-5))
+        assert(value(
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "K2CO3"]*3 +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KHCO3"]*3 +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KOH"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "H2O"]) ==
+            pytest.approx(value(
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "CO3--"]*3 +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "HCO3-"]*3 +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "OH-"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "H2O"]),
+                rel=1e-5))
+        assert(value(
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KHCO3"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "KOH"] +
+            m.fs.state[1].flow_mol_phase_comp_apparent["Liq", "H2O"]*2) ==
+            pytest.approx(value(
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "HCO3-"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "OH-"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "H+"] +
+                m.fs.state[1].flow_mol_phase_comp_true["Liq", "H2O"]*2),
+                rel=1e-5))
+
+        # Check true species mole fractions
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_true["Liq", "CO3--"]) ==
+            pytest.approx(0.142857, rel=1e-5))
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_true["Liq", "H+"]) ==
+            pytest.approx(2.90081e-16, rel=1e-5))
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_true["Liq", "H2O"]) ==
+            pytest.approx(0.571429, rel=1e-5))
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_true["Liq", "HCO3-"]) ==
+            pytest.approx(1.13961e-08, rel=1e-5))
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_true["Liq", "K+"]) ==
+            pytest.approx(0.285714, rel=1e-5))
+        assert(value(
+            m.fs.state[1].mole_frac_phase_comp_true["Liq", "OH-"]) ==
+            pytest.approx(1.139606e-08, rel=1e-5))
+
+
+# -----------------------------------------------------------------------------
+class TestTrueSpeciesBasisInherentIdeal():
+    config = {
+        # Specifying components
+        "components": {
+            'H2O': {"type": Solvent,
+                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "parameter_data": {
+                        "mw": (18E-3, pyunits.kg/pyunits.mol)}},
+            'KHCO3': {"type": Apparent,
+                      "dissociation_species": {"K+": 1, "HCO3-": 1},
+                      "parameter_data": {
+                          "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
+            'K2CO3': {"type": Apparent,
+                      "dissociation_species": {"K+": 2, "CO3--": 1},
+                      "parameter_data": {
+                          "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
+            'KOH': {"type": Apparent,
+                    "dissociation_species": {"K+": 1, "OH-": 1},
+                    "parameter_data": {
+                        "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
+            'H+': {"type": Cation,
+                   "charge": +1,
+                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "parameter_data": {
+                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
+            'K+': {"type": Cation,
+                   "charge": +1,
+                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "parameter_data": {
+                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
+            'OH-': {"type": Anion,
+                    "charge": -1,
+                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "parameter_data": {
+                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
+            'HCO3-': {"type": Anion,
+                      "charge": -1,
+                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "parameter_data": {
+                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
+            'CO3--': {"type": Anion,
+                      "charge": -2,
+                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "parameter_data": {
+                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
+
+        # Specifying phases
+        "phases":  {'Liq': {"type": AqueousPhase,
+                            "equation_of_state": Ideal,
+                            "equation_of_state_options": {
+                                "pH_range": "basic"}}},
+
+        # Set base units of measurement
+        "base_units": {"time": pyunits.s,
+                       "length": pyunits.m,
+                       "mass": pyunits.kg,
+                       "amount": pyunits.mol,
+                       "temperature": pyunits.K},
+
+        # Specifying state definition
+        "state_definition": FTPx,
+        "state_bounds": {"flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+                         "temperature": (273.15, 300, 500, pyunits.K),
+                         "pressure": (5e4, 1e5, 1e6, pyunits.Pa)},
+        "state_components": StateIndex.true,
+        "pressure_ref": (101325, pyunits.Pa),
+        "temperature_ref": (298.15, pyunits.K),
+
+        "inherent_reactions": {
+            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+                                         ("Liq", "H+"): 1,
+                                         ("Liq", "OH-"): 1},
+                       "heat_of_reaction": constant_dh_rxn,
+                       "equilibrium_constant": van_t_hoff,
+                       "equilibrium_form": power_law_equil,
+                       "concentration_form": ConcentrationForm.molarity,
+                       "parameter_data": {
+                           "reaction_order": {("Liq", "H+"): 1,
+                                              ("Liq", "OH-"): 1},
+                           "dh_rxn_ref": 1,
+                           "k_eq_ref": 1e-14,
+                           "T_eq_ref": 350}},
+            "co3_hco3": {"stoichiometry": {("Liq", "CO3--"): -1,
+                                           ("Liq", "H2O"): -1,
+                                           ("Liq", "HCO3-"): 1,
+                                           ("Liq", "OH-"): 1},
+                         "heat_of_reaction": constant_dh_rxn,
+                         "equilibrium_constant": van_t_hoff,
+                         "equilibrium_form": power_law_equil,
+                         "concentration_form": ConcentrationForm.molarity,
+                         "parameter_data": {
+                             "reaction_order": {("Liq", "CO3--"): -1,
+                                                ("Liq", "HCO3-"): 1,
+                                                ("Liq", "OH-"): 1},
+                             "dh_rxn_ref": 1,
+                             "k_eq_ref": 5e-11,
+                             "T_eq_ref": 350}}},
+        "default_scaling_factors": {("mole_frac_comp", "OH-"): 1e8,
+                                    ("mole_frac_comp", "HCO3-"): 1e8,
+                                    ("mole_frac_comp", "H+"): 1e16}}
+
+    @pytest.fixture(scope="class")
+    def frame(self):
+        m = ConcreteModel()
+
+        m.fs = FlowsheetBlock(default={'dynamic': False})
+
+        m.fs.props = GenericParameterBlock(
+            default=TestTrueSpeciesBasisInherentIdeal.config)
 
         m.fs.state = m.fs.props.build_state_block(
                 [1],

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh_electrolyte.py
@@ -241,12 +241,8 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h20(*args, **kwargs):
+def dens_mol_h2o(*args, **kwargs):
     return 55e3
-
-
-def dens_mol_other(*args, **kwargs):
-    return 0
 
 
 class TestApparentSpeciesBasisInherent():
@@ -254,47 +250,44 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                     "charge": +1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                     "charge": +1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                           "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                             "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                             "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -686,47 +679,44 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh_electrolyte.py
@@ -241,7 +241,7 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h2o(*args, **kwargs):
+def dens_mol_H2O(*args, **kwargs):
     return 55e3
 
 
@@ -250,7 +250,7 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
@@ -267,27 +267,27 @@ class TestApparentSpeciesBasisInherent():
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                     "charge": +1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                     "charge": +1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                           "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                             "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                             "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -315,7 +315,7 @@ class TestApparentSpeciesBasisInherent():
         "temperature_ref": (298.15, pyunits.K),
 
         "inherent_reactions": {
-            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+            "H2O_si": {"stoichiometry": {("Liq", "H2O"): -1,
                                          ("Liq", "H+"): 1,
                                          ("Liq", "OH-"): 1},
                        "heat_of_reaction": constant_dh_rxn,
@@ -437,7 +437,7 @@ class TestApparentSpeciesBasisInherent():
         assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
         assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
         for i in m.fs.state[1].params.inherent_reaction_idx:
-            assert i in ["h2o_si", "co3_hco3"]
+            assert i in ["H2O_si", "co3_hco3"]
 
         assert isinstance(m.fs.state[1].apparent_inherent_reaction_extent, Var)
         assert len(m.fs.state[1].apparent_inherent_reaction_extent) == 2
@@ -679,7 +679,7 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
@@ -696,27 +696,27 @@ class TestTrueSpeciesBasisInherent():
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -744,7 +744,7 @@ class TestTrueSpeciesBasisInherent():
         "temperature_ref": (298.15, pyunits.K),
 
         "inherent_reactions": {
-            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+            "H2O_si": {"stoichiometry": {("Liq", "H2O"): -1,
                                          ("Liq", "H+"): 1,
                                          ("Liq", "OH-"): 1},
                        "heat_of_reaction": constant_dh_rxn,
@@ -870,7 +870,7 @@ class TestTrueSpeciesBasisInherent():
         assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
         assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
         for i in m.fs.state[1].params.inherent_reaction_idx:
-            assert i in ["h2o_si", "co3_hco3"]
+            assert i in ["H2O_si", "co3_hco3"]
 
         assert not hasattr(m.fs.state[1], "apparent_inherent_reaction_extent")
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP_electrolyte.py
@@ -234,12 +234,8 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h20(*args, **kwargs):
+def dens_mol_h2o(*args, **kwargs):
     return 55e3
-
-
-def dens_mol_other(*args, **kwargs):
-    return 0
 
 
 class TestApparentSpeciesBasisInherent():
@@ -247,47 +243,44 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                         "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                         "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                          "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                            "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                            "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -672,47 +665,44 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                         "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                         "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                          "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                            "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                            "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP_electrolyte.py
@@ -234,7 +234,7 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h2o(*args, **kwargs):
+def dens_mol_H2O(*args, **kwargs):
     return 55e3
 
 
@@ -243,7 +243,7 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
@@ -260,27 +260,27 @@ class TestApparentSpeciesBasisInherent():
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                         "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                         "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                          "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                            "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                            "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -307,7 +307,7 @@ class TestApparentSpeciesBasisInherent():
         "temperature_ref": (298.15, pyunits.K),
 
         "inherent_reactions": {
-            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+            "H2O_si": {"stoichiometry": {("Liq", "H2O"): -1,
                                          ("Liq", "H+"): 1,
                                          ("Liq", "OH-"): 1},
                        "heat_of_reaction": constant_dh_rxn,
@@ -429,7 +429,7 @@ class TestApparentSpeciesBasisInherent():
         assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
         assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
         for i in m.fs.state[1].params.inherent_reaction_idx:
-            assert i in ["h2o_si", "co3_hco3"]
+            assert i in ["H2O_si", "co3_hco3"]
 
         assert isinstance(m.fs.state[1].apparent_inherent_reaction_extent, Var)
         assert len(m.fs.state[1].apparent_inherent_reaction_extent) == 2
@@ -665,7 +665,7 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
@@ -682,27 +682,27 @@ class TestTrueSpeciesBasisInherent():
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                         "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                         "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                          "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                            "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                            "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -729,7 +729,7 @@ class TestTrueSpeciesBasisInherent():
         "temperature_ref": (298.15, pyunits.K),
 
         "inherent_reactions": {
-            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+            "H2O_si": {"stoichiometry": {("Liq", "H2O"): -1,
                                          ("Liq", "H+"): 1,
                                          ("Liq", "OH-"): 1},
                        "heat_of_reaction": constant_dh_rxn,
@@ -855,7 +855,7 @@ class TestTrueSpeciesBasisInherent():
         assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
         assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
         for i in m.fs.state[1].params.inherent_reaction_idx:
-            assert i in ["h2o_si", "co3_hco3"]
+            assert i in ["H2O_si", "co3_hco3"]
 
         assert not hasattr(m.fs.state[1], "apparent_inherent_reaction_extent")
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP_electrolyte.py
@@ -223,7 +223,7 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h2o(*args, **kwargs):
+def dens_mol_H2O(*args, **kwargs):
     return 55e3
 
 
@@ -232,7 +232,7 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
@@ -249,27 +249,27 @@ class TestApparentSpeciesBasisInherent():
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -297,7 +297,7 @@ class TestApparentSpeciesBasisInherent():
         "temperature_ref": (298.15, pyunits.K),
 
         "inherent_reactions": {
-            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+            "H2O_si": {"stoichiometry": {("Liq", "H2O"): -1,
                                          ("Liq", "H+"): 1,
                                          ("Liq", "OH-"): 1},
                        "heat_of_reaction": constant_dh_rxn,
@@ -410,7 +410,7 @@ class TestApparentSpeciesBasisInherent():
         assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
         assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
         for i in m.fs.state[1].params.inherent_reaction_idx:
-            assert i in ["h2o_si", "co3_hco3"]
+            assert i in ["H2O_si", "co3_hco3"]
 
         assert isinstance(m.fs.state[1].apparent_inherent_reaction_extent, Var)
         assert len(m.fs.state[1].apparent_inherent_reaction_extent) == 2
@@ -637,7 +637,7 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
@@ -654,27 +654,27 @@ class TestTrueSpeciesBasisInherent():
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_h2o,
+                   "dens_mol_liq_comp": dens_mol_H2O,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_h2o,
+                    "dens_mol_liq_comp": dens_mol_H2O,
                     "parameter_data": {
                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_h2o,
+                      "dens_mol_liq_comp": dens_mol_H2O,
                       "parameter_data": {
                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -702,7 +702,7 @@ class TestTrueSpeciesBasisInherent():
         "temperature_ref": (298.15, pyunits.K),
 
         "inherent_reactions": {
-            "h2o_si": {"stoichiometry": {("Liq", "H2O"): -1,
+            "H2O_si": {"stoichiometry": {("Liq", "H2O"): -1,
                                          ("Liq", "H+"): 1,
                                          ("Liq", "OH-"): 1},
                        "heat_of_reaction": constant_dh_rxn,
@@ -819,7 +819,7 @@ class TestTrueSpeciesBasisInherent():
         assert isinstance(m.fs.state[1].params.inherent_reaction_idx, Set)
         assert len(m.fs.state[1].params.inherent_reaction_idx) == 2
         for i in m.fs.state[1].params.inherent_reaction_idx:
-            assert i in ["h2o_si", "co3_hco3"]
+            assert i in ["H2O_si", "co3_hco3"]
 
         assert not hasattr(m.fs.state[1], "apparent_inherent_reaction_extent")
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP_electrolyte.py
@@ -223,12 +223,8 @@ class TestApparentSpeciesBasisNoInherent():
 
 
 # -----------------------------------------------------------------------------
-def dens_mol_h20(*args, **kwargs):
+def dens_mol_h2o(*args, **kwargs):
     return 55e3
-
-
-def dens_mol_other(*args, **kwargs):
-    return 0
 
 
 class TestApparentSpeciesBasisInherent():
@@ -236,47 +232,44 @@ class TestApparentSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 
@@ -644,47 +637,44 @@ class TestTrueSpeciesBasisInherent():
         # Specifying components
         "components": {
             'H2O': {"type": Solvent,
-                    "dens_mol_liq_comp": dens_mol_h20,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (18E-3, pyunits.kg/pyunits.mol)}},
             'KHCO3': {"type": Apparent,
                       "dissociation_species": {"K+": 1, "HCO3-": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (100.1E-3, pyunits.kg/pyunits.mol)}},
             'K2CO3': {"type": Apparent,
                       "dissociation_species": {"K+": 2, "CO3--": 1},
-                      "dens_mol_liq_comp": dens_mol_other,
                       "parameter_data": {
                           "mw": (138.2E-3, pyunits.kg/pyunits.mol)}},
             'KOH': {"type": Apparent,
                     "dissociation_species": {"K+": 1, "OH-": 1},
-                    "dens_mol_liq_comp": dens_mol_other,
                     "parameter_data": {
                         "mw": (56.1E-3, pyunits.kg/pyunits.mol)}},
             'H+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                        "mw": (1E-3, pyunits.kg/pyunits.mol)}},
             'K+': {"type": Cation,
                    "charge": +1,
-                   "dens_mol_liq_comp": dens_mol_other,
+                   "dens_mol_liq_comp": dens_mol_h2o,
                    "parameter_data": {
                        "mw": (39.1E-3, pyunits.kg/pyunits.mol)}},
             'OH-': {"type": Anion,
                     "charge": -1,
-                    "dens_mol_liq_comp": dens_mol_other,
+                    "dens_mol_liq_comp": dens_mol_h2o,
                     "parameter_data": {
                         "mw": (17E-3, pyunits.kg/pyunits.mol)}},
             'HCO3-': {"type": Anion,
                       "charge": -1,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                           "mw": (61E-3, pyunits.kg/pyunits.mol)}},
             'CO3--': {"type": Anion,
                       "charge": -2,
-                      "dens_mol_liq_comp": dens_mol_other,
+                      "dens_mol_liq_comp": dens_mol_h2o,
                       "parameter_data": {
                           "mw": (60E-3, pyunits.kg/pyunits.mol)}}},
 


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
This is hopefully the final step in getting electrolytes working properly. This PR introduces a helper function for equations of state and other property methods tp get the correct `mole_frac_phase_comp` object depending on whether electrolytes are in use or not.

This method assume that if the system is using electrolytes that the correct `mole_frac_phase_comp` to use is that for the true species list. In short - if your are bothering to calculate true species compositions for an electrolyte system, you probably want to be using these to calculate the thermophysical properties of the system. Otherwise, why would you bother?

## Changes proposed in this PR:
- Adds helper method for getting correct `mole_frac_phase_comp` component.
- Updated `Ideal`  EoS to use the new helper method and adds flag to indicate support for electrolyte systems
- Adds 2 test to make sure `Ideal` EoS works for electrolyte systems
- Cleans up other electrolyte tests to remove unnecessary property definitions.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
