### PR TITLE
Fix separator scale factor calcs

### DIFF
--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -456,12 +456,14 @@ objects linked the mixed state and all outlet states,
         """
         # Sanity check to make sure method is not called when arg missing
         if self.config.mixed_state_block is None:
-            raise BurntToast(
-                "{} get_mixed_state_block method called when "
-                "mixed_state_block argument is None. This should "
-                "not happen.".format(self.name)
-            )
-
+            try:
+                return self.mixed_state
+            except AttributeError:
+                raise BurntToast(
+                    f"{self.name} get_mixed_state_block method called when the "
+                    "mixed_state_block argument is None, and no mixed_state "
+                    "block is contained in seperator. This should not happen."
+                )
         # Check that the user-provided StateBlock uses the same prop pack
         if (
             self.config.mixed_state_block[

--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -1608,33 +1608,34 @@ objects linked the mixed state and all outlet states,
 
     def calculate_scaling_factors(self):
         mb_type = self.config.material_balance_type
+        mixed_state = self.get_mixed_state_block()
         if mb_type == MaterialBalanceType.useDefault:
             t_ref = self.flowsheet().config.time.first()
-            mb_type = self.mixed_state[t_ref].default_material_balance_type()
+            mb_type = mixed_state[t_ref].default_material_balance_type()
         super().calculate_scaling_factors()
 
         if hasattr(self, "temperature_equality_eqn"):
             for (t, i), c in self.temperature_equality_eqn.items():
                 s = iscale.get_scaling_factor(
-                    self.mixed_state[t].temperature, default=1, warning=True)
+                    mixed_state[t].temperature, default=1, warning=True)
                 iscale.constraint_scaling_transform(c, s)
 
         if hasattr(self, "pressure_equality_eqn"):
             for (t, i), c in self.pressure_equality_eqn.items():
                 s = iscale.get_scaling_factor(
-                    self.mixed_state[t].pressure, default=1, warning=True)
+                    mixed_state[t].pressure, default=1, warning=True)
                 iscale.constraint_scaling_transform(c, s)
 
         if hasattr(self, "material_splitting_eqn"):
             if mb_type == MaterialBalanceType.componentPhase:
                 for (t, o, p, j), c in self.material_splitting_eqn.items():
-                    flow_term = self.mixed_state[t].get_material_flow_terms(p, j)
+                    flow_term = mixed_state[t].get_material_flow_terms(p, j)
                     s = iscale.get_scaling_factor(flow_term, default=1)
                     iscale.constraint_scaling_transform(c, s)
             elif mb_type == MaterialBalanceType.componentTotal:
                 for (t, o, j), c in self.material_splitting_eqn.items():
-                    for i, p in enumerate(self.mixed_state.phase_list):
-                        ft = self.mixed_state[t].get_material_flow_terms(p, j)
+                    for i, p in enumerate(mixed_state.phase_list):
+                        ft = mixed_state[t].get_material_flow_terms(p, j)
                         if i == 0:
                             s = iscale.get_scaling_factor(ft, default=1)
                         else:
@@ -1642,10 +1643,10 @@ objects linked the mixed state and all outlet states,
                             s = _s if _s < s else s
                     iscale.constraint_scaling_transform(c, s)
             elif mb_type == MaterialBalanceType.total:
-                pc_set = self.mixed_state.phase_component_set
+                pc_set = mixed_state.phase_component_set
                 for (t, o), c in self.material_splitting_eqn.items():
                     for i, (p, j) in enumerate(pc_set):
-                        ft = self.mixed_state[t].get_material_flow_terms(p, j)
+                        ft = mixed_state[t].get_material_flow_terms(p, j)
                         if i == 0:
                             s = iscale.get_scaling_factor(ft, default=1)
                         else:

--- a/idaes/generic_models/unit_models/tests/test_flash.py
+++ b/idaes/generic_models/unit_models/tests/test_flash.py
@@ -37,6 +37,8 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
 from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
 from idaes.core.util import get_solver
+import idaes.core.util.scaling as iscale
+
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -70,6 +72,16 @@ def test_config():
     assert m.fs.unit.config.property_package is m.fs.properties
     assert m.fs.unit.config.energy_split_basis == \
         EnergySplittingType.equal_temperature
+
+
+# -----------------------------------------------------------------------------
+@pytest.mark.unit
+def test_calc_scale():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.properties = PhysicalParameterTestBlock()
+    m.fs.unit = Flash(default={"property_package": m.fs.properties})
+    iscale.calculate_scaling_factors(m)
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/unit_models/tests/test_separator.py
+++ b/idaes/generic_models/unit_models/tests/test_separator.py
@@ -57,6 +57,7 @@ from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      TestStateBlock,
                                      initialization_tester)
 from idaes.core.util import get_solver
+import idaes.core.util.scaling as iscale
 
 
 # -----------------------------------------------------------------------------
@@ -282,6 +283,33 @@ class TestBaseConstruction(object):
 
         with pytest.raises(ConfigurationError):
             build.fs.sep.get_mixed_state_block()
+
+
+# -----------------------------------------------------------------------------
+# Tests of Separator unit model scaling factors
+@pytest.mark.unit
+class TestBaseScaling(object):
+    """ Test scaling calculations.  For now they just make sure there are no
+    exceptions. This can be expanded in the future.
+    """
+    @pytest.fixture(scope="function")
+    def m(self):
+        b = ConcreteModel()
+        b.fs = FlowsheetBlock(default={"dynamic": False})
+        b.fs.pp = PhysicalParameterTestBlock()
+        return b
+
+    def test_no_exception_scaling_calc_external_mixed_state(self, m):
+        m.fs.sb = TestStateBlock(m.fs.time, default={"parameters": m.fs.pp})
+        m.fs.sep1 = Separator(
+            default={
+                "property_package": m.fs.pp,
+                "mixed_state_block": m.fs.sb})
+        iscale.calculate_scaling_factors(m)
+
+    def test_no_exception_scaling_calc_internal_mixed_state(self, m):
+        m.fs.sep1 = Separator(default={"property_package": m.fs.pp})
+        iscale.calculate_scaling_factors(m)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Fixes

This is a problem reported by @minhwvu.  The scaling factor calculation is broken for separators when the separator doesn't have it's own mixed state block.  Unfortunate, I think we should try to get the fix in this release if possible.   I added a test that demonstrates the problem then fixed it.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
