### PR TITLE
Standardising distillation tests

### DIFF
--- a/idaes/generic_models/unit_models/distillation/tests/test_conventional_tray.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_conventional_tray.py
@@ -18,15 +18,14 @@ Author: Jaffer Ghouse
 import pytest
 from pyomo.environ import (ConcreteModel, TerminationCondition,
                            SolverStatus, value)
+from pyomo.util.check_units import assert_units_consistent
 
-from idaes.core import (FlowsheetBlock, MaterialBalanceType, EnergyBalanceType,
-                        MomentumBalanceType)
+from idaes.core import FlowsheetBlock
 from idaes.generic_models.unit_models.distillation import Tray
 from idaes.generic_models.properties.activity_coeff_models.\
     BTX_activity_coeff_VLE import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom, \
-    number_variables, number_total_constraints, number_unused_variables, \
-    fixed_variables_set, activated_constraints_set
+    number_variables, number_total_constraints, number_unused_variables
 from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
 from idaes.core.util import get_solver
@@ -68,6 +67,23 @@ class TestBTXIdeal():
         m.fs.unit = Tray(default={"property_package": m.fs.properties,
                                   "has_heat_transfer": True,
                                   "has_pressure_change": True})
+
+        # Fix the tray inputs (FTPz)
+        m.fs.unit.liq_in.flow_mol.fix(1)
+        m.fs.unit.liq_in.temperature.fix(369)
+        m.fs.unit.liq_in.pressure.fix(101325)
+        m.fs.unit.liq_in.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.liq_in.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.vap_in.flow_mol.fix(1)
+        m.fs.unit.vap_in.temperature.fix(372)
+        m.fs.unit.vap_in.pressure.fix(101325)
+        m.fs.unit.vap_in.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.vap_in.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.heat_duty.fix(0)
+
         return m
 
     @pytest.fixture(scope="class")
@@ -83,9 +99,23 @@ class TestBTXIdeal():
         m.fs.unit = Tray(default={"property_package": m.fs.properties,
                                   "has_heat_transfer": True,
                                   "has_pressure_change": True})
+
+        # Fix the tray inputs (FcTP)
+        m.fs.unit.liq_in.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.liq_in.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.liq_in.temperature.fix(369)
+        m.fs.unit.liq_in.pressure.fix(101325)
+
+        m.fs.unit.vap_in.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.vap_in.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.vap_in.temperature.fix(372)
+        m.fs.unit.vap_in.pressure.fix(101325)
+
+        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.heat_duty.fix(0)
+
         return m
 
-    @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, btx_ftpz, btx_fctp):
         # General build
@@ -192,52 +222,25 @@ class TestBTXIdeal():
 
     @pytest.mark.unit
     def test_dof(self, btx_ftpz, btx_fctp):
-
-        # Fix the tray inputs (FTPz)
-        btx_ftpz.fs.unit.liq_in.flow_mol.fix(1)
-        btx_ftpz.fs.unit.liq_in.temperature.fix(369)
-        btx_ftpz.fs.unit.liq_in.pressure.fix(101325)
-        btx_ftpz.fs.unit.liq_in.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.liq_in.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.vap_in.flow_mol.fix(1)
-        btx_ftpz.fs.unit.vap_in.temperature.fix(372)
-        btx_ftpz.fs.unit.vap_in.pressure.fix(101325)
-        btx_ftpz.fs.unit.vap_in.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.vap_in.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.deltaP.fix(0)
-        btx_ftpz.fs.unit.heat_duty.fix(0)
-
         assert degrees_of_freedom(btx_ftpz.fs.unit) == 0
-
-        # Fix the tray inputs (FcTP)
-        btx_fctp.fs.unit.liq_in.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.liq_in.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.liq_in.temperature.fix(369)
-        btx_fctp.fs.unit.liq_in.pressure.fix(101325)
-
-        btx_fctp.fs.unit.vap_in.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.vap_in.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.vap_in.temperature.fix(372)
-        btx_fctp.fs.unit.vap_in.pressure.fix(101325)
-
-        btx_fctp.fs.unit.deltaP.fix(0)
-        btx_fctp.fs.unit.heat_duty.fix(0)
-
         assert degrees_of_freedom(btx_fctp.fs.unit) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
+    @pytest.mark.component
+    def test_units_FTPz(self, btx_ftpz, btx_fctp):
+        assert_units_consistent(btx_ftpz)
+
+    @pytest.mark.component
+    def test_units_FcTP(self, btx_fctp):
+        assert_units_consistent(btx_fctp)
+
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, btx_ftpz, btx_fctp):
         initialization_tester(btx_ftpz)
         initialization_tester(btx_fctp)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, btx_ftpz, btx_fctp):
 
         results = solver.solve(btx_ftpz)
@@ -254,10 +257,8 @@ class TestBTXIdeal():
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, btx_ftpz, btx_fctp):
 
         # liq_out port

--- a/idaes/generic_models/unit_models/distillation/tests/test_feed_tray.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_feed_tray.py
@@ -18,15 +18,14 @@ Author: Jaffer Ghouse
 import pytest
 from pyomo.environ import (ConcreteModel, TerminationCondition,
                            SolverStatus, value)
+from pyomo.util.check_units import assert_units_consistent
 
-from idaes.core import (FlowsheetBlock, MaterialBalanceType, EnergyBalanceType,
-                        MomentumBalanceType)
+from idaes.core import FlowsheetBlock
 from idaes.generic_models.unit_models.distillation import Tray
 from idaes.generic_models.properties.activity_coeff_models.\
     BTX_activity_coeff_VLE import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom, \
-    number_variables, number_total_constraints, number_unused_variables, \
-    fixed_variables_set, activated_constraints_set
+    number_variables, number_total_constraints, number_unused_variables
 from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
 from idaes.core.util import get_solver
@@ -70,6 +69,29 @@ class TestBTXIdeal():
                                   "is_feed_tray": True,
                                   "has_heat_transfer": True,
                                   "has_pressure_change": True})
+
+        # Set inputs
+        m.fs.unit.feed.flow_mol.fix(1)
+        m.fs.unit.feed.temperature.fix(369)
+        m.fs.unit.feed.pressure.fix(101325)
+        m.fs.unit.feed.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.feed.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.liq_in.flow_mol.fix(1)
+        m.fs.unit.liq_in.temperature.fix(369)
+        m.fs.unit.liq_in.pressure.fix(101325)
+        m.fs.unit.liq_in.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.liq_in.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.vap_in.flow_mol.fix(1)
+        m.fs.unit.vap_in.temperature.fix(372)
+        m.fs.unit.vap_in.pressure.fix(101325)
+        m.fs.unit.vap_in.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.vap_in.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.heat_duty.fix(0)
+
         return m
 
     @pytest.fixture(scope="class")
@@ -86,9 +108,28 @@ class TestBTXIdeal():
                                   "is_feed_tray": True,
                                   "has_heat_transfer": True,
                                   "has_pressure_change": True})
+
+        # Set inputs
+        m.fs.unit.feed.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.feed.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.feed.temperature.fix(369)
+        m.fs.unit.feed.pressure.fix(101325)
+
+        m.fs.unit.liq_in.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.liq_in.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.liq_in.temperature.fix(369)
+        m.fs.unit.liq_in.pressure.fix(101325)
+
+        m.fs.unit.vap_in.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.vap_in.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.vap_in.temperature.fix(372)
+        m.fs.unit.vap_in.pressure.fix(101325)
+
+        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.heat_duty.fix(0)
+
         return m
 
-    @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, btx_ftpz, btx_fctp):
         # General build
@@ -204,63 +245,25 @@ class TestBTXIdeal():
 
     @pytest.mark.unit
     def test_dof(self, btx_ftpz, btx_fctp):
-
-        # Set inputs
-        btx_ftpz.fs.unit.feed.flow_mol.fix(1)
-        btx_ftpz.fs.unit.feed.temperature.fix(369)
-        btx_ftpz.fs.unit.feed.pressure.fix(101325)
-        btx_ftpz.fs.unit.feed.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.feed.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.liq_in.flow_mol.fix(1)
-        btx_ftpz.fs.unit.liq_in.temperature.fix(369)
-        btx_ftpz.fs.unit.liq_in.pressure.fix(101325)
-        btx_ftpz.fs.unit.liq_in.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.liq_in.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.vap_in.flow_mol.fix(1)
-        btx_ftpz.fs.unit.vap_in.temperature.fix(372)
-        btx_ftpz.fs.unit.vap_in.pressure.fix(101325)
-        btx_ftpz.fs.unit.vap_in.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.vap_in.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.deltaP.fix(0)
-        btx_ftpz.fs.unit.heat_duty.fix(0)
-
         assert degrees_of_freedom(btx_ftpz.fs.unit) == 0
-
-        # Set inputs
-        btx_fctp.fs.unit.feed.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.feed.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.feed.temperature.fix(369)
-        btx_fctp.fs.unit.feed.pressure.fix(101325)
-
-        btx_fctp.fs.unit.liq_in.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.liq_in.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.liq_in.temperature.fix(369)
-        btx_fctp.fs.unit.liq_in.pressure.fix(101325)
-
-        btx_fctp.fs.unit.vap_in.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.vap_in.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.vap_in.temperature.fix(372)
-        btx_fctp.fs.unit.vap_in.pressure.fix(101325)
-
-        btx_fctp.fs.unit.deltaP.fix(0)
-        btx_fctp.fs.unit.heat_duty.fix(0)
-
         assert degrees_of_freedom(btx_fctp.fs.unit) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
+    @pytest.mark.component
+    def test_units_FTPz(self, btx_ftpz, btx_fctp):
+        assert_units_consistent(btx_ftpz)
+
+    @pytest.mark.component
+    def test_units_FcTP(self, btx_fctp):
+        assert_units_consistent(btx_fctp)
+
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, btx_ftpz, btx_fctp):
         initialization_tester(btx_ftpz)
         initialization_tester(btx_fctp)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, btx_ftpz, btx_fctp):
 
         results = solver.solve(btx_ftpz)
@@ -277,10 +280,8 @@ class TestBTXIdeal():
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, btx_ftpz, btx_fctp):
 
         # liq_out port

--- a/idaes/generic_models/unit_models/distillation/tests/test_reboiler.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_reboiler.py
@@ -19,9 +19,10 @@ Author: Jaffer Ghouse
 import pytest
 from pyomo.environ import (ConcreteModel, TerminationCondition,
                            SolverStatus, value)
+from pyomo.util.check_units import assert_units_consistent
 
-from idaes.core import FlowsheetBlock, MaterialBalanceType, EnergyBalanceType, \
-    MomentumBalanceType
+from idaes.core import \
+    FlowsheetBlock, MaterialBalanceType, EnergyBalanceType, MomentumBalanceType
 from idaes.generic_models.unit_models.distillation import Reboiler
 from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VLE \
     import BTXParameterBlock
@@ -72,6 +73,17 @@ class TestBTXIdeal():
             default={"property_package": m.fs.properties,
                      "has_boilup_ratio": True})
 
+        # Fix the reboiler variables
+        m.fs.unit.boilup_ratio.fix(1)
+
+        # Fix the inputs (typically this will be the outlet liquid from the
+        # bottom tray)
+        m.fs.unit.inlet.flow_mol.fix(1)
+        m.fs.unit.inlet.temperature.fix(363)
+        m.fs.unit.inlet.pressure.fix(101325)
+        m.fs.unit.inlet.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.inlet.mole_frac_comp[0, "toluene"].fix(0.5)
+
         return m
 
     @pytest.fixture(scope="class")
@@ -89,9 +101,18 @@ class TestBTXIdeal():
             default={"property_package": m.fs.properties,
                      "has_boilup_ratio": True})
 
+        # Fix the reboiler variables
+        m.fs.unit.boilup_ratio.fix(1)
+
+        # Fix the inputs (typically this will be the outlet liquid from the
+        # bottom tray)
+        m.fs.unit.inlet.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.inlet.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.inlet.temperature.fix(363)
+        m.fs.unit.inlet.pressure.fix(101325)
+
         return m
 
-    @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, btx_ftpz, btx_fctp):
 
@@ -144,43 +165,25 @@ class TestBTXIdeal():
 
     @pytest.mark.unit
     def test_dof(self, btx_ftpz, btx_fctp):
-
-        # Fix the reboiler variables
-        btx_ftpz.fs.unit.boilup_ratio.fix(1)
-
-        # Fix the inputs (typically this will be the outlet liquid from the
-        # bottom tray)
-        btx_ftpz.fs.unit.inlet.flow_mol.fix(1)
-        btx_ftpz.fs.unit.inlet.temperature.fix(363)
-        btx_ftpz.fs.unit.inlet.pressure.fix(101325)
-        btx_ftpz.fs.unit.inlet.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.inlet.mole_frac_comp[0, "toluene"].fix(0.5)
-
         assert degrees_of_freedom(btx_ftpz) == 0
-
-        # Fix the reboiler variables
-        btx_fctp.fs.unit.boilup_ratio.fix(1)
-
-        # Fix the inputs (typically this will be the outlet liquid from the
-        # bottom tray)
-        btx_fctp.fs.unit.inlet.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.inlet.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.inlet.temperature.fix(363)
-        btx_fctp.fs.unit.inlet.pressure.fix(101325)
-
         assert degrees_of_freedom(btx_fctp) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
+    @pytest.mark.component
+    def test_units_FTPz(self, btx_ftpz, btx_fctp):
+        assert_units_consistent(btx_ftpz)
+
+    @pytest.mark.component
+    def test_units_FcTP(self, btx_fctp):
+        assert_units_consistent(btx_fctp)
+
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, btx_ftpz, btx_fctp):
         initialization_tester(btx_ftpz)
         initialization_tester(btx_fctp)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, btx_ftpz, btx_fctp):
         results = solver.solve(btx_ftpz)
 
@@ -196,10 +199,8 @@ class TestBTXIdeal():
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, btx_ftpz, btx_fctp):
         # Bottoms port
         assert (pytest.approx(0.5, abs=1e-3) ==
@@ -217,9 +218,11 @@ class TestBTXIdeal():
         assert (pytest.approx(0.5, abs=1e-3) ==
                 value(btx_ftpz.fs.unit.vapor_reboil.flow_mol[0]))
         assert (pytest.approx(0.6108, abs=1e-3) ==
-                value(btx_ftpz.fs.unit.vapor_reboil.mole_frac_comp[0, "benzene"]))
+                value(btx_ftpz.fs.unit.vapor_reboil.mole_frac_comp[
+                    0, "benzene"]))
         assert (pytest.approx(0.3892, abs=1e-3) ==
-                value(btx_ftpz.fs.unit.vapor_reboil.mole_frac_comp[0, "toluene"]))
+                value(btx_ftpz.fs.unit.vapor_reboil.mole_frac_comp[
+                    0, "toluene"]))
         assert (pytest.approx(368.728, abs=1e-2) ==
                 value(btx_ftpz.fs.unit.vapor_reboil.temperature[0]))
         assert (pytest.approx(101325, abs=1e-3) ==
@@ -243,9 +246,11 @@ class TestBTXIdeal():
 
         # Vapor reboil port
         assert (pytest.approx(0.3054, abs=1e-3) ==
-                value(btx_fctp.fs.unit.vapor_reboil.flow_mol_comp[0, "benzene"]))
+                value(btx_fctp.fs.unit.vapor_reboil.flow_mol_comp[
+                    0, "benzene"]))
         assert (pytest.approx(0.1946, abs=1e-3) ==
-                value(btx_fctp.fs.unit.vapor_reboil.flow_mol_comp[0, "toluene"]))
+                value(btx_fctp.fs.unit.vapor_reboil.flow_mol_comp[
+                    0, "toluene"]))
         assert (pytest.approx(368.728, abs=1e-2) ==
                 value(btx_fctp.fs.unit.vapor_reboil.temperature[0]))
         assert (pytest.approx(101325, abs=1e-3) ==
@@ -255,10 +260,8 @@ class TestBTXIdeal():
         assert (pytest.approx(16926.5, rel=1e-4) ==
                 value(btx_fctp.fs.unit.heat_duty[0]))
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_conservation(self, btx_ftpz, btx_fctp):
         assert abs(value(btx_ftpz.fs.unit.inlet.flow_mol[0] -
                          (btx_ftpz.fs.unit.bottoms.flow_mol[0] +

--- a/idaes/generic_models/unit_models/distillation/tests/test_total_condenser.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_total_condenser.py
@@ -19,12 +19,12 @@ Author: Jaffer Ghouse
 import pytest
 from pyomo.environ import (ConcreteModel, TerminationCondition,
                            SolverStatus, value)
+from pyomo.util.check_units import assert_units_consistent
 
-from idaes.core import (FlowsheetBlock, MaterialBalanceType, EnergyBalanceType,
-                        MomentumBalanceType)
+from idaes.core import FlowsheetBlock, MaterialBalanceType, EnergyBalanceType
 from idaes.generic_models.unit_models.distillation import Condenser
-from idaes.generic_models.unit_models.distillation.condenser import CondenserType, \
-    TemperatureSpec
+from idaes.generic_models.unit_models.distillation.condenser import \
+    CondenserType, TemperatureSpec
 from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VLE \
     import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom, \
@@ -75,6 +75,17 @@ class TestBTXIdeal(object):
                      "condenser_type": CondenserType.totalCondenser,
                      "temperature_spec": TemperatureSpec.atBubblePoint})
 
+        # Fix the total condenser variables (FTPz)
+        m.fs.unit.reflux_ratio.fix(1)
+        m.fs.unit.condenser_pressure.fix(101325)
+
+        # Fix the inputs (typically this will be the vapor from the top tray)
+        m.fs.unit.inlet.flow_mol.fix(1)
+        m.fs.unit.inlet.temperature.fix(375)
+        m.fs.unit.inlet.pressure.fix(101325)
+        m.fs.unit.inlet.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.inlet.mole_frac_comp[0, "toluene"].fix(0.5)
+
         return m
 
     @pytest.fixture(scope="class")
@@ -93,9 +104,18 @@ class TestBTXIdeal(object):
                      "condenser_type": CondenserType.totalCondenser,
                      "temperature_spec": TemperatureSpec.atBubblePoint})
 
+        # Fix the total condenser variables (FcTP)
+        m.fs.unit.reflux_ratio.fix(1)
+        m.fs.unit.condenser_pressure.fix(101325)
+
+        # Fix the inputs (typically the outlet vapor from the top tray)
+        m.fs.unit.inlet.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.inlet.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.inlet.temperature.fix(375)
+        m.fs.unit.inlet.pressure.fix(101325)
+
         return m
 
-    @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, btx_ftpz, btx_fctp):
         assert hasattr(btx_ftpz.fs.unit, "reflux_ratio")
@@ -151,43 +171,25 @@ class TestBTXIdeal(object):
 
     @pytest.mark.unit
     def test_dof(self, btx_ftpz, btx_fctp):
-
-        # Fix the total condenser variables (FTPz)
-        btx_ftpz.fs.unit.reflux_ratio.fix(1)
-        btx_ftpz.fs.unit.condenser_pressure.fix(101325)
-
-        # Fix the inputs (typically this will be the vapor from the top tray)
-        btx_ftpz.fs.unit.inlet.flow_mol.fix(1)
-        btx_ftpz.fs.unit.inlet.temperature.fix(375)
-        btx_ftpz.fs.unit.inlet.pressure.fix(101325)
-        btx_ftpz.fs.unit.inlet.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.inlet.mole_frac_comp[0, "toluene"].fix(0.5)
-
         assert degrees_of_freedom(btx_ftpz) == 0
-
-        # Fix the total condenser variables (FcTP)
-        btx_fctp.fs.unit.reflux_ratio.fix(1)
-        btx_fctp.fs.unit.condenser_pressure.fix(101325)
-
-        # Fix the inputs (typically this will be the outlet vapor from the top tray)
-        btx_fctp.fs.unit.inlet.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.inlet.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.inlet.temperature.fix(375)
-        btx_fctp.fs.unit.inlet.pressure.fix(101325)
-
         assert degrees_of_freedom(btx_fctp) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
+    @pytest.mark.component
+    def test_units_FTPz(self, btx_ftpz, btx_fctp):
+        assert_units_consistent(btx_ftpz)
+
+    @pytest.mark.component
+    def test_units_FcTP(self, btx_fctp):
+        assert_units_consistent(btx_fctp)
+
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, btx_ftpz, btx_fctp):
         initialization_tester(btx_ftpz)
         initialization_tester(btx_fctp)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, btx_ftpz, btx_fctp):
         results = solver.solve(btx_ftpz)
 
@@ -203,10 +205,8 @@ class TestBTXIdeal(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, btx_ftpz, btx_fctp):
         # Reflux port
         assert (pytest.approx(0.4999, abs=1e-3) ==
@@ -224,9 +224,11 @@ class TestBTXIdeal(object):
         assert (pytest.approx(0.4999, abs=1e-3) ==
                 value(btx_ftpz.fs.unit.distillate.flow_mol[0]))
         assert (pytest.approx(0.5, abs=1e-3) ==
-                value(btx_ftpz.fs.unit.distillate.mole_frac_comp[0, "benzene"]))
+                value(btx_ftpz.fs.unit.distillate.mole_frac_comp[
+                    0, "benzene"]))
         assert (pytest.approx(0.5, abs=1e-3) ==
-                value(btx_ftpz.fs.unit.distillate.mole_frac_comp[0, "toluene"]))
+                value(btx_ftpz.fs.unit.distillate.mole_frac_comp[
+                    0, "toluene"]))
         assert (pytest.approx(365.347, abs=1e-3) ==
                 value(btx_ftpz.fs.unit.distillate.temperature[0]))
         assert (pytest.approx(101325, abs=1e-3) ==
@@ -260,10 +262,8 @@ class TestBTXIdeal(object):
         assert (pytest.approx(-33711.295, rel=1e-4) ==
                 value(btx_fctp.fs.unit.heat_duty[0]))
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_conservation(self, btx_ftpz, btx_fctp):
         assert abs(value(btx_ftpz.fs.unit.inlet.flow_mol[0] -
                          (btx_ftpz.fs.unit.reflux.flow_mol[0] +

--- a/idaes/generic_models/unit_models/distillation/tests/test_tray_column.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_tray_column.py
@@ -18,6 +18,7 @@ Author: Jaffer Ghouse
 import pytest
 from pyomo.environ import (ConcreteModel, TerminationCondition,
                            SolverStatus, value)
+from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
 from idaes.generic_models.unit_models.distillation import TrayColumn
@@ -102,8 +103,6 @@ class TestBTXIdeal():
 
         m.fs.unit.reboiler.boilup_ratio.fix(1.3)
 
-        assert degrees_of_freedom(m.fs.unit) == 0
-
         return m
 
     @pytest.fixture(scope="class")
@@ -138,8 +137,6 @@ class TestBTXIdeal():
 
         m.fs.unit.reboiler.boilup_ratio.fix(1.3)
 
-        assert degrees_of_freedom(m) == 0
-
         return m
 
     @pytest.mark.unit
@@ -164,13 +161,25 @@ class TestBTXIdeal():
         assert hasattr(btx_fctp.fs.unit, "rectification_section")
         assert hasattr(btx_fctp.fs.unit, "stripping_section")
 
-    @pytest.mark.solver
+    @pytest.mark.unit
+    def test_dof(self, btx_ftpz, btx_fctp):
+        assert degrees_of_freedom(btx_ftpz.fs.unit) == 0
+        assert degrees_of_freedom(btx_fctp.fs.unit) == 0
+
+    @pytest.mark.component
+    def test_units_FTPz(self, btx_ftpz, btx_fctp):
+        assert_units_consistent(btx_ftpz)
+
+    @pytest.mark.component
+    def test_units_FcTP(self, btx_fctp):
+        assert_units_consistent(btx_fctp)
+
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, btx_ftpz, btx_fctp):
         initialization_tester(btx_ftpz)
         initialization_tester(btx_fctp)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, btx_ftpz, btx_fctp):
@@ -186,7 +195,6 @@ class TestBTXIdeal():
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, btx_ftpz, btx_fctp):
@@ -282,12 +290,9 @@ class TestBTXIdealGeneric():
 
         m.fs.unit.reboiler.boilup_ratio.fix(1.3)
 
-        assert degrees_of_freedom(m) == 0
-
         return m
 
     @pytest.mark.unit
-    @pytest.mark.generic
     def test_build(self, btx_ftpz_generic):
         assert len(btx_ftpz_generic.fs.unit.config) == 12
 
@@ -301,14 +306,19 @@ class TestBTXIdealGeneric():
 
         assert len(btx_ftpz_generic.fs.unit.config) == 12
 
-    @pytest.mark.solver
-    @pytest.mark.generic
+    @pytest.mark.unit
+    def test_dof(self, btx_ftpz_generic):
+        assert degrees_of_freedom(btx_ftpz_generic) == 0
+
+    @pytest.mark.component
+    def test_units_FTPz(self, btx_ftpz_generic):
+        assert_units_consistent(btx_ftpz_generic)
+
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, btx_ftpz_generic):
         initialization_tester(btx_ftpz_generic)
 
-    @pytest.mark.solver
-    @pytest.mark.generic
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, btx_ftpz_generic):
@@ -318,15 +328,14 @@ class TestBTXIdealGeneric():
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
-    @pytest.mark.generic
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, btx_ftpz_generic):
 
         # Distillate port - btx_ftpz
         assert (pytest.approx(49.28, rel=1e-2) ==
-                value(btx_ftpz_generic.fs.unit.condenser.distillate.flow_mol[0]))
+                value(
+                    btx_ftpz_generic.fs.unit.condenser.distillate.flow_mol[0]))
         assert (pytest.approx(0.8784, rel=1e-2) ==
                 value(btx_ftpz_generic.fs.unit.condenser.
                       distillate.mole_frac_comp[0, "benzene"]))

--- a/idaes/generic_models/unit_models/distillation/tests/test_tray_side_liq_draw.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_tray_side_liq_draw.py
@@ -16,17 +16,16 @@ Tests for conventional tray unit model (no feed, has liq side draws).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value)
+from pyomo.environ import (
+    ConcreteModel, TerminationCondition, SolverStatus, value)
+from pyomo.util.check_units import assert_units_consistent
 
-from idaes.core import (FlowsheetBlock, MaterialBalanceType, EnergyBalanceType,
-                        MomentumBalanceType)
+from idaes.core import FlowsheetBlock
 from idaes.generic_models.unit_models.distillation import Tray
 from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VLE \
     import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom, \
-    number_variables, number_total_constraints, number_unused_variables, \
-    fixed_variables_set, activated_constraints_set
+    number_variables, number_total_constraints, number_unused_variables
 from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
 from idaes.core.util import get_solver
@@ -69,6 +68,25 @@ class TestBTXIdeal():
                                   "has_liquid_side_draw": True,
                                   "has_heat_transfer": True,
                                   "has_pressure_change": True})
+
+        # Set inputs
+        m.fs.unit.liq_in.flow_mol.fix(1)
+        m.fs.unit.liq_in.temperature.fix(369)
+        m.fs.unit.liq_in.pressure.fix(101325)
+        m.fs.unit.liq_in.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.liq_in.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.vap_in.flow_mol.fix(1)
+        m.fs.unit.vap_in.temperature.fix(372)
+        m.fs.unit.vap_in.pressure.fix(101325)
+        m.fs.unit.vap_in.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.vap_in.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.heat_duty.fix(0)
+
+        m.fs.unit.liq_side_sf.fix(0.5)
+
         return m
 
     @pytest.fixture(scope="class")
@@ -85,9 +103,24 @@ class TestBTXIdeal():
                                   "has_liquid_side_draw": True,
                                   "has_heat_transfer": True,
                                   "has_pressure_change": True})
+
+        # Set inputs
+        m.fs.unit.liq_in.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.liq_in.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.liq_in.temperature.fix(369)
+        m.fs.unit.liq_in.pressure.fix(101325)
+
+        m.fs.unit.vap_in.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.vap_in.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.vap_in.temperature.fix(372)
+        m.fs.unit.vap_in.pressure.fix(101325)
+
+        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.heat_duty.fix(0)
+        m.fs.unit.liq_side_sf.fix(0.5)
+
         return m
 
-    @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, btx_ftpz, btx_fctp):
         # General build
@@ -190,55 +223,25 @@ class TestBTXIdeal():
 
     @pytest.mark.unit
     def test_dof(self, btx_ftpz, btx_fctp):
-
-        # Set inputs
-        btx_ftpz.fs.unit.liq_in.flow_mol.fix(1)
-        btx_ftpz.fs.unit.liq_in.temperature.fix(369)
-        btx_ftpz.fs.unit.liq_in.pressure.fix(101325)
-        btx_ftpz.fs.unit.liq_in.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.liq_in.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.vap_in.flow_mol.fix(1)
-        btx_ftpz.fs.unit.vap_in.temperature.fix(372)
-        btx_ftpz.fs.unit.vap_in.pressure.fix(101325)
-        btx_ftpz.fs.unit.vap_in.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.vap_in.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.deltaP.fix(0)
-        btx_ftpz.fs.unit.heat_duty.fix(0)
-
-        btx_ftpz.fs.unit.liq_side_sf.fix(0.5)
-
         assert degrees_of_freedom(btx_ftpz.fs.unit) == 0
-
-        # Set inputs
-        btx_fctp.fs.unit.liq_in.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.liq_in.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.liq_in.temperature.fix(369)
-        btx_fctp.fs.unit.liq_in.pressure.fix(101325)
-
-        btx_fctp.fs.unit.vap_in.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.vap_in.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.vap_in.temperature.fix(372)
-        btx_fctp.fs.unit.vap_in.pressure.fix(101325)
-
-        btx_fctp.fs.unit.deltaP.fix(0)
-        btx_fctp.fs.unit.heat_duty.fix(0)
-        btx_fctp.fs.unit.liq_side_sf.fix(0.5)
-
         assert degrees_of_freedom(btx_fctp.fs.unit) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
+    @pytest.mark.component
+    def test_units_FTPz(self, btx_ftpz, btx_fctp):
+        assert_units_consistent(btx_ftpz)
+
+    @pytest.mark.component
+    def test_units_FcTP(self, btx_fctp):
+        assert_units_consistent(btx_fctp)
+
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, btx_ftpz, btx_fctp):
         initialization_tester(btx_ftpz)
         initialization_tester(btx_fctp)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, btx_ftpz, btx_fctp):
 
         results = solver.solve(btx_ftpz)
@@ -255,10 +258,8 @@ class TestBTXIdeal():
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, btx_ftpz, btx_fctp):
 
         # liq_out port
@@ -277,9 +278,11 @@ class TestBTXIdeal():
         assert (pytest.approx(0.23168, abs=1e-3) ==
                 value(btx_ftpz.fs.unit.liq_side_draw.flow_mol[0]))
         assert (pytest.approx(0.33313, abs=1e-3) ==
-                value(btx_ftpz.fs.unit.liq_side_draw.mole_frac_comp[0, "benzene"]))
+                value(btx_ftpz.fs.unit.liq_side_draw.mole_frac_comp[
+                    0, "benzene"]))
         assert (pytest.approx(0.66686, abs=1e-3) ==
-                value(btx_ftpz.fs.unit.liq_side_draw.mole_frac_comp[0, "toluene"]))
+                value(btx_ftpz.fs.unit.liq_side_draw.mole_frac_comp[
+                    0, "toluene"]))
         assert (pytest.approx(370.567, abs=1e-3) ==
                 value(btx_ftpz.fs.unit.liq_side_draw.temperature[0]))
         assert (pytest.approx(101325, abs=1e-3) ==
@@ -309,9 +312,11 @@ class TestBTXIdeal():
 
         # side liq_out port
         assert (pytest.approx(0.07717, abs=1e-3) ==
-                value(btx_fctp.fs.unit.liq_side_draw.flow_mol_comp[0, "benzene"]))
+                value(btx_fctp.fs.unit.liq_side_draw.flow_mol_comp[
+                    0, "benzene"]))
         assert (pytest.approx(0.15449, abs=1e-3) ==
-                value(btx_fctp.fs.unit.liq_side_draw.flow_mol_comp[0, "toluene"]))
+                value(btx_fctp.fs.unit.liq_side_draw.flow_mol_comp[
+                    0, "toluene"]))
         assert (pytest.approx(370.567, abs=1e-3) ==
                 value(btx_fctp.fs.unit.liq_side_draw.temperature[0]))
         assert (pytest.approx(101325, abs=1e-3) ==

--- a/idaes/generic_models/unit_models/distillation/tests/test_tray_side_vap_draw.py
+++ b/idaes/generic_models/unit_models/distillation/tests/test_tray_side_vap_draw.py
@@ -16,17 +16,16 @@ Tests for conventional tray unit model (no feed, has vap side draw).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value)
+from pyomo.environ import (
+    ConcreteModel, TerminationCondition, SolverStatus, value)
+from pyomo.util.check_units import assert_units_consistent
 
-from idaes.core import (FlowsheetBlock, MaterialBalanceType, EnergyBalanceType,
-                        MomentumBalanceType)
+from idaes.core import FlowsheetBlock
 from idaes.generic_models.unit_models.distillation import Tray
 from idaes.generic_models.properties.activity_coeff_models.\
     BTX_activity_coeff_VLE import BTXParameterBlock
 from idaes.core.util.model_statistics import degrees_of_freedom, \
-    number_variables, number_total_constraints, number_unused_variables, \
-    fixed_variables_set, activated_constraints_set
+    number_variables, number_total_constraints, number_unused_variables
 from idaes.core.util.testing import \
     PhysicalParameterTestBlock, initialization_tester
 from idaes.core.util import get_solver
@@ -70,6 +69,25 @@ class TestBTXIdeal():
                                   "has_vapor_side_draw": True,
                                   "has_heat_transfer": True,
                                   "has_pressure_change": True})
+
+        # Set inputs
+        m.fs.unit.liq_in.flow_mol.fix(1)
+        m.fs.unit.liq_in.temperature.fix(369)
+        m.fs.unit.liq_in.pressure.fix(101325)
+        m.fs.unit.liq_in.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.liq_in.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.vap_in.flow_mol.fix(1)
+        m.fs.unit.vap_in.temperature.fix(372)
+        m.fs.unit.vap_in.pressure.fix(101325)
+        m.fs.unit.vap_in.mole_frac_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.vap_in.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.heat_duty.fix(0)
+
+        m.fs.unit.vap_side_sf.fix(0.5)
+
         return m
 
     @pytest.fixture(scope="class")
@@ -86,9 +104,24 @@ class TestBTXIdeal():
                                   "has_vapor_side_draw": True,
                                   "has_heat_transfer": True,
                                   "has_pressure_change": True})
+
+        # Set inputs
+        m.fs.unit.liq_in.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.liq_in.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.liq_in.temperature.fix(369)
+        m.fs.unit.liq_in.pressure.fix(101325)
+
+        m.fs.unit.vap_in.flow_mol_comp[0, "benzene"].fix(0.5)
+        m.fs.unit.vap_in.flow_mol_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.vap_in.temperature.fix(372)
+        m.fs.unit.vap_in.pressure.fix(101325)
+
+        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.heat_duty.fix(0)
+        m.fs.unit.vap_side_sf.fix(0.5)
+
         return m
 
-    @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, btx_ftpz, btx_fctp):
         # General build
@@ -191,55 +224,25 @@ class TestBTXIdeal():
 
     @pytest.mark.unit
     def test_dof(self, btx_ftpz, btx_fctp):
-
-        # Set inputs
-        btx_ftpz.fs.unit.liq_in.flow_mol.fix(1)
-        btx_ftpz.fs.unit.liq_in.temperature.fix(369)
-        btx_ftpz.fs.unit.liq_in.pressure.fix(101325)
-        btx_ftpz.fs.unit.liq_in.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.liq_in.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.vap_in.flow_mol.fix(1)
-        btx_ftpz.fs.unit.vap_in.temperature.fix(372)
-        btx_ftpz.fs.unit.vap_in.pressure.fix(101325)
-        btx_ftpz.fs.unit.vap_in.mole_frac_comp[0, "benzene"].fix(0.5)
-        btx_ftpz.fs.unit.vap_in.mole_frac_comp[0, "toluene"].fix(0.5)
-
-        btx_ftpz.fs.unit.deltaP.fix(0)
-        btx_ftpz.fs.unit.heat_duty.fix(0)
-
-        btx_ftpz.fs.unit.vap_side_sf.fix(0.5)
-
         assert degrees_of_freedom(btx_ftpz.fs.unit) == 0
-
-        # Set inputs
-        btx_fctp.fs.unit.liq_in.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.liq_in.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.liq_in.temperature.fix(369)
-        btx_fctp.fs.unit.liq_in.pressure.fix(101325)
-
-        btx_fctp.fs.unit.vap_in.flow_mol_comp[0, "benzene"].fix(0.5)
-        btx_fctp.fs.unit.vap_in.flow_mol_comp[0, "toluene"].fix(0.5)
-        btx_fctp.fs.unit.vap_in.temperature.fix(372)
-        btx_fctp.fs.unit.vap_in.pressure.fix(101325)
-
-        btx_fctp.fs.unit.deltaP.fix(0)
-        btx_fctp.fs.unit.heat_duty.fix(0)
-        btx_fctp.fs.unit.vap_side_sf.fix(0.5)
-
         assert degrees_of_freedom(btx_fctp.fs.unit) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
+    @pytest.mark.component
+    def test_units_FTPz(self, btx_ftpz, btx_fctp):
+        assert_units_consistent(btx_ftpz)
+
+    @pytest.mark.component
+    def test_units_FcTP(self, btx_fctp):
+        assert_units_consistent(btx_fctp)
+
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, btx_ftpz, btx_fctp):
         initialization_tester(btx_ftpz)
         initialization_tester(btx_fctp)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, btx_ftpz, btx_fctp):
 
         results = solver.solve(btx_ftpz)
@@ -256,10 +259,8 @@ class TestBTXIdeal():
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, btx_ftpz, btx_fctp):
 
         # liq_out port


### PR DESCRIPTION
## Fixes #344


## Summary/Motivation:
As part of testing for issue #344, it was revealed that the distillation tests were marking some tests using solvers with the `unit` mark. This PR standardises the use of pytest marks in the distillation tests, cleans up some deprecated marks and adds unit consistency checks.

## Changes proposed in this PR:
- Marks all tests involving a solver with the `component` mark
- To make the above work, moves setting of degrees of freedom to the fixture definition
- Removes older pytest marks that are no longer in use
- Adds unit consistency checks to all cases

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
