### PR TITLE
Fix issue where there are no extraction splits

### DIFF
--- a/idaes/power_generation/unit_models/helm/turbine_multistage.py
+++ b/idaes/power_generation/unit_models/helm/turbine_multistage.py
@@ -313,19 +313,24 @@ class HelmTurbineMultistageData(UnitModelBlockData):
                 default=s_sfg_default,
                 initialize=hp_splt_cfg
             )
+        else:
+            self.hp_split = {}
         if config.ip_split_locations:
             self.ip_split = HelmSplitter(
                 config.ip_split_locations,
                 default=s_sfg_default,
                 initialize=ip_splt_cfg
             )
+        else:
+            self.ip_split = {}
         if config.lp_split_locations:
             self.lp_split = HelmSplitter(
                 config.lp_split_locations,
                 default=s_sfg_default,
                 initialize=lp_splt_cfg
             )
-
+        else:
+            self.lp_split = {}
         # Done with unit models.  Adding Arcs (streams).
         # ------------------------------------------------
 


### PR DESCRIPTION
Seems I failed to consider that you may not have feedwater heaters and may not have extractions splits.  This fixes.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
