### PR TITLE
Fixing issue with units in the equilibrium_constant module

### DIFF
--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -176,5 +176,5 @@ class gibbs_energy():
         R = pyunits.convert(c.gas_constant, to_units=units["gas_constant"])
 
         keq_val = value(exp(-rblock.dh_rxn_ref/(R*rblock.T_eq_ref) +
-                            rblock.ds_rxn_ref/R))
+                            rblock.ds_rxn_ref/R) * rblock._keq_units)
         return 1/keq_val


### PR DESCRIPTION
## Fixes
This PR fixes an issue with units in the module `equilibrium_constant.py` method `def calculate_scaling_factors(b, rblock)`.

## Summary/Motivation:
The method was lacking conversion of units causing the scaling factors to be off by several orders of magnitude resulting in numerical issues.

## Changes proposed in this PR:
- The line `rblock._keq_units` was added to fix this issue

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
