### PR TITLE
Command line config tools

### DIFF
--- a/docs/user_guide/configuration.rst
+++ b/docs/user_guide/configuration.rst
@@ -14,79 +14,14 @@ Some configuration options can be changed after importing ``idaes`` by calling
 
 Configuration files are in `JSON format <https://www.json.org/json-en.html>`_.
 The default configuration is shown below and can be used as a template to create
-new configuration files. This is the configuration used by IDAES if nothing else
-is provided.
+new configuration files. To get the IDAES default configuration the command
+``idaes config-write --file idaes.conf --default`` can be used.
 
-.. code-block:: json
+Command Line Tools
+------------------
 
-  {
-      "use_idaes_solvers":true,
-      "logger_capture_solver":true,
-      "logger_tags":[
-          "framework",
-          "model",
-          "flowsheet",
-          "unit",
-          "control_volume",
-          "properties",
-          "reactions"
-      ],
-      "valid_logger_tags":[
-          "framework",
-          "model",
-          "flowsheet",
-          "unit",
-          "control_volume",
-          "properties",
-          "reactions",
-          "ui"
-      ],
-      "ipopt":{
-          "options":{
-              "nlp_scaling_method":"gradient-based"
-          }
-      },
-      "logging":{
-          "version":1,
-          "disable_existing_loggers":false,
-          "formatters":{
-              "default_format":{
-                  "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-                  "datefmt": "%Y-%m-%d %H:%M:%S"
-              }
-          },
-          "handlers":{
-              "console":{
-                  "class": "logging.StreamHandler",
-                  "formatter": "default_format",
-                  "stream": "ext://sys.stdout"
-              }
-          },
-          "loggers":{
-              "idaes":{
-                  "level": "INFO",
-                  "propagate": true,
-                  "handlers": ["console"]
-              },
-              "idaes.solve":{
-                  "propagate": false,
-                  "level": "INFO",
-                  "handlers": ["console"]
-              },
-              "idaes.init":{
-                  "propagate": false,
-                  "level": "INFO",
-                  "handlers": ["console"]
-              },
-              "idaes.model":{
-                  "propagate":false,
-                  "level": "INFO",
-                  "handlers": ["console"]
-              }
-          }
-      }
-  }
-
+See ``idaes --help`` for information about command line configuration tools.
+These tools help manage configuration files.
 
 Global Configuration Files
 --------------------------

--- a/idaes/__init__.py
+++ b/idaes/__init__.py
@@ -28,6 +28,7 @@ _local_config_file = "idaes.conf"
 
 # Create the general IDAES configuration block, with default config
 cfg = config._new_idaes_config_block()
+config.reconfig(cfg)
 # read global config and overwrite provided config options
 config.read_config(_global_config_file, cfg=cfg)
 # read local config and overwrite provided config options

--- a/idaes/commands/__init__.py
+++ b/idaes/commands/__init__.py
@@ -10,10 +10,14 @@
 # license information, respectively. Both files are also available online
 # at the URL "https://github.com/IDAES/idaes-pse".
 ##############################################################################
-import pkgutil
+
+import time
+
+_command_import_start_time = time.time()
 
 from idaes.commands.base import command_base as cb
 
+import pkgutil
 # import all the commands
 for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
     if module_name == "base":
@@ -22,3 +26,5 @@ for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
         pass
     else:
         loader.find_module(module_name).load_module(module_name)
+
+_command_import_total_time = time.time() - _command_import_start_time

--- a/idaes/commands/base.py
+++ b/idaes/commands/base.py
@@ -22,7 +22,7 @@ import logging
 # separate command logging from normal IDAES logging
 _log = logging.getLogger("idaes.commands")
 _h = logging.StreamHandler()
-_h.setFormatter(logging.Formatter("%(asctime)s %(levelname)-7s %(name)s: %(message)s"))
+_h.setFormatter(logging.Formatter("%(levelname)-7s %(name)s: %(message)s"))
 _log.addHandler(_h)
 _log.propagate = False
 
@@ -103,6 +103,10 @@ def copyright():
 """
     )
 
+@command_base.command(help="Show how long it takes to imoprt command modules")
+def import_time(name="import-time"):
+    from idaes.commands import _command_import_total_time
+    click.echo(f"Time: {_command_import_total_time}")
 
 if __name__ == "__main__":
     command_base()

--- a/idaes/commands/base.py
+++ b/idaes/commands/base.py
@@ -103,7 +103,7 @@ def copyright():
 """
     )
 
-@command_base.command(help="Show how long it takes to imoprt command modules")
+@command_base.command(help="Show how long it takes to import command modules")
 def import_time(name="import-time"):
     from idaes.commands import _command_import_total_time
     click.echo(f"Time: {_command_import_total_time}")

--- a/idaes/commands/config.py
+++ b/idaes/commands/config.py
@@ -10,7 +10,7 @@
 # license information, respectively. Both files are also available online
 # at the URL "https://github.com/IDAES/idaes-pse".
 ##############################################################################
-"""Commandline Utilities for Managing the IDAES Data Directory"""
+"""Commandline Utilities for Managing the IDAES Config files"""
 
 __author__ = "John Eslick"
 
@@ -95,7 +95,6 @@ def config_set(
         try:
             c = c[k]
         except KeyError:
-            print(type(c))
             if isinstance(c, pyomo.common.config.ConfigBlock):
                 c[k] = pyomo.common.config.ConfigBlock(implicit=True)
             else:

--- a/idaes/commands/config.py
+++ b/idaes/commands/config.py
@@ -1,0 +1,127 @@
+##############################################################################
+# Institute for the Design of Advanced Energy Systems Process Systems
+# Engineering Framework (IDAES PSE Framework) Copyright (c) 2018-2020, by the
+# software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
+# University Research Corporation, et al. All rights reserved.
+#
+# Please see the files COPYRIGHT.txt and LICENSE.txt for full copyright and
+# license information, respectively. Both files are also available online
+# at the URL "https://github.com/IDAES/idaes-pse".
+##############################################################################
+"""Commandline Utilities for Managing the IDAES Data Directory"""
+
+__author__ = "John Eslick"
+
+import os
+import idaes
+import click
+import json
+import pyomo.common.config
+from idaes.commands import cb
+import idaes.config as cfg
+
+@cb.command(name="config-write", help="Write the IDAES config")
+@click.option("--file", default="idaes_config.json", help="File name to write.")
+@click.option(
+    "--default", is_flag=True, help="Write the default config")
+def config_write(file, default):
+    idaes.write_config(file, default)
+    click.echo(f"Wrote config to {file}")
+
+@cb.command(name="config-file", help="Show the config file paths")
+@click.option("--global", "gbl", is_flag=True, help="Global config path")
+@click.option("--local", is_flag=True, help="Local config path")
+def config_file(gbl, local):
+    if gbl:
+        click.echo(idaes._global_config_file)
+    elif local:
+        click.echo(idaes._local_config_file)
+    else:
+        click.echo(f"global: {idaes._global_config_file}")
+        click.echo(f"local: {idaes._local_config_file}")
+
+@cb.command(name="config-set", help="Set a set a configuration option")
+@click.argument("key")
+@click.argument("value")
+@click.option("--global", "glb", is_flag=True, help="Write to global config")
+@click.option("--local", is_flag=True, help="Write to local config")
+@click.option("--file", help="Write to specified file", type=str)
+@click.option("--display", is_flag=True, help="Show new config")
+@click.option("--add", is_flag=True, help="Add to list or set")
+@click.option("--del", "dlt", is_flag=True, help="Delete from to list or set")
+@click.option(
+    "--file_as_global",
+    is_flag=True,
+    help="Testing option, alternate global config location")
+@click.option(
+    "--file_as_local",
+    is_flag=True,
+    help="Testing option, alternate local config file location")
+def config_set(
+    glb, local, key, value, file, file_as_local, file_as_global, display, add, dlt):
+    # get locations for the local and global config files
+    global_config_file = idaes._global_config_file
+    local_config_file = idaes._local_config_file
+    # for testing allow an alternate location to be used for local and global
+    # config files, to avoid messing with the real config files
+    if file_as_local:
+        local_config_file = file
+        file = None
+    if file_as_global:
+        global_config_file = file
+        file = None
+    # make sure one and only one place is specified to write to
+    if not (glb ^ local ^ bool(file)):
+        click.echo("Must specify exactly one of --global, --local, --file")
+        return
+    # if global make sure you don't pick up local config and write it back
+    if glb:
+        idaes.cfg = cfg._new_idaes_config_block()
+        idaes.read_config(global_config_file)
+        idaes.cfg.display()
+    elif local:
+        idaes.cfg = cfg._new_idaes_config_block()
+        idaes.read_config(global_config_file)
+        idaes.read_config(local_config_file)
+    idaes.cfg.display()
+    # get the config block entry
+    key = key.split(":") # use : instead of . due to logger names
+    value = value.replace("'", '"') # " expected by json but gets eaten by shell
+    value = json.loads(value)
+    c = idaes.cfg
+    for k in key[:-1]:
+        try:
+            c = c[k]
+        except KeyError:
+            print(type(c))
+            if isinstance(c, pyomo.common.config.ConfigBlock):
+                c[k] = pyomo.common.config.ConfigBlock(implicit=True)
+            else:
+                c[k] = {}
+            c = c[k]
+    # Set the config value
+    if add and isinstance(c[key[-1]], list):
+        c[key[-1]].append(value)
+    elif add and isinstance(c[key[-1]], set):
+        c[key[-1]].add(value)
+    elif dlt and isinstance(c[key[-1]], (set, list)):
+        c[key[-1]].remove(value)
+    elif dlt or add:
+        click.echo("--add or --del options must be used on a list or set")
+    else:
+        c[key[-1]] = value
+    # Write changes
+    if glb:
+        idaes.write_config(global_config_file)
+    elif local:
+        idaes.write_config(local_config_file)
+    elif file:
+        idaes.write_config(file)
+    if display:
+        idaes.cfg.display()
+
+@cb.command(name="config-display", help="Show IDAES config")
+def config_display():
+    idaes.cfg.display()

--- a/idaes/commands/convergence.py
+++ b/idaes/commands/convergence.py
@@ -22,7 +22,6 @@ import json
 import logging
 from pyomo.common.dependencies import attempt_import
 from idaes.commands import cb
-import idaes.convergence
 
 cnv = attempt_import('idaes.core.util.convergence.convergence_base')[0]
 dmf = attempt_import('idaes.dmf')[0]
@@ -43,6 +42,7 @@ _log = logging.getLogger("idaes.commands.convergence")
     help="Addtional module that registers ConvergenceEvaluation classes")
 def convergence_sample(
     evaluation_class, sample_file, number_samples, seed, convergence_module):
+    import idaes.convergence
     if convergence_module is not None:
         mod = importlib.import_module(convergence_module)
     if evaluation_class in cnv.convergence_classes:
@@ -79,6 +79,7 @@ def convergence_sample(
     help="Run only a single sample with given name")
 def convergence_eval(
     sample_file, dmf, report_file, json_file, convergence_module, single_sample):
+    import idaes.convergence
     if convergence_module is not None:
         mod = importlib.import_module(convergence_module)
     if dmf is not None:
@@ -113,6 +114,7 @@ def convergence_eval(
 @click.option('-m', '--convergence_module', default=None, type=str, required=False,
     help="Optional addtional module that registers convergence classes")
 def convergence_search(regex, convergence_module):
+    import idaes.convergence
     if convergence_module is not None:
         mod = importlib.import_module(convergence_module)
     if regex is not None:

--- a/idaes/commands/examples.py
+++ b/idaes/commands/examples.py
@@ -22,6 +22,9 @@ directory into a package called "idaes_examples".
 Options let the user choose a different version, directory, and
 whether to actually download or install.
 """
+# Pyomo utility for delayed import
+from pyomo.common.dependencies import attempt_import
+
 # stdlib
 from collections import namedtuple
 from datetime import datetime
@@ -30,7 +33,6 @@ import logging
 from operator import attrgetter
 import os
 import re
-from setuptools import setup, find_packages
 from pathlib import Path
 import shutil
 import sys
@@ -39,13 +41,15 @@ from uuid import uuid4
 from zipfile import ZipFile
 import json
 
+
 # third-party
 import click
-from nbconvert.exporters import NotebookExporter
-from nbconvert.writers import FilesWriter
-from traitlets.config import Config
-import nbformat
-import requests
+# third-party slow
+nb_exporters= attempt_import("nbconvert.exporters")[0]
+nb_writers = attempt_import("nbconvert.writers")[0]
+traitlets_config = attempt_import("traitlets.config")[0]
+nbformat = attempt_import("nbformat")[0]
+requests = attempt_import("requests")[0]
 
 # package
 from idaes.commands import cb
@@ -542,6 +546,7 @@ def install_src(version, target_dir):
     When done, name the directory back to 'src', and remove '__init__.py' files.
     Then clean up whatever cruft is left behind..
     """
+    from setuptools import setup, find_packages # import here due to slowness
     global g_egg
     orig_dir = Path(os.curdir).absolute()
     target_dir = Path(target_dir.absolute())
@@ -713,16 +718,17 @@ def strip_tags(nb: Path) -> bool:
             _log.warning(f"cannot create new notebook '{target_nb}': file exists")
             continue
         # Set up configuration for removing specially tagged cells
-        conf = Config()
+        conf = traitlets_config.Config()
         conf.TagRemovePreprocessor.remove_cell_tags = remove_tags
         conf.NotebookExporter.preprocessors = [
             # this requires the full module path
             "nbconvert.preprocessors.TagRemovePreprocessor"
         ]
         # Convert from Notebook format to Notebook format, stripping tags
-        (body, resources) = NotebookExporter(config=conf).from_filename(str(nb))
+        (body, resources) = nb_exporters.NotebookExporter(
+            config=conf).from_filename(str(nb))
         # Set up output destination
-        wrt = FilesWriter()
+        wrt = nb_writers.FilesWriter()
         wrt.build_directory = str(target_nb.parent)
         # Write stripped notebook to output file
         wrt.write(body, resources, notebook_name=target_nb.stem)

--- a/idaes/commands/tests/test_commands.py
+++ b/idaes/commands/tests/test_commands.py
@@ -659,7 +659,6 @@ def test_conf_set(runner):
         assert "ConfigDict" in str(type(idaes.cfg.ipopt_l1))
         assert "ConfigDict" in str(type(idaes.cfg.ipopt_l1.options))
         assert idaes.cfg.ipopt_l1.options.max_iter == 100
-
         if os.path.exists(fname):
             os.remove(fname)
 

--- a/idaes/commands/tests/test_commands.py
+++ b/idaes/commands/tests/test_commands.py
@@ -28,7 +28,7 @@ from click.testing import CliRunner
 import pytest
 
 # package
-from idaes.commands import examples, extensions, convergence
+from idaes.commands import examples, extensions, convergence, config
 from idaes.util.system import TemporaryDirectory
 from . import create_module_scratch, rmtree_scratch
 import idaes
@@ -606,3 +606,63 @@ def test_conv_eval(runner):
         os.remove(fname)
     if os.path.exists(fname2):
         os.remove(fname2)
+
+@pytest.mark.unit
+def test_conf_display(runner):
+    result = runner.invoke(config.config_display)
+    assert result.exit_code == 0
+
+@pytest.mark.unit
+def test_conf_file_paths(runner):
+    result = runner.invoke(config.config_file)
+    assert result.exit_code == 0
+    result = runner.invoke(config.config_file, ["--global"])
+    assert result.exit_code == 0
+    result = runner.invoke(config.config_file, ["--local"])
+    assert result.exit_code == 0
+
+@pytest.mark.unit
+def test_conf_file_paths(runner):
+    fname = os.path.join(idaes.testing_directory, "conf_test.json")
+    result = runner.invoke(config.config_write, ["--file", fname])
+    assert result.exit_code == 0
+    with open(fname, "r") as f:
+        d = json.load(f)
+        assert d["logger_capture_solver"] == True
+    if os.path.exists(fname):
+        os.remove(fname)
+
+@pytest.mark.unit
+def test_conf_set(runner):
+    fname = os.path.join(idaes.testing_directory, "conf_test.json")
+    def _tst(args):
+        result = runner.invoke(config.config_set, [
+            "logging:loggers:idaes.solver:handlers", "['console']"] + args)
+        assert result.exit_code == 0
+        with open(fname, "r") as f:
+            d = json.load(f)
+            assert len(d["logging"]["loggers"]["idaes.solver"]["handlers"]) == 1
+            assert d["logging"]["loggers"]["idaes.solver"]["handlers"][0] == 'console'
+        result = runner.invoke(config.config_set, [
+            "logging:loggers:idaes.solver:handlers", "'console'", "--del"] + args)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config_set, [
+            "logging:loggers:idaes.solver:handlers", "'console'", "--add"] + args)
+        assert result.exit_code == 0
+        with open(fname, "r") as f:
+            d = json.load(f)
+            assert len(d["logging"]["loggers"]["idaes.solver"]["handlers"]) == 1
+            assert d["logging"]["loggers"]["idaes.solver"]["handlers"][0] == 'console'
+        result = runner.invoke(config.config_set, [
+            "ipopt_l1:options:max_iter", "100"] + args)
+        assert result.exit_code == 0
+        assert "ConfigDict" in str(type(idaes.cfg.ipopt_l1))
+        assert "ConfigDict" in str(type(idaes.cfg.ipopt_l1.options))
+        assert idaes.cfg.ipopt_l1.options.max_iter == 100
+
+        if os.path.exists(fname):
+            os.remove(fname)
+
+    _tst(["--global", "--file", fname, "--file_as_global"])
+    _tst(["--local", "--file", fname, "--file_as_local"])
+    _tst(["--file", fname])

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -326,9 +326,6 @@ def _new_idaes_config_block():
             description="Solver output captured by logger?",
         ),
     )
-    #d = json.loads(default_config)
-    #cfg.set_value(d)
-    logging.config.dictConfig(cfg["logging"].value())
     return cfg
 
 
@@ -360,9 +357,7 @@ def read_config(val, cfg):
 
 def write_config(path, cfg=None):
     if cfg is None:
-        _cd = json.loads(default_config)
-        with open(path, 'w') as f:
-            json.dump(_cd, f, indent=4)
+        cfg = _new_idaes_config_block
     else:
         with open(path, 'w') as f:
             json.dump(cfg.value(), f, cls=ConfigBlockJSONEncoder, indent=4)

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -156,7 +156,63 @@ def _new_idaes_config_block():
             "logging.config.dictConfig() documentation for details.",
         ),
     )
-
+    cfg["logging"].declare(
+        "version", pyomo.common.config.ConfigValue(domain=int, default=1))
+    cfg["logging"].declare(
+        "disable_existing_loggers",
+        pyomo.common.config.ConfigValue(domain=bool, default=False))
+    cfg["logging"].declare(
+        "formatters", pyomo.common.config.ConfigBlock(implicit=True))
+    cfg["logging"]["formatters"].declare(
+        "default_format", pyomo.common.config.ConfigBlock(implicit=True))
+    cfg["logging"]["formatters"]["default_format"].declare(
+        "format",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
+    cfg["logging"]["formatters"]["default_format"].declare(
+        "datefmt",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="%Y-%m-%d %H:%M:%S"))
+    cfg["logging"].declare(
+        "handlers", pyomo.common.config.ConfigBlock(implicit=True))
+    cfg["logging"]["handlers"].declare(
+        "console", pyomo.common.config.ConfigBlock(implicit=True))
+    cfg["logging"]["handlers"]["console"].declare(
+        "class",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="logging.StreamHandler"))
+    cfg["logging"]["handlers"]["console"].declare(
+        "formatter",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="default_format"))
+    cfg["logging"]["handlers"]["console"].declare(
+        "stream",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="ext://sys.stdout"))
+    cfg["logging"].declare(
+        "loggers",
+        pyomo.common.config.ConfigValue(
+            domain=dict,
+            default={ # the period in the logger names is trouble for ConfigBlock
+                "idaes":{
+                    "level": "INFO",
+                    "propagate": True,
+                    "handlers": ["console"]
+                },
+                "idaes.solve":{
+                    "propagate": False,
+                },
+                "idaes.init":{
+                    "propagate": False,
+                },
+                "idaes.model":{
+                    "propagate":False,
+                }}))
     cfg.declare(
         "ipopt",
         pyomo.common.config.ConfigBlock(
@@ -233,7 +289,15 @@ def _new_idaes_config_block():
     cfg.declare(
         "valid_logger_tags",
         pyomo.common.config.ConfigValue(
-            default=set(),
+            default=set([
+                "framework",
+                "model",
+                "flowsheet",
+                "unit",
+                "control_volume",
+                "properties",
+                "reactions",
+                "ui"]),
             domain=set,
             description="List of valid logger tags",
         ),
@@ -242,7 +306,14 @@ def _new_idaes_config_block():
     cfg.declare(
         "logger_tags",
         pyomo.common.config.ConfigValue(
-            default=set(),
+            default=set([
+                "framework",
+                "model",
+                "flowsheet",
+                "unit",
+                "control_volume",
+                "properties",
+                "reactions"]),
             domain=set,
             description="List of logger tags to allow",
         ),
@@ -255,9 +326,9 @@ def _new_idaes_config_block():
             description="Solver output captured by logger?",
         ),
     )
-    d = json.loads(default_config)
-    cfg.set_value(d)
-    logging.config.dictConfig(cfg["logging"])
+    #d = json.loads(default_config)
+    #cfg.set_value(d)
+    logging.config.dictConfig(cfg["logging"].value())
     return cfg
 
 
@@ -294,11 +365,11 @@ def write_config(path, cfg=None):
             json.dump(_cd, f, indent=4)
     else:
         with open(path, 'w') as f:
-            json.dump(cfg.value(), f, cls=ConfigBlockJSONEncoder, indent=2)
+            json.dump(cfg.value(), f, cls=ConfigBlockJSONEncoder, indent=4)
 
 
 def reconfig(cfg):
-    logging.config.dictConfig(cfg.logging)
+    logging.config.dictConfig(cfg.logging.value())
     setup_environment(bin_directory, cfg.use_idaes_solvers)
 
 

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -357,10 +357,9 @@ def read_config(val, cfg):
 
 def write_config(path, cfg=None):
     if cfg is None:
-        cfg = _new_idaes_config_block
-    else:
-        with open(path, 'w') as f:
-            json.dump(cfg.value(), f, cls=ConfigBlockJSONEncoder, indent=4)
+        cfg = _new_idaes_config_block()
+    with open(path, 'w') as f:
+        json.dump(cfg.value(), f, cls=ConfigBlockJSONEncoder, indent=4)
 
 
 def reconfig(cfg):


### PR DESCRIPTION
Even though nobody asked for it, I put together a little utility for idaes configuration from the command line.   I also sped up the imports for the idaes command, so it doesn't run annoyingly slow.  @jsiirola I tried to move to pyomo ConfigBlocks as much as possible, but there is still a bit of an issue with logger configuration since loggers have periods in their names.  That means I have to use a dict there instead of a ConfigBlock, since ConfigBlock keys can't have periods (and I use logging.dictConfig() directly, in which keys may have periods).  @dangunter, I messed with your imports in get-examples to speed things up.  You'll probably want to take a look at that.  The main issue I had was figuring out how to mange setuptools.  I ended up just moving it in the command function call because I couldn't find another way that worked. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
