### PR TITLE
Use Ubuntu 18.04 binaries on all release from 18.04 to 19.10

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -43,7 +43,6 @@ known_binary_platform = {
         f"{binary_platform_map['linux']})",
     "centos7": "CentOS 7",
     "centos8": "CentOS 8",
-    "rhel6": "Red Hat Enterprise Linux 6",
     "rhel7": "Red Hat Enterprise Linux 7",
     "rhel8": "Red Hat Enterprise Linux 8",
     "ubuntu1804": "Ubuntu 18.04",

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -27,9 +27,11 @@ release_checksum_url = \
     "https://raw.githubusercontent.com/IDAES/idaes-ext/main/releases/sha256sum_{}.txt"
 # Map some platform names to others for get-extensions
 binary_platform_map = {
-    "rhel6": "centos6",
     "rhel7": "centos7",
     "rhel8": "centos8",
+    "ubuntu1810": "ubuntu1804",
+    "ubuntu1904": "ubuntu1804",
+    "ubuntu1910": "ubuntu1804",
     "linux": "centos7",
 }
 # Set of known platforms with available binaries and descriptions of them
@@ -37,14 +39,16 @@ known_binary_platform = {
     "auto":"Auto-select windows, darwin or linux",
     "windows":"Microsoft Windows (built on verion 1909)",
     "darwin": "OSX (currently not available)",
-    "linux": "Linux (maps to {})".format(binary_platform_map["linux"]),
-    "centos6": "CentOS 6",
+    "linux": f"Linux (auto select distribution or fall back on "
+        f"{binary_platform_map['linux']})",
     "centos7": "CentOS 7",
     "centos8": "CentOS 8",
     "rhel6": "Red Hat Enterprise Linux 6",
     "rhel7": "Red Hat Enterprise Linux 7",
     "rhel8": "Red Hat Enterprise Linux 8",
     "ubuntu1804": "Ubuntu 18.04",
+    "ubuntu1810": "Ubuntu 18.10",
+    "ubuntu1904": "Ubuntu 19.04",
     "ubuntu1910": "Ubuntu 19.10",
     "ubuntu2004": "Ubuntu 20.04",
 }


### PR DESCRIPTION
Ubuntu 19.10 is past the end of it's life, and I can't keep the docker container I use to build it up-to-date anymore.  I think I can just point it to the 18.04 binaries, and everything will be fine, and I'll have less work.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
