### PR TITLE
Add check in pytest to enforce that tests have required markers

### DIFF
--- a/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
+++ b/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
@@ -328,7 +328,7 @@ class TestUncertaintyPropagation:
         with pytest.raises(TypeError):
             propagate_results =  propagate_uncertainty(1, theta, cov, variable_name)
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_quantify_propagate_uncertainty_NRTL(self):
         '''
         It tests the function quantify_propagate_uncertainty with IDAES NRTL model.
@@ -349,9 +349,8 @@ class TestUncertaintyPropagation:
         np.testing.assert_array_almost_equal(results.gradient_f[0], [-0.19649493])
         np.testing.assert_almost_equal(results.cov, np.array([[0.01194738, -0.02557055], [-0.02557055, 0.05490639]]))
         assert results.propagation_f == pytest.approx(0.0021199499778127204)
-        
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_quantify_propagate_uncertainty_NRTL_exception(self):
         '''
         It tests an exception error when the ipopt fails for the function quantify_propagate_uncertainty with IDAES NRTL model.

--- a/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
+++ b/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
@@ -58,7 +58,7 @@ class TestUncertaintyPropagation:
         np.testing.assert_array_almost_equal(results.cov, np.array([[6.30579403, -0.4395341], [-0.4395341, 0.04193591]])) 
         assert results.propagation_f == pytest.approx(5.45439337747349)
 
-
+    @pytest.mark.component
     def test_quantify_propagate_uncertainty2(self):
         '''
         This is the same test as test_quantify_propagate_uncertainty1,
@@ -88,7 +88,7 @@ class TestUncertaintyPropagation:
         np.testing.assert_array_almost_equal(results.cov, np.array([[6.30579403, -0.4395341], [-0.4395341, 0.04193591]]))
         assert results.propagation_f == pytest.approx(5.45439337747349)
 
-
+    @pytest.mark.component
     def test_propagate_uncertainty(self):
         '''
         It tests the function propagate_uncertainty with rooney & biegler's model.
@@ -116,6 +116,7 @@ class TestUncertaintyPropagation:
         assert list(propagate_results.propagation_c) == []
         assert propagate_results.propagation_f == pytest.approx(5.45439337747349)
 
+    @pytest.mark.component
     def test_propagate_uncertainty1(self):
         '''
         It tests the function propagate_uncertainty with
@@ -305,6 +306,7 @@ class TestUncertaintyPropagation:
         # Check the uncertainty propagation results for the objective matches
         assert results.propagation_f == pytest.approx(sigma_f)
 
+    @pytest.mark.component
     def test_propagate_uncertainty_error(self):
         '''
         It tests a TypeError when the modle_uncertian of function propagate_uncertainty is neither python function nor Pyomo ConcreteModel
@@ -367,7 +369,7 @@ class TestUncertaintyPropagation:
         with pytest.raises(Exception):
             results =  quantify_propagate_uncertainty(NRTL_model,NRTL_model_opt_infeasible, data, variable_name, SSE)
 
-
+    @pytest.mark.unit
     def test_Exception1(self):
         '''
         It tests an ValueError when the tee is not bool for the function quantify_propagate_uncertainty with rooney & biegler's model.
@@ -383,7 +385,6 @@ class TestUncertaintyPropagation:
         tee = 1
         with pytest.raises(TypeError):
             results =  quantify_propagate_uncertainty(rooney_biegler_model,rooney_biegler_model_opt, data, variable_name, SSE,tee)
-
 
     @pytest.mark.unit
     def test_Exception2(self):
@@ -402,7 +403,6 @@ class TestUncertaintyPropagation:
         diagnostic_mode = 1
         with pytest.raises(TypeError):
             results =  quantify_propagate_uncertainty(rooney_biegler_model,rooney_biegler_model_opt, data, variable_name, SSE,tee,diagnostic_mode)
-
 
     @pytest.mark.unit
     def test_Exception3(self):
@@ -423,6 +423,7 @@ class TestUncertaintyPropagation:
         with pytest.raises(TypeError):
             results =  quantify_propagate_uncertainty(rooney_biegler_model,rooney_biegler_model_opt, data, variable_name, SSE,tee,diagnostic_mode,solver_options)
 
+    @pytest.mark.unit
     def test_clean_variable_name1(self):
         '''
         It tests the function clean_variable_name when variable names contain ' and spaces.
@@ -439,7 +440,8 @@ class TestUncertaintyPropagation:
         assert len(theta_names) == len(var_dic.values())
         assert all([a == b for a, b in zip(sorted(theta_names), sorted(var_dic.values()))])
         assert clean == True
-     
+
+    @pytest.mark.unit
     def test_clean_variable_name2(self):
         '''
         It tests the function clean_variable_name when variable names do not contain any ' and spaces.

--- a/idaes/conftest.py
+++ b/idaes/conftest.py
@@ -94,7 +94,7 @@ def _validate_required_markers(item, required_markers=None, expected_count=1):
     if required_count < expected_count:
         reason_to_fail = 'Too few required markers'
     if required_count > expected_count:
-        reason = 'Too many required markers'
+        reason_to_fail = 'Too many required markers'
     if reason_to_fail:
         extra_info = f'Expected: {expected_count} of {required_markers}; found: {item_markers}'
         msg = f'{reason_to_fail} for test function "{item.name}". {extra_info}'

--- a/idaes/conftest.py
+++ b/idaes/conftest.py
@@ -31,16 +31,20 @@ import sys
 ####
 
 
+REQUIRED_MARKERS = {"unit", "component", "integration"}
+ALL_PLATFORMS = {"darwin", "linux", "win32"}
+
+
 @pytest.hookimpl
 def pytest_runtest_setup(item):
     _validate_required_markers(
         item,
-        required_markers={"unit", "component", "integration"},
+        required_markers=REQUIRED_MARKERS,
         expected_count=1
     )
     _skip_for_unsupported_platforms(
         item,
-        all_platforms={"darwin", "linux", "win32"},
+        all_platforms=ALL_PLATFORMS,
         negate_tag=(lambda tag: f'no{tag}'),
     )
 

--- a/idaes/conftest.py
+++ b/idaes/conftest.py
@@ -98,7 +98,8 @@ def _validate_required_markers(item, required_markers=None, expected_count=1):
     if reason_to_fail:
         msg = (
             f'{reason_to_fail} for test function "{item.name}". '
-            f'Expected: {expected_count} of {required_markers}; found: {item_markers}'
+            f'Expected: {expected_count} of {required_markers}; '
+            f'found: {required_markers_on_item or required_count}'
         )
         pytest.fail(msg)
 

--- a/idaes/conftest.py
+++ b/idaes/conftest.py
@@ -96,8 +96,10 @@ def _validate_required_markers(item, required_markers=None, expected_count=1):
     if required_count > expected_count:
         reason_to_fail = 'Too many required markers'
     if reason_to_fail:
-        extra_info = f'Expected: {expected_count} of {required_markers}; found: {item_markers}'
-        msg = f'{reason_to_fail} for test function "{item.name}". {extra_info}'
+        msg = (
+            f'{reason_to_fail} for test function "{item.name}". '
+            f'Expected: {expected_count} of {required_markers}; found: {item_markers}'
+        )
         pytest.fail(msg)
 
 

--- a/idaes/tests/test_headers.py
+++ b/idaes/tests/test_headers.py
@@ -44,6 +44,7 @@ def patterns(package_root):
     return conf_data["patterns"]
 
 
+@pytest.mark.unit
 def test_headers(package_root, patterns):
     if patterns is None:
         print(f"ERROR: Did not get glob patterns: skipping test")

--- a/idaes/tests/test_style.py
+++ b/idaes/tests/test_style.py
@@ -64,3 +64,15 @@ def test_flake8():
         proc.wait()
         status = proc.returncode
         assert status == 0, f"Style checker '{STYLE_CHECK_CMD}' had errors for {path}"
+
+
+# @pytest.mark.xfail
+def test_function_without_a_mark():
+    assert True
+
+
+# @pytest.mark.xfail
+@pytest.mark.unit
+@pytest.mark.component
+def test_function_with_too_many_required_marks():
+    assert True

--- a/idaes/tests/test_style.py
+++ b/idaes/tests/test_style.py
@@ -64,15 +64,3 @@ def test_flake8():
         proc.wait()
         status = proc.returncode
         assert status == 0, f"Style checker '{STYLE_CHECK_CMD}' had errors for {path}"
-
-
-# @pytest.mark.xfail
-def test_function_without_a_mark():
-    assert True
-
-
-# @pytest.mark.xfail
-@pytest.mark.unit
-@pytest.mark.component
-def test_function_with_too_many_required_marks():
-    assert True

--- a/idaes/tests/test_tests.py
+++ b/idaes/tests/test_tests.py
@@ -1,0 +1,30 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+"Tests used to test the functionality of the test suite itself."
+
+import pytest
+
+
+# pytestmark = pytest.mark.skip("Tests for the test suite are always skipped under normal circumstances")
+
+
+@pytest.mark.xfail
+def test_function_without_any_required_mark():
+    assert True
+
+
+@pytest.mark.xfail
+@pytest.mark.unit
+@pytest.mark.component
+def test_function_with_too_many_required_marks():
+    assert True


### PR DESCRIPTION
## Fixes #170

## Summary/Motivation
All tests in the pytest test suite should have at least one of the required markers (`unit`, `component`, `integration`).
This PR implements this by adding a check that runs when the tests items are collected and causes any test without a required marker to fail.

## Changes proposed in this PR:
- Add function in `conftest.py` to check that test items have required markers
- Refactor existing code running during `pytest_runtest_setup` for consistency

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
