### PR TITLE
4 bug fixes

### DIFF
--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -16,7 +16,7 @@ IDAES Component objects
 @author: alee
 """
 from pyomo.environ import Set, Param, Var, units as pyunits
-from pyomo.common.config import ConfigBlock, ConfigValue
+from pyomo.common.config import ConfigBlock, ConfigValue, In
 from pyomo.core.base.units_container import _PyomoUnit
 
 from .process_base import (declare_process_block_class,
@@ -68,6 +68,11 @@ class ComponentData(ProcessBlockData):
         description="Method to calculate liquid component molar entropies"))
     CONFIG.declare("entr_mol_ig_comp", ConfigValue(
         description="Method to calculate ideal gas component molar entropies"))
+
+    CONFIG.declare("has_vapor_pressure", ConfigValue(
+        default=True,
+        domain=In([True, False]),
+        description="Flag indicating whether component has a vapor pressure"))
     CONFIG.declare("pressure_sat_comp", ConfigValue(
         description="Method to use to calculate saturation pressure"))
 
@@ -90,7 +95,7 @@ class ComponentData(ProcessBlockData):
             "component_lists needs to be populated."))
 
     def build(self):
-        super(ComponentData, self).build()
+        super().build()
 
         # If the component_list does not exist, add reference to new Component
         # The IF is mostly for backwards compatability, to allow for old-style
@@ -282,6 +287,11 @@ class IonData(SoluteData):
 
     # Remove valid_phase_types argument, as ions are aqueous phase only
     CONFIG.__delitem__("valid_phase_types")
+    # Set as not having a vapor pressure
+    has_psat = CONFIG.get("has_vapor_pressure")
+    has_psat.set_value(False)
+    has_psat.set_default_value(False)
+    has_psat.set_domain(In([False]))
 
     CONFIG.declare("charge", ConfigValue(
             domain=int,

--- a/idaes/core/control_volume0d.py
+++ b/idaes/core/control_volume0d.py
@@ -1815,7 +1815,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 for (t, j), c in self.material_balances.items():
                     sf = iscale.min_scaling_factor(
                         [self.properties_in[t].get_material_flow_terms(p, j)
-                         for p in phase_list])
+                         for p in phase_list if (p, j) in phase_component_set])
                     iscale.constraint_scaling_transform(c, sf)
             else:
                 # There are some other material balance types but they create

--- a/idaes/core/control_volume1d.py
+++ b/idaes/core/control_volume1d.py
@@ -2133,7 +2133,8 @@ argument)."""))
             elif mb_type == MaterialBalanceType.componentTotal:
                 for (t, x, j), c in self.material_balances.items():
                     sf = iscale.min_scaling_factor(
-                        [self._flow_terms[t, x, p, j] for p in phase_list])
+                        [self._flow_terms[t, x, p, j] for p in phase_list
+                         if (p, j) in phase_component_set])
                     iscale.constraint_scaling_transform(c, sf)
             else:
                 _log.warning(f"Unknown material balance type {mb_type}")

--- a/idaes/core/tests/test_components.py
+++ b/idaes/core/tests/test_components.py
@@ -49,7 +49,8 @@ class TestComponent():
         assert m.comp.config.valid_phase_types is None
         assert m.comp.config.elemental_composition is None
         assert not m.comp.config._component_list_exists
-        assert m.config.henry_components is None
+        assert m.comp.config.henry_component is None
+        assert m.comp.config.has_vapor_pressure
 
     @pytest.mark.unit
     def test_populate_component_list(self, m):
@@ -427,6 +428,9 @@ class TestIon():
         assert "valid_phase_types" not in m.comp.config
         assert m.comp.config.charge is None
         assert not m.comp.config._component_list_exists
+        assert not m.comp.config.has_vapor_pressure
+        with pytest.raises(ValueError):
+            m.comp.config.has_vapor_pressure = True
 
     @pytest.mark.unit
     def test_populate_component_list(self, m):
@@ -483,6 +487,9 @@ class TestAnion():
         assert "valid_phase_types" not in m.comp.config
         assert m.comp.config.charge == -1
         assert not m.comp.config._component_list_exists
+        assert not m.comp.config.has_vapor_pressure
+        with pytest.raises(ValueError):
+            m.comp.config.has_vapor_pressure = True
 
     @pytest.mark.unit
     def test_populate_component_list(self, m):
@@ -554,6 +561,9 @@ class TestCation():
         assert "valid_phase_types" not in m.comp.config
         assert m.comp.config.charge == +1
         assert not m.comp.config._component_list_exists
+        assert not m.comp.config.has_vapor_pressure
+        with pytest.raises(ValueError):
+            m.comp.config.has_vapor_pressure = True
 
     @pytest.mark.unit
     def test_populate_component_list(self, m):

--- a/idaes/core/unit_model.py
+++ b/idaes/core/unit_model.py
@@ -522,8 +522,9 @@ Must be True if dynamic = True,
                 state_1[rep_time].default_material_balance_type()
             )
 
-        phase_list = state_1[rep_time].params.phase_list
-        component_list = state_1[rep_time].params.component_list
+        phase_list = state_1.phase_list
+        component_list = state_1.component_list
+        pc_set = state_1.phase_component_set
 
         if balance_type == MaterialBalanceType.componentPhase:
             # TODO : Should we include an optional phase equilibrium term here
@@ -531,8 +532,7 @@ Must be True if dynamic = True,
 
             @self.Constraint(
                 self.flowsheet().config.time,
-                phase_list,
-                component_list,
+                pc_set,
                 doc="State material balances",
             )
             def state_material_balances(b, t, p, j):
@@ -550,10 +550,10 @@ Must be True if dynamic = True,
             def state_material_balances(b, t, j):
                 return sum(
                     state_1[t].get_material_flow_terms(p, j)
-                    for p in phase_list
+                    for p in phase_list if (p, j) in pc_set
                 ) == sum(
                     state_2[t].get_material_flow_terms(p, j)
-                    for p in phase_list
+                    for p in phase_list if (p, j) in pc_set
                 )
 
         elif balance_type == MaterialBalanceType.total:
@@ -564,17 +564,9 @@ Must be True if dynamic = True,
             )
             def state_material_balances(b, t):
                 return sum(
-                    sum(
-                        state_1[t].get_material_flow_terms(p, j)
-                        for j in component_list
-                    )
-                    for p in phase_list
+                    state_1[t].get_material_flow_terms(p, j) for p, j in pc_set
                 ) == sum(
-                    sum(
-                        state_2[t].get_material_flow_terms(p, j)
-                        for j in component_list
-                    )
-                    for p in phase_list
+                    state_2[t].get_material_flow_terms(p, j) for p, j in pc_set
                 )
 
         elif balance_type == MaterialBalanceType.elementTotal:

--- a/idaes/generic_models/properties/core/eos/ideal.py
+++ b/idaes/generic_models/properties/core/eos/ideal.py
@@ -133,12 +133,16 @@ class Ideal(EoSBase):
     @staticmethod
     def log_fug_phase_comp_eq(b, p, j, pp):
         pobj = b.params.get_phase(p)
+
         if pobj.is_vapor_phase():
             return log(b.get_mole_frac()[p, j]) + log(b.pressure)
         elif pobj.is_liquid_phase():
-            return (log(b.get_mole_frac()[p, j]) +
-                    log(get_method(b, "pressure_sat_comp", j)(
-                        b, cobj(b, j), b.temperature)))
+            if cobj(b, j).config.has_vapor_pressure:
+                return (log(b.get_mole_frac()[p, j]) +
+                        log(get_method(b, "pressure_sat_comp", j)(
+                            b, cobj(b, j), b.temperature)))
+            else:
+                return Expression.Skip
         else:
             raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))
 
@@ -205,14 +209,14 @@ def _invalid_phase_msg(name, phase):
 def _fug_phase_comp(b, p, j, T):
     pobj = b.params.get_phase(p)
 
-    if cobj(b, j).config.has_vapor_pressure:
-        if pobj.is_vapor_phase():
-            return b.get_mole_frac()[p, j] * b.pressure
-        elif pobj.is_liquid_phase():
+    if pobj.is_vapor_phase():
+        return b.get_mole_frac()[p, j] * b.pressure
+    elif pobj.is_liquid_phase():
+        if cobj(b, j).config.has_vapor_pressure:
             return (b.get_mole_frac()[p, j] *
                     get_method(b, "pressure_sat_comp", j)(
                         b, cobj(b, j), T))
         else:
-            raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))
+            return Expression.Skip
     else:
-        return Expression.Skip
+        raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))

--- a/idaes/generic_models/properties/core/eos/ideal.py
+++ b/idaes/generic_models/properties/core/eos/ideal.py
@@ -15,7 +15,7 @@ Methods for ideal equations of state.
 
 Currently only supports liquid and vapor phases
 """
-from pyomo.environ import log
+from pyomo.environ import Expression, log
 
 from idaes.core.util.exceptions import PropertyNotSupportedError
 from idaes.generic_models.properties.core.generic.utility import (
@@ -204,11 +204,15 @@ def _invalid_phase_msg(name, phase):
 
 def _fug_phase_comp(b, p, j, T):
     pobj = b.params.get_phase(p)
-    if pobj.is_vapor_phase():
-        return b.get_mole_frac()[p, j] * b.pressure
-    elif pobj.is_liquid_phase():
-        return (b.get_mole_frac()[p, j] *
-                get_method(b, "pressure_sat_comp", j)(
-                    b, cobj(b, j), T))
+
+    if cobj(b, j).config.has_vapor_pressure:
+        if pobj.is_vapor_phase():
+            return b.get_mole_frac()[p, j] * b.pressure
+        elif pobj.is_liquid_phase():
+            return (b.get_mole_frac()[p, j] *
+                    get_method(b, "pressure_sat_comp", j)(
+                        b, cobj(b, j), T))
+        else:
+            raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))
     else:
-        raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))
+        return Expression.Skip

--- a/idaes/generic_models/properties/core/eos/tests/test_ideal.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_ideal.py
@@ -256,7 +256,7 @@ def test_fug_phase_comp_vap(m):
 @pytest.mark.unit
 def test_fug_phase_comp_invalid_phase(m_sol):
     with pytest.raises(PropertyNotSupportedError):
-        Ideal.fug_phase_comp(m_sol.props[1], "Sol", "foo")
+        Ideal.fug_phase_comp(m_sol.props[1], "Sol", "a")
 
 
 @pytest.mark.unit
@@ -281,7 +281,7 @@ def test_fug_phase_comp_vap_eq(m):
 @pytest.mark.unit
 def test_fug_phase_comp_invalid_phase_eq(m_sol):
     with pytest.raises(PropertyNotSupportedError):
-        Ideal.fug_phase_comp_eq(m_sol.props[1], "Sol", "foo", ("Vap", "Liq"))
+        Ideal.fug_phase_comp_eq(m_sol.props[1], "Sol", "a", ("Vap", "Liq"))
 
 
 @pytest.mark.unit

--- a/idaes/generic_models/properties/core/phase_equil/forms.py
+++ b/idaes/generic_models/properties/core/phase_equil/forms.py
@@ -28,12 +28,23 @@ class fugacity():
 
     @staticmethod
     def calculate_scaling_factors(b, phase1, phase2, comp):
-        sf_1 = iscale.get_scaling_factor(
-            b.fug_phase_comp[phase1, comp], default=1, warning=True)
-        sf_2 = iscale.get_scaling_factor(
-            b.fug_phase_comp[phase2, comp], default=1, warning=True)
+        with b.lock_attribute_creation_context():
+            if hasattr(b, "fug_phase_comp_eq"):
+                sf_1 = iscale.get_scaling_factor(
+                    b.fug_phase_comp[phase1, comp], default=1, warning=True)
+                sf_2 = iscale.get_scaling_factor(
+                    b.fug_phase_comp[phase2, comp], default=1, warning=True)
 
-        return min(sf_1, sf_2)
+                return min(sf_1, sf_2)
+            elif hasattr(b, "fug_phase_comp"):
+                sf_1 = iscale.get_scaling_factor(
+                    b.fug_phase_comp[phase1, comp], default=1, warning=True)
+                sf_2 = iscale.get_scaling_factor(
+                    b.fug_phase_comp[phase2, comp], default=1, warning=True)
+
+                return min(sf_1, sf_2)
+            else:
+                return 1
 
 
 class log_fugacity():

--- a/idaes/generic_models/properties/core/pure/RPP5.py
+++ b/idaes/generic_models/properties/core/pure/RPP5.py
@@ -76,7 +76,7 @@ class enth_mol_ig_comp():
 
     @staticmethod
     def build_parameters(cobj):
-        if not hasattr(cobj, "cp_mol_ig_comp_coeff_A"):
+        if not hasattr(cobj, "cp_mol_ig_comp_coeff_a0"):
             cp_mol_ig_comp.build_parameters(cobj)
 
         if cobj.parent_block().config.include_enthalpy_of_formation:
@@ -110,7 +110,7 @@ class entr_mol_ig_comp():
 
     @staticmethod
     def build_parameters(cobj):
-        if not hasattr(cobj, "cp_mol_ig_comp_coeff_A"):
+        if not hasattr(cobj, "cp_mol_ig_comp_coeff_a0"):
             cp_mol_ig_comp.build_parameters(cobj)
 
         units = cobj.parent_block().get_metadata().derived_units

--- a/idaes/generic_models/properties/core/reactions/dh_rxn.py
+++ b/idaes/generic_models/properties/core/reactions/dh_rxn.py
@@ -46,4 +46,10 @@ class constant_dh_rxn():
 
     @staticmethod
     def calculate_scaling_factors(b, rblock):
-        return 1/abs(value(rblock.dh_rxn_ref))
+        v = abs(value(rblock.dh_rxn_ref))
+
+        # Need to make sure dh_rxn is not 0 to avoid division by 0
+        if v != 0:
+            return 1/abs(value(rblock.dh_rxn_ref))
+        else:
+            return 1

--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -146,7 +146,9 @@ class gibbs_energy():
         if config.heat_of_reaction is not constant_dh_rxn:
             raise ConfigurationError(
                 "{} calculating equilibrium constants from Gibbs energy "
-                "assumes constant heat of reaction.".format(rblock.name))
+                "assumes constant heat of reaction. Please ensure you are "
+                "using the constant_dh_rxn method for this reaction"
+                .format(rblock.name))
 
         rblock.ds_rxn_ref = Var(
                 doc="Specific molar entropy of reaction at reference state",

--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -17,6 +17,7 @@ from pyomo.environ import exp, Var, units as pyunits, value
 
 from idaes.generic_models.properties.core.generic.generic_reaction import \
     ConcentrationForm
+from .dh_rxn import constant_dh_rxn
 from idaes.core.util.misc import set_param_from_config
 from idaes.core.util.constants import Constants as c
 from idaes.core.util.exceptions import BurntToast, ConfigurationError
@@ -151,12 +152,13 @@ class gibbs_energy():
 
             e_units = c_units**order
 
-        rblock._keq_units = e_units
+        # Check that heat of reaction is constant
+        if config.heat_of_reaction is not constant_dh_rxn:
+            raise ConfigurationError(
+                "{} calculating equilibrium constants from Gibbs energy "
+                "assumes constant heat of reaction.".format(rblock.name))
 
-        rblock.dh_rxn_ref = Var(
-                doc="Specific molar heat of reaction at reference state",
-                units=units["energy_mole"])
-        set_param_from_config(rblock, param="dh_rxn_ref", config=config)
+        rblock._keq_units = e_units
 
         rblock.ds_rxn_ref = Var(
                 doc="Specific molar entropy of reaction at reference state",

--- a/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
@@ -300,7 +300,8 @@ class TestGibbsEnergy(object):
         with pytest.raises(ConfigurationError,
                            match="rparams.reaction_r1 calculating equilibrium "
                            "constants from Gibbs energy assumes constant "
-                           "heat of reaction."):
+                           "heat of reaction. Please ensure you are using the "
+                           "constant_dh_rxn method for this reaction"):
             gibbs_energy.build_parameters(
                 model.rparams.reaction_r1,
                 model.rparams.config.equilibrium_reactions["r1"])

--- a/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
@@ -22,6 +22,7 @@ from pyomo.util.check_units import assert_units_equivalent
 from idaes.generic_models.properties.core.generic.generic_reaction import \
     GenericReactionParameterBlock, ConcentrationForm
 from idaes.generic_models.properties.core.reactions.equilibrium_constant import *
+from idaes.generic_models.properties.core.reactions.dh_rxn import constant_dh_rxn
 from idaes.core import MaterialFlowBasis
 from idaes.core.util.testing import PhysicalParameterTestBlock
 
@@ -267,19 +268,19 @@ class TestVanTHoff(object):
 class TestGibbsEnergy(object):
     @pytest.mark.unit
     def test_gibbs_energy_mole_frac(self, model):
+        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
+            constant_dh_rxn
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": 2,
             "ds_rxn_ref": 1,
             "T_eq_ref": 500}
+        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
+                                                   units=pyunits.J/pyunits.mol)
 
         gibbs_energy.build_parameters(
             model.rparams.reaction_r1,
             model.rparams.config.equilibrium_reactions["r1"])
 
         # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
         assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
         assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
@@ -303,6 +304,14 @@ class TestGibbsEnergy(object):
 
     @pytest.mark.unit
     def test_gibbs_energy_mole_frac_convert(self, model):
+        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
+            constant_dh_rxn
+        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
+            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
+            "T_eq_ref": (900, pyunits.degR)}
+        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
+                                                   units=pyunits.J/pyunits.mol)
+
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
             "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
             "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
@@ -313,9 +322,6 @@ class TestGibbsEnergy(object):
             model.rparams.config.equilibrium_reactions["r1"])
 
         # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
         assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
         assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
@@ -341,19 +347,19 @@ class TestGibbsEnergy(object):
     def test_gibbs_energy_molarity(self, model):
         model.rparams.config.equilibrium_reactions.r1.concentration_form = \
             ConcentrationForm.molarity
+        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
+            constant_dh_rxn
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": 2,
             "ds_rxn_ref": 1,
             "T_eq_ref": 500}
+        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
+                                                   units=pyunits.J/pyunits.mol)
 
         gibbs_energy.build_parameters(
             model.rparams.reaction_r1,
             model.rparams.config.equilibrium_reactions["r1"])
 
         # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
         assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
         assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
@@ -379,19 +385,19 @@ class TestGibbsEnergy(object):
     def test_gibbs_energy_molarity_convert(self, model):
         model.rparams.config.equilibrium_reactions.r1.concentration_form = \
             ConcentrationForm.molarity
+        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
+            constant_dh_rxn
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
             "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
             "T_eq_ref": (900, pyunits.degR)}
+        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
+                                                   units=pyunits.J/pyunits.mol)
 
         gibbs_energy.build_parameters(
             model.rparams.reaction_r1,
             model.rparams.config.equilibrium_reactions["r1"])
 
         # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
         assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
         assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
@@ -414,22 +420,22 @@ class TestGibbsEnergy(object):
         assert_units_equivalent(rform, pyunits.mol*pyunits.m**-3)
 
     @pytest.mark.unit
-    def test_gibss_energy_molality(self, model):
+    def test_gibbs_energy_molality(self, model):
         model.rparams.config.equilibrium_reactions.r1.concentration_form = \
             ConcentrationForm.molality
+        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
+            constant_dh_rxn
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": 2,
             "ds_rxn_ref": 1,
             "T_eq_ref": 500}
+        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
+                                                   units=pyunits.J/pyunits.mol)
 
         gibbs_energy.build_parameters(
             model.rparams.reaction_r1,
             model.rparams.config.equilibrium_reactions["r1"])
 
         # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
         assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
         assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
@@ -455,19 +461,19 @@ class TestGibbsEnergy(object):
     def test_gibbs_energy_molality_convert(self, model):
         model.rparams.config.equilibrium_reactions.r1.concentration_form = \
             ConcentrationForm.molality
+        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
+            constant_dh_rxn
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
             "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
             "T_eq_ref": (900, pyunits.degR)}
+        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
+                                                   units=pyunits.J/pyunits.mol)
 
         gibbs_energy.build_parameters(
             model.rparams.reaction_r1,
             model.rparams.config.equilibrium_reactions["r1"])
 
         # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
         assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
         assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
@@ -493,19 +499,19 @@ class TestGibbsEnergy(object):
     def test_gibbs_energy_partial_pressure(self, model):
         model.rparams.config.equilibrium_reactions.r1.concentration_form = \
             ConcentrationForm.partialPressure
+        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
+            constant_dh_rxn
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": 2,
             "ds_rxn_ref": 1,
             "T_eq_ref": 500}
+        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
+                                                   units=pyunits.J/pyunits.mol)
 
         gibbs_energy.build_parameters(
             model.rparams.reaction_r1,
             model.rparams.config.equilibrium_reactions["r1"])
 
         # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
         assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
         assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 
@@ -531,19 +537,19 @@ class TestGibbsEnergy(object):
     def test_gibbs_energy_partial_pressure_convert(self, model):
         model.rparams.config.equilibrium_reactions.r1.concentration_form = \
             ConcentrationForm.partialPressure
+        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
+            constant_dh_rxn
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "dh_rxn_ref": (2000, pyunits.J/pyunits.kmol),
             "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
             "T_eq_ref": (900, pyunits.degR)}
+        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
+                                                   units=pyunits.J/pyunits.mol)
 
         gibbs_energy.build_parameters(
             model.rparams.reaction_r1,
             model.rparams.config.equilibrium_reactions["r1"])
 
         # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.dh_rxn_ref, Var)
-        assert model.rparams.reaction_r1.dh_rxn_ref.value == 2
-
         assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
         assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
 


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
This PR addresses 4 bugs identified recently.

1. Generic Reactions: Gibbs energy and van 't Hoff forms of calculating equilibrium constants could not be combined.
2. Generic Properties: Scaling tools raised an `Exception` due to trying to create fugacity expressions for non-vapourisable components.
3. Generic Properties: RPP5 library had misnamed variable when checking for prior parameter creation resulting in implicit replacement of parameters.
4. Unit model: `add_state_material_balances` had indexing issues due to not checking for non-vapourisables and non-condensables.

## Changes proposed in this PR:
- Reworked Gibbs energy form to not build its own `dh_rxn`
- Added new option to component declaration to indicate that a component does not have a vapour pressure and can thus be skipped when calculating frugalities. Applied this to key models.
- Fixed typo in RPP5
- Fixed indexing of Expressions in `add_state_material_balances`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
