### PR TITLE
Bumping the pyomo dependency to Pyomo 6.0.1 (rc1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo==6.0",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.1.idaes.2021.06.04.zip",
 ]
 
 


### PR DESCRIPTION
## Fixes N/A


## Summary/Motivation:
Pyomo 6.0.0 logs some errors when running `solve(tee=True` within a Jupyter notebook.  The Pyomo team is preparing a 6.0.1 release (due out today); this PR tests IDAES/main against the RC1 for that release.

## Changes proposed in this PR:
- Test IDAES against Pyomo 6.0.1 (rc1)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
