### PR TITLE
ALAMO pyomo expression generation

### DIFF
--- a/idaes/surrogate/alamopy/__init__.py
+++ b/idaes/surrogate/alamopy/__init__.py
@@ -9,11 +9,11 @@ __all__ = ['alamo', 'doalamo', 'getlabels', 'makelabs', 'addCustomFunctions',
            'data', 'debug', 'deletefile', 'movefile', 'catfile', 
            'copyfile', 'has_alamo', 'allcard', 'almlsq',
            'almlsqjac', 'almfeatmat',
-           'ackley', 'branin', 'sixcamel', 'col']
+           'ackley', 'branin', 'sixcamel', 'col', 'generatePyomoExpressions']
 
 from .doalamo import alamo, doalamo, getlabels, makelabs, addCustomFunctions, \
     addCustomConstraints, addBasisGroups, addBasisGroup, addBasisConstraints, \
-    addBasisConstraint, get_alamo_version
+    addBasisConstraint, get_alamo_version, generatePyomoExpressions
 from .allcard import allcard, almlsq, almlsqjac, almfeatmat
 from .almwriter import almwriter
 from .almconfidence import almconfidence

--- a/idaes/surrogate/alamopy/doalamo.py
+++ b/idaes/surrogate/alamopy/doalamo.py
@@ -370,9 +370,6 @@ def generatePyomoExpressions(res, pyomo_vars):
     pymodel = {}
     for zlabel in res['zlabels']:
         # Generate pyomo expression
-        m = pyo.ConcreteModel()
-        # m.x = pyomo_vars
-
         obj_map = PyomoSympyBimap()
         obj_map.sympy2pyomo = {}
         sympy_locals = {}
@@ -381,12 +378,10 @@ def generatePyomoExpressions(res, pyomo_vars):
             sympy_locals[label] = sympy.Symbol(label)
             sympy_obj = sympy.Symbol(label)
             obj_map.sympy2pyomo[sympy_obj] = pyomo_vars[i]
-            # obj_map.sympy2pyomo[sympy_obj] = m.x[i]
             i += 1
 
         model_string = ""
         if type(res['model']) is dict:
-            # key = list(res['model'].keys())[0]
             model_string = res['model'][zlabel].split('=')[1]
         else:
             model_string = res['model'].split('=')[1]

--- a/idaes/surrogate/alamopy/tests/test_mi.py
+++ b/idaes/surrogate/alamopy/tests/test_mi.py
@@ -141,4 +141,3 @@ def test_single_input_CV():
                 'cvfun':True}
 
     res = alamopy.doalamo(x, z)
-    print(res)


### PR DESCRIPTION
## Fixes

## Summary/Motivation:
Generates pyomo expressions for use in pyomo models without the need for an import statement. A test example uses the pyomo expression in a toy pyomo model.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
