### PR TITLE
Fixing unit consistency issue in Gibbs Energy form for Keq

### DIFF
--- a/docs/user_guide/components/property_package/general_reactions/equil_constant.rst
+++ b/docs/user_guide/components/property_package/general_reactions/equil_constant.rst
@@ -22,7 +22,9 @@ The method uses the van 't Hoff equation to calculate the equilibrium constant.
 Gibbs Energy (gibbs_energy)
 ---------------------------
 
-The method uses the thermodynamic relationship with Gibbs energy to calculate the equilibrium constant.
+The method uses the thermodynamic relationship with Gibbs energy to calculate the equilibrium constant. This form is only supported for reactions using a molarity or activity basis due to challenges associated with automatically converting concentrations to other bases.
+
+Note that by convention (for aqueous systems at least), the standard units of k_eq in this form are :math:`(mol/L)^{order}`, which will be converted to the correct units automatically.
 
 .. math:: k_{eq} = e^{-\frac{\Delta H_{rxn, ref}}{R T} + \frac{\Delta S_{rxn, ref}}{R}}
 
@@ -35,4 +37,3 @@ The method uses the thermodynamic relationship with Gibbs energy to calculate th
    ":math:`\Delta S_{rxn, ref}`", "ds_rxn_ref", "Base units", "Entropy of reaction at reference temperature"
    ":math:`T_{ref, eq}`", "temperature_eq_ref", "Base units", "Reference temperature, used for calculating scaling factors"
 
-Note that the above form is strictly unitless - units for the equilibrium constant are calculated separately and appended to the expression.

--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -114,12 +114,10 @@ class gibbs_energy():
                 "{} concentration_form configuration argument was not set. "
                 "Please ensure that this argument is included in your "
                 "configuration dict.".format(rblock.name))
-        elif (c_form == ConcentrationForm.moleFraction or
-              c_form == ConcentrationForm.massFraction):
-            e_units = pyunits.dimensionless
-        else:
-            order = 0
+        elif (c_form == ConcentrationForm.molarity or
+              c_form == ConcentrationForm.activity):
 
+            order = 0
             try:
                 # This will work for Reaction Packages
                 pc_set = parent.config.property_package._phase_component_set
@@ -135,23 +133,13 @@ class gibbs_energy():
             for p, j in pc_set:
                 order += rblock.reaction_order[p, j].value
 
-            if (c_form == ConcentrationForm.molarity or
-                    c_form == ConcentrationForm.activity):
-                c_units = units["density_mole"]
-            elif c_form == ConcentrationForm.molality:
-                c_units = units["amount"]*units["mass"]**-1
-            elif c_form == ConcentrationForm.partialPressure:
-                c_units = units["pressure"]
-            else:
-                raise BurntToast(
-                    "{} get_concentration_term received unrecognised "
-                    "ConcentrationForm ({}). This should not happen - please "
-                    "contact the IDAES developers with this bug."
-                    .format(rblock.name, c_form))
-
-            e_units = c_units**order
-
-        rblock._keq_units = e_units
+            rblock._keq_units = (pyunits.convert(1*pyunits.mol/pyunits.L,
+                                                 units["density_mole"]))**order
+        else:
+            raise ConfigurationError(
+                "{} calculation of equilibrium constant based on Gibbs energy "
+                "is only supported for molarity or activity forms. "
+                "Currently selected form: {}".format(rblock.name, c_form))
 
         rblock.dh_rxn_ref = Var(
                 doc="Specific molar heat of reaction at reference state",

--- a/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
@@ -24,6 +24,7 @@ from idaes.generic_models.properties.core.generic.generic_reaction import \
 from idaes.generic_models.properties.core.reactions.equilibrium_constant import *
 from idaes.core import MaterialFlowBasis
 from idaes.core.util.testing import PhysicalParameterTestBlock
+from idaes.core.util.exceptions import ConfigurationError
 
 
 @pytest.fixture
@@ -272,70 +273,15 @@ class TestGibbsEnergy(object):
             "ds_rxn_ref": 1,
             "T_eq_ref": 500}
 
-        gibbs_energy.build_parameters(
-            model.rparams.reaction_r1,
-            model.rparams.config.equilibrium_reactions["r1"])
-
-        # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
-        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
-        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
-
-        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-        assert model.rparams.reaction_r1.T_eq_ref.value == 500
-
-        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
-                                pyunits.dimensionless)
-
-        # Check expression
-        rform = gibbs_energy.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
-
-        assert str(rform) == (
-            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*dimensionless')
-        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
-        assert_units_equivalent(rform, None)
-
-    @pytest.mark.unit
-    def test_gibbs_energy_mole_frac_convert(self, model):
-        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
-            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
-            "T_eq_ref": (900, pyunits.degR)}
-
-        gibbs_energy.build_parameters(
-            model.rparams.reaction_r1,
-            model.rparams.config.equilibrium_reactions["r1"])
-
-        # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
-        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
-        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
-
-        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-        assert model.rparams.reaction_r1.T_eq_ref.value == 500
-
-        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
-                                pyunits.dimensionless)
-
-        # Check expression
-        rform = gibbs_energy.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
-
-        assert str(rform) == (
-            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*dimensionless')
-        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
-        assert_units_equivalent(rform, None)
+        with pytest.raises(
+                ConfigurationError,
+                match="rparams.reaction_r1 calculation of equilibrium constant"
+                " based on Gibbs energy is only supported for molarity or"
+                " activity forms. Currently selected form: "
+                "ConcentrationForm.moleFraction"):
+            gibbs_energy.build_parameters(
+                model.rparams.reaction_r1,
+                model.rparams.config.equilibrium_reactions["r1"])
 
     @pytest.mark.unit
     def test_gibbs_energy_molarity(self, model):
@@ -371,8 +317,9 @@ class TestGibbsEnergy(object):
             'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
             '(8.314462618*(J)/mol/K)*(300*K)) + '
             '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*(mol*m**-3)')
-        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+            'rparams.reaction_r1.ds_rxn_ref)*'
+            '(999.9999999999999*l/m**3*(mol/l))')
+        assert value(rform) == pytest.approx(1.1269e3, rel=1e-3)
         assert_units_equivalent(rform, pyunits.mol*pyunits.m**-3)
 
     @pytest.mark.unit
@@ -409,8 +356,9 @@ class TestGibbsEnergy(object):
             'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
             '(8.314462618*(J)/mol/K)*(300*K)) + '
             '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*(mol*m**-3)')
-        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
+            'rparams.reaction_r1.ds_rxn_ref)*'
+            '(999.9999999999999*l/m**3*(mol/l))')
+        assert value(rform) == pytest.approx(1.1269e3, rel=1e-3)
         assert_units_equivalent(rform, pyunits.mol*pyunits.m**-3)
 
     @pytest.mark.unit
@@ -422,72 +370,15 @@ class TestGibbsEnergy(object):
             "ds_rxn_ref": 1,
             "T_eq_ref": 500}
 
-        gibbs_energy.build_parameters(
-            model.rparams.reaction_r1,
-            model.rparams.config.equilibrium_reactions["r1"])
-
-        # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
-        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
-        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
-
-        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-        assert model.rparams.reaction_r1.T_eq_ref.value == 500
-
-        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
-                                pyunits.mol/pyunits.kg)
-
-        # Check expression
-        rform = gibbs_energy.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
-
-        assert str(rform) == (
-            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*(mol*kg**-1)')
-        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.mol/pyunits.kg)
-
-    @pytest.mark.unit
-    def test_gibbs_energy_molality_convert(self, model):
-        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-            ConcentrationForm.molality
-        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
-            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
-            "T_eq_ref": (900, pyunits.degR)}
-
-        gibbs_energy.build_parameters(
-            model.rparams.reaction_r1,
-            model.rparams.config.equilibrium_reactions["r1"])
-
-        # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
-        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
-        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
-
-        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-        assert model.rparams.reaction_r1.T_eq_ref.value == 500
-
-        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
-                                pyunits.mol/pyunits.kg)
-
-        # Check expression
-        rform = gibbs_energy.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
-
-        assert str(rform) == (
-            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*(mol*kg**-1)')
-        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.mol*pyunits.kg**-1)
+        with pytest.raises(
+                ConfigurationError,
+                match="rparams.reaction_r1 calculation of equilibrium constant"
+                " based on Gibbs energy is only supported for molarity or"
+                " activity forms. Currently selected form: "
+                "ConcentrationForm.molality"):
+            gibbs_energy.build_parameters(
+                model.rparams.reaction_r1,
+                model.rparams.config.equilibrium_reactions["r1"])
 
     @pytest.mark.unit
     def test_gibbs_energy_partial_pressure(self, model):
@@ -498,69 +389,12 @@ class TestGibbsEnergy(object):
             "ds_rxn_ref": 1,
             "T_eq_ref": 500}
 
-        gibbs_energy.build_parameters(
-            model.rparams.reaction_r1,
-            model.rparams.config.equilibrium_reactions["r1"])
-
-        # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
-        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
-        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
-
-        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-        assert model.rparams.reaction_r1.T_eq_ref.value == 500
-
-        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
-                                pyunits.Pa)
-
-        # Check expression
-        rform = gibbs_energy.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
-
-        assert str(rform) == (
-            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*(kg*m**-1*s**-2)')
-        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.Pa)
-
-    @pytest.mark.unit
-    def test_gibbs_energy_partial_pressure_convert(self, model):
-        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-            ConcentrationForm.partialPressure
-        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
-            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
-            "T_eq_ref": (900, pyunits.degR)}
-
-        gibbs_energy.build_parameters(
-            model.rparams.reaction_r1,
-            model.rparams.config.equilibrium_reactions["r1"])
-
-        # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
-        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
-        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
-
-        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-        assert model.rparams.reaction_r1.T_eq_ref.value == 500
-
-        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
-                                pyunits.Pa)
-
-        # Check expression
-        rform = gibbs_energy.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
-
-        assert str(rform) == (
-            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*(kg*m**-1*s**-2)')
-        assert value(rform) == pytest.approx(1.1269, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.Pa)
+        with pytest.raises(
+                ConfigurationError,
+                match="rparams.reaction_r1 calculation of equilibrium constant"
+                " based on Gibbs energy is only supported for molarity or"
+                " activity forms. Currently selected form: "
+                "ConcentrationForm.partialPressure"):
+            gibbs_energy.build_parameters(
+                model.rparams.reaction_r1,
+                model.rparams.config.equilibrium_reactions["r1"])


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
When using the Gibbs energy form to calculate equilibrium constants, by convention the units of Keq are (mol/L)^order. This was not captured correctly in the origin implementation.

## Changes proposed in this PR:
- Limit the use of `gibbs_energy` method to reactions using molarity or activity basis
- Add unit conversion to convert (mol/L)^order to the base system of units.
- Document limitations of `gibbs_energy` implementation.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
