### PR TITLE
Updates for Pyomo 6 compatibility

### DIFF
--- a/idaes/core/util/model_statistics.py
+++ b/idaes/core/util/model_statistics.py
@@ -324,7 +324,7 @@ def activated_equalities_generator(block):
     for c in block.component_data_objects(
                 Constraint, active=True, descend_into=True):
         if (c.upper is not None and c.lower is not None and
-                c.upper.value == c.lower.value):
+                value(c.upper) == value(c.lower)):
             yield c
 
 

--- a/idaes/core/util/model_statistics.py
+++ b/idaes/core/util/model_statistics.py
@@ -324,7 +324,7 @@ def activated_equalities_generator(block):
     for c in block.component_data_objects(
                 Constraint, active=True, descend_into=True):
         if (c.upper is not None and c.lower is not None and
-                c.upper == c.lower):
+                c.upper.value == c.lower.value):
             yield c
 
 
@@ -672,7 +672,8 @@ def number_unfixed_variables(block):
     return len(unfixed_variables_set(block))
 
 
-def variables_near_bounds_generator(block, tol=1e-4, relative=True, skip_lb = False, skip_ub = False):
+def variables_near_bounds_generator(
+        block, tol=1e-4, relative=True, skip_lb=False, skip_ub=False):
     """
     Generator which returns all Var components in a model which have a value
     within tol (default: relative) of a bound.
@@ -693,12 +694,12 @@ def variables_near_bounds_generator(block, tol=1e-4, relative=True, skip_lb = Fa
         # To avoid errors, check that v has a value
         if v.value is None:
             continue
-            
+
         if relative:
             # First, determine absolute tolerance to apply to bounds
             if v.ub is not None and v.lb is not None:
                 # Both upper and lower bounds, apply tol to (upper - lower)
-                    atol = value((v.ub - v.lb)*tol)
+                atol = value((v.ub - v.lb)*tol)
             elif v.ub is not None:
                 # Only upper bound, apply tol to bound value
                 atol = abs(value(v.ub*tol))
@@ -712,11 +713,13 @@ def variables_near_bounds_generator(block, tol=1e-4, relative=True, skip_lb = Fa
 
         if v.ub is not None and not skip_lb and value(v.ub - v.value) <= atol:
             yield v
-        elif v.lb is not None and not skip_ub and value(v.value - v.lb) <= atol:
+        elif (v.lb is not None and not skip_ub and
+              value(v.value - v.lb) <= atol):
             yield v
 
 
-def variables_near_bounds_set(block, tol=1e-4, relative=True, skip_lb = False, skip_ub = False):
+def variables_near_bounds_set(
+        block, tol=1e-4, relative=True, skip_lb=False, skip_ub=False):
     """
     Method to return a ComponentSet of all Var components in a model which have
     a value within tol (relative) of a bound.
@@ -732,11 +735,9 @@ def variables_near_bounds_set(block, tol=1e-4, relative=True, skip_lb = False, s
         A ComponentSet including all Var components block that are close to a
         bound
     """
-    return ComponentSet(variables_near_bounds_generator(block, 
-                                                        tol, 
-                                                        relative, 
-                                                        skip_lb,
-                                                        skip_ub))
+    return ComponentSet(variables_near_bounds_generator(
+        block, tol, relative, skip_lb, skip_ub))
+
 
 def number_variables_near_bounds(block, tol=1e-4):
     """
@@ -1290,21 +1291,24 @@ def large_residuals_set(block, tol=1e-5, return_residual_values=False):
     Args:
         block : model to be studied
         tol : residual threshold for inclusion in ComponentSet
-        return_residual_values: boolean, if true return dictionary with residual values
+        return_residual_values: boolean, if true return dictionary with
+            residual values
 
     Returns:
-        large_residual_set: A ComponentSet including all Constraint components with a residual
-        greater than tol which appear in block (if return_residual_values is false)
-        residual_values: dictionary with constraint as key and residual (float) as value (if return_residual_values is true)
+        large_residual_set: A ComponentSet including all Constraint components
+        with a residual greater than tol which appear in block (if
+        return_residual_values is false) residual_values: dictionary with
+        constraint as key and residual (float) as value (if
+        return_residual_values is true)
     """
     large_residuals_set = ComponentSet()
     if return_residual_values:
         residual_values = dict()
     for c in block.component_data_objects(
             ctype=Constraint, active=True, descend_into=True):
-            
-        r = 0.0 # residual
-        
+
+        r = 0.0  # residual
+
         # skip if no lower bound set
         if c.lower is None:
             r_temp = 0
@@ -1313,7 +1317,7 @@ def large_residuals_set(block, tol=1e-5, return_residual_values=False):
         # update the residual
         if r_temp > r:
             r = r_temp
-    
+
         # skip if no upper bound set
         if c.upper is None:
             r_temp = 0
@@ -1323,14 +1327,14 @@ def large_residuals_set(block, tol=1e-5, return_residual_values=False):
         # update the residual
         if r_temp > r:
             r = r_temp
-        
+
         # save residual if it is above threshold
         if r > tol:
             large_residuals_set.add(c)
-            
+
             if return_residual_values:
                 residual_values[c] = r
-    
+
     if return_residual_values:
         return residual_values
     else:

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -70,14 +70,15 @@ def test_port_copy():
     m.b2.port.add(m.b2.x, "x")
     m.b2.port.add(m.b2.y, "y")
     m.b2.port.add(m.b2.z, "z")
+
     def assert_copied_right():
-        assert(m.b2.x == 3)
-        assert(m.b2.y[0] == 4)
-        assert(m.b2.y[1] == 5)
-        assert(m.b2.z[0, "A"] == 6)
-        assert(m.b2.z[0, "B"] == 7)
-        assert(m.b2.z[1, "A"] == 8)
-        assert(m.b2.z[1, "B"] == 9)
+        assert(m.b2.x.value == 3)
+        assert(m.b2.y[0].value == 4)
+        assert(m.b2.y[1].value == 5)
+        assert(m.b2.z[0, "A"].value == 6)
+        assert(m.b2.z[0, "B"].value == 7)
+        assert(m.b2.z[1, "A"].value == 8)
+        assert(m.b2.z[1, "B"].value == 9)
 
     def reset():
         m.b2.x = 0
@@ -92,7 +93,6 @@ def test_port_copy():
     copy_port_values(m.b2.port, m.b1.port)
     assert_copied_right()
     reset()
-
 
     copy_port_values(source=m.b1.port, destination=m.b2.port)
     assert_copied_right()
@@ -119,9 +119,6 @@ def test_port_copy():
         copy_port_values(source=m.b1.port, destination=m.arc)
 
 
-
-
-
 # Author: John Eslick
 @pytest.mark.unit
 def test_tag_reference():
@@ -138,8 +135,8 @@ def test_tag_reference():
     m.b[0].y = Var(initialize=1)
     m.b[1].y = Var(initialize=2)
     test_tag = TagReference(m.b[:].y, description="y tag")
-    assert(test_tag[0] == 1)
-    assert(test_tag[1] == 2)
+    assert(test_tag[0].value == 1)
+    assert(test_tag[1].value == 2)
     assert(test_tag.description == "y tag")
 
 

--- a/idaes/core/util/tests/test_model_statistics.py
+++ b/idaes/core/util/tests/test_model_statistics.py
@@ -25,6 +25,7 @@ from pyomo.environ import (Block,
                            Var,
                            TransformationFactory)
 from pyomo.dae import ContinuousSet, DerivativeVar
+from pyomo.common.collections import ComponentSet
 
 from idaes.core.util.model_statistics import *
 
@@ -254,41 +255,47 @@ def test_variables_near_bounds_set(m):
     tset = variables_near_bounds_set(m)
     assert len(tset) == 6
     for i in tset:
-        assert i in [m.b2["a"].v1, m.b2["b"].v1, m.b2["a"].v2["a"],
-                     m.b2["a"].v2["b"], m.b2["b"].v2["a"], m.b2["b"].v2["b"]]
+        assert i in ComponentSet(
+            [m.b2["a"].v1, m.b2["b"].v1, m.b2["a"].v2["a"],
+             m.b2["a"].v2["b"], m.b2["b"].v2["a"], m.b2["b"].v2["b"]])
 
     m.b2["a"].v1.value = 1.001
     tset = variables_near_bounds_set(m)
     assert len(tset) == 5
     for i in tset:
-        assert i in [m.b2["b"].v1, m.b2["a"].v2["a"],
-                     m.b2["a"].v2["b"], m.b2["b"].v2["a"], m.b2["b"].v2["b"]]
+        assert i in ComponentSet(
+            [m.b2["b"].v1, m.b2["a"].v2["a"],
+             m.b2["a"].v2["b"], m.b2["b"].v2["a"], m.b2["b"].v2["b"]])
 
     tset = variables_near_bounds_set(m, tol=1e-3)
     assert len(tset) == 6
     for i in tset:
-        assert i in [m.b2["a"].v1, m.b2["b"].v1, m.b2["a"].v2["a"],
-                     m.b2["a"].v2["b"], m.b2["b"].v2["a"], m.b2["b"].v2["b"]]
+        assert i in ComponentSet(
+            [m.b2["a"].v1, m.b2["b"].v1, m.b2["a"].v2["a"],
+             m.b2["a"].v2["b"], m.b2["b"].v2["a"], m.b2["b"].v2["b"]])
 
     m.b2["a"].v1.setlb(None)
     tset = variables_near_bounds_set(m)
     assert len(tset) == 5
     for i in tset:
-        assert i in [m.b2["b"].v1, m.b2["a"].v2["a"],
-                     m.b2["a"].v2["b"], m.b2["b"].v2["a"], m.b2["b"].v2["b"]]
+        assert i in ComponentSet(
+            [m.b2["b"].v1, m.b2["a"].v2["a"],
+             m.b2["a"].v2["b"], m.b2["b"].v2["a"], m.b2["b"].v2["b"]])
 
     m.b2["a"].v2["a"].setub(None)
     tset = variables_near_bounds_set(m)
     assert len(tset) == 4
     for i in tset:
-        assert i in [m.b2["b"].v1, m.b2["a"].v2["b"],
-                     m.b2["b"].v2["a"], m.b2["b"].v2["b"]]
+        assert i in ComponentSet(
+            [m.b2["b"].v1, m.b2["a"].v2["b"],
+             m.b2["b"].v2["a"], m.b2["b"].v2["b"]])
 
     m.b2["a"].v2["b"].value = None
     tset = variables_near_bounds_set(m)
     assert len(tset) == 3
     for i in tset:
-        assert i in [m.b2["b"].v1, m.b2["a"].v2["b"], m.b2["b"].v2["b"]]
+        assert i in ComponentSet(
+            [m.b2["b"].v1, m.b2["b"].v2["a"], m.b2["b"].v2["b"]])
 
 
 @pytest.mark.unit

--- a/idaes/core/util/tests/test_phase_equilibria.py
+++ b/idaes/core/util/tests/test_phase_equilibria.py
@@ -20,9 +20,10 @@ import pytest
 
 import idaes.logger as idaeslog
 
-from pyomo.environ import ConcreteModel, Expression, Set, Block, Var
+from pyomo.environ import ConcreteModel
 # Import Pyomo units
 from pyomo.environ import units as pyunits
+from pyomo.util.check_units import assert_units_equivalent
 
 from idaes.core import LiquidPhase, VaporPhase, Component
 from idaes.core.phases import PhaseType as PT
@@ -33,35 +34,43 @@ from idaes.generic_models.properties.core.eos.ceos import Cubic, CubicType
 from idaes.generic_models.properties.core.phase_equil import smooth_VLE
 from idaes.generic_models.properties.core.phase_equil.bubble_dew import \
         IdealBubbleDew, LogBubbleDew
-from idaes.generic_models.properties.core.phase_equil.forms import fugacity, log_fugacity
+from idaes.generic_models.properties.core.phase_equil.forms import \
+    fugacity, log_fugacity
 
 import idaes.generic_models.properties.core.pure.NIST as NIST
-import idaes.generic_models.properties.core.pure.RPP4 as RPP4
 import idaes.generic_models.properties.core.pure.RPP5 as RPP5
-
-from idaes.core import FlowsheetBlock
 
 from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)
 
-from idaes.core.util.phase_equilibria import (TXYDataClass,Txy_data)
+from idaes.core.util.phase_equilibria import (TXYDataClass, Txy_data)
+
 
 @pytest.mark.unit
 def test_Txy_dataclass():
 
-    TD = TXYDataClass('benzene', 'toluene', pyunits.kg / pyunits.m / pyunits.s ** 2, pyunits.K, 101325)
+    TD = TXYDataClass('benzene', 'toluene',
+                      pyunits.kg / pyunits.m / pyunits.s ** 2, pyunits.K,
+                      101325)
     TD.TBubb = [353.3205, 365.3478, 383.8817]
     TD.TDew = [353.3237, 372.0203, 383.8845]
     TD.x = [0.9999, 0.5, 0.01]
 
     assert TD.Component_1 == 'benzene'
     assert TD.Component_2 == 'toluene'
-    assert TD.Punits == pyunits.kg / pyunits.m / pyunits.s ** 2
-    assert TD.Tunits == pyunits.K
+    assert_units_equivalent(TD.Punits, pyunits.kg / pyunits.m / pyunits.s ** 2)
+    assert_units_equivalent(TD.Tunits, pyunits.K)
     assert TD.P == 101325
-    assert TD.TBubb == [pytest.approx(353.3205, abs=1e-4), pytest.approx(365.3478, abs=1e-4), pytest.approx(383.8817, abs=1e-4)]
-    assert TD.TDew == [pytest.approx(353.3237, abs=1e-4), pytest.approx(372.0203, abs=1e-4), pytest.approx(383.8845, abs=1e-4)]
-    assert TD.x == [pytest.approx(0.9999, abs=1e-4), pytest.approx(0.5, abs=1e-4), pytest.approx(0.01, abs=1e-4)]
+    assert TD.TBubb == [pytest.approx(353.3205, abs=1e-4),
+                        pytest.approx(365.3478, abs=1e-4),
+                        pytest.approx(383.8817, abs=1e-4)]
+    assert TD.TDew == [pytest.approx(353.3237, abs=1e-4),
+                       pytest.approx(372.0203, abs=1e-4),
+                       pytest.approx(383.8845, abs=1e-4)]
+    assert TD.x == [pytest.approx(0.9999, abs=1e-4),
+                    pytest.approx(0.5, abs=1e-4),
+                    pytest.approx(0.01, abs=1e-4)]
+
 
 # Author: Alejandro Garciadiego
 @pytest.mark.component
@@ -120,17 +129,25 @@ def test_Txy_data():
 
     model.params = GenericParameterBlock(default=configuration)
 
-    TD = Txy_data(model, 'benzene', 'toluene', 101325, num_points = 3, temperature = 298.15,
-    print_level=idaeslog.CRITICAL, solver_op={'tol': 1e-6})
+    TD = Txy_data(model, 'benzene', 'toluene', 101325,
+                  num_points=3, temperature=298.15,
+                  print_level=idaeslog.CRITICAL, solver_op={'tol': 1e-6})
 
     assert TD.Component_1 == 'benzene'
     assert TD.Component_2 == 'toluene'
-    assert TD.Punits == pyunits.kg / pyunits.m / pyunits.s ** 2
-    assert TD.Tunits == pyunits.K
+    assert_units_equivalent(TD.Punits, pyunits.kg / pyunits.m / pyunits.s ** 2)
+    assert_units_equivalent(TD.Tunits, pyunits.K)
     assert TD.P == 101325
-    assert TD.TBubb == [pytest.approx(353.4853, abs=1e-4), pytest.approx(365.2127, abs=1e-4), pytest.approx(383.2909, abs=1e-4)]
-    assert TD.TDew == [pytest.approx(353.7978, abs=1e-2), pytest.approx(371.8702, abs=1e-4), pytest.approx(383.5685, abs=1e-4)]
-    assert TD.x == [pytest.approx(0.99, abs=1e-4), pytest.approx(0.5, abs=1e-4), pytest.approx(0.01, abs=1e-4)]
+    assert TD.TBubb == [pytest.approx(353.4853, abs=1e-4),
+                        pytest.approx(365.2127, abs=1e-4),
+                        pytest.approx(383.2909, abs=1e-4)]
+    assert TD.TDew == [pytest.approx(353.7978, abs=1e-2),
+                       pytest.approx(371.8702, abs=1e-4),
+                       pytest.approx(383.5685, abs=1e-4)]
+    assert TD.x == [pytest.approx(0.99, abs=1e-4),
+                    pytest.approx(0.5, abs=1e-4),
+                    pytest.approx(0.01, abs=1e-4)]
+
 
 # Author: Alejandro Garciadiego
 @pytest.mark.component
@@ -197,17 +214,23 @@ def test_Txy_data_no_dew():
 
     model.params = GenericParameterBlock(default=configuration)
 
-    TD = Txy_data(model, "carbon_dioxide", "bmimPF6", 101325, num_points = 3, temperature = 150.15,
-    print_level=idaeslog.CRITICAL, solver_op={'tol': 1e-6})
+    TD = Txy_data(model, "carbon_dioxide", "bmimPF6", 101325,
+                  num_points=3, temperature=150.15,
+                  print_level=idaeslog.CRITICAL, solver_op={'tol': 1e-6})
 
     assert TD.Component_1 == 'carbon_dioxide'
     assert TD.Component_2 == 'bmimPF6'
-    assert TD.Punits == pyunits.kg / pyunits.m / pyunits.s ** 2
-    assert TD.Tunits == pyunits.K
+    assert_units_equivalent(TD.Punits, pyunits.kg / pyunits.m / pyunits.s ** 2)
+    assert_units_equivalent(TD.Tunits, pyunits.K)
     assert TD.P == 101325
-    assert TD.TBubb == [pytest.approx(185.6468, abs=1e-4), pytest.approx(191.4697, abs=1e-4), pytest.approx(331.1625, abs=1e-4)]
+    assert TD.TBubb == [pytest.approx(185.6468, abs=1e-4),
+                        pytest.approx(191.4697, abs=1e-4),
+                        pytest.approx(331.1625, abs=1e-4)]
     assert TD.TDew == []
-    assert TD.x == [pytest.approx(0.99, abs=1e-4), pytest.approx(0.5, abs=1e-4), pytest.approx(0.01, abs=1e-4)]
+    assert TD.x == [pytest.approx(0.99, abs=1e-4),
+                    pytest.approx(0.5, abs=1e-4),
+                    pytest.approx(0.01, abs=1e-4)]
+
 
 # Author: Alejandro Garciadiego
 @pytest.mark.component
@@ -273,14 +296,19 @@ def test_Txy_data_no_liq():
 
     model.params = GenericParameterBlock(default=configuration)
 
-    TD = Txy_data(model, 'methane', 'ethane', 101325 , num_points = 3, temperature = 298,
-    print_level=idaeslog.CRITICAL, solver_op={'tol': 1e-6})
+    TD = Txy_data(model, 'methane', 'ethane', 101325,
+                  num_points=3, temperature=298,
+                  print_level=idaeslog.CRITICAL, solver_op={'tol': 1e-6})
 
     assert TD.Component_1 == 'methane'
     assert TD.Component_2 == 'ethane'
-    assert TD.Punits == pyunits.kg / pyunits.m / pyunits.s ** 2
-    assert TD.Tunits == pyunits.K
+    assert_units_equivalent(TD.Punits, pyunits.kg / pyunits.m / pyunits.s ** 2)
+    assert_units_equivalent(TD.Tunits, pyunits.K)
     assert TD.P == 101325
     assert TD.TBubb == []
-    assert TD.TDew == [pytest.approx(126.9025, abs=1e-2), pytest.approx(172.1489, abs=1e-4), pytest.approx(184.2534, abs=1e-4)]
-    assert TD.x == [pytest.approx(0.99, abs=1e-4), pytest.approx(0.5, abs=1e-4), pytest.approx(0.01, abs=1e-4)]
+    assert TD.TDew == [pytest.approx(126.9025, abs=1e-2),
+                       pytest.approx(172.1489, abs=1e-4),
+                       pytest.approx(184.2534, abs=1e-4)]
+    assert TD.x == [pytest.approx(0.99, abs=1e-4),
+                    pytest.approx(0.5, abs=1e-4),
+                    pytest.approx(0.01, abs=1e-4)]

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -798,7 +798,7 @@ class TestGenericParameterBlock(object):
         for i in m.params.reaction_e1.reaction_order:
             order = {("p1", "a"): -3, ("p1", "b"): 4,
                      ("p2", "a"): 0, ("p2", "b"): 0, ("p2", "c"): 0}
-            assert m.params.reaction_e1.reaction_order[i] == order[i]
+            assert m.params.reaction_e1.reaction_order[i].value == order[i]
 
     @pytest.mark.unit
     def test_inherent_reactions_no_stoichiometry(self):

--- a/idaes/generic_models/properties/core/reactions/tests/test_rate_forms.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_rate_forms.py
@@ -124,10 +124,10 @@ def test_power_law_rate_with_order():
     # Check parameter construction
     assert isinstance(m.rparams.reaction_r1.reaction_order, Var)
     assert len(m.rparams.reaction_r1.reaction_order) == 4
-    assert m.rparams.reaction_r1.reaction_order["p1", "c1"] == 1
-    assert m.rparams.reaction_r1.reaction_order["p1", "c2"] == 2
-    assert m.rparams.reaction_r1.reaction_order["p2", "c1"] == 3
-    assert m.rparams.reaction_r1.reaction_order["p2", "c2"] == 4
+    assert m.rparams.reaction_r1.reaction_order["p1", "c1"].value == 1
+    assert m.rparams.reaction_r1.reaction_order["p1", "c2"].value == 2
+    assert m.rparams.reaction_r1.reaction_order["p2", "c1"].value == 3
+    assert m.rparams.reaction_r1.reaction_order["p2", "c2"].value == 4
 
     # Check reaction form
     rform = power_law_rate.return_expression(

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx.py
@@ -1062,31 +1062,36 @@ class TestCommon(object):
     # Test General Methods
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):
-        for p in frame.params.phase_list:
-            for j in frame.params.component_list:
-                assert frame.props[1].get_material_flow_terms(p, j) == (
-                    frame.props[1].flow_mol_phase[p] *
-                    frame.props[1].mole_frac_phase_comp[p, j])
+        for (p, j) in frame.params._phase_component_set:
+            assert str(frame.props[1].get_material_flow_terms(p, j)) == str(
+                frame.props[1].flow_mol_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_enthalpy_flow_terms(p) == (
+            assert str(frame.props[1].get_enthalpy_flow_terms(p)) == str(
+                frame.props[1]._enthalpy_flow_term[p])
+            assert str(frame.props[1]._enthalpy_flow_term[p].expr) == str(
                 frame.props[1].flow_mol_phase[p] *
                 frame.props[1].enth_mol_phase[p])
 
     @pytest.mark.unit
     def test_get_material_density_terms(self, frame):
-        for p in frame.params.phase_list:
-            for j in frame.params.component_list:
-                assert frame.props[1].get_material_density_terms(p, j) == (
-                    frame.props[1].dens_mol_phase[p] *
-                    frame.props[1].mole_frac_phase_comp[p, j])
+        for (p, j) in frame.params._phase_component_set:
+            assert str(frame.props[1].get_material_density_terms(p, j)) == str(
+                frame.props[1]._material_density_term[p, j])
+            assert str(
+                frame.props[1]._material_density_term[p, j].expr) == str(
+                frame.props[1].dens_mol_phase[p] *
+                frame.props[1].mole_frac_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_energy_density_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_energy_density_terms(p) == (
+            assert str(frame.props[1].get_energy_density_terms(p)) == str(
+                frame.props[1]._energy_density_term[p])
+            assert str(
+                frame.props[1]._energy_density_term[p].expr) == str(
                 frame.props[1].dens_mol_phase[p] *
                 frame.props[1].energy_internal_mol_phase[p])
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx.py
@@ -1031,31 +1031,36 @@ class TestCommon(object):
     # Test General Methods
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):
-        for p in frame.params.phase_list:
-            for j in frame.params.component_list:
-                assert frame.props[1].get_material_flow_terms(p, j) == (
-                    frame.props[1].flow_mol_phase[p] *
-                    frame.props[1].mole_frac_phase_comp[p, j])
+        for (p, j) in frame.params._phase_component_set:
+            assert str(frame.props[1].get_material_flow_terms(p, j)) == str(
+                frame.props[1].flow_mol_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_enthalpy_flow_terms(p) == (
+            assert str(frame.props[1].get_enthalpy_flow_terms(p)) == str(
+                frame.props[1]._enthalpy_flow_term[p])
+            assert str(frame.props[1]._enthalpy_flow_term[p].expr) == str(
                 frame.props[1].flow_mol_phase[p] *
                 frame.props[1].enth_mol_phase[p])
 
     @pytest.mark.unit
     def test_get_material_density_terms(self, frame):
-        for p in frame.params.phase_list:
-            for j in frame.params.component_list:
-                assert frame.props[1].get_material_density_terms(p, j) == (
-                    frame.props[1].dens_mol_phase[p] *
-                    frame.props[1].mole_frac_phase_comp[p, j])
+        for (p, j) in frame.params._phase_component_set:
+            assert str(frame.props[1].get_material_density_terms(p, j)) == str(
+                frame.props[1]._material_density_term[p, j])
+            assert str(
+                frame.props[1]._material_density_term[p, j].expr) == str(
+                frame.props[1].dens_mol_phase[p] *
+                frame.props[1].mole_frac_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_energy_density_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_energy_density_terms(p) == (
+            assert str(frame.props[1].get_energy_density_terms(p)) == str(
+                frame.props[1]._energy_density_term[p])
+            assert str(
+                frame.props[1]._energy_density_term[p].expr) == str(
                 frame.props[1].dens_mol_phase[p] *
                 frame.props[1].energy_internal_mol_phase[p])
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh.py
@@ -1165,28 +1165,35 @@ class TestCommon(object):
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):
         for (p, j) in frame.params._phase_component_set:
-            assert frame.props[1].get_material_flow_terms(p, j) == (
-                frame.props[1].flow_mol_phase[p] *
-                frame.props[1].mole_frac_phase_comp[p, j])
+            assert str(frame.props[1].get_material_flow_terms(p, j)) == str(
+                frame.props[1].flow_mol_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_enthalpy_flow_terms(p) == (
+            assert str(frame.props[1].get_enthalpy_flow_terms(p)) == str(
+                frame.props[1]._enthalpy_flow_term[p])
+            assert str(frame.props[1]._enthalpy_flow_term[p].expr) == str(
                 frame.props[1].flow_mol_phase[p] *
                 frame.props[1].enth_mol_phase[p])
 
     @pytest.mark.unit
     def test_get_material_density_terms(self, frame):
         for (p, j) in frame.params._phase_component_set:
-            assert frame.props[1].get_material_density_terms(p, j) == (
+            assert str(frame.props[1].get_material_density_terms(p, j)) == str(
+                frame.props[1]._material_density_term[p, j])
+            assert str(
+                frame.props[1]._material_density_term[p, j].expr) == str(
                 frame.props[1].dens_mol_phase[p] *
                 frame.props[1].mole_frac_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_energy_density_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_energy_density_terms(p) == (
+            assert str(frame.props[1].get_energy_density_terms(p)) == str(
+                frame.props[1]._energy_density_term[p])
+            assert str(
+                frame.props[1]._energy_density_term[p].expr) == str(
                 frame.props[1].dens_mol_phase[p] *
                 frame.props[1].energy_internal_mol_phase[p])
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP.py
@@ -1104,28 +1104,35 @@ class TestCommon(object):
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):
         for (p, j) in frame.params._phase_component_set:
-            assert frame.props[1].get_material_flow_terms(p, j) == (
-                frame.props[1].flow_mol_phase[p] *
-                frame.props[1].mole_frac_phase_comp[p, j])
+            assert str(frame.props[1].get_material_flow_terms(p, j)) == str(
+                frame.props[1].flow_mol_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_enthalpy_flow_terms(p) == (
+            assert str(frame.props[1].get_enthalpy_flow_terms(p)) == str(
+                frame.props[1]._enthalpy_flow_term[p])
+            assert str(frame.props[1]._enthalpy_flow_term[p].expr) == str(
                 frame.props[1].flow_mol_phase[p] *
                 frame.props[1].enth_mol_phase[p])
 
     @pytest.mark.unit
     def test_get_material_density_terms(self, frame):
         for (p, j) in frame.params._phase_component_set:
-            assert frame.props[1].get_material_density_terms(p, j) == (
+            assert str(frame.props[1].get_material_density_terms(p, j)) == str(
+                frame.props[1]._material_density_term[p, j])
+            assert str(
+                frame.props[1]._material_density_term[p, j].expr) == str(
                 frame.props[1].dens_mol_phase[p] *
                 frame.props[1].mole_frac_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_energy_density_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_energy_density_terms(p) == (
+            assert str(frame.props[1].get_energy_density_terms(p)) == str(
+                frame.props[1]._energy_density_term[p])
+            assert str(
+                frame.props[1]._energy_density_term[p].expr) == str(
                 frame.props[1].dens_mol_phase[p] *
                 frame.props[1].energy_internal_mol_phase[p])
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP.py
@@ -1012,28 +1012,35 @@ class TestCommon(object):
     @pytest.mark.unit
     def test_get_material_flow_terms(self, frame):
         for (p, j) in frame.params._phase_component_set:
-            assert frame.props[1].get_material_flow_terms(p, j) == (
-                frame.props[1].flow_mol_phase[p] *
-                frame.props[1].mole_frac_phase_comp[p, j])
+            assert str(frame.props[1].get_material_flow_terms(p, j)) == str(
+                frame.props[1].flow_mol_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_enthalpy_flow_terms(p) == (
+            assert str(frame.props[1].get_enthalpy_flow_terms(p)) == str(
+                frame.props[1]._enthalpy_flow_term[p])
+            assert str(frame.props[1]._enthalpy_flow_term[p].expr) == str(
                 frame.props[1].flow_mol_phase[p] *
                 frame.props[1].enth_mol_phase[p])
 
     @pytest.mark.unit
     def test_get_material_density_terms(self, frame):
         for (p, j) in frame.params._phase_component_set:
-            assert frame.props[1].get_material_density_terms(p, j) == (
+            assert str(frame.props[1].get_material_density_terms(p, j)) == str(
+                frame.props[1]._material_density_term[p, j])
+            assert str(
+                frame.props[1]._material_density_term[p, j].expr) == str(
                 frame.props[1].dens_mol_phase[p] *
                 frame.props[1].mole_frac_phase_comp[p, j])
 
     @pytest.mark.unit
     def test_get_energy_density_terms(self, frame):
         for p in frame.params.phase_list:
-            assert frame.props[1].get_energy_density_terms(p) == (
+            assert str(frame.props[1].get_energy_density_terms(p)) == str(
+                frame.props[1]._energy_density_term[p])
+            assert str(
+                frame.props[1]._energy_density_term[p].expr) == str(
                 frame.props[1].dens_mol_phase[p] *
                 frame.props[1].energy_internal_mol_phase[p])
 

--- a/idaes/generic_models/properties/examples/tests/test_saponification_thermo.py
+++ b/idaes/generic_models/properties/examples/tests/test_saponification_thermo.py
@@ -136,14 +136,15 @@ class TestStateBlock(object):
     def test_get_material_flow_terms(self, model):
         for p in model.params.phase_list:
             for j in model.params.component_list:
-                assert model.props[1].get_material_flow_terms(p, j) == (
-                        model.props[1].flow_vol *
-                        model.props[1].conc_mol_comp[j])
+                assert str(
+                    model.props[1].get_material_flow_terms(p, j)) == str(
+                    model.props[1].flow_vol *
+                    model.props[1].conc_mol_comp[j])
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
-            assert model.props[1].get_enthalpy_flow_terms(p) == (
+            assert str(model.props[1].get_enthalpy_flow_terms(p)) == str(
                     model.props[1].flow_vol*model.props[1].params.dens_mol *
                     model.props[1].params.cp_mol*(
                             model.props[1].temperature -
@@ -153,13 +154,14 @@ class TestStateBlock(object):
     def test_get_material_density_terms(self, model):
         for p in model.params.phase_list:
             for j in model.params.component_list:
-                assert model.props[1].get_material_density_terms(p, j) == (
-                        model.props[1].conc_mol_comp[j])
+                assert str(
+                    model.props[1].get_material_density_terms(p, j)) == str(
+                    model.props[1].conc_mol_comp[j])
 
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert model.props[1].get_energy_density_terms(p) == (
+            assert str(model.props[1].get_energy_density_terms(p)) == str(
                     model.props[1].params.dens_mol *
                     model.props[1].params.cp_mol*(
                             model.props[1].temperature -

--- a/idaes/generic_models/properties/tests/test_iapws95.py
+++ b/idaes/generic_models/properties/tests/test_iapws95.py
@@ -114,9 +114,9 @@ class TestMixPh(object):
     def model(self):
         model = ConcreteModel()
         model.params = iapws95.Iapws95ParameterBlock(default={
-                "temperature_bounds":(249*pyunits.K, 2501*pyunits.K),
-                "pressure_bounds":(0.11*pyunits.Pa, 1.1e9*pyunits.Pa),
-                "enthalpy_mol_bounds":(
+                "temperature_bounds": (249*pyunits.K, 2501*pyunits.K),
+                "pressure_bounds": (0.11*pyunits.Pa, 1.1e9*pyunits.Pa),
+                "enthalpy_mol_bounds": (
                     0.1*pyunits.J/pyunits.mol, 1.1e5*pyunits.J/pyunits.mol),
             }
         )
@@ -128,14 +128,15 @@ class TestMixPh(object):
         l = 0.1/0.018
         u = 1.1e5/0.018
         model.params = iapws95.Iapws95ParameterBlock(default={
-                "enthalpy_mass_bounds":(
+                "enthalpy_mass_bounds": (
                     l*pyunits.J/pyunits.kg,
                     u*pyunits.J/pyunits.kg)
             }
         )
-        assert pytest.approx(0.1, rel=1e-3) == model.params.default_enthalpy_bounds[0]
-        assert pytest.approx(1.1e5, rel=1e-3) == model.params.default_enthalpy_bounds[1]
-
+        assert pytest.approx(0.1, rel=1e-3) == value(
+            model.params.default_enthalpy_bounds[0])
+        assert pytest.approx(1.1e5, rel=1e-3) == value(
+            model.params.default_enthalpy_bounds[1])
 
     @pytest.mark.unit
     def test_config(self, model):
@@ -146,12 +147,18 @@ class TestMixPh(object):
         for i in model.params.phase_list:
             assert i in ["Mix"]
 
-        assert pytest.approx(249) == model.params.default_temperature_bounds[0]
-        assert pytest.approx(2501) == model.params.default_temperature_bounds[1]
-        assert pytest.approx(0.11) == model.params.default_pressure_bounds[0]
-        assert pytest.approx(1.1e9) == model.params.default_pressure_bounds[1]
-        assert pytest.approx(0.1) == model.params.default_enthalpy_bounds[0]
-        assert pytest.approx(1.1e5) == model.params.default_enthalpy_bounds[1]
+        assert pytest.approx(249) == value(
+            model.params.default_temperature_bounds[0])
+        assert pytest.approx(2501) == value(
+            model.params.default_temperature_bounds[1])
+        assert pytest.approx(0.11) == value(
+            model.params.default_pressure_bounds[0])
+        assert pytest.approx(1.1e9) == value(
+            model.params.default_pressure_bounds[1])
+        assert pytest.approx(0.1) == value(
+            model.params.default_enthalpy_bounds[0])
+        assert pytest.approx(1.1e5) == value(
+            model.params.default_enthalpy_bounds[1])
 
     @pytest.mark.unit
     def test_build(self, model):
@@ -179,8 +186,8 @@ class TestMixPh(object):
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
             assert (
-                model.prop[1].get_enthalpy_flow_terms(p)
-                == model.prop[1].enth_mol * model.prop[1].flow_mol
+                value(model.prop[1].get_enthalpy_flow_terms(p))
+                == value(model.prop[1].enth_mol * model.prop[1].flow_mol)
             )
 
     @pytest.mark.unit
@@ -195,9 +202,9 @@ class TestMixPh(object):
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert (
-                model.prop[1].get_energy_density_terms(p)
-                == model.prop[1].dens_mol * model.prop[1].energy_internal_mol
+            assert value(
+                model.prop[1].get_energy_density_terms(p)) == value(
+                model.prop[1].dens_mol * model.prop[1].energy_internal_mol
             )
 
     @pytest.mark.unit
@@ -250,7 +257,7 @@ class TestMixPh(object):
     @pytest.mark.unit
     def test_intensive_state_vars(self, model):
         for i in model.prop[1].intensive_set:
-            assert i in [model.prop[1].enth_mol, model.prop[1].pressure]
+            assert i.name in ["prop[1].enth_mol", "prop[1].pressure"]
 
     @pytest.mark.unit
     def test_model_check(self, model):
@@ -455,15 +462,15 @@ class TestLGPh(object):
     def test_get_material_flow_terms(self, model):
         for p in model.params.phase_list:
             for j in model.params.component_list:
-                assert (
-                    model.prop[1].get_material_flow_terms(p, j)
-                    == model.prop[1].flow_mol * model.prop[1].phase_frac[p]
+                assert value(
+                    model.prop[1].get_material_flow_terms(p, j)) == value(
+                    model.prop[1].flow_mol * model.prop[1].phase_frac[p]
                 )
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_enthalpy_flow_terms(p) == (
+            assert value(model.prop[1].get_enthalpy_flow_terms(p)) == value(
                 model.prop[1].enth_mol_phase[p]
                 * model.prop[1].phase_frac[p]
                 * model.prop[1].flow_mol
@@ -481,7 +488,7 @@ class TestLGPh(object):
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_energy_density_terms(p) == (
+            assert value(model.prop[1].get_energy_density_terms(p)) == value(
                 model.prop[1].dens_mol_phase[p]
                 * model.prop[1].energy_internal_mol_phase[p]
             )
@@ -536,7 +543,7 @@ class TestLGPh(object):
     @pytest.mark.unit
     def test_intensive_state_vars(self, model):
         for i in model.prop[1].intensive_set:
-            assert i in [model.prop[1].enth_mol, model.prop[1].pressure]
+            assert i.name in ["prop[1].enth_mol", "prop[1].pressure"]
 
     @pytest.mark.unit
     def test_model_check(self, model):
@@ -741,15 +748,15 @@ class TestLPh(object):
     def test_get_material_flow_terms(self, model):
         for p in model.params.phase_list:
             for j in model.params.component_list:
-                assert (
-                    model.prop[1].get_material_flow_terms(p, j)
-                    == model.prop[1].flow_mol * model.prop[1].phase_frac[p]
+                assert value(
+                    model.prop[1].get_material_flow_terms(p, j)) == value(
+                    model.prop[1].flow_mol * model.prop[1].phase_frac[p]
                 )
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_enthalpy_flow_terms(p) == (
+            assert value(model.prop[1].get_enthalpy_flow_terms(p)) == value(
                 model.prop[1].enth_mol_phase[p]
                 * model.prop[1].phase_frac[p]
                 * model.prop[1].flow_mol
@@ -767,7 +774,7 @@ class TestLPh(object):
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_energy_density_terms(p) == (
+            assert value(model.prop[1].get_energy_density_terms(p)) == value(
                 model.prop[1].dens_mol_phase[p]
                 * model.prop[1].energy_internal_mol_phase[p]
             )
@@ -822,7 +829,7 @@ class TestLPh(object):
     @pytest.mark.unit
     def test_intensive_state_vars(self, model):
         for i in model.prop[1].intensive_set:
-            assert i in [model.prop[1].enth_mol, model.prop[1].pressure]
+            assert i.name in ["prop[1].enth_mol", "prop[1].pressure"]
 
     @pytest.mark.unit
     def test_model_check(self, model):
@@ -1027,15 +1034,15 @@ class TestGPh(object):
     def test_get_material_flow_terms(self, model):
         for p in model.params.phase_list:
             for j in model.params.component_list:
-                assert (
-                    model.prop[1].get_material_flow_terms(p, j)
-                    == model.prop[1].flow_mol * model.prop[1].phase_frac[p]
+                assert value(
+                    model.prop[1].get_material_flow_terms(p, j)) == value(
+                    model.prop[1].flow_mol * model.prop[1].phase_frac[p]
                 )
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_enthalpy_flow_terms(p) == (
+            assert value(model.prop[1].get_enthalpy_flow_terms(p)) == value(
                 model.prop[1].enth_mol_phase[p]
                 * model.prop[1].phase_frac[p]
                 * model.prop[1].flow_mol
@@ -1053,7 +1060,7 @@ class TestGPh(object):
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_energy_density_terms(p) == (
+            assert value(model.prop[1].get_energy_density_terms(p)) == value(
                 model.prop[1].dens_mol_phase[p]
                 * model.prop[1].energy_internal_mol_phase[p]
             )
@@ -1108,7 +1115,7 @@ class TestGPh(object):
     @pytest.mark.unit
     def test_intensive_state_vars(self, model):
         for i in model.prop[1].intensive_set:
-            assert i in [model.prop[1].enth_mol, model.prop[1].pressure]
+            assert i.name in ["prop[1].enth_mol", "prop[1].pressure"]
 
     @pytest.mark.unit
     def test_model_check(self, model):
@@ -1322,9 +1329,9 @@ class TestMixTpx(object):
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
-            assert (
-                model.prop[1].get_enthalpy_flow_terms(p)
-                == model.prop[1].enth_mol * model.prop[1].flow_mol
+            assert value(
+                model.prop[1].get_enthalpy_flow_terms(p)) == value(
+                model.prop[1].enth_mol * model.prop[1].flow_mol
             )
 
     @pytest.mark.unit
@@ -1339,9 +1346,9 @@ class TestMixTpx(object):
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert (
-                model.prop[1].get_energy_density_terms(p)
-                == model.prop[1].dens_mol * model.prop[1].energy_internal_mol
+            assert value(
+                model.prop[1].get_energy_density_terms(p)) == value(
+                model.prop[1].dens_mol * model.prop[1].energy_internal_mol
             )
 
     @pytest.mark.unit
@@ -1394,10 +1401,10 @@ class TestMixTpx(object):
     @pytest.mark.unit
     def test_intensive_state_vars(self, model):
         for i in model.prop[1].intensive_set:
-            assert i in [
-                model.prop[1].temperature,
-                model.prop[1].pressure,
-                model.prop[1].vapor_frac,
+            assert i.name in [
+                "prop[1].temperature",
+                "prop[1].pressure",
+                "prop[1].vapor_frac",
             ]
 
     @pytest.mark.unit
@@ -1639,15 +1646,15 @@ class TestLgTpx(object):
     def test_get_material_flow_terms(self, model):
         for p in model.params.phase_list:
             for j in model.params.component_list:
-                assert (
-                    model.prop[1].get_material_flow_terms(p, j)
-                    == model.prop[1].flow_mol * model.prop[1].phase_frac[p]
+                assert value(
+                    model.prop[1].get_material_flow_terms(p, j)) == value(
+                    model.prop[1].flow_mol * model.prop[1].phase_frac[p]
                 )
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_enthalpy_flow_terms(p) == (
+            assert value(model.prop[1].get_enthalpy_flow_terms(p)) == value(
                 model.prop[1].enth_mol_phase[p]
                 * model.prop[1].phase_frac[p]
                 * model.prop[1].flow_mol
@@ -1665,7 +1672,7 @@ class TestLgTpx(object):
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_energy_density_terms(p) == (
+            assert value(model.prop[1].get_energy_density_terms(p)) == value(
                 model.prop[1].dens_mol_phase[p]
                 * model.prop[1].energy_internal_mol_phase[p]
             )
@@ -1720,10 +1727,10 @@ class TestLgTpx(object):
     @pytest.mark.unit
     def test_intensive_state_vars(self, model):
         for i in model.prop[1].intensive_set:
-            assert i in [
-                model.prop[1].temperature,
-                model.prop[1].pressure,
-                model.prop[1].vapor_frac,
+            assert i.name in [
+                "prop[1].temperature",
+                "prop[1].pressure",
+                "prop[1].vapor_frac",
             ]
 
     @pytest.mark.unit
@@ -1948,15 +1955,15 @@ class TestLTpx(object):
     def test_get_material_flow_terms(self, model):
         for p in model.params.phase_list:
             for j in model.params.component_list:
-                assert (
-                    model.prop[1].get_material_flow_terms(p, j)
-                    == model.prop[1].flow_mol * model.prop[1].phase_frac[p]
+                assert value(
+                    model.prop[1].get_material_flow_terms(p, j)) == value(
+                    model.prop[1].flow_mol * model.prop[1].phase_frac[p]
                 )
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_enthalpy_flow_terms(p) == (
+            assert value(model.prop[1].get_enthalpy_flow_terms(p)) == value(
                 model.prop[1].enth_mol_phase[p]
                 * model.prop[1].phase_frac[p]
                 * model.prop[1].flow_mol
@@ -1974,7 +1981,7 @@ class TestLTpx(object):
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_energy_density_terms(p) == (
+            assert value(model.prop[1].get_energy_density_terms(p)) == value(
                 model.prop[1].dens_mol_phase[p]
                 * model.prop[1].energy_internal_mol_phase[p]
             )
@@ -2029,10 +2036,10 @@ class TestLTpx(object):
     @pytest.mark.unit
     def test_intensive_state_vars(self, model):
         for i in model.prop[1].intensive_set:
-            assert i in [
-                model.prop[1].temperature,
-                model.prop[1].pressure,
-                model.prop[1].vapor_frac,
+            assert i.name in [
+                "prop[1].temperature",
+                "prop[1].pressure",
+                "prop[1].vapor_frac",
             ]
 
     @pytest.mark.unit
@@ -2258,15 +2265,15 @@ class TestGTpx(object):
     def test_get_material_flow_terms(self, model):
         for p in model.params.phase_list:
             for j in model.params.component_list:
-                assert (
-                    model.prop[1].get_material_flow_terms(p, j)
-                    == model.prop[1].flow_mol * model.prop[1].phase_frac[p]
+                assert value(
+                    model.prop[1].get_material_flow_terms(p, j)) == value(
+                    model.prop[1].flow_mol * model.prop[1].phase_frac[p]
                 )
 
     @pytest.mark.unit
     def test_get_enthalpy_flow_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_enthalpy_flow_terms(p) == (
+            assert value(model.prop[1].get_enthalpy_flow_terms(p)) == value(
                 model.prop[1].enth_mol_phase[p]
                 * model.prop[1].phase_frac[p]
                 * model.prop[1].flow_mol
@@ -2284,7 +2291,7 @@ class TestGTpx(object):
     @pytest.mark.unit
     def test_get_energy_density_terms(self, model):
         for p in model.params.phase_list:
-            assert model.prop[1].get_energy_density_terms(p) == (
+            assert value(model.prop[1].get_energy_density_terms(p)) == value(
                 model.prop[1].dens_mol_phase[p]
                 * model.prop[1].energy_internal_mol_phase[p]
             )
@@ -2339,10 +2346,10 @@ class TestGTpx(object):
     @pytest.mark.unit
     def test_intensive_state_vars(self, model):
         for i in model.prop[1].intensive_set:
-            assert i in [
-                model.prop[1].temperature,
-                model.prop[1].pressure,
-                model.prop[1].vapor_frac,
+            assert i.name in [
+                "prop[1].temperature",
+                "prop[1].pressure",
+                "prop[1].vapor_frac",
             ]
 
     @pytest.mark.unit

--- a/idaes/generic_models/unit_models/tests/test_separator.py
+++ b/idaes/generic_models/unit_models/tests/test_separator.py
@@ -332,7 +332,7 @@ class TestSplitConstruction(object):
         for t in build.fs.time:
             for o in build.fs.sep.outlet_idx:
                 for p in build.fs.sep.config.property_package.phase_list:
-                    assert build.fs.sep.split_fraction[t, o, p] == 0.5
+                    assert build.fs.sep.split_fraction[t, o, p].value == 0.5
 
         assert isinstance(build.fs.sep.sum_split_frac, Constraint)
         assert len(build.fs.sep.sum_split_frac) == 2
@@ -352,7 +352,7 @@ class TestSplitConstruction(object):
         for t in build.fs.time:
             for o in build.fs.sep.outlet_idx:
                 for j in build.fs.sep.config.property_package.component_list:
-                    assert build.fs.sep.split_fraction[t, o, j] == 0.5
+                    assert build.fs.sep.split_fraction[t, o, j].value == 0.5
 
         assert isinstance(build.fs.sep.sum_split_frac, Constraint)
         assert len(build.fs.sep.sum_split_frac) == 2
@@ -373,7 +373,8 @@ class TestSplitConstruction(object):
             for o in build.fs.sep.outlet_idx:
                 for p in build.fs.sep.config.property_package.phase_list:
                     for j in build.fs.sep.config.property_package.component_list:
-                        assert build.fs.sep.split_fraction[t, o, p, j] == 0.5
+                        assert 0.5 == \
+                            build.fs.sep.split_fraction[t, o, p, j].value
 
         assert isinstance(build.fs.sep.sum_split_frac, Constraint)
         assert len(build.fs.sep.sum_split_frac) == 4


### PR DESCRIPTION
## Partially addresses #340


## Summary/Motivation:
This PR should fix all the issues relating to https://github.com/Pyomo/pyomo/pull/1954. This process also identified and fixed a number of tests that did not work as expected.

## Changes proposed in this PR:
- Fix tests where `.value` or `value()` should have been used
- Fix a few tools which rely on values which ere not using `value()`
- Fix some tests for set membership that fail under Pyomo 6.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
