### PR TITLE
Fix inefficient function for Jacobian elements

### DIFF
--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -572,10 +572,11 @@ def extreme_jacobian_entries(
         jac, nlp = get_jacobian(m, scaled)
     el = []
     for i, c in enumerate(nlp.clist):
-        for j, v in enumerate(nlp.vlist):
-            if (abs(jac[i, j]) <= small and abs(jac[i, j] > zero)) \
-                or abs(jac[i,j]) >= large:
-                el.append((abs(jac[i, j]), c, v))
+        for j in jac[i].indices:
+            v = nlp.vlist[j]
+            e = abs(jac[i, j])
+            if (e <= small and e > zero) or e >= large:
+                el.append((e, c, v))
     return el
 
 
@@ -587,6 +588,7 @@ def jacobian_cond(m=None, scaled=True, ord=None, pinv=False, jac=None):
         m: calculate the condition number of the Jacobian from this model.
         scaled: if True use scaled Jacobian, else use unscaled
         ord: norm order, None = Frobenius, see scipy.sparse.linalg.norm for more
+        pinv: Use pseudoinverse, works for non-square matrixes
         jac: (optional) perviously calculated jacobian
 
     Returns:


### PR DESCRIPTION
This improves the speed of the function for finding large and small Jacobian elements.  The previous version wasn't iterating through the sparse matrix properly, and wasting time. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
