### PR TITLE
Fixing some issues with indexing sets in generic properties

### DIFF
--- a/idaes/generic_models/properties/core/eos/ceos.py
+++ b/idaes/generic_models/properties/core/eos/ceos.py
@@ -594,11 +594,11 @@ class Cubic(EoSBase):
 
         kappa = getattr(blk.params, cname+"_kappa")
         am = sum(sum(x[xidx, i]*x[xidx, j]*sqrt(a(i)*a(j))*(1-kappa[i, j])
-                     for j in blk.params.component_list)
-                 for i in blk.params.component_list)
+                     for j in blk.component_list)
+                 for i in blk.component_list)
 
         b = getattr(blk, cname+"_b")
-        bm = sum(x[xidx, i]*b[i] for i in blk.params.component_list)
+        bm = sum(x[xidx, i]*b[i] for i in blk.component_list)
 
         A = am*blk.pressure/(Cubic.gas_constant(blk) *
                              blk.temperature_bubble[pp])**2
@@ -606,7 +606,7 @@ class Cubic(EoSBase):
                              blk.temperature_bubble[pp])
 
         delta = (2*sqrt(a(j))/am * sum(x[xidx, i]*sqrt(a(i))*(1-kappa[j, i])
-                                       for i in blk.params.component_list))
+                                       for i in blk.component_list))
 
         f = getattr(blk, "_"+cname+"_ext_func_param")
         if pobj.is_vapor_phase():
@@ -647,11 +647,11 @@ class Cubic(EoSBase):
 
         kappa = getattr(blk.params, cname+"_kappa")
         am = sum(sum(x[xidx, i]*x[xidx, j]*sqrt(a(i)*a(j))*(1-kappa[i, j])
-                     for j in blk.params.component_list)
-                 for i in blk.params.component_list)
+                     for j in blk.component_list)
+                 for i in blk.component_list)
 
         b = getattr(blk, cname+"_b")
-        bm = sum(x[xidx, i]*b[i] for i in blk.params.component_list)
+        bm = sum(x[xidx, i]*b[i] for i in blk.component_list)
 
         A = am*blk.pressure/(Cubic.gas_constant(blk) *
                              blk.temperature_dew[pp])**2
@@ -659,7 +659,7 @@ class Cubic(EoSBase):
                              blk.temperature_dew[pp])
 
         delta = (2*sqrt(a(j))/am * sum(x[xidx, i]*sqrt(a(i))*(1-kappa[j, i])
-                                       for i in blk.params.component_list))
+                                       for i in blk.component_list))
 
         f = getattr(blk, "_"+cname+"_ext_func_param")
         if pobj.is_vapor_phase():
@@ -693,11 +693,11 @@ class Cubic(EoSBase):
         kappa = getattr(blk.params, cname+"_kappa")
         am = sum(sum(x[xidx, i]*x[xidx, j] *
                      sqrt(a[i]*a[j])*(1-kappa[i, j])
-                     for j in blk.params.component_list)
-                 for i in blk.params.component_list)
+                     for j in blk.component_list)
+                 for i in blk.component_list)
 
         b = getattr(blk, cname+"_b")
-        bm = sum(x[xidx, i]*b[i] for i in blk.params.component_list)
+        bm = sum(x[xidx, i]*b[i] for i in blk.component_list)
 
         A = am*blk.pressure_bubble[pp]/(Cubic.gas_constant(blk) *
                                         blk.temperature)**2
@@ -705,7 +705,7 @@ class Cubic(EoSBase):
                                         blk.temperature)
 
         delta = (2*sqrt(a[j])/am * sum(x[xidx, i]*sqrt(a[i])*(1-kappa[j, i])
-                                       for i in blk.params.component_list))
+                                       for i in blk.component_list))
 
         f = getattr(blk, "_"+cname+"_ext_func_param")
         if pobj.is_vapor_phase():
@@ -739,18 +739,18 @@ class Cubic(EoSBase):
         kappa = getattr(blk.params, cname+"_kappa")
         am = sum(sum(x[xidx, i]*x[xidx, j] *
                      sqrt(a[i]*a[j])*(1-kappa[i, j])
-                     for j in blk.params.component_list)
-                 for i in blk.params.component_list)
+                     for j in blk.component_list)
+                 for i in blk.component_list)
 
         b = getattr(blk, cname+"_b")
-        bm = sum(x[xidx, i]*b[i] for i in blk.params.component_list)
+        bm = sum(x[xidx, i]*b[i] for i in blk.component_list)
 
         A = am*blk.pressure_dew[pp]/(Cubic.gas_constant(blk) *
                                      blk.temperature)**2
         B = bm*blk.pressure_dew[pp]/(Cubic.gas_constant(blk)*blk.temperature)
 
         delta = (2*sqrt(a[j])/am * sum(x[xidx, i]*sqrt(a[i])*(1-kappa[j, i])
-                                       for i in blk.params.component_list))
+                                       for i in blk.component_list))
 
         f = getattr(blk, "_"+cname+"_ext_func_param")
         if pobj.is_vapor_phase():

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1423,7 +1423,7 @@ class GenericStateBlockData(StateBlockData):
                 units=t_units)
 
         # Create common components for each property package
-        for p in self.params.phase_list:
+        for p in self.phase_list:
             pobj = self.params.get_phase(p)
             pobj.config.equation_of_state.common(self, pobj)
 
@@ -1436,8 +1436,8 @@ class GenericStateBlockData(StateBlockData):
                 pe_form_config[pp].phase_equil(self, pp)
 
             def rule_equilibrium(b, phase1, phase2, j):
-                if ((phase1, j) not in b.params._phase_component_set or
-                        (phase2, j) not in b.params._phase_component_set):
+                if ((phase1, j) not in b.phase_component_set or
+                        (phase2, j) not in b.phase_component_set):
                     return Constraint.Skip
                 config = b.params.get_component(j).config
                 try:
@@ -1452,7 +1452,7 @@ class GenericStateBlockData(StateBlockData):
                 return e_mthd(self, phase1, phase2, j)
             self.equilibrium_constraint = Constraint(
                 self.params._pe_pairs,
-                self.params.component_list,
+                self.component_list,
                 rule=rule_equilibrium)
 
         # Add inherent reaction constraints if necessary
@@ -1508,7 +1508,7 @@ class GenericStateBlockData(StateBlockData):
                     iscale.set_scaling_factor(v, sf_T)
 
         # Other EoS variables and constraints
-        for p in self.params.phase_list:
+        for p in self.phase_list:
             pobj = self.params.get_phase(p)
             pobj.config.equation_of_state.calculate_scaling_factors(self, pobj)
 
@@ -1666,8 +1666,8 @@ class GenericStateBlockData(StateBlockData):
 
             b._mole_frac_tbub = Var(
                     b.params._pe_pairs,
-                    b.params.component_list,
-                    initialize=1/len(b.params.component_list),
+                    b.component_list,
+                    initialize=1/len(b.component_list),
                     bounds=(0, None),
                     doc="Vapor mole fractions at bubble temperature",
                     units=None)
@@ -1692,8 +1692,8 @@ class GenericStateBlockData(StateBlockData):
 
             b._mole_frac_tdew = Var(
                     b.params._pe_pairs,
-                    b.params.component_list,
-                    initialize=1/len(b.params.component_list),
+                    b.component_list,
+                    initialize=1/len(b.component_list),
                     bounds=(0, None),
                     doc="Liquid mole fractions at dew temperature",
                     units=None)
@@ -1719,8 +1719,8 @@ class GenericStateBlockData(StateBlockData):
 
             b._mole_frac_pbub = Var(
                     b.params._pe_pairs,
-                    b.params.component_list,
-                    initialize=1/len(b.params.component_list),
+                    b.component_list,
+                    initialize=1/len(b.component_list),
                     bounds=(0, None),
                     doc="Vapor mole fractions at bubble pressure",
                     units=None)
@@ -1746,8 +1746,8 @@ class GenericStateBlockData(StateBlockData):
 
             b._mole_frac_pdew = Var(
                     b.params._pe_pairs,
-                    b.params.component_list,
-                    initialize=1/len(b.params.component_list),
+                    b.component_list,
+                    initialize=1/len(b.component_list),
                     bounds=(0, None),
                     doc="Liquid mole fractions at dew pressure",
                     units=None)
@@ -1766,7 +1766,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.compress_fact_phase(b, p)
             self.compress_fact_phase = Expression(
-                    self.params.phase_list,
+                    self.phase_list,
                     doc="Compressibility of each phase",
                     rule=rule_Z_phase)
         except AttributeError:
@@ -1826,7 +1826,7 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_cp_mol(b):
                 return sum(b.cp_mol_phase[p]*b.phase_frac[p]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.cp_mol = Expression(rule=rule_cp_mol,
                                      doc="Mixture molar heat capacity")
         except AttributeError:
@@ -1838,7 +1838,7 @@ class GenericStateBlockData(StateBlockData):
             def rule_cp_mol_phase(b, p):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.cp_mol_phase(b, p)
-            self.cp_mol_phase = Expression(self.params.phase_list,
+            self.cp_mol_phase = Expression(self.phase_list,
                                            rule=rule_cp_mol_phase)
         except AttributeError:
             self.del_component(self.cp_mol_phase)
@@ -1850,7 +1850,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.cp_mol_phase_comp(b, p, j)
             self.cp_mol_phase_comp = Expression(
-                self.params._phase_component_set,
+                self.phase_component_set,
                 rule=rule_cp_mol_phase_comp)
         except AttributeError:
             self.del_component(self.cp_mol_phase_comp)
@@ -1860,7 +1860,7 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_cv_mol(b):
                 return sum(b.cv_mol_phase[p]*b.phase_frac[p]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.cv_mol = Expression(rule=rule_cv_mol,
                                      doc="Mixture molar heat capacity")
         except AttributeError:
@@ -1872,7 +1872,7 @@ class GenericStateBlockData(StateBlockData):
             def rule_cv_mol_phase(b, p):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.cv_mol_phase(b, p)
-            self.cv_mol_phase = Expression(self.params.phase_list,
+            self.cv_mol_phase = Expression(self.phase_list,
                                            rule=rule_cv_mol_phase)
         except AttributeError:
             self.del_component(self.cv_mol_phase)
@@ -1884,7 +1884,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.cv_mol_phase_comp(b, p, j)
             self.cv_mol_phase_comp = Expression(
-                self.params._phase_component_set,
+                self.phase_component_set,
                 rule=rule_cv_mol_phase_comp)
         except AttributeError:
             self.del_component(self.cv_mol_phase_comp)
@@ -1894,7 +1894,7 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_dens_mass(b):
                 return sum(b.dens_mass_phase[p]*b.phase_frac[p]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.dens_mass = Expression(
                     doc="Mixture mass density",
                     rule=rule_dens_mass)
@@ -1908,7 +1908,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.dens_mass_phase(b, p)
             self.dens_mass_phase = Expression(
-                    self.params.phase_list,
+                    self.phase_list,
                     doc="Mass density of each phase",
                     rule=rule_dens_mass_phase)
         except AttributeError:
@@ -1919,7 +1919,7 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_dens_mol(b):
                 return sum(b.dens_mol_phase[p]*b.phase_frac[p]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.dens_mol = Expression(
                     doc="Mixture molar density",
                     rule=rule_dens_mol)
@@ -1933,7 +1933,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.dens_mol_phase(b, p)
             self.dens_mol_phase = Expression(
-                    self.params.phase_list,
+                    self.phase_list,
                     doc="Molar density of each phase",
                     rule=rule_dens_mol_phase)
         except AttributeError:
@@ -1944,7 +1944,7 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_energy_internal_mol(b):
                 return sum(b.energy_internal_mol_phase[p]*b.phase_frac[p]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.energy_internal_mol = Expression(
                 rule=rule_energy_internal_mol,
                 doc="Mixture molar internal energy")
@@ -1958,7 +1958,7 @@ class GenericStateBlockData(StateBlockData):
                 eos = b.params.get_phase(p).config.equation_of_state
                 return eos.energy_internal_mol_phase(b, p)
             self.energy_internal_mol_phase = Expression(
-                self.params.phase_list, rule=rule_energy_internal_mol_phase)
+                self.phase_list, rule=rule_energy_internal_mol_phase)
         except AttributeError:
             self.del_component(self.energy_internal_mol_phase)
             raise
@@ -1969,7 +1969,7 @@ class GenericStateBlockData(StateBlockData):
                 eos = b.params.get_phase(p).config.equation_of_state
                 return eos.energy_internal_mol_phase_comp(b, p, j)
             self.energy_internal_mol_phase_comp = Expression(
-                self.params._phase_component_set,
+                self.phase_component_set,
                 rule=rule_energy_internal_mol_phase_comp)
         except AttributeError:
             self.del_component(self.energy_internal_mol_phase_comp)
@@ -1979,7 +1979,7 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_enth_mol(b):
                 return sum(b.enth_mol_phase[p]*b.phase_frac[p]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.enth_mol = Expression(rule=rule_enth_mol,
                                        doc="Mixture molar enthalpy")
         except AttributeError:
@@ -1991,7 +1991,7 @@ class GenericStateBlockData(StateBlockData):
             def rule_enth_mol_phase(b, p):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.enth_mol_phase(b, p)
-            self.enth_mol_phase = Expression(self.params.phase_list,
+            self.enth_mol_phase = Expression(self.phase_list,
                                              rule=rule_enth_mol_phase)
         except AttributeError:
             self.del_component(self.enth_mol_phase)
@@ -2003,7 +2003,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.enth_mol_phase_comp(b, p, j)
             self.enth_mol_phase_comp = Expression(
-                self.params._phase_component_set,
+                self.phase_component_set,
                 rule=rule_enth_mol_phase_comp)
         except AttributeError:
             self.del_component(self.enth_mol_phase_comp)
@@ -2013,7 +2013,7 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_entr_mol(b):
                 return sum(b.entr_mol_phase[p]*b.phase_frac[p]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.entr_mol = Expression(rule=rule_entr_mol,
                                        doc="Mixture molar entropy")
         except AttributeError:
@@ -2025,7 +2025,7 @@ class GenericStateBlockData(StateBlockData):
             def rule_entr_mol_phase(b, p):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.entr_mol_phase(b, p)
-            self.entr_mol_phase = Expression(self.params.phase_list,
+            self.entr_mol_phase = Expression(self.phase_list,
                                              rule=rule_entr_mol_phase)
         except AttributeError:
             self.del_component(self.entr_mol_phase)
@@ -2037,7 +2037,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.entr_mol_phase_comp(b, p, j)
             self.entr_mol_phase_comp = Expression(
-                self.params._phase_component_set,
+                self.phase_component_set,
                 rule=rule_entr_mol_phase_comp)
         except AttributeError:
             self.del_component(self.entr_mol_phase_comp)
@@ -2048,7 +2048,7 @@ class GenericStateBlockData(StateBlockData):
             if self.get_material_flow_basis() == MaterialFlowBasis.mass:
                 self.flow_mass = Expression(
                     expr=sum(self.flow_mass_comp[j]
-                             for p, j in self.component_list),
+                             for j in self.component_list),
                     doc="Mass flow rate")
             elif self.get_material_flow_basis() == MaterialFlowBasis.molar:
                 self.flow_mass = Expression(
@@ -2075,7 +2075,7 @@ class GenericStateBlockData(StateBlockData):
                         "material flow basis: {}"
                         .format(self.name, self.get_material_flow_basis()))
             self.flow_mass_phase = Expression(
-                    self.params.phase_list,
+                    self.phase_list,
                     doc="Mass flow rate of each phase",
                     rule=rule_flow_mass_phase)
         except AttributeError:
@@ -2095,7 +2095,7 @@ class GenericStateBlockData(StateBlockData):
                         "material flow basis: {}"
                         .format(self.name, self.get_material_flow_basis()))
             self.flow_mass_comp = Expression(
-                self.params.component_list,
+                self.component_list,
                 doc="Component mass flow rate",
                 rule=rule_flow_mass_comp)
         except AttributeError:
@@ -2130,7 +2130,7 @@ class GenericStateBlockData(StateBlockData):
             if self.get_material_flow_basis() == MaterialFlowBasis.molar:
                 self.flow_mol = Expression(
                     expr=sum(self.flow_mol_comp[j]
-                             for p, j in self.component_list),
+                             for j in self.component_list),
                     doc="Total molar flow rate")
             elif self.get_material_flow_basis() == MaterialFlowBasis.mass:
                 self.flow_mol = Expression(
@@ -2157,7 +2157,7 @@ class GenericStateBlockData(StateBlockData):
                         "material flow basis: {}"
                         .format(self.name, self.get_material_flow_basis()))
             self.flow_mol_phase = Expression(
-                    self.params.phase_list,
+                    self.phase_list,
                     doc="Molar flow rate of each phase",
                     rule=rule_flow_mol_phase)
         except AttributeError:
@@ -2177,7 +2177,7 @@ class GenericStateBlockData(StateBlockData):
                         "material flow basis: {}"
                         .format(self.name, self.get_material_flow_basis()))
             self.flow_mol_comp = Expression(
-                self.params.component_list,
+                self.component_list,
                 doc="Component molar flow rate",
                 rule=rule_flow_mol_comp)
         except AttributeError:
@@ -2238,7 +2238,7 @@ class GenericStateBlockData(StateBlockData):
                         "material flow basis: {}"
                         .format(self.name, self.get_material_flow_basis()))
             self.flow_vol_phase = Expression(
-                    self.params.phase_list,
+                    self.phase_list,
                     doc="Volumetric flow rate of each phase",
                     rule=rule_flow_vol_phase)
         except AttributeError:
@@ -2250,7 +2250,7 @@ class GenericStateBlockData(StateBlockData):
             def rule_fug_phase_comp(b, p, j):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.fug_phase_comp(b, p, j)
-            self.fug_phase_comp = Expression(self.params._phase_component_set,
+            self.fug_phase_comp = Expression(self.phase_component_set,
                                              rule=rule_fug_phase_comp)
         except AttributeError:
             self.del_component(self.fug_phase_comp)
@@ -2262,7 +2262,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.fug_coeff_phase_comp(b, p, j)
             self.fug_coeff_phase_comp = Expression(
-                    self.params._phase_component_set,
+                    self.phase_component_set,
                     rule=rule_fug_coeff_phase_comp)
         except AttributeError:
             self.del_component(self.fug_coeff_phase_comp)
@@ -2272,7 +2272,7 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_gibbs_mol(b):
                 return sum(b.gibbs_mol_phase[p]*b.phase_frac[p]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.gibbs_mol = Expression(rule=rule_gibbs_mol,
                                         doc="Mixture molar Gibbs energy")
         except AttributeError:
@@ -2284,7 +2284,7 @@ class GenericStateBlockData(StateBlockData):
             def rule_gibbs_mol_phase(b, p):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.gibbs_mol_phase(b, p)
-            self.gibbs_mol_phase = Expression(self.params.phase_list,
+            self.gibbs_mol_phase = Expression(self.phase_list,
                                               rule=rule_gibbs_mol_phase)
         except AttributeError:
             self.del_component(self.gibbs_mol_phase)
@@ -2296,7 +2296,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.gibbs_mol_phase_comp(b, p, j)
             self.gibbs_mol_phase_comp = Expression(
-                self.params._phase_component_set,
+                self.phase_component_set,
                 rule=rule_gibbs_mol_phase_comp)
         except AttributeError:
             self.del_component(self.gibbs_mol_phase_comp)
@@ -2309,8 +2309,9 @@ class GenericStateBlockData(StateBlockData):
                     expr=sum(self.phase_frac[p] *
                              sum(self.mole_frac_phase_comp[p, j] *
                                  self.params.get_component(j).mw
-                                 for j in self.params.component_list)
-                             for p in self.params.phase_list))
+                                 if (p, j) in self.phase_component_set else 0
+                                 for j in self.component_list)
+                             for p in self.phase_list))
         except AttributeError:
             self.del_component(self.mw)
             raise
@@ -2320,9 +2321,9 @@ class GenericStateBlockData(StateBlockData):
         try:
             def rule_mole_frac_comp(b, i):
                 return sum(b.phase_frac[p]*b.mole_frac_phase_comp[p, i]
-                           for p in b.params.phase_list)
+                           for p in b.phase_list)
             self.mole_frac_comp = Expression(
-                    self.params.component_list,
+                    self.component_list,
                     doc="Mole fraction of each component",
                     rule=rule_mole_frac_comp)
         except AttributeError:
@@ -2334,9 +2335,10 @@ class GenericStateBlockData(StateBlockData):
             def rule_mw_phase(b, p):
                 return sum(b.mole_frac_phase_comp[p, j] *
                            b.params.get_component(j).mw
-                           for j in b.params.component_list)
+                           if (p, j) in b.phase_component_set else 0
+                           for j in b.component_list)
             self.mw_phase = Expression(
-                    self.params.phase_list,
+                    self.phase_list,
                     doc="Average molecular weight of each phase",
                     rule=rule_mw_phase)
         except AttributeError:
@@ -2350,7 +2352,7 @@ class GenericStateBlockData(StateBlockData):
                 return get_method(b, "pressure_sat_comp")(
                     b, cobj, b.temperature)
             self.pressure_sat_comp = Expression(
-                self.params.component_list,
+                self.component_list,
                 rule=rule_pressure_sat_comp)
         except AttributeError:
             self.del_component(self.pressure_sat_comp)
@@ -2380,9 +2382,9 @@ def _valid_VL_component_list(blk, pp):
         (pparams.get_phase(pp[0]).is_vapor_phase() and
          pparams.get_phase(pp[1]).is_liquid_phase())):
 
-        for j in blk.params.component_list:
-            if ((pp[0], j) in pparams._phase_component_set and
-                    (pp[1], j) in pparams._phase_component_set):
+        for j in blk.component_list:
+            if ((pp[0], j) in blk.phase_component_set and
+                    (pp[1], j) in blk.phase_component_set):
                 valid_comps.append(j)
 
     return valid_comps


### PR DESCRIPTION
## Fixes #338


## Summary/Motivation:
Cleans up a missing check for non-vapourisable and non-condensable components, plus updating to the new API for indexing sets.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
