### PR TITLE
Fixing some pytest marks

### DIFF
--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -76,9 +76,9 @@ class TestParamBlock(object):
 
         assertStructuredAlmostEqual(
             model.params.config.state_bounds,
-            { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
-              "temperature": (273.15, 300, 450, pyunits.K),
-              "pressure": (5e4, 1e5, 1e6, pyunits.Pa) },
+            {"flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
+             "temperature": (273.15, 300, 450, pyunits.K),
+             "pressure": (5e4, 1e5, 1e6, pyunits.Pa)},
             item_callback=lambda x: value(x) * (
                 pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
         )
@@ -121,23 +121,30 @@ class TestStateBlock(object):
 
         model.props[1].calculate_scaling_factors()
 
+        # Fix state
+        model.props[1].flow_mol.fix(1)
+        model.props[1].temperature.fix(368)
+        model.props[1].pressure.fix(101325)
+        model.props[1].mole_frac_comp["benzene"].fix(0.5)
+        model.props[1].mole_frac_comp["toluene"].fix(0.5)
+
         return model
 
     @pytest.mark.unit
     def test_build(self, model):
         # Check state variable values and bounds
         assert isinstance(model.props[1].flow_mol, Var)
-        assert value(model.props[1].flow_mol) == 100
+        assert value(model.props[1].flow_mol) == 1
         assert model.props[1].flow_mol.ub == 1000
         assert model.props[1].flow_mol.lb == 0
 
         assert isinstance(model.props[1].pressure, Var)
-        assert value(model.props[1].pressure) == 1e5
+        assert value(model.props[1].pressure) == 101325
         assert model.props[1].pressure.ub == 1e6
         assert model.props[1].pressure.lb == 5e4
 
         assert isinstance(model.props[1].temperature, Var)
-        assert value(model.props[1].temperature) == 300
+        assert value(model.props[1].temperature) == 368
         assert model.props[1].temperature.ub == 450
         assert model.props[1].temperature.lb == 273.15
 
@@ -183,13 +190,6 @@ class TestStateBlock(object):
 
     @pytest.mark.unit
     def test_dof(self, model):
-        # Fix state
-        model.props[1].flow_mol.fix(1)
-        model.props[1].temperature.fix(368)
-        model.props[1].pressure.fix(101325)
-        model.props[1].mole_frac_comp["benzene"].fix(0.5)
-        model.props[1].mole_frac_comp["toluene"].fix(0.5)
-
         assert degrees_of_freedom(model.props[1]) == 0
 
     @pytest.mark.unit
@@ -241,10 +241,8 @@ class TestStateBlock(object):
         assert model.props[1].scaling_factor[
             model.props[1].temperature_dew["Vap", "Liq"]] == 1e-2
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, model):
         orig_fixed_vars = fixed_variables_set(model)
         orig_act_consts = activated_constraints_set(model)
@@ -264,9 +262,8 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, model):
         results = solver.solve(model)
 
@@ -275,10 +272,8 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, model):
         # Check phase equilibrium results
         assert model.props[1].mole_frac_phase_comp["Liq", "benzene"].value == \

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -202,23 +202,30 @@ class TestStateBlock(object):
 
         model.props[1].calculate_scaling_factors()
 
+        # Fix state
+        model.props[1].flow_mol.fix(1)
+        model.props[1].enth_mol.fix(47297)
+        model.props[1].pressure.fix(101325)
+        model.props[1].mole_frac_comp["benzene"].fix(0.5)
+        model.props[1].mole_frac_comp["toluene"].fix(0.5)
+
         return model
 
     @pytest.mark.unit
     def test_build(self, model):
         # Check state variable values and bounds
         assert isinstance(model.props[1].flow_mol, Var)
-        assert value(model.props[1].flow_mol) == 100
+        assert value(model.props[1].flow_mol) == 1
         assert model.props[1].flow_mol.ub == 1000
         assert model.props[1].flow_mol.lb == 0
 
         assert isinstance(model.props[1].pressure, Var)
-        assert value(model.props[1].pressure) == 1e5
+        assert value(model.props[1].pressure) == 101325
         assert model.props[1].pressure.ub == 1e6
         assert model.props[1].pressure.lb == 5e4
 
         assert isinstance(model.props[1].enth_mol, Var)
-        assert value(model.props[1].enth_mol) == 5e4
+        assert value(model.props[1].enth_mol) == 47297
         assert model.props[1].enth_mol.ub == 2e5
         assert model.props[1].enth_mol.lb == 1e4
 
@@ -320,19 +327,10 @@ class TestStateBlock(object):
 
     @pytest.mark.unit
     def test_dof(self, model):
-        # Fix state
-        model.props[1].flow_mol.fix(1)
-        model.props[1].enth_mol.fix(47297)
-        model.props[1].pressure.fix(101325)
-        model.props[1].mole_frac_comp["benzene"].fix(0.5)
-        model.props[1].mole_frac_comp["toluene"].fix(0.5)
-
         assert degrees_of_freedom(model.props[1]) == 0
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, model):
         orig_fixed_vars = fixed_variables_set(model)
         orig_act_consts = activated_constraints_set(model)
@@ -352,9 +350,8 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, model):
         results = solver.solve(model)
 
@@ -363,10 +360,8 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, model):
         # Check phase equilibrium results
         assert model.props[1].mole_frac_phase_comp["Liq", "benzene"].value == \

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
@@ -162,9 +162,9 @@ class TestParamBlock(object):
 
         assertStructuredAlmostEqual(
             model.params.config.state_bounds,
-            { "flow_mol_comp": (0, 100, 1000, pyunits.mol/pyunits.s),
-              "temperature": (273.15, 300, 450, pyunits.K),
-              "pressure": (5e4, 1e5, 1e6, pyunits.Pa) },
+            {"flow_mol_comp": (0, 100, 1000, pyunits.mol/pyunits.s),
+             "temperature": (273.15, 300, 450, pyunits.K),
+              "pressure": (5e4, 1e5, 1e6, pyunits.Pa)},
             item_callback=lambda x: value(x) * (
                 pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
         )
@@ -200,6 +200,11 @@ class TestStateBlock(object):
 
         model.props[1].calculate_scaling_factors()
 
+        # Fix state
+        model.props[1].flow_mol_comp.fix(0.5)
+        model.props[1].temperature.fix(368)
+        model.props[1].pressure.fix(101325)
+
         return model
 
     @pytest.mark.unit
@@ -208,17 +213,17 @@ class TestStateBlock(object):
         assert isinstance(model.props[1].flow_mol, Expression)
         assert isinstance(model.props[1].flow_mol_comp, Var)
         for j in model.params.component_list:
-            assert value(model.props[1].flow_mol_comp[j]) == 100
+            assert value(model.props[1].flow_mol_comp[j]) == 0.5
             assert model.props[1].flow_mol_comp[j].ub == 1000
             assert model.props[1].flow_mol_comp[j].lb == 0
 
         assert isinstance(model.props[1].pressure, Var)
-        assert value(model.props[1].pressure) == 1e5
+        assert value(model.props[1].pressure) == 101325
         assert model.props[1].pressure.ub == 1e6
         assert model.props[1].pressure.lb == 5e4
 
         assert isinstance(model.props[1].temperature, Var)
-        assert value(model.props[1].temperature) == 300
+        assert value(model.props[1].temperature) == 368
         assert model.props[1].temperature.ub == 450
         assert model.props[1].temperature.lb == 273.15
 
@@ -315,14 +320,9 @@ class TestStateBlock(object):
 
     @pytest.mark.unit
     def test_dof(self, model):
-        # Fix state
-        model.props[1].flow_mol_comp.fix(0.5)
-        model.props[1].temperature.fix(368)
-        model.props[1].pressure.fix(101325)
-
         assert degrees_of_freedom(model.props[1]) == 0
 
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_initialize(self, model):
         orig_fixed_vars = fixed_variables_set(model)
         orig_act_consts = activated_constraints_set(model)
@@ -342,7 +342,7 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solve(self, model):
         results = solver.solve(model)
 
@@ -351,7 +351,7 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_solution(self, model):
         # Check phase equilibrium results
         assert model.props[1].mole_frac_phase_comp["Liq", "benzene"].value == \

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
@@ -313,12 +313,9 @@ class TestStateBlock(object):
                          "Temperature",
                          "Pressure"]
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, model):
-
 
         orig_fixed_vars = fixed_variables_set(model)
         orig_act_consts = activated_constraints_set(model)
@@ -338,7 +335,6 @@ class TestStateBlock(object):
         for v in fin_fixed_vars:
             assert v in orig_fixed_vars
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, model):
@@ -349,8 +345,6 @@ class TestStateBlock(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.initialize
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, model):


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Whilst looking through some tests, I found some tests marked as `unit` which required solvers.

## Changes proposed in this PR:
- Added correct pytest marks, and removed a few deprecated marks
- Move setting of degrees of freedom to fixtures in a few cases to support separation of unit and component tests.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
