### PR TITLE
Making time a property of flowsheets

### DIFF
--- a/idaes/core/tests/test_flowsheet_model.py
+++ b/idaes/core/tests/test_flowsheet_model.py
@@ -239,7 +239,7 @@ class TestBuild(object):
 
         assert m.fs.config.dynamic is False
         assert m.fs.config.time is m.s
-        assert not hasattr(m.fs, "time")
+        assert m.fs.time is m.s
         assert m.fs.time_units is None
 
     @pytest.mark.unit
@@ -252,7 +252,7 @@ class TestBuild(object):
 
         assert m.fs.config.dynamic is False
         assert m.fs.config.time is m.s
-        assert not hasattr(m.fs, "time")
+        assert m.fs.time is m.s
         assert m.fs.time_units is None
 
     @pytest.mark.unit
@@ -265,7 +265,7 @@ class TestBuild(object):
 
         assert m.fs.config.dynamic is True
         assert m.fs.config.time is m.s
-        assert not hasattr(m.fs, "time")
+        assert m.fs.time is m.s
         assert m.fs.time_units is None
 
     @pytest.mark.unit
@@ -290,7 +290,7 @@ class TestBuild(object):
 
         assert m.fs.config.dynamic is False
         assert m.fs.config.time is m.s
-        assert not hasattr(m.fs, "time")
+        assert m.fs.time is m.s
         assert m.fs.time_units is None
 
     @pytest.mark.unit
@@ -305,7 +305,7 @@ class TestBuild(object):
 
         assert m.fs.config.dynamic is True
         assert m.fs.config.time is m.s
-        assert not hasattr(m.fs, "time")
+        assert m.fs.time is m.s
         assert m.fs.time_units is None
 
     @pytest.mark.unit


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Currently, there is some inconsistency in how the time domain is handled between top level and sub-flowsheets. Notably, `flowsheet.time` works for top-level flowsheets, but `flowsheet.config.time` is required for sub-flowsheets. This PR makes `time` a property of all `FlowsheetBlocks` so that `flowsheet.time` will work for all flowsheets.

## Changes proposed in this PR:
- Make `time` a property of `FlowsheetBlocks`
- Store the time domain or a reference to in in `_time`
- Update `_setup_dynamics` to define the `_time` attribute.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
