### PR TITLE
Correcting unsymmetric reference state to be near-zero instead of zero

### DIFF
--- a/idaes/generic_models/properties/core/eos/enrtl_reference_states.py
+++ b/idaes/generic_models/properties/core/eos/enrtl_reference_states.py
@@ -35,6 +35,10 @@ import idaes.logger as idaeslog
 _log = idaeslog.getLogger(__name__)
 
 
+# Near-zero value to use for unsymmetric reference state
+EPS = 1e-20
+
+
 class Unsymmetric(object):
     """
     Sub-methods for the symmetric (fused-salt) reference state
@@ -48,7 +52,7 @@ class Unsymmetric(object):
                         sum(b.mole_frac_phase_comp_true[pname, j]
                             for j in b.params.solvent_set|b.params.solute_set))
             else:
-                return 0
+                return EPS
 
         b.add_component(pname+"_x_ref",
                         Expression(b.params.true_species_set, rule=rule_x_ref))


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
The Unsymmetric reference state for the eNRTL model is based on infinite-dilution of ionic species. Previously this was represented using zero mole fractions for ionic species, but this resulted in issues with raising 0 to fractional and negative powers.

## Changes proposed in this PR:
- Changes the mole fractions of ionic species at the unsymmetric reference state to an EPS value rather than zero.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
