### PR TITLE
Refactor setup.py and requirements-dev.txt to streamline installation workflows

### DIFF
--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -11,7 +11,7 @@ runs:
         $PIP_INSTALL --upgrade pip setuptools wheel
         # TODO the pylint version will have to be pinned
         # TODO installing idaes is necessary in our case because we import some idaes code in pylint plugins
-        $PIP_INSTALL pylint -r requirements.txt
+        $PIP_INSTALL -r requirements-dev.txt
         # don't think we need to install the extensions, though
     - name: Run pylint (errors only)
       shell: bash

--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -24,7 +24,7 @@ runs:
         echo '::group::Output of "pip show pyomo idaes-pse"'
         pip show pyomo idaes-pse
         echo '::endgroup::'
-        idaes --version
+        # idaes --version
     - name: Install extensions
       shell: bash
       run: |

--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -20,9 +20,6 @@ runs:
       run: |
         echo '::group::Output of "pip install" command'
         ${{ inputs.install-command }} ${{ inputs.install-target}}
-        # added temporary additional installation of pysp while waiting for Pyomo/pyomo#1778 to get merged
-        # see https://github.com/IDAES/idaes-pse/pull/249#issuecomment-816108862 for more details
-        ${{ inputs.install-command }} https://github.com/Pyomo/pysp/archive/master.zip
         echo '::endgroup::'
         echo '::group::Output of "pip show pyomo idaes-pse"'
         pip show pyomo idaes-pse

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To install with `pip`:
 # install latest stable release
 pip install idaes_pse
 # install latest version from the main branch of this repository
-pip install 'idaes-pse[unstable] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
+pip install 'idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
 ```
 
 To install with Anaconda's `conda`: **coming soon**

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ in the LICENSE.txt and COPYRIGHT.txt files in this directory.**
 To install with `pip`:
 
 ```bash
+# install latest stable release
 pip install idaes_pse
+# install latest version from the main branch of this repository
+pip install 'idaes-pse[unstable] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
 ```
 
 To install with Anaconda's `conda`: **coming soon**

--- a/docs/advanced_user_guide/advanced_install/index.rst
+++ b/docs/advanced_user_guide/advanced_install/index.rst
@@ -93,26 +93,16 @@ Now that conda and pip are installed, and you are in the "idaes" conda environme
 
 .. code-block:: sh
 
-    pip install .
+    pip install -r requirements-dev.txt
     idaes get-extensions
 
 .. warning::
     The IDAES binary extensions are not yet supported on Mac/OSX
 
 .. note::
-   There are a few options for installing the requirements.
-
-    1) ``pip install .`` - basic install using what is in setup.py
-
-    2) ``pip install .[dev]`` - basic install as above and also installs the Sphinx doc tools for building the documentation locally
-
-    3) ``pip install -r requirements.txt`` - same as # 1 but installs our "development" Pyomo and PyUtilib
-
-    4) ``pip install -r requirements-dev.txt`` -  same as # 3 with the Sphinx doc tools
-
-    Also note that these pip installs would override any package within the conda environment, 
-    so if you would like a specific package (e.g. git clone Pyomo), you should look at the 
-    requirements files and only install the packages you need.
+    This ``pip install`` command would override any package within the conda environment, 
+    so if you would like to use a specific version of a package (e.g. a local clone of the Pyomo git repository), you should look at the 
+    ``requirements-dev.txt`` file and use it as a reference to either install the individual packages manually, or create a separate requirements file customized to your development use case.
 
 You can test that everything is installed properly by running the tests with
 Pytest_:

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -127,7 +127,7 @@ Powershell Prompt.  Regardless of OS and shell, the following steps are the same
 
   c. To get the latest version from the GitHub main branch::
 
-      pip install 'idaes-pse[unstable] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
+      pip install 'idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
 
   d. To get the latest version from the GitHub main branch, including development dependencies::
 

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -129,13 +129,11 @@ Powershell Prompt.  Regardless of OS and shell, the following steps are the same
 
       pip install 'idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
 
-  d. To get the latest version from the GitHub main branch, including development dependencies::
+  d. To get a specific fork or branch, for example myfork (of idaes-pse) and mybranch::
 
-      pip install 'idaes-pse[dev] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
+      pip install 'idaes-pse[prerelease] @ https://github.com/myfork/idaes-pse/archive/mybranch.zip'
 
-  e. To get a specific fork or branch, for example myfork (of idaes-pse) and mybranch::
-
-      pip install 'idaes-pse[dev] @ https://github.com/myfork/idaes-pse/archive/mybranch.zip'
+  e. For developers: follow the :ref:`advanced user installation<advanced_user_guide/advanced_install/index:Advanced User Installation>`.
 
 2. Run the :doc:`idaes get-extensions command<../user_guide/commands/get_extensions>`
    to install the compiled binaries::

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -125,13 +125,17 @@ Powershell Prompt.  Regardless of OS and shell, the following steps are the same
 
       pip install idaes-pse==1.7
 
-  c. To get the latest development main branch::
+  c. To get the latest version from the GitHub main branch::
 
-      pip install git+https://github.com/idaes/idaes-pse
+      pip install 'idaes-pse[unstable] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
 
-  d. To get a specific fork or branch, for example myfork (of idaes-pse) and mybranch::
+  d. To get the latest version from the GitHub main branch, including development dependencies::
 
-      pip install git+https://github.com/myfork/idaes-pse@mybranch
+      pip install 'idaes-pse[dev] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
+
+  e. To get a specific fork or branch, for example myfork (of idaes-pse) and mybranch::
+
+      pip install 'idaes-pse[dev] @ https://github.com/myfork/idaes-pse/archive/mybranch.zip'
 
 2. Run the :doc:`idaes get-extensions command<../user_guide/commands/get_extensions>`
    to install the compiled binaries::

--- a/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
+++ b/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
@@ -12,13 +12,13 @@
 ##############################################################################
 import sys
 import os
+from unittest.mock import patch
 sys.path.append(os.path.abspath('..')) # current folder is ~/tests
 import numpy as np
 import pandas as pd
 from scipy import sparse
 import pytest
 from pytest import approx
-from mock import patch
 from idaes.apps.uncertainty_propagation.uncertainties import quantify_propagate_uncertainty, propagate_uncertainty,clean_variable_name
 from pyomo.opt import SolverFactory
 from pyomo.environ import *

--- a/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
+++ b/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
@@ -28,12 +28,12 @@ ipopt_available = SolverFactory('ipopt').available()
 kaug_available = SolverFactory('k_aug').available()
 dotsens_available = SolverFactory('dot_sens').available()
 
+@pytest.mark.skipif(not ipopt_available, reason="The 'ipopt' command is not available")
+@pytest.mark.skipif(not kaug_available, reason="The 'k_aug' command is not available")
+@pytest.mark.skipif(not dotsens_available, reason="The 'dot_sens' command is not available")
 class TestUncertaintyPropagation:
 
     @pytest.mark.unit
-    @pytest.mark.skipif(not ipopt_available, reason="The 'ipopt' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'k_aug' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'dot_sens' command is not available")
     def test_quantify_propagate_uncertainty1(self):
         '''
         It tests the function quantify_propagate_uncertainty with rooney & biegler's model.
@@ -327,9 +327,6 @@ class TestUncertaintyPropagation:
             propagate_results =  propagate_uncertainty(1, theta, cov, variable_name)
 
     @pytest.mark.unit
-    @pytest.mark.skipif(not ipopt_available, reason="The 'ipopt' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'k_aug' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'dot_sens' command is not available")
     def test_quantify_propagate_uncertainty_NRTL(self):
         '''
         It tests the function quantify_propagate_uncertainty with IDAES NRTL model.
@@ -353,9 +350,6 @@ class TestUncertaintyPropagation:
         
 
     @pytest.mark.unit
-    @pytest.mark.skipif(not ipopt_available, reason="The 'ipopt' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'k_aug' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'dot_sens' command is not available")
     def test_quantify_propagate_uncertainty_NRTL_exception(self):
         '''
         It tests an exception error when the ipopt fails for the function quantify_propagate_uncertainty with IDAES NRTL model.
@@ -374,9 +368,6 @@ class TestUncertaintyPropagation:
             results =  quantify_propagate_uncertainty(NRTL_model,NRTL_model_opt_infeasible, data, variable_name, SSE)
 
 
-    @pytest.mark.skipif(not ipopt_available, reason="The 'ipopt' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'k_aug' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'dot_sens' command is not available")
     def test_Exception1(self):
         '''
         It tests an ValueError when the tee is not bool for the function quantify_propagate_uncertainty with rooney & biegler's model.
@@ -395,9 +386,6 @@ class TestUncertaintyPropagation:
 
 
     @pytest.mark.unit
-    @pytest.mark.skipif(not ipopt_available, reason="The 'ipopt' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'k_aug' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'dot_sens' command is not available")
     def test_Exception2(self):
         '''
         It tests an ValueError when the diagnostic_mode is not bool for the function quantify_propagate_uncertainty with rooney & biegler's model.
@@ -417,9 +405,6 @@ class TestUncertaintyPropagation:
 
 
     @pytest.mark.unit
-    @pytest.mark.skipif(not ipopt_available, reason="The 'ipopt' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'k_aug' command is not available")
-    @pytest.mark.skipif(not ipopt_available, reason="The 'dot_sens' command is not available")
     def test_Exception3(self):
         '''
         It tests an ValeError when solver_options is not a dictionary for the function quantify_propagate_uncertainty with rooney & biegler's model.

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -19,7 +19,7 @@ import importlib
 
 _log = logging.getLogger(__name__)
 # Default release version if no options provided for get-extensions
-default_binary_release = "2.4.2"
+default_binary_release = "2.4.3"
 # Where to download releases from get-extensions
 release_base_url = "https://github.com/IDAES/idaes-ext/releases/download"
 # Where to get release checksums

--- a/idaes/dmf/tests/util.py
+++ b/idaes/dmf/tests/util.py
@@ -19,13 +19,13 @@ import logging
 import os
 import shutil
 import time
+from unittest.mock import MagicMock, patch
 import warnings
 # third party
 import pytest
 # local
 from idaes.dmf import dmfbase
 from idaes.util.system import mkdtemp
-from mock import MagicMock, patch
 
 __author__ = "Dan Gunter"
 

--- a/idaes/surrogate/pysmo/tests/test_kriging.py
+++ b/idaes/surrogate/pysmo/tests/test_kriging.py
@@ -13,6 +13,7 @@
 import sys
 import os
 import io
+from unittest.mock import patch
 sys.path.append(os.path.abspath('..')) # current folder is ~/tests
 from idaes.surrogate.pysmo.kriging import (
     KrigingModel, MyBounds
@@ -23,7 +24,6 @@ from scipy.spatial import distance
 import scipy.optimize as opt
 import scipy.stats as stats
 import pytest
-from mock import patch
 
 class TestKrigingModel:
     y = np.array([[i, j, ((i + 1) ** 2) + ((j + 1) ** 2)] for i in np.linspace(0, 10, 21) for j in np.linspace(0, 10, 21)])

--- a/idaes/surrogate/pysmo/tests/test_polynomial_regression.py
+++ b/idaes/surrogate/pysmo/tests/test_polynomial_regression.py
@@ -11,6 +11,7 @@
 # at the URL "https://github.com/IDAES/idaes-pse".
 ##############################################################################
 import sys, os
+from unittest.mock import patch
 
 sys.path.append(os.path.abspath('..'))  # current folder is ~/tests
 from idaes.surrogate.pysmo.polynomial_regression import (
@@ -19,7 +20,6 @@ from idaes.surrogate.pysmo.polynomial_regression import (
 import numpy as np
 import pandas as pd
 import pytest
-from mock import patch
 
 
 class TestFeatureScaling:

--- a/idaes/surrogate/pysmo/tests/test_radial_basis_function.py
+++ b/idaes/surrogate/pysmo/tests/test_radial_basis_function.py
@@ -12,6 +12,7 @@
 ##############################################################################
 import sys
 import os
+from unittest.mock import patch
 
 sys.path.append(os.path.abspath('..'))  # current folder is ~/tests\
 from idaes.surrogate.pysmo.radial_basis_function import (
@@ -21,7 +22,6 @@ import numpy as np
 import pandas as pd
 from scipy.spatial import distance
 import pytest
-from mock import patch
 
 
 class TestFeatureScaling:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,4 @@
 --index-url https://pypi.python.org/simple/
 
-# Put versions of dependencies, required for deployment, here.
-# They will override abstract dependencies in `setup.py`
-
-# Pyomo
-git+https://github.com/PyUtilib/pyutilib
-git+https://github.com/IDAES/pyomo.git@IDAES
-
-# Install abstract dependencies from `setup.py`
--e .
--e .[dev]
+# dev dependencies are specified in setup.py
+--editable .[dev]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,25 @@
 --index-url https://pypi.python.org/simple/
 
-# dev dependencies are specified in setup.py
---editable .[dev]
+# Developer extra packages
+alabaster>=0.7.7
+# temporarily hold coverage version due to avoid bug in coveralls
+# -alee 12/20/2019
+coverage==4.5.4
+flake8
+jsonschema
+jupyter_contrib_nbextensions
+mock
+pylint
+pytest-cov
+python-coveralls
+snowballstemmer==1.2.1
+# Newer sphinx needed for proper type hint support in docstrings
+sphinx>=3.0.0
+# note: 4/22/2020, removed the version requirement here
+sphinx-rtd-theme
+sphinxcontrib-napoleon>=0.5.0
+sphinx-argparse
+
+# this will install IDAES in editable mode using the dependencies defined under the `prerelease` tag of `extras_require` in `setup.py`
+# to customize this (e.g. to install a local clone of the Pyomo git repository), install IDAES without the `prerelease` tag and then install the dependencies separately
+--editable .[prerelease]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,24 +1,28 @@
 --index-url https://pypi.python.org/simple/
 
 # Developer extra packages
+
+### docs
 alabaster>=0.7.7
-# temporarily hold coverage version due to avoid bug in coveralls
-# -alee 12/20/2019
-coverage==4.5.4
-flake8
-jsonschema
-jupyter_contrib_nbextensions
-mock
-pylint
-pytest-cov
-python-coveralls
-snowballstemmer==1.2.1
 # Newer sphinx needed for proper type hint support in docstrings
 sphinx>=3.0.0
 # note: 4/22/2020, removed the version requirement here
 sphinx-rtd-theme
 sphinxcontrib-napoleon>=0.5.0
 sphinx-argparse
+
+### testing and linting
+# TODO/NOTE pytest is specified as a dependency in setup.py, but we might want to pin a specific version here
+pytest
+coverage
+pytest-cov
+pylint
+flake8
+
+### other/misc
+jsonschema
+jupyter_contrib_nbextensions
+snowballstemmer==1.2.1
 
 # this will install IDAES in editable mode using the dependencies defined under the `prerelease` tag of `extras_require` in `setup.py`
 # to customize this (e.g. to install a local clone of the Pyomo git repository), install IDAES without the `prerelease` tag and then install the dependencies separately

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 --index-url https://pypi.python.org/simple/
 
 # all dependencies are specified in setup.py
---editable .[unstable]
+--editable .[prerelease]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
---index-url https://pypi.python.org/simple/
-
-# all dependencies are specified in setup.py
---editable .[prerelease]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 --index-url https://pypi.python.org/simple/
 
-# Pyomo from Git
-git+https://github.com/PyUtilib/pyutilib
-git+https://github.com/IDAES/pyomo.git@IDAES
-
--e .
+# all dependencies are specified in setup.py
+--editable .[unstable]

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ def rglob(path, glob):
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
     "pyutilib @ https://github.com/PyUtilib/pyutilib/archive/master.zip",
-    "pyomo @ https://github.com/IDAES/pyomo/archive/842a2a4892929a2a032c0711a29381a8a5d17c24.zip",
-    "pysp @ https://github.com/Pyomo/pysp/archive/c08015310bd9615ebbb2b0eb9042334c9306b458.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.0.idaes.2021.05.05.zip",
+    "pysp @ https://github.com/Pyomo/pysp/archive/master.zip",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,12 @@ def rglob(path, glob):
     return list(map(str, p.rglob(glob)))
 
 
+DEPENDENCIES_FOR_UNSTABLE_VERSION = [
+    "https://github.com/IDAES/Pyomo/archive/IDAES.zip",
+    "https://github.com/Pyomo/PySP/archive/master.zip",
+]
+
+
 kwargs = dict(
     zip_safe=False,
     name=NAME,
@@ -78,7 +84,9 @@ kwargs = dict(
     },
     # Only installed if [<key>] is added to package name
     extras_require={
-        "dev": [  # Developer extra packages
+        "unstable": DEPENDENCIES_FOR_UNSTABLE_VERSION,
+        "dev": DEPENDENCIES_FOR_UNSTABLE_VERSION + [
+            # Developer extra packages
             "alabaster>=0.7.7",
             # temporarily hold coverage version due to avoid bug in coveralls
             # -alee 12/20/2019

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def rglob(path, glob):
     return list(map(str, p.rglob(glob)))
 
 
-DEPENDENCIES_FOR_UNSTABLE_VERSION = [
+DEPENDENCIES_FOR_PRERELEASE_VERSION = [
     "pyutilib @ https://github.com/PyUtilib/pyutilib/archive/master.zip",
     "pyomo @ https://github.com/IDAES/pyomo/archive/842a2a4892929a2a032c0711a29381a8a5d17c24.zip",
     "pysp @ https://github.com/Pyomo/pysp/archive/c08015310bd9615ebbb2b0eb9042334c9306b458.zip",
@@ -85,8 +85,8 @@ kwargs = dict(
     },
     # Only installed if [<key>] is added to package name
     extras_require={
-        "unstable": DEPENDENCIES_FOR_UNSTABLE_VERSION,
-        "dev": DEPENDENCIES_FOR_UNSTABLE_VERSION + [
+        "prerelease": DEPENDENCIES_FOR_PRERELEASE_VERSION,
+        "dev": DEPENDENCIES_FOR_PRERELEASE_VERSION + [
             # Developer extra packages
             "alabaster>=0.7.7",
             # temporarily hold coverage version due to avoid bug in coveralls

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ kwargs = dict(
         "jupyter",
         "lxml",
         "matplotlib",
-        "mock",
         "nbconvert",
         "nbformat",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_UNSTABLE_VERSION = [
-    "https://github.com/IDAES/Pyomo/archive/IDAES.zip",
-    "https://github.com/Pyomo/PySP/archive/master.zip",
+    "https://github.com/IDAES/pyomo/archive/842a2a4892929a2a032c0711a29381a8a5d17c24.zip",
+    "https://github.com/Pyomo/pysp/archive/c08015310bd9615ebbb2b0eb9042334c9306b458.zip",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,9 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_UNSTABLE_VERSION = [
-    "https://github.com/IDAES/pyomo/archive/842a2a4892929a2a032c0711a29381a8a5d17c24.zip",
-    "https://github.com/Pyomo/pysp/archive/c08015310bd9615ebbb2b0eb9042334c9306b458.zip",
+    "pyutilib @ https://github.com/PyUtilib/pyutilib/archive/master.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/842a2a4892929a2a032c0711a29381a8a5d17c24.zip",
+    "pysp @ https://github.com/Pyomo/pysp/archive/c08015310bd9615ebbb2b0eb9042334c9306b458.zip",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -86,27 +86,6 @@ kwargs = dict(
     # Only installed if [<key>] is added to package name
     extras_require={
         "prerelease": DEPENDENCIES_FOR_PRERELEASE_VERSION,
-        "dev": DEPENDENCIES_FOR_PRERELEASE_VERSION + [
-            # Developer extra packages
-            "alabaster>=0.7.7",
-            # temporarily hold coverage version due to avoid bug in coveralls
-            # -alee 12/20/2019
-            "coverage==4.5.4",
-            "flake8",
-            "jsonschema",
-            "jupyter_contrib_nbextensions",
-            "mock",
-            "pylint",
-            "pytest-cov",
-            "python-coveralls",
-            "snowballstemmer==1.2.1",
-            # Newer sphinx needed for proper type hint support in docstrings
-            "sphinx>=3.0.0",
-            # note: 4/22/2020, removed the version requirement here
-            "sphinx-rtd-theme",
-            "sphinxcontrib-napoleon>=0.5.0",
-            "sphinx-argparse"
-        ]
     },
     package_data={
         # If any package contains these files, include them:

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ def rglob(path, glob):
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
     "pyutilib @ https://github.com/PyUtilib/pyutilib/archive/master.zip",
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.0.idaes.2021.05.05.zip",
-    "pysp @ https://github.com/Pyomo/pysp/archive/master.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.0.idaes.2021.05.09.zip",
 ]
 
 


### PR DESCRIPTION
## Summary/Motivation:
- Move dependencies needed to install a prerelease version of IDAES to `setup.py` so that it can be installed without having to clone the repository
- Streamline installation process by reducing number of recommended installation workflows to two (for **users** and **developers**)

## Changes proposed in this PR:
- Update `setup.py` defining a `[prerelease]` optional tag (`extras_require`) for `pip install` containing the appropriate versions of Pyomo ~~(and, following #249, currently also PySP)~~
- Move developer dependencies to `requirements-dev.txt`
- Remove unnecessary dependencies (e.g. `mock` which is part of the Python stdlib as `unittest.mock`)
- Update documentation accordingly

## Detailed breakdown of motivations for the changes proposed in this PR

### Conceptual constraints (`C`)

- `C1`: Persons who need to install IDAES are divided in **2 categories**, depending on whether they **need to access the source code** (~cloning the repo)
  - **Users**: :x: no access to source needed
  - **Developers**: :white_check_mark: need access to source
- `C2`: Both categories need to be able to install **prerelease versions** of IDAES
- `C3`: The **default install command** (`pip install idaes-pse`) should install the latest released version
- `C4`: When possible, follow _principle of **least privilege**_
- `C5`: When possible, **minimize complexity** and redundancy

### Technical constraints (`T`)

- `T1`: Dependencies need to be *accessible* to `setup.py` to be able to **install IDAES without cloning** the repo
- `T2`: Installing dependencies using **requirement files** (`pip install -r requirements.txt`) only possible from a local repo clone
- `T3`: Installing IDAES in **editable mode** (`pip install -e/--editable .`) only makes sense when installing from a local repo clone
- `T4`: Installing **optional dependencies** without cloning requires an `extras_require` install target in `setup.py`
  - e.g. `pip install 'idaes-pse[my_target]'` would install dependencies defined under the `my_target` key of `extras_require` in `setup.py`

### Derived constraints (`D`)

- `C1 & C4` :arrow_right: `D1`: Installation procedure for **users shall not require cloning** the repo (important when working with protected data)
  - :arrow_right: `D2`: Workflows requiring cloning the repo can be considered *developer workflows*

### Results

- `D1 & C2 & C3` :arrow_right: Use `extras_install` target to install prerelease dependencies
- `D2 & C5` :arrow_right: All developer workflows shall require cloning the repo
- `D2 & T2` :arrow_right: `requirements.txt` files only needed by developer workflows
  - `& T3 & C5` :arrow_right: Any `requirements.txt` shall install IDAES in editable mode
    - `& T4 & C5` :arrow_right: No need for `[dev]` target in `extras_install`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
