### PR TITLE
Updating pyomo to the 6.0.rc1 tag, removing PyUtilib dependency

### DIFF
--- a/docs/user_guide/logging.rst
+++ b/docs/user_guide/logging.rst
@@ -183,7 +183,7 @@ Logging Solver Output
 
 The solver output can be captured and directed to a logger using the
 ``idaes.logger.solver_log(logger, level)`` context manager, which uses
-``pyutilib.misc.capture_output()`` to temporarily redirect
+``pyomo.common.tee.capture_output()`` to temporarily redirect
 ``sys.stdout`` and ``sys.stderr`` to a string buffer.  The ``logger``
 argument is the logger to log to, and the ``level`` argument is the
 level at which records are sent to the logger. The output is logged by a

--- a/idaes/apps/caprese/nmpc.py
+++ b/idaes/apps/caprese/nmpc.py
@@ -20,7 +20,7 @@ from pyomo.environ import (
         ComponentUID,
         )
 from pyomo.util.slices import slice_component_along_sets
-from pyutilib.misc.config import ConfigDict, ConfigValue
+from pyomo.common.config import ConfigDict, ConfigValue
 
 from idaes.apps.caprese.dynamic_block import (
         DynamicBlock,

--- a/idaes/apps/matopt/opt/mat_modeling.py
+++ b/idaes/apps/matopt/opt/mat_modeling.py
@@ -2534,7 +2534,7 @@ class MatOptModel(object):
             (``Design``/list<``Design``>) Optimal designs.
 
         Raises:
-            ``pyutilib.ApplicationError`` if MatOpt can not find usable solver (CPLEX or NEOS-CPLEX)
+            ``pyomo.common.errors.ApplicationError`` if MatOpt can not find usable solver (CPLEX or NEOS-CPLEX)
 
         See ``MatOptModel.optimize`` method for details.
         """
@@ -2551,7 +2551,7 @@ class MatOptModel(object):
             (``Design``/list<``Design``>) Optimal designs.
 
         Raises:
-            ``pyutilib.ApplicationError`` if MatOpt can not find usable solver (CPLEX or NEOS-CPLEX)
+            ``pyomo.common.errors.ApplicationError`` if MatOpt can not find usable solver (CPLEX or NEOS-CPLEX)
 
         See ``MatOptModel.optimize`` method for details.
         """
@@ -2595,7 +2595,7 @@ class MatOptModel(object):
             (``Design``/list<``Design``>) Optimal design or designs, depending on the number of solutions requested by argument ``nSolns``.
 
         Raises:
-            ``pyutilib.ApplicationError`` if MatOpt can not find usable solver (CPLEX or NEOS-CPLEX)
+            ``pyomo.common.errors.ApplicationError`` if MatOpt can not find usable solver (CPLEX or NEOS-CPLEX)
         """
         if nSolns > 1:
             return self.populate(func, sense=sense, nSolns=nSolns,
@@ -2646,7 +2646,7 @@ class MatOptModel(object):
             (list<``Design``>) A list of optimal Designs in order of decreasing optimality.
 
         Raises:
-            ``pyutilib.ApplicationError`` if MatOpt can not find usable solver (CPLEX or NEOS-CPLEX)
+            ``pyomo.common.errors.ApplicationError`` if MatOpt can not find usable solver (CPLEX or NEOS-CPLEX)
         """
         self._pyomo_m = self._make_pyomo_model(func, sense)
         self._pyomo_m.iSolns = Set(initialize=list(range(nSolns)))

--- a/idaes/core/plugins/simple_equality_eliminator.py
+++ b/idaes/core/plugins/simple_equality_eliminator.py
@@ -15,7 +15,7 @@ __author__ = "John Eslick"
 
 """Transformation to replace variables with other variables."""
 import pyomo.environ as pyo
-from pyomo.core.base.plugin import TransformationFactory
+from pyomo.core.base.transformation import TransformationFactory
 from pyomo.core.plugins.transform.hierarchy import NonIsomorphicTransformation
 from pyomo.core.expr import current as EXPR
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr

--- a/idaes/core/plugins/variable_replace.py
+++ b/idaes/core/plugins/variable_replace.py
@@ -14,7 +14,7 @@
 __author__ = "John Eslick"
 
 """Transformation to replace variables with other variables."""
-from pyomo.core.base.plugin import TransformationFactory
+from pyomo.core.base.transformation import TransformationFactory
 from pyomo.core.plugins.transform.hierarchy import NonIsomorphicTransformation
 from pyomo.core.expr import current as EXPR
 from pyomo.common.config import ConfigBlock, ConfigValue, add_docstring_list

--- a/idaes/core/util/convergence/convergence_base.py
+++ b/idaes/core/util/convergence/convergence_base.py
@@ -67,8 +67,8 @@ import numpy as np
 import sys
 from io import StringIO
 # pyomo
-import pyutilib.services
-from pyutilib.misc import capture_output
+from pyomo.common.tempfiles import TempfileManager
+from pyomo.common.tee import capture_output
 from pyomo.core import Param, Var
 from pyomo.opt import TerminationCondition
 from pyomo.common.log import LoggingIntercept
@@ -247,8 +247,8 @@ def _run_ipopt_with_stats(model, solver, max_iter=500, max_cpu_time=120):
     """
     # ToDo: Check that the "solver" is, in fact, IPOPT
 
-    pyutilib.services.TempfileManager.push()
-    tempfile = pyutilib.services.TempfileManager.create_tempfile(
+    TempfileManager.push()
+    tempfile = TempfileManager.create_tempfile(
                         suffix='ipopt_out',
                         text=True)
     opts = {'output_file': tempfile,
@@ -277,7 +277,7 @@ def _run_ipopt_with_stats(model, solver, max_iter=500, max_cpu_time=120):
                 tokens = line.split()
                 time += float(tokens[8])
 
-    pyutilib.services.TempfileManager.pop(remove=True)
+    TempfileManager.pop(remove=True)
     return status_obj, solved, iters, time
 
 

--- a/idaes/core/util/convergence/tests/test_convergence.py
+++ b/idaes/core/util/convergence/tests/test_convergence.py
@@ -15,6 +15,7 @@ Tests for the convergence testing module
 
 Author: Carl Laird
 """
+import json
 import pytest
 import os
 import os.path

--- a/idaes/core/util/convergence/tests/test_convergence.py
+++ b/idaes/core/util/convergence/tests/test_convergence.py
@@ -18,9 +18,9 @@ Author: Carl Laird
 import pytest
 import os
 import os.path
-from pyutilib.misc import compare_json_files
 import pyomo.environ as pe
 from pyomo.common.fileutils import this_file_dir
+from pyomo.common.unittest import assertStructuredAlmostEqual
 import idaes.core.util.convergence.convergence_base as cb
 import idaes
 
@@ -55,9 +55,12 @@ def test_convergence_evaluation_specification_file_fixedvar_mutableparam():
     baseline_fname = os.path.join(
             currdir,
             'ceval_fixedvar_mutableparam.3.42.baseline.json')
-    compare_json_files(baseline_fname=baseline_fname,
-                       output_fname=fname,
-                       tolerance=1e-8)
+
+    with open(fname) as FILE:
+        test = json.load(FILE)
+    with open(baseline_fname) as FILE:
+        baseline = json.load(FILE)
+    assertStructuredAlmostEqual(baseline, test, abstol=1e-8)
 
     if os.path.exists(fname):
         os.remove(fname)
@@ -78,9 +81,12 @@ def test_convergence_evaluation_specification_file_unfixedvar_mutableparam():
     baseline_fname = os.path.join(
             currdir,
             'ceval_unfixedvar_mutableparam.3.42.baseline.json')
-    compare_json_files(baseline_fname=baseline_fname,
-                       output_fname=fname,
-                       tolerance=1e-8)
+
+    with open(fname) as FILE:
+        test = json.load(FILE)
+    with open(baseline_fname) as FILE:
+        baseline = json.load(FILE)
+    assertStructuredAlmostEqual(baseline, test, abstol=1e-8)
 
     # expect an exception because var is not fixed
     with pytest.raises(ValueError):
@@ -109,31 +115,27 @@ def test_convergence_evaluation_stats_from_to():
     d = s.to_dict()
     s2 = cb.Stats(from_dict=d)
     fname1 = os.path.join(wrtdir, 'stats1.json')
-    fname2 = os.path.join(wrtdir, 'stats2.json')
-    fname3 = os.path.join(wrtdir, 'stats3.json')
 
     with open(fname1, "w") as f:
         s.to_json(f)
-    with open(fname2, "w") as f:
-        s2.to_json(f)
-    compare_json_files(baseline_fname=fname1,
-                       output_fname=fname2,
-                       tolerance=1e-8)
+    with open(fname1) as FILE:
+        baseline = json.load(FILE)
+
+    buf = StringIO()
+    s2.to_json(buf)
+    test = json.loads(buf.getvalue())
+    assertStructuredAlmostEqual(baseline, test, abstol=1e-8)
+
     s3 = cb.Stats(from_json=fname1)
-    with open(fname3, "w") as f:
-        s3.to_json(f)
-    compare_json_files(baseline_fname=fname1,
-                       output_fname=fname3,
-                       tolerance=1e-8)
+    buf = StringIO()
+    s3.to_json(buf)
+    test = json.loads(buf.getvalue())
+    assertStructuredAlmostEqual(baseline, test, abstol=1e-8)
 
     if os.path.exists(fname):
         os.remove(fname)
     if os.path.exists(fname1):
         os.remove(fname1)
-    if os.path.exists(fname2):
-        os.remove(fname2)
-    if os.path.exists(fname3):
-        os.remove(fname3)
 
 @pytest.mark.skipif(not ipopt_available, reason="Ipopt solver not available")
 @pytest.mark.unit
@@ -167,9 +169,12 @@ def test_convergence_evaluation_specification_file_fixedvar_immutableparam():
     baseline_fname = os.path.join(
             currdir,
             'ceval_fixedvar_immutableparam.3.42.baseline.json')
-    compare_json_files(baseline_fname=baseline_fname,
-                       output_fname=fname,
-                       tolerance=1e-8)
+
+    with open(fname) as FILE:
+        test = json.load(FILE)
+    with open(baseline_fname) as FILE:
+        baseline = json.load(FILE)
+    assertStructuredAlmostEqual(baseline, test, abstol=1e-8)
 
     # expect an exception because param is not mutable
     with pytest.raises(ValueError):

--- a/idaes/core/util/convergence/tests/test_convergence.py
+++ b/idaes/core/util/convergence/tests/test_convergence.py
@@ -15,6 +15,7 @@ Tests for the convergence testing module
 
 Author: Carl Laird
 """
+import io
 import json
 import pytest
 import os
@@ -122,13 +123,13 @@ def test_convergence_evaluation_stats_from_to():
     with open(fname1) as FILE:
         baseline = json.load(FILE)
 
-    buf = StringIO()
+    buf = io.StringIO()
     s2.to_json(buf)
     test = json.loads(buf.getvalue())
     assertStructuredAlmostEqual(baseline, test, abstol=1e-8)
 
     s3 = cb.Stats(from_json=fname1)
-    buf = StringIO()
+    buf = io.StringIO()
     s3.to_json(buf)
     test = json.loads(buf.getvalue())
     assertStructuredAlmostEqual(baseline, test, abstol=1e-8)

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -18,7 +18,7 @@ import xml.dom.minidom
 
 import pyomo.environ as pyo
 from pyomo.core.base.expression import _GeneralExpressionData
-from pyomo.core.base.plugin import ModelComponentFactory
+from pyomo.core.base.component import ModelComponentFactory
 from pyomo.core.base.indexed_component import (
     UnindexedComponent_set, )
 from pyomo.core.base.util import disable_methods

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
@@ -22,6 +22,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -76,10 +77,14 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FTPx
 
-        assert model.params.config.state_bounds == {
-            "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
-            "temperature": (10, 300, 350, pyunits.K),
-            "pressure": (5e4, 1e5, 1e7, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "temperature": (10, 300, 350, pyunits.K),
+              "pressure": (5e4, 1e5, 1e7, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): SmoothVLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
@@ -22,6 +22,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -80,10 +81,14 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FTPx
 
-        assert model.params.config.state_bounds == {
-            "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
-            "temperature": (10, 300, 350, pyunits.K),
-            "pressure": (5e4, 1e5, 1e7, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "temperature": (10, 300, 350, pyunits.K),
+              "pressure": (5e4, 1e5, 1e7, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): SmoothVLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -23,6 +23,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -73,10 +74,14 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FTPx
 
-        assert model.params.config.state_bounds == {
-            "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
-            "temperature": (273.15, 300, 450, pyunits.K),
-            "pressure": (5e4, 1e5, 1e6, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "temperature": (273.15, 300, 450, pyunits.K),
+              "pressure": (5e4, 1e5, 1e6, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): SmoothVLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -22,6 +22,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -160,11 +161,15 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FPhx
 
-        assert model.params.config.state_bounds == {
-            "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
-            "enth_mol": (1e4, 5e4, 2e5, pyunits.J/pyunits.mol),
-            "temperature": (273.15, 300, 450, pyunits.K),
-            "pressure": (5e4, 1e5, 1e6, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "enth_mol": (1e4, 5e4, 2e5, pyunits.J/pyunits.mol),
+              "temperature": (273.15, 300, 450, pyunits.K),
+              "pressure": (5e4, 1e5, 1e6, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): SmoothVLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
@@ -23,6 +23,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -161,11 +162,15 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FcPh
 
-        assert model.params.config.state_bounds == {
-            "flow_mol_comp": (0, 100, 1000, pyunits.mol/pyunits.s),
-            "enth_mol": (1e4, 5e4, 2e5, pyunits.J/pyunits.mol),
-            "temperature": (273.15, 300, 450, pyunits.K),
-            "pressure": (5e4, 1e5, 1e6, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol_comp": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "enth_mol": (1e4, 5e4, 2e5, pyunits.J/pyunits.mol),
+              "temperature": (273.15, 300, 450, pyunits.K),
+              "pressure": (5e4, 1e5, 1e6, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): SmoothVLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
@@ -23,6 +23,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -159,10 +160,14 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FcTP
 
-        assert model.params.config.state_bounds == {
-                "flow_mol_comp": (0, 100, 1000, pyunits.mol/pyunits.s),
-                "temperature": (273.15, 300, 450, pyunits.K),
-                "pressure": (5e4, 1e5, 1e6, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol_comp": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "temperature": (273.15, 300, 450, pyunits.K),
+              "pressure": (5e4, 1e5, 1e6, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): SmoothVLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
@@ -24,6 +24,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component
 
@@ -79,11 +80,15 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FTPx
 
-        assert model.params.config.state_bounds == {
-            "flow_mol": (0, 10, 20, pyunits.mol/pyunits.s),
-            "temperature": (273.15, 323.15, 1000, pyunits.K),
-            "pressure": (5e4, 108900, 1e7, pyunits.Pa),
-            "mole_frac_comp": {"H2O": (0, 0.5, 1),"CO2": (0, 0.5, 1)}}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol": (0, 10, 20, pyunits.mol/pyunits.s),
+              "temperature": (273.15, 323.15, 1000, pyunits.K),
+              "pressure": (5e4, 108900, 1e7, pyunits.Pa),
+              "mole_frac_comp": {"H2O": (0, 0.5, 1),"CO2": (0, 0.5, 1)} },
+             item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): SmoothVLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -78,7 +78,7 @@ class TestParamBlock(object):
         assert model.param.config.state_definition == FTPx
 
         assertStructuredAlmostEqual(
-            model.params.config.state_bounds,
+            model.param.config.state_bounds,
             { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
               "temperature": (10, 300, 500, pyunits.K),
               "pressure": (5e-4, 1e5, 1e10, pyunits.Pa) },

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -22,6 +22,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component, FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -76,10 +77,14 @@ class TestParamBlock(object):
 
         assert model.param.config.state_definition == FTPx
 
-        assert model.param.config.state_bounds == {
-            "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
-            "temperature": (10, 300, 500, pyunits.K),
-            "pressure": (5e-4, 1e5, 1e10, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "temperature": (10, 300, 500, pyunits.K),
+              "pressure": (5e-4, 1e5, 1e10, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.param.config.phase_equilibrium_state == {
             ("Vap", "Liq"): smooth_VLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
@@ -23,6 +23,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import Component
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -94,10 +95,14 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FTPx
 
-        assert model.params.config.state_bounds == {
-            "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
-            "temperature": (273.15, 300, 1500, pyunits.K),
-            "pressure": (5e4, 1e5, 1e7, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "temperature": (273.15, 300, 1500, pyunits.K),
+              "pressure": (5e4, 1e5, 1e7, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.config.phase_equilibrium_state == {
             ("Vap", "Liq"): smooth_VLE}

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
@@ -24,6 +24,7 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
+from pyomo.common.unittest import assertStructuredAlmostEqual
 
 from idaes.core import (MaterialBalanceType,
                         EnergyBalanceType,
@@ -93,10 +94,14 @@ class TestParamBlock(object):
 
         assert model.params.config.state_definition == FTPx
 
-        assert model.params.config.state_bounds == {
-            "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
-            "temperature": (273.15, 300, 1500, pyunits.K),
-            "pressure": (5e4, 1e5, 1e7, pyunits.Pa)}
+        assertStructuredAlmostEqual(
+            model.params.config.state_bounds,
+            { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+              "temperature": (273.15, 300, 1500, pyunits.K),
+              "pressure": (5e4, 1e5, 1e7, pyunits.Pa) },
+            item_callback=lambda x: value(x) * (
+                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+        )
 
         assert model.params.pressure_ref.value == 101325
         assert model.params.temperature_ref.value == 298.15

--- a/idaes/logger.py
+++ b/idaes/logger.py
@@ -17,7 +17,7 @@ import threading
 from collections.abc import Iterable
 
 from contextlib import contextmanager
-from pyutilib.misc import capture_output
+from pyomo.common.tee import capture_output
 
 
 # Throw the standard levels in here, just let you access it all in one place

--- a/idaes/surrogate/pysmo/tests/test_sampling_modified.py
+++ b/idaes/surrogate/pysmo/tests/test_sampling_modified.py
@@ -15,7 +15,7 @@ import sys
 from idaes.surrogate.pysmo.sampling import LatinHypercubeSampling, UniformSampling, HaltonSampling, HammersleySampling, CVTSampling, SamplingMethods, FeatureScaling
 import numpy as np
 import pandas as pd
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 import pytest
 
 

--- a/idaes/surrogate/pysmo/tests/test_utils.py
+++ b/idaes/surrogate/pysmo/tests/test_utils.py
@@ -20,7 +20,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyutilib.th
+import pyomo.common.unittest as unittest
 import pytest
 from idaes.surrogate.pysmo.utils import NumpyEvaluator
 from pyomo.environ import ConcreteModel, Param, Var, value, sin, atan, atanh
@@ -32,7 +32,7 @@ try:
 except ImportError:
     _numpy_available = False
 
-@pyutilib.th.skipIf(not _numpy_available, "Test requires numpy")
+@unittest.skipIf(not _numpy_available, "Test requires numpy")
 class TestNumpyEvaluator:
 
     @pytest.mark.unit

--- a/idaes/util/update_workshop_materials.py
+++ b/idaes/util/update_workshop_materials.py
@@ -38,7 +38,6 @@ import os
 import logging
 import pyomo.common.fileutils as futils
 import pyomo.common.download as dload
-from pyutilib.misc import import_file
 
 _install_idaes_workshop_materials_url = 'http://www.pyomo.org/s/install_idaes_workshop_materials.py'
 
@@ -78,7 +77,7 @@ def import_install_module(download_dest):
     """
     Imports the path in download_dest (install_idaes_workshop_materials.py module)
     """
-    install_module = import_file(download_dest)
+    install_module = futils.import_file(download_dest)
     print('... importing install module')
     return install_module
 

--- a/scripts/workshops/update_workshop_materials.py
+++ b/scripts/workshops/update_workshop_materials.py
@@ -38,7 +38,6 @@ import os
 import logging
 import pyomo.common.fileutils as futils
 import pyomo.common.download as dload
-from pyutilib.misc import import_file
 
 _install_idaes_workshop_materials_url = 'http://www.pyomo.org/s/install_idaes_workshop_materials.py'
 
@@ -76,7 +75,7 @@ def import_install_module(download_dest):
     """
     Imports the path in download_dest (install_idaes_workshop_materials.py module)
     """
-    install_module = import_file(download_dest)
+    install_module = futils.import_file(download_dest)
     print('... importing install module')
     return install_module
 

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyutilib @ https://github.com/PyUtilib/pyutilib/archive/master.zip",
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.0.idaes.2021.05.17.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.0.idaes.2021.05.19.zip",
 ]
 
 
@@ -64,7 +63,6 @@ kwargs = dict(
         "pandas",
         "pint",
         "psutil",
-        "pyutilib>=6.0.0",
         "pyomo>=5.7.3",
         "pytest",
         "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.0.idaes.2021.05.19.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.0.idaes.2021.05.20.zip",
 ]
 
 


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This is testing against the Pyomo 6.0 RC1

## Changes proposed in this PR:
- Update Pyomo tag
- Remove PyUtilib dependency

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
