### PR TITLE
Update binary version to fix uncertainty tool with newer Pyomo

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -19,7 +19,7 @@ import importlib
 
 _log = logging.getLogger(__name__)
 # Default release version if no options provided for get-extensions
-default_binary_release = "2.4.2"
+default_binary_release = "2.4.3"
 # Where to download releases from get-extensions
 release_base_url = "https://github.com/IDAES/idaes-ext/releases/download"
 # Where to get release checksums


### PR DESCRIPTION
This just bumps the binary release number to get the updated version of k_aug the produces a more standard version string.  This should fix the problem with the uncertainty tool several people ran into recently.  There is also a secret solver.  The new Ipopt L1 restoration mode is available in an alternate Ipopt version called ipopt_l1 on all platforms except Cent OS 6 and 7.  It doesn't yet compile with the older compiler versions, but I figured this would at least let us do a little evaluation before officially releasing and announcing it. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
