### PR TITLE
Bump bin version

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -19,7 +19,7 @@ import importlib
 
 _log = logging.getLogger(__name__)
 # Default release version if no options provided for get-extensions
-default_binary_release = "2.4.1"
+default_binary_release = "2.4.2"
 # Where to download releases from get-extensions
 release_base_url = "https://github.com/IDAES/idaes-ext/releases/download"
 # Where to get release checksums


### PR DESCRIPTION
This bumps the binary version.  There is no need for people to update now.  Here are the changes

1. As requested by Pyomo team, the solver executables are statically linked with the ipopt libraries.
2. The possibility of missing zlib1.dll on Windows is fixed.
3. Added a test external function for testing string args and variable length argument lists.  This is for https://github.com/Pyomo/pyomo/pull/1904.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
