### PR TITLE
Adding ideal properties to eNRTL model

### DIFF
--- a/idaes/core/property_base.py
+++ b/idaes/core/property_base.py
@@ -892,7 +892,7 @@ should be constructed in this state block,
             raise PropertyNotSupportedError(
                     '{} {} is not supported by property package (property is '
                     'not listed in package metadata properties).'
-                    .format(self.name, attr, attr))
+                    .format(self.name, attr))
 
         # Get method name from resulting properties
         try:
@@ -973,9 +973,8 @@ should be constructed in this state block,
         super().calculate_scaling_factors()
         # Get scaling factor defaults, if no scaling factor set
         for v in self.component_data_objects(
-            (Constraint, Var, Expression),
-            descend_into=False):
-            if iscale.get_scaling_factor(v) is None: # don't replace if set
+                (Constraint, Var, Expression), descend_into=False):
+            if iscale.get_scaling_factor(v) is None:  # don't replace if set
                 name = v.getname().split("[")[0]
                 index = v.index()
                 sf = self.config.parameters.get_default_scaling(name, index)

--- a/idaes/generic_models/properties/core/eos/enrtl.py
+++ b/idaes/generic_models/properties/core/eos/enrtl.py
@@ -510,11 +510,18 @@ class ENRTL(Ideal):
         pass
 
     @staticmethod
-    def log_act_coeff(b, p, j):
-        # Overall log gamma
-        pdh = getattr(p, +"_log_gamma_pdh")
-        lc = getattr(p, +"_log_gamma_lc")
-        return pdh[j] + lc[j]
+    def act_phase_comp(b, p, j):
+        return b.mole_frac_phase_comp[p, j]*b.act_coeff_phase_comp[p, j]
+
+    @staticmethod
+    def log_act_phase_comp(b, p, j):
+        ln_gamma = getattr(b, p+"_log_gamma")
+        return log(b.mole_frac_phase_comp[p, j]) + ln_gamma[p, j]
+
+    @staticmethod
+    def act_coeff_phase_comp(b, p, j):
+        ln_gamma = getattr(b, p+"_log_gamma")
+        return exp(ln_gamma[j])
 
     @staticmethod
     def dens_mol_phase(b, p):

--- a/idaes/generic_models/properties/core/eos/enrtl.py
+++ b/idaes/generic_models/properties/core/eos/enrtl.py
@@ -28,7 +28,7 @@ ionic charge.
 """
 from pyomo.environ import Expression, exp, log, Set, units as pyunits
 
-from .eos_base import EoSBase
+from .ideal import Ideal
 from .enrtl_reference_states import Symmetric
 from .enrtl_parameters import ConstantAlpha, ConstantTau
 from idaes.generic_models.properties.core.generic.utility import (
@@ -51,7 +51,7 @@ DefaultRefState = Symmetric
 ClosestApproach = 14.9
 
 
-class ENRTL(EoSBase):
+class ENRTL(Ideal):
     # Add attribute indicating support for electrolyte systems
     electrolyte_support = True
 

--- a/idaes/generic_models/properties/core/eos/enrtl.py
+++ b/idaes/generic_models/properties/core/eos/enrtl.py
@@ -33,6 +33,8 @@ from .enrtl_reference_states import Symmetric
 from .enrtl_parameters import ConstantAlpha, ConstantTau
 from idaes.generic_models.properties.core.generic.utility import (
     get_method, get_component_object as cobj)
+from idaes.generic_models.properties.core.generic.generic_property import \
+    StateIndex
 from idaes.core.util.constants import Constants
 from idaes.core.util.exceptions import BurntToast
 import idaes.logger as idaeslog
@@ -505,6 +507,32 @@ class ENRTL(Ideal):
                 rule=rule_log_gamma,
                 doc="Log of activity coefficient"))
 
+        # Activity coefficient of apparent species
+        def rule_log_gamma_pm(b, j):
+            cobj = b.params.get_component(j)
+
+            if "dissociation_species" in cobj.config:
+                dspec = cobj.config.dissociation_species
+
+                n = 0
+                d = 0
+                for s in dspec:
+                    dobj = b.params.get_component(s)
+                    ln_g = getattr(b, pname+"_log_gamma")[s]
+                    n += abs(dobj.config.charge)*ln_g
+                    d += abs(dobj.config.charge)
+
+                return n/d
+            else:
+                return getattr(b, pname+"_log_gamma")[j]
+
+        b.add_component(
+            pname+"_log_gamma_appr",
+            Expression(
+                b.params.apparent_species_set,
+                rule=rule_log_gamma_pm,
+                doc="Log of mean activity coefficient"))
+
     @staticmethod
     def calculate_scaling_factors(b, pobj):
         pass
@@ -514,26 +542,50 @@ class ENRTL(Ideal):
         return b.mole_frac_phase_comp[p, j]*b.act_coeff_phase_comp[p, j]
 
     @staticmethod
-    def log_act_phase_comp(b, p, j):
+    def act_phase_comp_true(b, p, j):
         ln_gamma = getattr(b, p+"_log_gamma")
+        return b.mole_frac_phase_comp_true[p, j]*exp(ln_gamma[j])
+
+    @staticmethod
+    def act_phase_comp_appr(b, p, j):
+        ln_gamma = getattr(b, p+"_log_gamma_appr")
+        return b.mole_frac_phase_comp_apparent[p, j]*exp(ln_gamma[j])
+
+    @staticmethod
+    def log_act_phase_comp(b, p, j):
+        if b.params.config.state_components == StateIndex.true:
+            ln_gamma = getattr(b, p+"_log_gamma")
+        else:
+            ln_gamma = getattr(b, p+"_log_gamma_appr")
         return log(b.mole_frac_phase_comp[p, j]) + ln_gamma[p, j]
 
     @staticmethod
+    def log_act_phase_comp_true(b, p, j):
+        ln_gamma = getattr(b, p+"_log_gamma")
+        return log(b.mole_frac_phase_comp_true[p, j]) + ln_gamma[p, j]
+
+    @staticmethod
+    def log_act_phase_comp_appr(b, p, j):
+        ln_gamma = getattr(b, p+"_log_gamma_appr")
+        return log(b.mole_frac_phase_comp_apparent[p, j]) + ln_gamma[p, j]
+
+    @staticmethod
     def act_coeff_phase_comp(b, p, j):
+        if b.params.config.state_components == StateIndex.true:
+            ln_gamma = getattr(b, p+"_log_gamma")
+        else:
+            ln_gamma = getattr(b, p+"_log_gamma_appr")
+        return exp(ln_gamma[j])
+
+    @staticmethod
+    def act_coeff_phase_comp_true(b, p, j):
         ln_gamma = getattr(b, p+"_log_gamma")
         return exp(ln_gamma[j])
 
     @staticmethod
-    def dens_mol_phase(b, p):
-        return 55e3
-
-    @staticmethod
-    def enth_mol_phase(b, p):
-        return 1e2*b.temperature
-
-    @staticmethod
-    def enth_mol_phase_comp(b, p, j):
-        return 1e2*b.temperature
+    def act_coeff_phase_comp_appr(b, p, j):
+        ln_gamma = getattr(b, p+"_log_gamma_appr")
+        return exp(ln_gamma[j])
 
 
 def log_gamma_lc(b, pname, s, X, G, tau):

--- a/idaes/generic_models/properties/core/eos/eos_base.py
+++ b/idaes/generic_models/properties/core/eos/eos_base.py
@@ -56,12 +56,36 @@ class EoSBase():
         raise NotImplementedError(_msg(b, "act_phase_comp"))
 
     @staticmethod
+    def act_phase_comp_true(b, p, j):
+        raise NotImplementedError(_msg(b, "act_phase_comp_true"))
+
+    @staticmethod
+    def act_phase_comp_appr(b, p, j):
+        raise NotImplementedError(_msg(b, "act_phase_comp_appr"))
+
+    @staticmethod
     def log_act_phase_comp(b, p, j):
         raise NotImplementedError(_msg(b, "log_act_phase_comp"))
 
     @staticmethod
+    def log_act_phase_comp_true(b, p, j):
+        raise NotImplementedError(_msg(b, "log_act_phase_comp_true"))
+
+    @staticmethod
+    def log_act_phase_comp_appr(b, p, j):
+        raise NotImplementedError(_msg(b, "log_act_phase_comp_appr"))
+
+    @staticmethod
     def act_coeff_phase_comp(b, p, j):
         raise NotImplementedError(_msg(b, "act_coeff_phase_comp"))
+
+    @staticmethod
+    def act_coeff_phase_comp_true(b, p, j):
+        raise NotImplementedError(_msg(b, "act_coeff_phase_comp_true"))
+
+    @staticmethod
+    def act_coeff_phase_comp_appr(b, p, j):
+        raise NotImplementedError(_msg(b, "act_coeff_phase_comp_appr"))
 
     @staticmethod
     def cp_mol_phase(b, p):

--- a/idaes/generic_models/properties/core/eos/eos_base.py
+++ b/idaes/generic_models/properties/core/eos/eos_base.py
@@ -52,6 +52,18 @@ class EoSBase():
         raise NotImplementedError(_msg(b, "build_parameters"))
 
     @staticmethod
+    def act_phase_comp(b, p, j):
+        raise NotImplementedError(_msg(b, "act_phase_comp"))
+
+    @staticmethod
+    def log_act_phase_comp(b, p, j):
+        raise NotImplementedError(_msg(b, "log_act_phase_comp"))
+
+    @staticmethod
+    def act_coeff_phase_comp(b, p, j):
+        raise NotImplementedError(_msg(b, "act_coeff_phase_comp"))
+
+    @staticmethod
     def cp_mol_phase(b, p):
         raise NotImplementedError(_msg(b, "cp_mol_phase"))
 

--- a/idaes/generic_models/properties/core/eos/ideal.py
+++ b/idaes/generic_models/properties/core/eos/ideal.py
@@ -44,14 +44,38 @@ class Ideal(EoSBase):
 
     @staticmethod
     def act_phase_comp(b, p, j):
-        return b.get_mole_frac()[p, j]
+        return b.mole_frac_phase_comp[p, j]
+
+    @staticmethod
+    def act_phase_comp_true(b, p, j):
+        return b.mole_frac_phase_comp_true[p, j]
+
+    @staticmethod
+    def act_phase_comp_appr(b, p, j):
+        return b.mole_frac_phase_comp_apparent[p, j]
 
     @staticmethod
     def log_act_phase_comp(b, p, j):
-        return log(b.get_mole_frac()[p, j])
+        return log(b.mole_frac_phase_comp[p, j])
+
+    @staticmethod
+    def log_act_phase_comp_true(b, p, j):
+        return log(b.mole_frac_phase_comp_true[p, j])
+
+    @staticmethod
+    def log_act_phase_comp_appr(b, p, j):
+        return log(b.mole_frac_phase_comp_apparent[p, j])
 
     @staticmethod
     def act_coeff_phase_comp(b, p, j):
+        return 1
+
+    @staticmethod
+    def act_coeff_phase_comp_true(b, p, j):
+        return 1
+
+    @staticmethod
+    def act_coeff_phase_comp_appr(b, p, j):
         return 1
 
     @staticmethod

--- a/idaes/generic_models/properties/core/eos/ideal.py
+++ b/idaes/generic_models/properties/core/eos/ideal.py
@@ -43,6 +43,18 @@ class Ideal(EoSBase):
         pass
 
     @staticmethod
+    def act_phase_comp(b, p, j):
+        return b.get_mole_frac()[p, j]
+
+    @staticmethod
+    def log_act_phase_comp(b, p, j):
+        return log(b.get_mole_frac()[p, j])
+
+    @staticmethod
+    def act_coeff_phase_comp(b, p, j):
+        return 1
+
+    @staticmethod
     def compress_fact_phase(b, p):
         pobj = b.params.get_phase(p)
         if pobj.is_vapor_phase():

--- a/idaes/generic_models/properties/core/eos/tests/test_enrtl_verification_NaCl.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_enrtl_verification_NaCl.py
@@ -166,6 +166,8 @@ class TestStateBlockSymmetric(object):
 
             assert pytest.approx(g, rel=4.5e-2, abs=0.01) == value(
                 model.state[1].Liq_log_gamma["H2O"])
+            assert pytest.approx(g, rel=4.5e-2, abs=0.01) == value(
+                model.state[1].Liq_log_gamma_appr["H2O"])
 
     @pytest.mark.unit
     def test_log_gamma_pdh(self, model):
@@ -390,6 +392,8 @@ class TestStateBlockSymmetric(object):
                 model.state[1].Liq_log_gamma["Na+"])
             assert pytest.approx(g-OFFSET, rel=4e-2, abs=2e-2) == value(
                 model.state[1].Liq_log_gamma["Cl-"])
+            assert pytest.approx(g-OFFSET, rel=4e-2, abs=2e-2) == value(
+                model.state[1].Liq_log_gamma_appr["NaCl"])
 
     @pytest.mark.unit
     def test_pure_water(self, model):
@@ -630,6 +634,8 @@ class TestStateBlockUnsymmetric(object):
 
             assert pytest.approx(g, rel=4.5e-2, abs=0.01) == value(
                 model.state[1].Liq_log_gamma["H2O"])
+            assert pytest.approx(g, rel=4.5e-2, abs=0.01) == value(
+                model.state[1].Liq_log_gamma_appr["H2O"])
 
     @pytest.mark.unit
     def test_log_gamma_pdh(self, model):
@@ -845,6 +851,8 @@ class TestStateBlockUnsymmetric(object):
                 model.state[1].Liq_log_gamma["Na+"])
             assert pytest.approx(g, rel=3e-2, abs=6e-2) == value(
                 model.state[1].Liq_log_gamma["Cl-"])
+            assert pytest.approx(g, rel=3e-2, abs=6e-2) == value(
+                model.state[1].Liq_log_gamma_appr["NaCl"])
 
     @pytest.mark.unit
     def test_pure_water(self, model):

--- a/idaes/generic_models/properties/core/eos/tests/test_enrtl_verification_NaCl.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_enrtl_verification_NaCl.py
@@ -25,7 +25,7 @@ May 2021
 Author: Andrew Lee
 """
 import pytest
-from math import exp
+from math import exp, log
 
 from pyomo.environ import (ConcreteModel,
                            units as pyunits,
@@ -515,6 +515,9 @@ class TestStateBlockSymmetric(object):
                       model.state[1].Liq_log_gamma_lc["Na+"]) ==
                 pytest.approx(
                     value(model.state[1].Liq_log_gamma["Na+"]), abs=1e-10))
+        assert pytest.approx(value(
+            model.state[1].Liq_log_gamma["Na+"]), abs=1e-10) == log(
+            value(model.state[1].act_coeff_phase_comp["Liq", "Na+"]))
 
         assert (value(model.state[1].Liq_log_gamma_pdh["Cl-"]) ==
                 pytest.approx(0, abs=1e-10))
@@ -535,6 +538,9 @@ class TestStateBlockSymmetric(object):
                       model.state[1].Liq_log_gamma_lc["Cl-"]) ==
                 pytest.approx(
                     value(model.state[1].Liq_log_gamma["Cl-"]), abs=1e-10))
+        assert pytest.approx(value(
+            model.state[1].Liq_log_gamma["Cl-"]), abs=1e-10) == log(
+            value(model.state[1].act_coeff_phase_comp["Liq", "Cl-"]))
 
 
 class TestStateBlockUnsymmetric(object):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -243,8 +243,7 @@ class TestStateBlock(object):
 
     @pytest.mark.unit
     def test_basic_scaling(self, model):
-
-        assert len(model.props[1].scaling_factor) == 24
+        assert len(model.props[1].scaling_factor) == 26
 
         assert model.props[1].scaling_factor[
             model.props[1]._mole_frac_tbub["Vap", "Liq", "benzene"]] == 1000
@@ -258,6 +257,10 @@ class TestStateBlock(object):
             model.props[1]._t1_Vap_Liq] == 1e-2
         assert model.props[1].scaling_factor[
             model.props[1]._teq["Vap", "Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].dens_mol_phase["Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].dens_mol_phase["Vap"]] == 1e-2
         assert model.props[1].scaling_factor[model.props[1].enth_mol] == 1e-4
         assert model.props[1].scaling_factor[model.props[1].flow_mol] == 1e-2
         assert model.props[1].scaling_factor[

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
@@ -245,7 +245,11 @@ class TestStateBlock(object):
     @pytest.mark.unit
     def test_basic_scaling(self, model):
 
-        assert len(model.props[1].scaling_factor) == 26
+        assert len(model.props[1].scaling_factor) == 28
+        assert model.props[1].scaling_factor[
+            model.props[1].dens_mol_phase["Liq"]] == 1e-2
+        assert model.props[1].scaling_factor[
+            model.props[1].dens_mol_phase["Vap"]] == 1e-2
         assert model.props[1].scaling_factor[model.props[1].enth_mol] == 1e-4
         assert model.props[1].scaling_factor[model.props[1].flow_mol] == 1e-2
         assert model.props[1].scaling_factor[

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
@@ -303,7 +303,7 @@ class TestStateBlock(object):
                 / value(m.fs.flash.inlet.flow_mol[0])
             assert frac == pytest.approx(expected_sol[t][0], abs=1e-4)
             hduty = value(m.fs.flash.heat_duty[0])
-            assert hduty == pytest.approx(expected_sol[t][1], abs=1e-4)
+            assert hduty == pytest.approx(expected_sol[t][1], rel=1e-4)
 
     @pytest.mark.unit
     def test_report(self, model):

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -23,7 +23,6 @@ from pyomo.environ import (Block,
                            Expression,
                            Set,
                            Param,
-                           SolverFactory,
                            value,
                            Var,
                            units as pyunits)

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1828,7 +1828,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.act_phase_comp_true(b, p, j)
             self.act_phase_comp_true = Expression(
-                    self.true_phase_component_set,
+                    self.params.true_phase_component_set,
                     doc="Component activity in each phase",
                     rule=rule_act_phase_comp_true)
         except AttributeError:
@@ -1841,7 +1841,7 @@ class GenericStateBlockData(StateBlockData):
                 p_config = b.params.get_phase(p).config
                 return p_config.equation_of_state.act_phase_comp_appr(b, p, j)
             self.act_phase_comp_appr = Expression(
-                    self.apparent_phase_component_set,
+                    self.params.apparent_phase_component_set,
                     doc="Component activity in each phase",
                     rule=rule_act_phase_comp_appr)
         except AttributeError:
@@ -1868,7 +1868,7 @@ class GenericStateBlockData(StateBlockData):
                 return p_config.equation_of_state.log_act_phase_comp_true(
                     b, p, j)
             self.log_act_phase_comp_true = Expression(
-                    self.true_phase_component_set,
+                    self.params.true_phase_component_set,
                     doc="Natural log of component activity in each phase",
                     rule=rule_log_act_phase_comp_true)
         except AttributeError:
@@ -1882,7 +1882,7 @@ class GenericStateBlockData(StateBlockData):
                 return p_config.equation_of_state.log_act_phase_comp_appr(
                     b, p, j)
             self.log_act_phase_comp_appr = Expression(
-                    self.apparent_phase_component_set,
+                    self.params.apparent_phase_component_set,
                     doc="Natural log of component activity in each phase",
                     rule=rule_log_act_phase_comp_appr)
         except AttributeError:
@@ -1910,7 +1910,7 @@ class GenericStateBlockData(StateBlockData):
                 return p_config.equation_of_state.act_coeff_phase_comp_true(
                     b, p, j)
             self.act_coeff_phase_comp_true = Expression(
-                    self.true_phase_component_set,
+                    self.params.true_phase_component_set,
                     doc="Component activity coefficient in each phase",
                     rule=rule_act_coeff_phase_comp_true)
         except AttributeError:
@@ -1924,7 +1924,7 @@ class GenericStateBlockData(StateBlockData):
                 return p_config.equation_of_state.act_coeff_phase_comp_appr(
                     b, p, j)
             self.act_coeff_phase_comp_appr = Expression(
-                    self.apparent_phase_component_set,
+                    self.params.apparent_phase_component_set,
                     doc="Component activity coefficient in each phase",
                     rule=rule_act_coeff_phase_comp_appr)
         except AttributeError:

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -860,8 +860,16 @@ class GenericParameterData(PhysicalParameterBlock):
              'temperature': {'method': None},
              'pressure': {'method': None},
              'act_phase_comp': {'method': '_act_phase_comp'},
+             'act_phase_comp_true': {'method': '_act_phase_comp_true'},
+             'act_phase_comp_appr': {'method': '_act_phase_comp_appr'},
              'log_act_phase_comp': {'method': '_log_act_phase_comp'},
+             'log_act_phase_comp_true': {'method': '_log_act_phase_comp_true'},
+             'log_act_phase_comp_appr': {'method': '_log_act_phase_comp_appr'},
              'act_coeff_phase_comp': {'method': '_act_coeff_phase_comp'},
+             'act_coeff_phase_comp_true': {
+                 'method': '_act_coeff_phase_comp_true'},
+             'act_coeff_phase_comp_appr': {
+                 'method': '_act_coeff_phase_comp_appr'},
              'compress_fact_phase': {'method': '_compress_fact_phase'},
              'conc_mol_comp': {'method': '_conc_mol_comp'},
              'conc_mol_phase_comp': {'method': '_conc_mol_phase_comp'},
@@ -875,7 +883,8 @@ class GenericParameterData(PhysicalParameterBlock):
              'cv_mol': {'method': '_cv_mol'},
              'cv_mol_phase': {'method': '_cv_mol_phase'},
              'cv_mol_phase_comp': {'method': '_cv_mol_phase_comp'},
-             'heat_capacity_ratio_phase': {'method': '_heat_capacity_ratio_phase'},
+             'heat_capacity_ratio_phase': {
+                 'method': '_heat_capacity_ratio_phase'},
              'dens_mass': {'method': '_dens_mass'},
              'dens_mass_phase': {'method': '_dens_mass_phase'},
              'dens_mol': {'method': '_dens_mol'},
@@ -1813,6 +1822,32 @@ class GenericStateBlockData(StateBlockData):
             self.del_component(self.act_phase_comp)
             raise
 
+    def _act_phase_comp_true(self):
+        try:
+            def rule_act_phase_comp_true(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.act_phase_comp_true(b, p, j)
+            self.act_phase_comp_true = Expression(
+                    self.true_phase_component_set,
+                    doc="Component activity in each phase",
+                    rule=rule_act_phase_comp_true)
+        except AttributeError:
+            self.del_component(self.act_phase_comp_true)
+            raise
+
+    def _act_phase_comp_appr(self):
+        try:
+            def rule_act_phase_comp_appr(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.act_phase_comp_appr(b, p, j)
+            self.act_phase_comp_appr = Expression(
+                    self.apparent_phase_component_set,
+                    doc="Component activity in each phase",
+                    rule=rule_act_phase_comp_appr)
+        except AttributeError:
+            self.del_component(self.act_phase_comp_appr)
+            raise
+
     def _log_act_phase_comp(self):
         try:
             def rule_log_act_phase_comp(b, p, j):
@@ -1824,6 +1859,34 @@ class GenericStateBlockData(StateBlockData):
                     rule=rule_log_act_phase_comp)
         except AttributeError:
             self.del_component(self.log_act_phase_comp)
+            raise
+
+    def _log_act_phase_comp_true(self):
+        try:
+            def rule_log_act_phase_comp_true(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.log_act_phase_comp_true(
+                    b, p, j)
+            self.log_act_phase_comp_true = Expression(
+                    self.true_phase_component_set,
+                    doc="Natural log of component activity in each phase",
+                    rule=rule_log_act_phase_comp_true)
+        except AttributeError:
+            self.del_component(self.log_act_phase_comp_true)
+            raise
+
+    def _log_act_phase_comp_appr(self):
+        try:
+            def rule_log_act_phase_comp_appr(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.log_act_phase_comp_appr(
+                    b, p, j)
+            self.log_act_phase_comp_appr = Expression(
+                    self.apparent_phase_component_set,
+                    doc="Natural log of component activity in each phase",
+                    rule=rule_log_act_phase_comp_appr)
+        except AttributeError:
+            self.del_component(self.log_act_phase_comp_appr)
             raise
 
     def _act_coeff_phase_comp(self):
@@ -1838,6 +1901,34 @@ class GenericStateBlockData(StateBlockData):
                     rule=rule_act_coeff_phase_comp)
         except AttributeError:
             self.del_component(self.act_coeff_phase_comp)
+            raise
+
+    def _act_coeff_phase_comp_true(self):
+        try:
+            def rule_act_coeff_phase_comp_true(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.act_coeff_phase_comp_true(
+                    b, p, j)
+            self.act_coeff_phase_comp_true = Expression(
+                    self.true_phase_component_set,
+                    doc="Component activity coefficient in each phase",
+                    rule=rule_act_coeff_phase_comp_true)
+        except AttributeError:
+            self.del_component(self.act_coeff_phase_comp_true)
+            raise
+
+    def _act_coeff_phase_comp_appr(self):
+        try:
+            def rule_act_coeff_phase_comp_appr(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.act_coeff_phase_comp_appr(
+                    b, p, j)
+            self.act_coeff_phase_comp_appr = Expression(
+                    self.apparent_phase_component_set,
+                    doc="Component activity coefficient in each phase",
+                    rule=rule_act_coeff_phase_comp_appr)
+        except AttributeError:
+            self.del_component(self.act_coeff_phase_comp_appr)
             raise
 
     def _compress_fact_phase(self):

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -859,6 +859,9 @@ class GenericParameterData(PhysicalParameterBlock):
              'phase_frac': {'method': None},
              'temperature': {'method': None},
              'pressure': {'method': None},
+             'act_phase_comp': {'method': '_act_phase_comp'},
+             'log_act_phase_comp': {'method': '_log_act_phase_comp'},
+             'act_coeff_phase_comp': {'method': '_act_coeff_phase_comp'},
              'compress_fact_phase': {'method': '_compress_fact_phase'},
              'conc_mol_comp': {'method': '_conc_mol_comp'},
              'conc_mol_phase_comp': {'method': '_conc_mol_phase_comp'},
@@ -1797,6 +1800,46 @@ class GenericStateBlockData(StateBlockData):
 
     # -------------------------------------------------------------------------
     # Property Methods
+    def _act_phase_comp(self):
+        try:
+            def rule_act_phase_comp(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.act_phase_comp(b, p, j)
+            self.act_phase_comp = Expression(
+                    self.phase_component_set,
+                    doc="Component activity in each phase",
+                    rule=rule_act_phase_comp)
+        except AttributeError:
+            self.del_component(self.act_phase_comp)
+            raise
+
+    def _log_act_phase_comp(self):
+        try:
+            def rule_log_act_phase_comp(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.log_act_phase_comp(b, p, j)
+            self.log_act_phase_comp = Expression(
+                    self.phase_component_set,
+                    doc="Natural log of component activity in each phase",
+                    rule=rule_log_act_phase_comp)
+        except AttributeError:
+            self.del_component(self.log_act_phase_comp)
+            raise
+
+    def _act_coeff_phase_comp(self):
+        try:
+            def rule_act_coeff_phase_comp(b, p, j):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.act_coeff_phase_comp(
+                    b, p, j)
+            self.act_coeff_phase_comp = Expression(
+                    self.phase_component_set,
+                    doc="Component activity coefficient in each phase",
+                    rule=rule_act_coeff_phase_comp)
+        except AttributeError:
+            self.del_component(self.act_coeff_phase_comp)
+            raise
+
     def _compress_fact_phase(self):
         try:
             def rule_Z_phase(b, p):


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
The PR make the Ideal property package the base class for the eNRTL model so that it has access to common ideal properties. This should make the eNRTL model usable in unit models, and non-ideal properties can be added gradually as they are developed.

This PR also corrects a bug in the Ideal property package where the pressure dependent term for enthalpy of incompressible materials was not included.

## Changes proposed in this PR:
- Lots
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
