### PR TITLE
Fix model serializer root name issue

### DIFF
--- a/idaes/core/util/model_serializer.py
+++ b/idaes/core/util/model_serializer.py
@@ -846,6 +846,14 @@ def from_json(o, sd=None, fname=None, s=None, wts=None, gz=None, root_name=None)
     lookup = {} # A dict to use for a lookup tables
     suffixes={} # A list of suffixes delayed to end so lookup is complete
     # Read toplevel componet (is recursive)
+    if root_name is None:
+        for k in sd:
+            if k.startswith("__") and k.endswith("__"):
+                # This is metadata or maybe some similar future addition.
+                continue
+            else:
+                root_name = k
+                break # should be one root, use it's name
     _read_component(
         sd, o, wts, lookup=lookup, suffixes=suffixes, root_name=root_name)
     read_time = time.time() # to calc time to read model state minus suffixes

--- a/idaes/core/util/tests/test_model_serializer.py
+++ b/idaes/core/util/tests/test_model_serializer.py
@@ -43,8 +43,11 @@ class TestModelSerialize(unittest.TestCase):
         except:
             pass
 
-    def setup_model01(self):
-        model = ConcreteModel()
+    def setup_model01(self, name=None):
+        if name is not None:
+            model = ConcreteModel(name)
+        else:
+            model = ConcreteModel()
         model.b = Block([1,2,3])
         a = model.b[1].a = Var(bounds=(-100, 100), initialize=2)
         b = model.b[1].b = Var(bounds=(-100, 100), initialize=20)
@@ -88,6 +91,21 @@ class TestModelSerialize(unittest.TestCase):
         model.ipopt_zU_out = Suffix(direction=Suffix.IMPORT)
         return model
 
+    @pytest.mark.unit
+    def test01_name(self):
+        """
+        Simple test of load save json with differnt model names
+        """
+        model = self.setup_model01("m1")
+        model2 = self.setup_model01("m2")
+
+        model2.b[1].a = 0.11
+        model2.b[1].b = 0.11
+        to_json(model, fname=self.fname, human_read=True)
+        from_json(model2, fname=self.fname)
+        #make sure they are right
+        assert pytest.approx(20) == value(model2.b[1].b)
+        assert pytest.approx(2) == value(model2.b[1].a)
 
     @pytest.mark.unit
     def test01(self):


### PR DESCRIPTION
## Fixes
Fixes an issue where the root component name of the block or module doesn't match what's in the saved state.  Places where this root name mismatch occur is when you have models with different name, but the same structure, or when you have indexed blocks and want to copy the results for one block to other blocks.  This was possible to do before by providing the root name, but now it should just work automatically.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
