### PR TITLE
Update all references to time domain

### DIFF
--- a/idaes/core/control_volume0d.py
+++ b/idaes/core/control_volume0d.py
@@ -83,7 +83,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         """
         units = self.config.property_package.get_metadata().get_derived_units
 
-        self.volume = Var(self.flowsheet().config.time, initialize=1.0,
+        self.volume = Var(self.flowsheet().time, initialize=1.0,
                           doc='Volume of material in control volume',
                           units=units('volume'))
 
@@ -131,7 +131,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         self.properties_in = (
                 self.config.property_package.build_state_block(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         doc="Material properties at inlet",
                         default=tmp_dict))
 
@@ -141,7 +141,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         self.properties_out = (
                 self.config.property_package.build_state_block(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         doc="Material properties at outlet",
                         default=tmp_dict_2))
 
@@ -174,7 +174,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         self.reactions = (
                 self.config.reaction_package.build_reaction_block(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         doc="Reaction properties in control volume",
                         default=tmp_dict))
 
@@ -207,7 +207,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         if has_equilibrium_reactions:
             # Check that reaction block is set to calculate equilibrium
-            for t in self.flowsheet().config.time:
+            for t in self.flowsheet().time:
                 if self.reactions[t].config.has_equilibrium is False:
                     raise ConfigurationError(
                             "{} material balance was set to include "
@@ -219,7 +219,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         if has_phase_equilibrium:
             # Check that state blocks are set to calculate equilibrium
-            for t in self.flowsheet().config.time:
+            for t in self.flowsheet().time:
                 if not self.properties_out[t].config.has_phase_equilibrium:
                     raise ConfigurationError(
                             "{} material balance was set to include phase "
@@ -240,10 +240,10 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         # Get units from property package
         units = self.config.property_package.get_metadata().get_derived_units
 
-        if (self.properties_in[self.flowsheet().config.time.first()]
+        if (self.properties_in[self.flowsheet().time.first()]
                 .get_material_flow_basis() == MaterialFlowBasis.molar):
             flow_units = units("flow_mole")
-        elif (self.properties_in[self.flowsheet().config.time.first()]
+        elif (self.properties_in[self.flowsheet().time.first()]
               .get_material_flow_basis() == MaterialFlowBasis.mass):
             flow_units = units("flow_mass")
         else:
@@ -251,7 +251,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         # Get units for accumulation term if required
         if self.config.dynamic:
-            f_time_units = self.flowsheet().config.time_units
+            f_time_units = self.flowsheet().time_units
             if (f_time_units is None) ^ (units('time') is None):
                 raise ConfigurationError(
                     "{} incompatible time unit specification between "
@@ -260,10 +260,10 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
             if f_time_units is None:
                 acc_units = None
-            elif (self.properties_in[self.flowsheet().config.time.first()]
+            elif (self.properties_in[self.flowsheet().time.first()]
                   .get_material_flow_basis() == MaterialFlowBasis.molar):
                 acc_units = units('amount')/f_time_units
-            elif (self.properties_in[self.flowsheet().config.time.first()]
+            elif (self.properties_in[self.flowsheet().time.first()]
                   .get_material_flow_basis() == MaterialFlowBasis.mass):
                 acc_units = units('mass')/f_time_units
             else:
@@ -280,7 +280,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         # Material holdup and accumulation
         if has_holdup:
-            self.material_holdup = Var(self.flowsheet().config.time,
+            self.material_holdup = Var(self.flowsheet().time,
                                        pc_set,
                                        domain=Reals,
                                        initialize=1.0,
@@ -289,7 +289,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         if dynamic:
             self.material_accumulation = DerivativeVar(
                     self.material_holdup,
-                    wrt=self.flowsheet().config.time,
+                    wrt=self.flowsheet().time,
                     doc="Material accumulation in control volume",
                     units=acc_units)
 
@@ -302,7 +302,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                     "reactions (rate_reaction_idx), thus does not support "
                     "rate-based reactions.".format(self.name))
             self.rate_reaction_generation = Var(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         pc_set,
                         domain=Reals,
                         initialize=0.0,
@@ -320,7 +320,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                     "does not support equilibrium-based reactions."
                     .format(self.name))
             self.equilibrium_reaction_generation = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 pc_set,
                 domain=Reals,
                 initialize=0.0,
@@ -338,7 +338,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                     "include_inherent_reactions is True."
                     .format(self.name))
             self.inherent_reaction_generation = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 pc_set,
                 domain=Reals,
                 initialize=0.0,
@@ -356,7 +356,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                     "equilibrium reactions (phase_equilibrium_idx), thus does "
                     "not support phase equilibrium.".format(self.name))
             self.phase_equilibrium_generation = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.config.property_package.phase_equilibrium_idx,
                 domain=Reals,
                 initialize=0.0,
@@ -366,7 +366,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         # Material transfer term
         if has_mass_transfer:
             self.mass_transfer_term = Var(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         pc_set,
                         domain=Reals,
                         initialize=0.0,
@@ -426,7 +426,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             if not hasattr(self, "phase_fraction"):
                 self._add_phase_fractions()
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              pc_set,
                              doc="Material holdup calculations")
             def material_holdup_calculation(b, t, p, j):
@@ -438,14 +438,14 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         if has_rate_reactions:
             # Add extents of reaction and stoichiometric constraints
             self.rate_reaction_extent = Var(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.config.reaction_package.rate_reaction_idx,
                     domain=Reals,
                     initialize=0.0,
                     doc="Extent of kinetic reactions",
                     units=flow_units)
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              pc_set,
                              doc="Kinetic reaction stoichiometry constraint")
             def rate_reaction_stoichiometry_constraint(b, t, p, j):
@@ -462,14 +462,14 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         if has_equilibrium_reactions:
             # Add extents of reaction and stoichiometric constraints
             self.equilibrium_reaction_extent = Var(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.config.reaction_package.equilibrium_reaction_idx,
                     domain=Reals,
                     initialize=0.0,
                     doc="Extent of equilibrium reactions",
                     units=flow_units)
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              pc_set,
                              doc="Equilibrium reaction stoichiometry")
             def equilibrium_reaction_stoichiometry_constraint(b, t, p, j):
@@ -486,14 +486,14 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         if self.properties_out.include_inherent_reactions:
             # Add extents of reaction and stoichiometric constraints
             self.inherent_reaction_extent = Var(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.config.property_package.inherent_reaction_idx,
                     domain=Reals,
                     initialize=0.0,
                     doc="Extent of inherent reactions",
                     units=flow_units)
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              pc_set,
                              doc="Inherent reaction stoichiometry")
             def inherent_reaction_stoichiometry_constraint(b, t, p, j):
@@ -559,7 +559,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 else:
                     return 0
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              pc_set,
                              doc="Material balances")
             def material_balances(b, t, p, j):
@@ -629,7 +629,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 else:
                     return 0
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              component_list,
                              doc="Material balances")
             def material_balances(b, t, j):
@@ -827,7 +827,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         # Get units for accumulation term if required
         if self.config.dynamic:
-            f_time_units = self.flowsheet().config.time_units
+            f_time_units = self.flowsheet().time_units
             if (f_time_units is None) ^ (units('time') is None):
                 raise ConfigurationError(
                     "{} incompatible time unit specification between "
@@ -845,7 +845,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         linearly_dependent = []
 
         # Get a representative time point
-        rtime = self.flowsheet().config.time.first()
+        rtime = self.flowsheet().time.first()
 
         # For each component in the material, search for elements which are
         # unique to it
@@ -889,7 +889,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         # Add Material Balance terms
         if has_holdup:
             self.element_holdup = Var(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.config.property_package.element_list,
                     domain=Reals,
                     initialize=1.0,
@@ -899,7 +899,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         if dynamic:
             self.element_accumulation = DerivativeVar(
                     self.element_holdup,
-                    wrt=self.flowsheet().config.time,
+                    wrt=self.flowsheet().time,
                     doc="Elemental accumulation in control volume",
                     units=acc_units)
 
@@ -916,7 +916,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                     "automatically generate elemental balances."
                     .format(self.name))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          phase_list,
                          self.config.property_package.element_list,
                          doc="Inlet elemental flow terms")
@@ -926,7 +926,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                        b.properties_out[t].params.element_comp[j][e]
                        for j in component_list)
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          phase_list,
                          self.config.property_package.element_list,
                          doc="Outlet elemental flow terms")
@@ -939,7 +939,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         # Create material balance terms as needed
         if has_mass_transfer:
             self.elemental_mass_transfer_term = Var(
-                            self.flowsheet().config.time,
+                            self.flowsheet().time,
                             e_index,
                             domain=Reals,
                             initialize=0.0,
@@ -966,7 +966,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 return 0
 
         # Element balances
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          e_index,
                          doc="Elemental material balances")
         def element_balances(b, t, e):
@@ -983,7 +983,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             if not hasattr(self, "phase_fraction"):
                 self._add_phase_fractions()
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.config.property_package.element_list,
                              doc="Elemental holdup calculation")
             def elemental_holdup_calculation(b, t, e):
@@ -1059,7 +1059,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         # Get units for accumulation term if required
         if self.config.dynamic:
-            f_time_units = self.flowsheet().config.time_units
+            f_time_units = self.flowsheet().time_units
             if (f_time_units is None) ^ (units('time') is None):
                 raise ConfigurationError(
                     "{} incompatible time unit specification between "
@@ -1074,7 +1074,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         # Create variables
         if has_holdup:
             self.energy_holdup = Var(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         phase_list,
                         domain=Reals,
                         initialize=1.0,
@@ -1084,14 +1084,14 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         if dynamic is True:
             self.energy_accumulation = DerivativeVar(
                         self.energy_holdup,
-                        wrt=self.flowsheet().config.time,
+                        wrt=self.flowsheet().time,
                         doc="Energy accumulation in control volume",
                         units=acc_units)
 
         # Create energy balance terms as needed
         # Heat transfer term
         if has_heat_transfer:
-            self.heat = Var(self.flowsheet().config.time,
+            self.heat = Var(self.flowsheet().time,
                             domain=Reals,
                             initialize=0.0,
                             doc="Heat transferred into control volume",
@@ -1099,7 +1099,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         # Work transfer
         if has_work_transfer:
-            self.work = Var(self.flowsheet().config.time,
+            self.work = Var(self.flowsheet().time,
                             domain=Reals,
                             initialize=0.0,
                             doc="Work transferred into control volume",
@@ -1108,7 +1108,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         # Enthalpy transfer
         if has_enthalpy_transfer:
             self.enthalpy_transfer = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 domain=Reals,
                 initialize=0.0,
                 doc="Enthalpy transferred into control volume due to "
@@ -1117,7 +1117,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         # Heat of Reaction
         if has_heat_of_reaction:
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc="Heat of reaction term")
             def heat_of_reaction(b, t):
                 if hasattr(self, "rate_reaction_extent"):
@@ -1166,7 +1166,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 return 0
 
         # Energy balance equation
-        @self.Constraint(self.flowsheet().config.time, doc="Energy balances")
+        @self.Constraint(self.flowsheet().time, doc="Energy balances")
         def enthalpy_balances(b, t):
             return sum(accumulation_term(b, t, p) for p in phase_list) == (
                 sum(b.properties_in[t].get_enthalpy_flow_terms(p)
@@ -1184,7 +1184,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             if not hasattr(self, "phase_fraction"):
                 self._add_phase_fractions()
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              phase_list,
                              doc="Enthalpy holdup constraint")
             def energy_holdup_calculation(b, t, p):
@@ -1232,7 +1232,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         # Add Momentum Balance Variables as necessary
         if has_pressure_change:
-            self.deltaP = Var(self.flowsheet().config.time,
+            self.deltaP = Var(self.flowsheet().time,
                               domain=Reals,
                               initialize=0.0,
                               doc="Pressure difference across unit",
@@ -1251,7 +1251,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 return 0
 
         # Momentum balance equation
-        @self.Constraint(self.flowsheet().config.time, doc='Momentum balance')
+        @self.Constraint(self.flowsheet().time, doc='Momentum balance')
         def pressure_balance(b, t):
             return 0 == (
                 b.properties_in[t].pressure
@@ -1293,7 +1293,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             None
         """
         # Try property block model check
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             try:
                 blk.properties_in[t].model_check()
             except AttributeError:
@@ -1352,7 +1352,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             state_args = {}
             state_dict = (
                 blk.properties_in[
-                    blk.flowsheet().config.time.first()]
+                    blk.flowsheet().time.first()]
                 .define_port_members())
 
             for k in state_dict.keys():
@@ -1433,18 +1433,18 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         phase_list = self.properties_in.phase_list
         if len(phase_list) > 1:
             self.phase_fraction = Var(
-                            self.flowsheet().config.time,
+                            self.flowsheet().time,
                             phase_list,
                             initialize=1 / len(phase_list),
                             doc='Volume fraction of holdup by phase')
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc='Sum of phase fractions == 1')
             def sum_of_phase_fractions(self, t):
                 return 1 == sum(self.phase_fraction[t, p]
                                 for p in phase_list)
         else:
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              phase_list,
                              doc='Volume fraction of holdup by phase')
             def phase_fraction(self, t, p):

--- a/idaes/core/control_volume_base.py
+++ b/idaes/core/control_volume_base.py
@@ -818,7 +818,7 @@ have a config block which derives from CONFIG_Base,
 
     def _get_representative_property_block(self):
         try:
-            t_ref = self.flowsheet().config.time.first()
+            t_ref = self.flowsheet().time.first()
         except AttributeError:
             raise ConfigurationError(
                     "{} control volume does not appear to be part of a "

--- a/idaes/core/process_base.py
+++ b/idaes/core/process_base.py
@@ -170,21 +170,21 @@ class ProcessBlockData(_BlockData):
                 # Try to fix material_accumulation @ first time point
                 try:
                     obj.material_accumulation[
-                            obj.flowsheet().config.time.first(), ...].fix(0.0)
+                            obj.flowsheet().time.first(), ...].fix(0.0)
                 except AttributeError:
                     pass
 
                 # Try to fix element_accumulation @ first time point
                 try:
                     obj.element_accumulation[
-                            obj.flowsheet().config.time.first(), ...].fix(0.0)
+                            obj.flowsheet().time.first(), ...].fix(0.0)
                 except AttributeError:
                     pass
 
                 # Try to fix energy_accumulation @ first time point
                 try:
                     obj.energy_accumulation[
-                            obj.flowsheet().config.time.first(), ...].fix(0.0)
+                            obj.flowsheet().time.first(), ...].fix(0.0)
                 except AttributeError:
                     pass
 
@@ -205,21 +205,21 @@ class ProcessBlockData(_BlockData):
             # Try to unfix material_accumulation @ first time point
             try:
                 obj.material_accumulation[
-                        obj.flowsheet().config.time.first(), ...].unfix()
+                        obj.flowsheet().time.first(), ...].unfix()
             except AttributeError:
                 pass
 
             # Try to fix element_accumulation @ first time point
             try:
                 obj.element_accumulation[
-                        obj.flowsheet().config.time.first(), ...].unfix()
+                        obj.flowsheet().time.first(), ...].unfix()
             except AttributeError:
                 pass
 
             # Try to fix energy_accumulation @ first time point
             try:
                 obj.energy_accumulation[
-                        obj.flowsheet().config.time.first(), ...].unfix()
+                        obj.flowsheet().time.first(), ...].unfix()
             except AttributeError:
                 pass
 

--- a/idaes/core/tests/test_control_volume_0d.py
+++ b/idaes/core/tests/test_control_volume_0d.py
@@ -892,7 +892,7 @@ def test_add_phase_component_balances_custom_molar_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.phase_list,
                            m.fs.cv.config.property_package.component_list)
 
@@ -922,7 +922,7 @@ def test_add_phase_component_balances_custom_molar_term_no_mw():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.phase_list,
                            m.fs.cv.config.property_package.component_list)
 
@@ -948,7 +948,7 @@ def test_add_phase_component_balances_custom_molar_term_mass_flow_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.phase_list,
                            m.fs.cv.config.property_package.component_list)
 
@@ -983,7 +983,7 @@ def test_add_phase_component_balances_custom_molar_term_undefined_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.phase_list,
                            m.fs.cv.config.property_package.component_list)
 
@@ -1009,7 +1009,7 @@ def test_add_phase_component_balances_custom_mass_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.phase_list,
                            m.fs.cv.config.property_package.component_list)
 
@@ -1039,7 +1039,7 @@ def test_add_phase_component_balances_custom_mass_term_no_mw():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.phase_list,
                            m.fs.cv.config.property_package.component_list)
 
@@ -1065,7 +1065,7 @@ def test_add_phase_component_balances_custom_mass_term_mole_flow_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.phase_list,
                            m.fs.cv.config.property_package.component_list)
 
@@ -1100,7 +1100,7 @@ def test_add_phase_component_balances_custom_mass_term_undefined_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.phase_list,
                            m.fs.cv.config.property_package.component_list)
 
@@ -1419,7 +1419,7 @@ def test_add_total_component_balances_custom_molar_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.component_list)
 
     def custom_method(t, j):
@@ -1448,7 +1448,7 @@ def test_add_total_component_balances_custom_molar_term_no_mw():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.component_list)
 
     def custom_method(t, j):
@@ -1473,7 +1473,7 @@ def test_add_total_component_balances_custom_molar_term_mass_flow_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.component_list)
 
     def custom_method(t, j):
@@ -1507,7 +1507,7 @@ def test_add_total_component_balances_custom_molar_term_undefined_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.component_list)
 
     def custom_method(t, j):
@@ -1532,7 +1532,7 @@ def test_add_total_component_balances_custom_mass_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.component_list)
 
     def custom_method(t, j):
@@ -1561,7 +1561,7 @@ def test_add_total_component_balances_custom_mass_term_no_mw():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.component_list)
 
     def custom_method(t, j):
@@ -1586,7 +1586,7 @@ def test_add_total_component_balances_custom_mass_term_mole_flow_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.component_list)
 
     def custom_method(t, j):
@@ -1620,7 +1620,7 @@ def test_add_total_component_balances_custom_mass_term_undefined_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.cv.config.property_package.component_list)
 
     def custom_method(t, j):
@@ -1807,7 +1807,7 @@ def test_add_total_element_balances_custom_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.element_list)
 
     def custom_method(t, e):
@@ -2069,7 +2069,7 @@ def test_add_total_enthalpy_balances_custom_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time)
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time)
 
     def custom_method(t):
         return m.fs.cv.test_var[t]*units.J/units.s
@@ -2261,7 +2261,7 @@ def test_add_total_pressure_balances_custom_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time)
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time)
 
     def custom_method(t):
         return m.fs.cv.test_var[t]*units.Pa

--- a/idaes/core/tests/test_control_volume_1d.py
+++ b/idaes/core/tests/test_control_volume_1d.py
@@ -1381,7 +1381,7 @@ def test_add_phase_component_balances_custom_molar_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.phase_list,
                            m.fs.pp.component_list)
 
@@ -1415,7 +1415,7 @@ def test_add_phase_component_balances_custom_molar_term_no_mw():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.phase_list,
                            m.fs.pp.component_list)
 
@@ -1445,7 +1445,7 @@ def test_add_phase_component_balances_custom_molar_term_mass_flow_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.phase_list,
                            m.fs.pp.component_list)
 
@@ -1485,7 +1485,7 @@ def test_add_phase_component_balances_custom_molar_term_undefined_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.phase_list,
                            m.fs.pp.component_list)
 
@@ -1515,7 +1515,7 @@ def test_add_phase_component_balances_custom_mass_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.phase_list,
                            m.fs.pp.component_list)
 
@@ -1549,7 +1549,7 @@ def test_add_phase_component_balances_custom_mass_term_no_mw_comp():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.phase_list,
                            m.fs.pp.component_list)
 
@@ -1579,7 +1579,7 @@ def test_add_phase_component_balances_custom_mass_term_mole_flow_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.phase_list,
                            m.fs.pp.component_list)
 
@@ -1619,7 +1619,7 @@ def test_add_phase_component_balances_custom_mass_term_undefined_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.phase_list,
                            m.fs.pp.component_list)
 
@@ -2045,7 +2045,7 @@ def test_add_total_component_balances_custom_molar_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.component_list)
 
     def custom_method(t, x, j):
@@ -2078,7 +2078,7 @@ def test_add_total_component_balances_custom_molar_term_no_mw():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.component_list)
 
     def custom_method(t, x, j):
@@ -2107,7 +2107,7 @@ def test_add_total_component_balances_custom_molar_term_mass_flow_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.component_list)
 
     def custom_method(t, x, j):
@@ -2146,7 +2146,7 @@ def test_add_total_component_balances_custom_molar_term_undefined_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.component_list)
 
     def custom_method(t, x, j):
@@ -2175,7 +2175,7 @@ def test_add_total_component_balances_custom_mass_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.component_list)
 
     def custom_method(t, x, j):
@@ -2208,7 +2208,7 @@ def test_add_total_component_balances_custom_mass_term_no_mw():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.component_list)
 
     def custom_method(t, x, j):
@@ -2237,7 +2237,7 @@ def test_add_total_component_balances_custom_mass_term_mole_flow_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.component_list)
 
     def custom_method(t, x, j):
@@ -2276,7 +2276,7 @@ def test_add_total_component_balances_custom_mass_term_undefined_basis():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.component_list)
 
     def custom_method(t, x, j):
@@ -2543,7 +2543,7 @@ def test_add_total_element_balances_custom_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time,
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time,
                            m.fs.pp.element_list)
 
     def custom_method(t, x, e):
@@ -2912,7 +2912,7 @@ def test_add_total_enthalpy_balances_custom_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time)
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time)
 
     def custom_method(t, x):
         return m.fs.cv.test_var[t]*units.J/units.s/units.m
@@ -3181,7 +3181,7 @@ def test_add_total_pressure_balances_custom_term():
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
     m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
-    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().config.time)
+    m.fs.cv.test_var = Var(m.fs.cv.flowsheet().time)
 
     def custom_method(t, x):
         return m.fs.cv.test_var[t]*units.Pa/units.m

--- a/idaes/core/unit_model.py
+++ b/idaes/core/unit_model.py
@@ -146,7 +146,7 @@ Must be True if dynamic = True,
 
         # Get dict of Port members and names
         member_list = block[
-                blk.flowsheet().config.time.first()].define_port_members()
+                blk.flowsheet().time.first()].define_port_members()
 
         # Create References for port members
         for s in member_list:
@@ -222,13 +222,13 @@ Must be True if dynamic = True,
         if isinstance(block, ControlVolumeBlockData):
             try:
                 member_list = (block.properties_in[
-                                    block.flowsheet().config.time.first()]
+                                    block.flowsheet().time.first()]
                                .define_port_members())
                 p._state_block = (block.properties_in, )
             except AttributeError:
                 try:
                     member_list = (block.properties[
-                                    block.flowsheet().config.time.first(), 0]
+                                    block.flowsheet().time.first(), 0]
                                    .define_port_members())
                     if block._flow_direction == FlowDirection.forward:
                         p._state_block = (block.properties,
@@ -244,7 +244,7 @@ Must be True if dynamic = True,
                             "package.".format(blk.name))
         elif isinstance(block, StateBlock):
             member_list = block[
-                    blk.flowsheet().config.time.first()].define_port_members()
+                    blk.flowsheet().time.first()].define_port_members()
             p._state_block = (block, )
         else:
             raise ConfigurationError(
@@ -377,13 +377,13 @@ Must be True if dynamic = True,
         if isinstance(block, ControlVolumeBlockData):
             try:
                 member_list = (block.properties_out[
-                                    block.flowsheet().config.time.first()]
+                                    block.flowsheet().time.first()]
                                .define_port_members())
                 p._state_block = (block.properties_out, )
             except AttributeError:
                 try:
                     member_list = (block.properties[
-                                    block.flowsheet().config.time.first(), 0]
+                                    block.flowsheet().time.first(), 0]
                                    .define_port_members())
                     if block._flow_direction == FlowDirection.forward:
                         p._state_block = (block.properties,
@@ -399,7 +399,7 @@ Must be True if dynamic = True,
                             "package.".format(blk.name))
         elif isinstance(block, StateBlock):
             member_list = block[
-                    blk.flowsheet().config.time.first()].define_port_members()
+                    blk.flowsheet().time.first()].define_port_members()
             p._state_block = (block, )
         else:
             raise ConfigurationError(
@@ -511,7 +511,7 @@ Must be True if dynamic = True,
                     "once per UnitModel.".format(self.name))
 
         # Get a representative time point for testing
-        rep_time = self.flowsheet().config.time.first()
+        rep_time = self.flowsheet().time.first()
         if state_1[rep_time].params is not state_2[rep_time].params:
             raise ConfigurationError(
                     "{} add_state_material_balances method was provided with "
@@ -534,7 +534,7 @@ Must be True if dynamic = True,
             # to allow for systems where a phase-transition may occur?
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 pc_set,
                 doc="State material balances",
             )
@@ -546,7 +546,7 @@ Must be True if dynamic = True,
         elif balance_type == MaterialBalanceType.componentTotal:
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 component_list,
                 doc="State material balances",
             )
@@ -562,7 +562,7 @@ Must be True if dynamic = True,
         elif balance_type == MaterialBalanceType.total:
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 doc="State material balances",
             )
             def state_material_balances(b, t):

--- a/idaes/core/util/unit_costing.py
+++ b/idaes/core/util/unit_costing.py
@@ -286,11 +286,11 @@ def pressure_changer_costing(self, Mat_factor="stain_steel",
     if self.parent_block().config.thermodynamic_assumption.name == 'pump':
         w = (self.parent_block().
              work_fluid[self.parent_block().
-                        flowsheet().config.time.first()])
+                        flowsheet().time.first()])
     else:
         w = (self.parent_block().
              work_mechanical[self.parent_block().
-                             flowsheet().config.time.first()])
+                             flowsheet().time.first()])
 
     work_hp = pyunits.convert(w, to_units=pyunits.hp) / self.number_of_units
 
@@ -309,7 +309,7 @@ def pressure_changer_costing(self, Mat_factor="stain_steel",
         if self.parent_block().config.thermodynamic_assumption.name == 'pump':
             # assign work fluid  = to w
             w = self.parent_block().work_fluid[self.parent_block().
-                                               flowsheet().config.time.first()]
+                                               flowsheet().time.first()]
 
             # new variables only used by pump costing
             self.pump_head = Var(

--- a/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
@@ -457,7 +457,7 @@ see reaction package for documentation.}"""))
             self.solid_emulsion.reactions = (
                 self.config.solid_phase_config.reaction_package.
                 reaction_block_class(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.length_domain,
                     doc="Reaction properties in control volume",
                     default=tmp_dict))
@@ -488,22 +488,22 @@ see reaction package for documentation.}"""))
         # varying solid flow directions (co_current and counter_current)
         self.gas_inlet_block = (
             self.config.gas_phase_config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 default={"defined_state": True}))
 
         self.gas_outlet_block = (
             self.config.gas_phase_config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 default={"defined_state": False}))
 
         self.solid_inlet_block = (
             self.config.solid_phase_config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 default={"defined_state": True}))
 
         self.solid_outlet_block = (
             self.config.solid_phase_config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 default={"defined_state": False}))
 
         # Add Ports for gas side
@@ -561,79 +561,79 @@ see reaction package for documentation.}"""))
 
         # Velocities
         self.velocity_superficial_gas = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Gas Superficial Velocity [m/s]')
         self.velocity_bubble = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain, domain=Reals,
                 doc='Bubble Velocity [m/s]')
         self.velocity_emulsion_gas = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Emulsion Region Superficial Gas Velocity [m/s]')
         self.velocity_superficial_solid = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 domain=Reals, initialize=0.01,
                 doc='Solid superficial velocity [m/s]')
 
         # Bubble Dimensions and Hydrodynamics
         self.bubble_diameter = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 initialize=1,
                 doc='Average Bubble Diameter [m]')
         self.delta = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 initialize=1,
                 doc='Volume Fraction Occupied by Bubble Region [m^3/m^3]')
         self.delta_e = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 initialize=1,
                 doc='Volume Fraction Occupied by Emulsion Region [m^3/m^3]')
         self.voidage_average = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 initialize=1,
                 doc='Cross-Sectional Average Voidage Fraction [m^3/m^3]')
         self.voidage_emulsion = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 initialize=1,
                 doc='Emulsion Region Voidage Fraction [m^3/m^3]')
         self.bubble_growth_coeff = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Bubble Growth Coefficient [-]')
         self.bubble_diameter_max = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Maximum Theoretical Bubble Diameter [m]')
         self.velocity_bubble_rise = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Bubble Rise Velocity [m/s]')
         self.average_gas_density = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='average gas density [mol/m3]')
 
         # Gas emulsion heterogeneous reaction variable
         self.gas_emulsion_hetero_rxn = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 self.config.gas_phase_config.property_package.component_list,
                 domain=Reals,
@@ -643,14 +643,14 @@ see reaction package for documentation.}"""))
 
         # Mass transfer coefficients
         self.Kbe = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 self.config.gas_phase_config.property_package.component_list,
                 domain=Reals,
                 initialize=1,
                 doc='Bubble to Emulsion Gas Mass Transfer Coefficient [1/s]')
         self.Kgbulk_c = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 self.config.gas_phase_config.property_package.component_list,
                 domain=Reals,
@@ -659,18 +659,18 @@ see reaction package for documentation.}"""))
 
         # Heat transfer coefficients
         self.Hbe = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Bubble to Emulsion Gas Heat Transfer Coefficient'
                     '[kJ/m^3.K.s]')
         self.Hgbulk = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Gas Phase Bulk Enthalpy Transfer Rate [kJ/m.s]')
         self.htc_conv = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Gas to Solid Energy Convective Heat Transfer'
@@ -678,7 +678,7 @@ see reaction package for documentation.}"""))
 
         # Heat transfer terms
         self.ht_conv = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Gas to Solid Convective Enthalpy Transfer in'
@@ -686,13 +686,13 @@ see reaction package for documentation.}"""))
 
         # Reformulation variables
         self._reform_var_1 = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 doc='Reformulation Variable in Bubble'
                     'Diameter Equation [reform var 1]')
         self._reform_var_2 = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 self.config.gas_phase_config.property_package.component_list,
                 domain=Reals,
@@ -700,21 +700,21 @@ see reaction package for documentation.}"""))
                 doc='Bubble to Emulsion Gas Mass Transfer'
                     'Coefficient Reformulation Variable [reform var 2]')
         self._reform_var_3 = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 initialize=1,
                 doc='Bubble to Emulsion Gas Mass Transfer'
                     'Coefficient Reformulation Variable [reform var 3]')
         self._reform_var_4 = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 initialize=1,
                 doc='Bubble to Emulsion Gas Heat Transfer'
                     'Coefficient Reformulation Variable [reform var 4]')
         self._reform_var_5 = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals,
                 initialize=1,
@@ -790,21 +790,21 @@ see reaction package for documentation.}"""))
                     constants.pi*(0.5*b.bed_diameter)**2)
 
         # Area of bubble, gas_emulsion, solid_emulsion
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Cross-sectional Area Occupied by Bubbles")
         def bubble_area(b, t, x):
             return (b.bubble.area[t, x] ==
                     b.bed_area*b.delta[t, x])
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Cross-sectional Area Occupied by Gas Emulsion")
         def gas_emulsion_area(b, t, x):
             return (b.gas_emulsion.area[t, x] ==
                     b.bed_area*b.delta_e[t, x]*b.voidage_emulsion[t, x])
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Cross-sectional Area Occupied by Solid Emulsion")
         def solid_emulsion_area(b, t, x):
@@ -828,14 +828,14 @@ see reaction package for documentation.}"""))
         # Hydrodynamic contraints
 
         # Emulsion region volume fraction
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Emulsion Region Volume Fraction")
         def emulsion_vol_frac(b, t, x):
             return (b.delta_e[t, x] == 1 - b.delta[t, x])
 
         # Average cross-sectional voidage
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Average Cross-sectional Voidage")
         def average_voidage(b, t, x):
@@ -843,7 +843,7 @@ see reaction package for documentation.}"""))
                     (1 - b.voidage_emulsion[t, x]))
 
         # Bubble growth coefficient
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Bubble Growth Coefficient")
         def bubble_growth_coefficient(b, t, x):
@@ -854,7 +854,7 @@ see reaction package for documentation.}"""))
                         b.bed_diameter/constants.acceleration_gravity))
 
         # Maximum bubble diameter
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Maximum Bubble Diameter")
         def bubble_diameter_maximum(b, t, x):
@@ -865,14 +865,14 @@ see reaction package for documentation.}"""))
                                b.bed_area)**2)
 
         # Bubble diameter reformulation equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Bubble Diameter Reformulation")
         def _reformulation_eqn_1(b, t, x):
             return (b._reform_var_1[t, x]**2 ==
                     b.bed_diameter*b.bubble_diameter[t, x])
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Bubble Diameter")
         def bubble_diameter_eqn(b, t, x):
@@ -890,7 +890,7 @@ see reaction package for documentation.}"""))
                         b.bubble_growth_coeff[t, x]*b._reform_var_1[t, x]))
 
         # Bubble rise velocity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Bubble Rise Velocity")
         def bubble_velocity_rise(b, t, x):
@@ -899,7 +899,7 @@ see reaction package for documentation.}"""))
                     b.bubble_diameter[t, x])
 
         # Emulsion region voidage - Davidson model
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Emulsion Region Voidage")
         def emulsion_voidage(b, t, x):
@@ -907,7 +907,7 @@ see reaction package for documentation.}"""))
                     b.solid_emulsion.properties[t, x]._params.voidage_mf)
 
         # Bubble velocity - Davidson model
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Bubble Velocity")
         def bubble_velocity(b, t, x):
@@ -918,7 +918,7 @@ see reaction package for documentation.}"""))
                 b.velocity_bubble_rise[t, x])
 
         # Average gas density (moles)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Average gas density")
         def average_gas_density_eqn(b, t, x):
@@ -933,7 +933,7 @@ see reaction package for documentation.}"""))
                 )
 
         # Superficial gas velocity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Superficial Gas Velocity")
         def velocity_gas_superficial(b, t, x):
@@ -946,7 +946,7 @@ see reaction package for documentation.}"""))
 
         # Bubble volume fraction
         # This computes delta for emulsion at minimum fluidization velocity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="volume fraction occupied by bubbles")
         def bubble_vol_frac_eqn(b, t, x):
@@ -955,7 +955,7 @@ see reaction package for documentation.}"""))
                     b.solid_emulsion.properties[t, x]._params.velocity_mf)
 
         # Solid superficial velocity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Solid superficial velocity")
         # This equation uses inlet values to compute the constant solid
@@ -968,7 +968,7 @@ see reaction package for documentation.}"""))
 
         # Gas_emulsion pressure drop calculation
         if self.config.has_pressure_change:
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Gas Emulsion Pressure Drop Calculation")
             def gas_emulsion_pressure_drop(b, t, x):
@@ -982,7 +982,7 @@ see reaction package for documentation.}"""))
 
         elif self.config.has_pressure_change is False:
             # If pressure change is false set pressure drop to zero
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Isobaric Gas emulsion")
             def isobaric_gas_emulsion(b, t, x):
@@ -992,7 +992,7 @@ see reaction package for documentation.}"""))
         # ---------------------------------------------------------------------
         # Mass transfer constraints
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 gas_phase.property_package.component_list,
                 doc="Bubble to Emulsion Gas Mass Transfer"
@@ -1005,7 +1005,7 @@ see reaction package for documentation.}"""))
                     b.gas_emulsion.properties[t, x].diffusion_comp[j]) *
                     constants.acceleration_gravity ** 0.5)
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Bubble to Emulsion Gas Mass Transfer"
                              "Coefficient Reformulation [reform eqn 3]")
@@ -1014,7 +1014,7 @@ see reaction package for documentation.}"""))
                     1e2*b.bubble_diameter[t, x])
 
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 gas_phase.property_package.component_list,
                 doc="Bubble to Emulsion Gas Mass Transfer Coefficient")
@@ -1027,7 +1027,7 @@ see reaction package for documentation.}"""))
 
         # Bulk gas mass transfer
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 gas_phase.property_package.component_list,
                 doc="Bulk Gas Mass Transfer Between Bubble and Emulsion")
@@ -1045,7 +1045,7 @@ see reaction package for documentation.}"""))
 
         if self.config.energy_balance_type != EnergyBalanceType.none:
             # Bubble to emulsion gas heat transfer coefficient
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Bubble to Emulsion Gas Heat Transfer"
                                  "Coeff. Reformulation Eqn [reform eqn 4]")
@@ -1057,7 +1057,7 @@ see reaction package for documentation.}"""))
                         (constants.acceleration_gravity ** 0.5))
 
             # Convective heat transfer coefficient
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Convective Heat Transfer"
                                  "Coeff. Reformulation Eqn [reform eqn 5]")
@@ -1069,7 +1069,7 @@ see reaction package for documentation.}"""))
                     b.solid_emulsion.properties[t, x]._params.particle_dia *
                     b.gas_emulsion.properties[t, x].dens_mol)
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Bubble to Emulsion Gas Heat Transfer"
                                  "Coefficient")
@@ -1082,7 +1082,7 @@ see reaction package for documentation.}"""))
                     b._reform_var_3[t, x] +
                     b._reform_var_4[t, x])
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Convective Heat Transfer Coefficient")
             def convective_heat_trans_coeff(b, t, x):
@@ -1094,7 +1094,7 @@ see reaction package for documentation.}"""))
 
             # Gas to solid convective heat transfer # replaced "ap" with
             # "6/(dp*rho_sol)"
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Gas to Solid Convective Enthalpy Transfer"
                                  "in Emulsion Region")
@@ -1108,7 +1108,7 @@ see reaction package for documentation.}"""))
                      b.solid_emulsion.properties[t, x].temperature))
 
             # Bulk gas heat transfer
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Bulk Gas Heat Transfer Between"
                                  "Bubble and Emulsion")
@@ -1128,7 +1128,7 @@ see reaction package for documentation.}"""))
 
         # Bubble mass transfer
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 gas_phase.property_package.component_list,
                 doc="Bubble Mass Transfer")
@@ -1147,7 +1147,7 @@ see reaction package for documentation.}"""))
                     if solid_phase.reaction_package else 0)
 
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 gas_phase.property_package.component_list,
                 doc="Gas Emulsion Mass Transfer")
@@ -1163,7 +1163,7 @@ see reaction package for documentation.}"""))
 
         if self.config.energy_balance_type != EnergyBalanceType.none:
             # Bubble - heat transfer
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Bubble - Heat Transfer")
             def bubble_heat_transfer(b, t, x):
@@ -1174,7 +1174,7 @@ see reaction package for documentation.}"""))
                         b.bubble.area[t, x])
 
             # Gas emulsion - heat transfer
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Gas Emulsion - Heat Transfer")
             def gas_emulsion_heat_transfer(b, t, x):
@@ -1186,7 +1186,7 @@ see reaction package for documentation.}"""))
                         b.ht_conv[t, x] * b.bed_area)
 
             # Solid emulsion - heat transfer
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Solid Emulsion - Heat Transfer")
             def solid_emulsion_heat_transfer(b, t, x):
@@ -1201,7 +1201,7 @@ see reaction package for documentation.}"""))
         if gas_phase.reaction_package is not None:
             # Bubble rate reaction extent
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 gas_phase.reaction_package.rate_reaction_idx,
                 doc="Bubble Rate Reaction Extent")
@@ -1213,7 +1213,7 @@ see reaction package for documentation.}"""))
         if gas_phase.reaction_package is not None:
             # Gas emulsion rate reaction extent
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 gas_phase.reaction_package.rate_reaction_idx,
                 doc="Gas Emulsion Rate Reaction Extent")
@@ -1226,7 +1226,7 @@ see reaction package for documentation.}"""))
         if solid_phase.reaction_package is not None:
             # Solid side rate reaction extent
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 solid_phase.reaction_package.rate_reaction_idx,
                 doc="Solid Emulsion Rate Reaction Extent")
@@ -1238,7 +1238,7 @@ see reaction package for documentation.}"""))
 
             # Gas side heterogeneous rate reaction generation
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 gas_phase.property_package.component_list,
                 doc="Gas Emulsion Heterogeneous Rate Reaction Generation")
@@ -1258,7 +1258,7 @@ see reaction package for documentation.}"""))
         # Bubble gas flowrate - this eqn calcs bubble conc. (dens_mol)
         # which is then used to calculate the bubble pressure
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 doc="Bubble Gas Flowrate Constraint")
         def bubble_gas_flowrate(b, t, x):
@@ -1271,7 +1271,7 @@ see reaction package for documentation.}"""))
         # gas_emulsion CV1D.
         # This eqn arises because the emulsion region gas is assumed to be at
         # minimum fluidization conditions (delta varies to account for this)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Emulsion Gas Flowrate Constraint")
         def emulsion_gas_flowrate(b, t, x):
@@ -1284,14 +1284,14 @@ see reaction package for documentation.}"""))
 
         # Gas_emulsion pressure at inlet
         if self.config.has_pressure_change:
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Gas Emulsion Pressure at Inlet")
             def gas_emulsion_pressure_in(b, t):
                 return (1e2*b.gas_emulsion.properties[t, 0].pressure ==
                         1e2*b.gas_inlet_block[t].pressure - b.deltaP_orifice)
 
         # Total gas balance at inlet
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Total Gas Balance at Inlet")
         def gas_mole_flow_in(b, t):
             return (b.gas_inlet_block[t].flow_mol ==
@@ -1300,7 +1300,7 @@ see reaction package for documentation.}"""))
 
         # Particle porosity at inlet
         @self.Constraint(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Constant particle porosity")
         def particle_porosity_in(b, t):
             x = b.length_domain.first()
@@ -1309,7 +1309,7 @@ see reaction package for documentation.}"""))
                 b.solid_inlet_block[t].particle_porosity)
 
         # Emulsion region gas velocity at inlet - Davidson model
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Emulsion Region Superficial Gas Velocity")
         def emulsion_gas_velocity_in(b, t):
             x = self.length_domain.first()
@@ -1319,7 +1319,7 @@ see reaction package for documentation.}"""))
 
         # Bubble mole frac at inlet
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 gas_phase.property_package.component_list,
                 doc="Bubble Mole Fraction at Inlet")
         def bubble_mole_frac_in(b, t, j):
@@ -1328,7 +1328,7 @@ see reaction package for documentation.}"""))
 
         # Gas_emulsion mole frac at inlet
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 gas_phase.property_package.component_list,
                 doc="Gas Emulsion Mole Fraction at Inlet")
         def gas_emulsion_mole_frac_in(b, t, j):
@@ -1336,7 +1336,7 @@ see reaction package for documentation.}"""))
                     1e2*b.gas_emulsion.properties[t, 0].mole_frac_comp[j])
 
         # Solid emulsion mass flow at inlet
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Solid Emulsion Mass Flow at Inlet")
         def solid_emulsion_mass_flow_in(b, t):
             if (self.config.flow_type == "co_current"):
@@ -1348,7 +1348,7 @@ see reaction package for documentation.}"""))
 
         # Solid emulsion mass frac at inlet
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 solid_phase.property_package.component_list,
                 doc="Solid Emulsion Mass Fraction at Inlet")
         def solid_emulsion_mass_frac_in(b, t, j):
@@ -1363,7 +1363,7 @@ see reaction package for documentation.}"""))
 
         if self.config.energy_balance_type != EnergyBalanceType.none:
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     gas_phase.property_package.phase_list,
                     doc="Gas Inlet Energy Balance")
             def gas_energy_balance_in(b, t, p):
@@ -1373,7 +1373,7 @@ see reaction package for documentation.}"""))
 
             # Gas emulsion temperature at inlet
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     doc="Gas Emulsion Temperature at Inlet")
             def gas_emulsion_temperature_in(b, t):
                 return (b.gas_inlet_block[t].temperature ==
@@ -1381,7 +1381,7 @@ see reaction package for documentation.}"""))
 
             # Solid inlet energy balance
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     doc="Solid Inlet Energy Balance")
             def solid_energy_balance_in(b, t):
                 if (self.config.flow_type == "co_current"):
@@ -1396,7 +1396,7 @@ see reaction package for documentation.}"""))
         elif self.config.energy_balance_type == EnergyBalanceType.none:
             # If energy balance is none fix gas and solid temperatures to inlet
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.length_domain,
                     doc="Isothermal solid emulsion constraint")
             def isothermal_solid_emulsion(b, t, x):
@@ -1405,7 +1405,7 @@ see reaction package for documentation.}"""))
                         b.solid_inlet.temperature[t])
 
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.length_domain,
                     doc="Isothermal gas emulsion constraint")
             def isothermal_gas_emulsion(b, t, x):
@@ -1414,7 +1414,7 @@ see reaction package for documentation.}"""))
                         b.gas_inlet.temperature[t])
 
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.length_domain,
                     doc="Isothermal gas emulsion constraint")
             def isothermal_bubble(b, t, x):
@@ -1425,7 +1425,7 @@ see reaction package for documentation.}"""))
         # ---------------------------------------------------------------------
         # Outlet boundary Conditions
         # Gas outlet pressure
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Gas Outlet Pressure")
         def gas_pressure_out(b, t):
             return (1e2*b.gas_outlet.pressure[t] ==
@@ -1433,7 +1433,7 @@ see reaction package for documentation.}"""))
 
         # Gas outlet material balance
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 gas_phase.property_package.phase_list,
                 gas_phase.property_package.component_list,
                 doc="Gas Outlet Material Balance")
@@ -1444,7 +1444,7 @@ see reaction package for documentation.}"""))
 
         # Solid outlet material balance
         @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 solid_phase.property_package.phase_list,
                 solid_phase.property_package.component_list,
                 doc="Solid Outlet Material Balance")
@@ -1460,7 +1460,7 @@ see reaction package for documentation.}"""))
 
         # Solid outlet particle porosity
         @self.Constraint(
-                self.flowsheet().config.time)
+                self.flowsheet().time)
         def solid_particle_porosity_out(b, t):
             x = b.length_domain.last()
             return (
@@ -1470,7 +1470,7 @@ see reaction package for documentation.}"""))
         if self.config.energy_balance_type != EnergyBalanceType.none:
             # Gas outlet energy balance
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     doc="Gas Outlet Energy Balance")
             def gas_energy_balance_out(b, t):
                 return (b.gas_outlet_block[t].get_enthalpy_flow_terms('Vap') ==
@@ -1479,7 +1479,7 @@ see reaction package for documentation.}"""))
 
             # Solid outlet energy balance
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     doc="Solid Outlet Energy Balance")
             def solid_energy_balance_out(b, t):
                 if (self.config.flow_type == "co_current"):
@@ -1496,7 +1496,7 @@ see reaction package for documentation.}"""))
         elif self.config.energy_balance_type == EnergyBalanceType.none:
             # Gas outlet energy balance
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     doc="Gas Outlet Energy Balance")
             def gas_energy_balance_out(b, t):
                 return (b.gas_outlet_block[t].temperature ==
@@ -1504,7 +1504,7 @@ see reaction package for documentation.}"""))
 
             # Solid outlet energy balance
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     doc="Solid Outlet Energy Balance")
             def solid_energy_balance_out(b, t):
                 if (self.config.flow_type == "co_current"):
@@ -1649,7 +1649,7 @@ see reaction package for documentation.}"""))
         # ---------------------------------------------------------------------
         # Initialize hydrodynamics
         # vel_superficial_gas, delta are fixed during this stage
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.length_domain:
                 # Superficial velocity initialized at 3 * min fluidization vel.
                 blk.velocity_superficial_gas[t, x].fix(
@@ -1733,7 +1733,7 @@ see reaction package for documentation.}"""))
         # Initialize mass balance - no reaction
 
         # Initialize variables
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.length_domain:
                 calculate_variable_from_constraint(
                     blk._reform_var_3[t, x],
@@ -1754,7 +1754,7 @@ see reaction package for documentation.}"""))
         blk.solid_emulsion.properties.release_state(
                 solid_emulsion_region_flags)
 
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.length_domain:
                 blk.gas_emulsion.properties[t, x].pressure.fix()
                 blk.bubble.properties[t, x].temperature.fix()
@@ -1764,7 +1764,7 @@ see reaction package for documentation.}"""))
         # Fix reaction rate variables (no rxns assumed)
         # Homogeneous reactions (gas phase rxns)
         if gas_phase.reaction_package is not None:
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 bubble_rxn_gen = blk.bubble.rate_reaction_generation
                 gas_emulsion_rxn_gen = (
                     blk.gas_emulsion.rate_reaction_generation)
@@ -1780,7 +1780,7 @@ see reaction package for documentation.}"""))
             # local alias
             solid_emulsion_rxn_gen = (
                 blk.solid_emulsion.rate_reaction_generation)
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 # Solid emulsion region
                 for x in blk.length_domain:
                     for j in solid_phase.property_package.component_list:
@@ -1830,7 +1830,7 @@ see reaction package for documentation.}"""))
             blk.gas_emulsion_pressure_drop.activate()
             blk.gas_emulsion.pressure_balance.activate()
 
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     blk.gas_emulsion.properties[t, x].pressure.unfix()
                     calculate_variable_from_constraint(
@@ -1840,7 +1840,7 @@ see reaction package for documentation.}"""))
         elif blk.config.has_pressure_change is False:
             blk.isobaric_gas_emulsion.activate()
 
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     blk.gas_emulsion.properties[t, x].pressure.unfix()
 
@@ -1870,7 +1870,7 @@ see reaction package for documentation.}"""))
 
             # Initialize, unfix and activate relevant model and CV1D
             # variables and constraints
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     for r in (gas_phase.reaction_package.rate_reaction_idx):
                         calculate_variable_from_constraint(
@@ -1898,7 +1898,7 @@ see reaction package for documentation.}"""))
             blk.bubble.reactions.activate()
             blk.gas_emulsion.reactions.activate()
 
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     bubble = blk.bubble.reactions[t, x]
                     for c in bubble.component_objects(
@@ -1927,7 +1927,7 @@ see reaction package for documentation.}"""))
 
             # Initialize, unfix and activate relevant model and
             # CV1D variables and constraints
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     for j in gas_phase.property_package.component_list:
                         blk.gas_emulsion_hetero_rxn[t, x, j].unfix()
@@ -1956,7 +1956,7 @@ see reaction package for documentation.}"""))
 
             # Initialize heterogeneous reaction property package
             blk.solid_emulsion.reactions.activate()
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     obj = blk.solid_emulsion.reactions[t, x]
                     for c in obj.component_objects(
@@ -1986,7 +1986,7 @@ see reaction package for documentation.}"""))
         # Initialize energy balance
         if blk.config.energy_balance_type != EnergyBalanceType.none:
             # Initialize relevant heat transfer variables
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     calculate_variable_from_constraint(
                         blk._reform_var_4[t, x],
@@ -2005,7 +2005,7 @@ see reaction package for documentation.}"""))
                         blk.convective_heat_transfer[t, x])
 
             # Unfix temperature variables
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     blk.bubble.properties[t, x].temperature.unfix()
                     blk.gas_emulsion.properties[t, x].temperature.unfix()
@@ -2047,7 +2047,7 @@ see reaction package for documentation.}"""))
 
         # Initialize energy balance
         if blk.config.energy_balance_type == EnergyBalanceType.none:
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     blk.bubble.properties[t, x].temperature.unfix()
                     blk.gas_emulsion.properties[t, x].temperature.unfix()
@@ -2151,7 +2151,7 @@ see reaction package for documentation.}"""))
         cet = []
         cbt = []
 
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.gas_emulsion.length_domain:
                 Tge.append(value(
                         blk.gas_emulsion.properties[t, x].temperature))
@@ -2203,7 +2203,7 @@ see reaction package for documentation.}"""))
         plt.ylabel("gas conc. mol/s")
 
         # Gas phase mole composition
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for i in (gas_phase.property_package.component_list):
                 y_b = []
                 for x in blk.gas_emulsion.length_domain:
@@ -2218,7 +2218,7 @@ see reaction package for documentation.}"""))
         plt.ylabel("Gas bubble mole frac. (-)")
 
         # Solid phase mass composition
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for i in (solid_phase.property_package.component_list):
                 x_e = []
                 for x in blk.solid_emulsion.length_domain:

--- a/idaes/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/moving_bed.py
@@ -424,7 +424,7 @@ see reaction package for documentation.}"""))
             self.solid_phase.reactions = (
                     self.config.solid_phase_config.reaction_package.
                     reaction_block_class(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         self.length_domain,
                         doc="Reaction properties in control volume",
                         default=tmp_dict))
@@ -520,31 +520,31 @@ see reaction package for documentation.}"""))
 
         # Phase specific variables
         self.velocity_superficial_gas = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.length_domain,
                 domain=Reals, initialize=0.05,
                 doc='Gas superficial velocity [m/s]')
         self.velocity_superficial_solid = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 domain=Reals, initialize=0.005,
                 doc='Solid superficial velocity [m/s]')
 
         # Dimensionless numbers, mass and heat transfer coefficients
-        self.Re_particle = Var(self.flowsheet().config.time,
+        self.Re_particle = Var(self.flowsheet().time,
                                self.length_domain,
                                domain=Reals, initialize=1.0,
                                doc='Particle Reynolds number [-]')
 
-        self.Pr = Var(self.flowsheet().config.time,
+        self.Pr = Var(self.flowsheet().time,
                       self.length_domain,
                       domain=Reals, initialize=1.0,
                       doc='Prandtl number of gas in bed [-]')
 
-        self.Nu_particle = Var(self.flowsheet().config.time,
+        self.Nu_particle = Var(self.flowsheet().time,
                                self.length_domain,
                                domain=Reals, initialize=1.0,
                                doc='Particle Nusselt number [-]')
-        self.gas_solid_htc = Var(self.flowsheet().config.time,
+        self.gas_solid_htc = Var(self.flowsheet().time,
                                  self.length_domain,
                                  domain=Reals, initialize=1.0,
                                  doc='Gas-solid heat transfer coefficient'
@@ -569,14 +569,14 @@ see reaction package for documentation.}"""))
                     constants.pi*(0.5*b.bed_diameter)**2)
 
         # Area of gas side, and solid side
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Gas side area")
         def gas_phase_area(b, t, x):
             return (b.gas_phase.area[t, x] ==
                     b.bed_area*b.bed_voidage)
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Solid side area")
         def solid_phase_area(b, t, x):
@@ -596,7 +596,7 @@ see reaction package for documentation.}"""))
         # Hydrodynamic contraints
 
         # Gas superficial velocity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Gas superficial velocity")
         def gas_super_vel(b, t, x):
@@ -605,7 +605,7 @@ see reaction package for documentation.}"""))
                     b.gas_phase.properties[t, x].flow_mol)
 
         # Solid superficial velocity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.length_domain,
                          doc="Solid superficial velocity")
         # This equation uses inlet values to compute the constant solid
@@ -621,7 +621,7 @@ see reaction package for documentation.}"""))
             self.config.pressure_drop_type ==
                 "simple_correlation"):
             # Simplified pressure drop
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Gas side pressure drop calculation -"
                                  "simplified pressure drop")
@@ -633,7 +633,7 @@ see reaction package for documentation.}"""))
         elif (self.config.has_pressure_change and
               self.config.pressure_drop_type == "ergun_correlation"):
             # Ergun equation
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Gas side pressure drop calculation -"
                                  "ergun equation")
@@ -666,7 +666,7 @@ see reaction package for documentation.}"""))
         # Build homogeneous reaction constraints
         if gas_phase.reaction_package is not None:
             # Gas side rate reaction extent
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              gas_phase.reaction_package.rate_reaction_idx,
                              doc="Gas side rate reaction extent")
@@ -678,7 +678,7 @@ see reaction package for documentation.}"""))
         # Build hetereogeneous reaction constraints
         if solid_phase.reaction_package is not None:
             # Solid side rate reaction extent
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              solid_phase.reaction_package.rate_reaction_idx,
                              doc="Solid side rate reaction extent")
@@ -688,7 +688,7 @@ see reaction package for documentation.}"""))
                         b.solid_phase.area[t, x])
 
             # Gas side heterogeneous rate reaction generation
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              gas_phase.property_package.phase_list,
                              gas_phase.property_package.component_list,
@@ -706,7 +706,7 @@ see reaction package for documentation.}"""))
         # ---------------------------------------------------------------------
         if self.config.energy_balance_type != EnergyBalanceType.none:
             # Solid phase - gas to solid heat transfer
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Solid phase - gas to solid heat transfer")
             def solid_phase_heat_transfer(b, t, x):
@@ -719,7 +719,7 @@ see reaction package for documentation.}"""))
 
             # Dimensionless numbers, mass and heat transfer coefficients
             # Particle Reynolds number
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Particle Reynolds number")
             def reynolds_number_particle(b, t, x):
@@ -730,7 +730,7 @@ see reaction package for documentation.}"""))
                         b.gas_phase.properties[t, x].dens_mass)
 
             # Prandtl number
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Prandtl number of gas in bed")
             def prandtl_number(b, t, x):
@@ -740,7 +740,7 @@ see reaction package for documentation.}"""))
                         b.gas_phase.properties[t, x].visc_d)
 
             # Particle Nusselt number
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Particle Nusselt number")
             def nusselt_number_particle(b, t, x):
@@ -750,7 +750,7 @@ see reaction package for documentation.}"""))
                         b.Pr[t, x])
 
             # Gas-solid heat transfer coefficient
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Gas-solid heat transfer coefficient")
             def gas_solid_htc_eqn(b, t, x):
@@ -760,7 +760,7 @@ see reaction package for documentation.}"""))
                         b.gas_phase.properties[t, x].therm_cond)
 
             # Gas phase - gas to solid heat transfer
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.length_domain,
                              doc="Gas phase - gas to solid heat transfer")
             def gas_phase_heat_transfer(b, t, x):
@@ -774,7 +774,7 @@ see reaction package for documentation.}"""))
         elif self.config.energy_balance_type == EnergyBalanceType.none:
             # If energy balance is none fix gas and solid temperatures to inlet
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.length_domain,
                     doc="Isothermal gas phase constraint")
             def isothermal_gas_phase(b, t, x):
@@ -786,7 +786,7 @@ see reaction package for documentation.}"""))
                             b.gas_inlet.temperature[t])
 
             @self.Constraint(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     self.length_domain,
                     doc="Isothermal solid phase constraint")
             def isothermal_solid_phase(b, t, x):
@@ -879,7 +879,7 @@ see reaction package for documentation.}"""))
 
         # ---------------------------------------------------------------------
         # Initialize hydrodynamics (gas velocity)
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.length_domain:
                 calculate_variable_from_constraint(
                     blk.velocity_superficial_gas[t, x],
@@ -909,7 +909,7 @@ see reaction package for documentation.}"""))
                 gas_phase_flags)
         blk.solid_phase.properties.release_state(
                 solid_phase_flags)
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.length_domain:
                 blk.gas_phase.properties[t, x].pressure.fix()
                 blk.gas_phase.properties[t, x].temperature.fix()
@@ -918,7 +918,7 @@ see reaction package for documentation.}"""))
         blk.gas_phase.material_balances.activate()
 
         if gas_phase.reaction_package is not None:
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 gas_rxn_gen = blk.gas_phase.rate_reaction_generation
                 for x in blk.length_domain:
                     for p in gas_phase.property_package.phase_list:
@@ -929,7 +929,7 @@ see reaction package for documentation.}"""))
         blk.solid_super_vel.activate()
 
         if solid_phase.reaction_package is not None:
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 solid_rxn_gen = blk.solid_phase.rate_reaction_generation
                 for x in blk.length_domain:
                     for p in solid_phase.property_package.phase_list:
@@ -967,7 +967,7 @@ see reaction package for documentation.}"""))
 
             # Initialize reaction property package
             blk.gas_phase.reactions.activate()
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     obj = blk.gas_phase.reactions[t, x]
                     for c in obj.component_objects(
@@ -978,7 +978,7 @@ see reaction package for documentation.}"""))
                                                optarg=optarg,
                                                solver=solver)
 
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     for r in gas_phase.reaction_package.rate_reaction_idx:
                         calculate_variable_from_constraint(
@@ -1010,7 +1010,7 @@ see reaction package for documentation.}"""))
 
             # Initialize reaction property package
             blk.solid_phase.reactions.activate()
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     obj = blk.solid_phase.reactions[t, x]
                     for c in obj.component_objects(
@@ -1021,7 +1021,7 @@ see reaction package for documentation.}"""))
                                                  optarg=optarg,
                                                  solver=solver)
 
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     for p in gas_phase.property_package.phase_list:
                         for j in gas_phase.property_package.component_list:
@@ -1069,7 +1069,7 @@ see reaction package for documentation.}"""))
                              .format(blk.name))
 
         # Initialize mass balance - with pressure drop
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.length_domain:
                 # Unfix all pressure variables except at the inlet
                 if (blk.gas_phase.properties[t, x].config.defined_state
@@ -1084,7 +1084,7 @@ see reaction package for documentation.}"""))
         if blk.config.has_pressure_change:
             blk.gas_phase_config_pressure_drop.activate()
 
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     calculate_variable_from_constraint(
                         blk.gas_phase.deltaP[t, x],
@@ -1108,7 +1108,7 @@ see reaction package for documentation.}"""))
         if blk.config.energy_balance_type != EnergyBalanceType.none:
             # Initialize dimensionless numbers,
             # mass and heat transfer coefficients
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     calculate_variable_from_constraint(
                         blk.Re_particle[t, x],
@@ -1130,7 +1130,7 @@ see reaction package for documentation.}"""))
                         blk.solid_phase_heat_transfer[t, x])
 
             # Unfix temperatures
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     # Unfix all gas temperature variables except at the inlet
                     if (blk.gas_phase.properties[t, x].config.defined_state
@@ -1170,7 +1170,7 @@ see reaction package for documentation.}"""))
 
         # Initialize energy balance
         if blk.config.energy_balance_type == EnergyBalanceType.none:
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for x in blk.length_domain:
                     # Unfix all gas temperature variables except at the inlet
                     if (blk.gas_phase.properties[t, x].config.defined_state
@@ -1227,7 +1227,7 @@ see reaction package for documentation.}"""))
         Mtotal = []
         vg = []
 
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.gas_phase.length_domain:
                 vg.append(value(blk.velocity_superficial_gas[t, x]))
 
@@ -1240,7 +1240,7 @@ see reaction package for documentation.}"""))
         fig_vg.savefig('superficial_vel.png')
 
         # Pressure profile
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.gas_phase.length_domain:
                 P.append(blk.gas_phase.properties[t, x].pressure.value)
 
@@ -1253,7 +1253,7 @@ see reaction package for documentation.}"""))
         fig_P.savefig('Pressure.png')
 
         # Temperature profile
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.gas_phase.length_domain:
                 Tg.append(blk.gas_phase.properties[t, x].temperature.value)
             for x in blk.solid_phase.length_domain:
@@ -1268,7 +1268,7 @@ see reaction package for documentation.}"""))
         fig_T.savefig('Temperature.png')
 
         # Bulk gas phase total molar flow rate
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.gas_phase.length_domain:
                 Ftotal.append(blk.gas_phase.properties[t, x].flow_mol.value)
         fig_Ftotal = plt.figure(4)
@@ -1279,7 +1279,7 @@ see reaction package for documentation.}"""))
         fig_Ftotal.savefig('Total_gas_flow.png')
 
         # Bulk solid phase total mass flow rate
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for x in blk.solid_phase.length_domain:
                 Mtotal.append(blk.solid_phase.properties[t, x].flow_mass.value)
         fig_Mtotal = plt.figure(5)
@@ -1290,7 +1290,7 @@ see reaction package for documentation.}"""))
         fig_Mtotal.savefig('Total_solid_flow.png')
 
         # Gas phase mole fractions
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for j in gas_phase.property_package.component_list:
                 y_frac = []
                 for x in blk.gas_phase.length_domain:
@@ -1305,7 +1305,7 @@ see reaction package for documentation.}"""))
         fig_y.savefig('Gas_mole_fractions.png')
 
         # Solid phase mass fractions
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for j in solid_phase.property_package.component_list:
                 x_frac = []
                 for x in blk.solid_phase.length_domain:
@@ -1321,7 +1321,7 @@ see reaction package for documentation.}"""))
         fig_x.savefig('Solid_mass_fractions.png')
 
         # Gas phase concentrations
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for j in gas_phase.property_package.component_list:
                 Cg = []
                 for x in blk.gas_phase.length_domain:

--- a/idaes/generic_models/control/pid_controller.py
+++ b/idaes/generic_models/control/pid_controller.py
@@ -171,11 +171,11 @@ class PIDBlockData(ProcessBlockData):
                 "Controller configuration requires 'output'")
 
         # Shorter pointers to time set information
-        time_set = self.flowsheet().config.time
+        time_set = self.flowsheet().time
         t0 = time_set.first()
 
         # Get units of time domain, PV and output
-        t_units = self.flowsheet().config.time_units
+        t_units = self.flowsheet().time_units
         pv_units = self.config.pv.get_units()
         out_units = self.config.output.get_units()
         gain_units = out_units/pv_units if pv_units is not None else None

--- a/idaes/generic_models/control/tests/test_steam_tank.py
+++ b/idaes/generic_models/control/tests/test_steam_tank.py
@@ -56,7 +56,7 @@ def _valve_pressure_flow_cb(b):
     b.flow_var = pyo.Reference(b.control_volume.properties_in[:].flow_mol)
     b.pressure_flow_equation_scale = lambda x: x**2
 
-    @b.Constraint(b.flowsheet().config.time)
+    @b.Constraint(b.flowsheet().time)
     def pressure_flow_equation(b2, t):
         Po = b2.control_volume.properties_out[t].pressure
         Pi = b2.control_volume.properties_in[t].pressure

--- a/idaes/generic_models/unit_models/cstr.py
+++ b/idaes/generic_models/unit_models/cstr.py
@@ -215,7 +215,7 @@ see reaction package for documentation.}"""))
         self.volume = Reference(self.control_volume.volume[:])
 
         # Add CSTR performance equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.config.reaction_package.rate_reaction_idx,
                          doc="CSTR performance equation")
         def cstr_performance_eqn(b, t, r):
@@ -254,7 +254,7 @@ see reaction package for documentation.}"""))
         self.diameter = Var(initialize=1,
                             units=units_meta('length'),
                             doc='vessel diameter')
-        time = self.flowsheet().config.time.first()
+        time = self.flowsheet().time.first()
         self.volume_eq = Constraint(expr=self.volume[time]
                                     == self.length*self.diameter)
         module.cstr_costing(self.costing, **kwargs)

--- a/idaes/generic_models/unit_models/distillation/condenser.py
+++ b/idaes/generic_models/unit_models/distillation/condenser.py
@@ -219,7 +219,7 @@ see property package for documentation.}"""))
                 # the assumption is that there will only be a single pair
                 # i.e. vap-liq. 
                 idx = next(iter(self.control_volume.properties_out[
-                    self.flowsheet().config.time.first()].temperature_bubble))
+                    self.flowsheet().time.first()].temperature_bubble))
 
                 def rule_total_cond(self, t):
                     return self.control_volume.properties_out[t].\
@@ -717,7 +717,7 @@ see property package for documentation.}"""))
             state_args = {}
             state_dict = (
                 self.control_volume.properties_in[
-                    self.flowsheet().config.time.first()]
+                    self.flowsheet().time.first()]
                 .define_port_members())
 
             for k in state_dict.keys():

--- a/idaes/generic_models/unit_models/distillation/reboiler.py
+++ b/idaes/generic_models/unit_models/distillation/reboiler.py
@@ -601,7 +601,7 @@ see property package for documentation.}"""))
         state_args_outlet = {}
         state_dict_outlet = (
             self.control_volume.properties_in[
-                self.flowsheet().config.time.first()]
+                self.flowsheet().time.first()]
             .define_port_members())
 
         for k in state_dict_outlet.keys():

--- a/idaes/generic_models/unit_models/distillation/tray.py
+++ b/idaes/generic_models/unit_models/distillation/tray.py
@@ -155,7 +155,7 @@ see property package for documentation.}"""))
 
         for i in inlet_list:
             state_obj = self.config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 doc="State block for " + i + "_inlet to tray",
                 default=state_block_args)
 
@@ -167,7 +167,7 @@ see property package for documentation.}"""))
         mixed_block_args["defined_state"] = False
 
         self.properties_out = self.config.property_package.\
-            build_state_block(self.flowsheet().config.time,
+            build_state_block(self.flowsheet().time,
                               doc="State block for mixed outlet from tray",
                               default=mixed_block_args)
 
@@ -201,7 +201,7 @@ see property package for documentation.}"""))
     def _add_material_balance(self):
         """Method to construct the mass balance equation."""
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.config.property_package.component_list,
                          doc="material balance")
         def material_mixing_equations(b, t, j):
@@ -224,12 +224,12 @@ see property package for documentation.}"""))
 
         if self.config.has_heat_transfer:
             units_meta = self.config.property_package.get_metadata()
-            self.heat_duty = Var(self.flowsheet().config.time,
+            self.heat_duty = Var(self.flowsheet().time,
                                  initialize=0,
                                  doc="Heat duty for the tray",
                                  units=units_meta.get_derived_units("power"))
 
-        @self.Constraint(self.flowsheet().config.time, doc="energy balance")
+        @self.Constraint(self.flowsheet().time, doc="energy balance")
         def enthalpy_mixing_equations(b, t):
             if self.config.is_feed_tray:
                 if self.config.has_heat_transfer:
@@ -290,12 +290,12 @@ see property package for documentation.}"""))
         """Method to construct the pressure balance."""
         if self.config.has_pressure_change:
             units_meta = self.config.property_package.get_metadata()
-            self.deltaP = Var(self.flowsheet().config.time,
+            self.deltaP = Var(self.flowsheet().time,
                               initialize=0,
                               doc="Pressure drop across tray",
                               units=units_meta.get_derived_units("pressure"))
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="pressure balance for tray")
         def pressure_drop_equation(self, t):
             if self.config.has_pressure_change:
@@ -678,7 +678,7 @@ see property package for documentation.}"""))
             state_args_vap = {}
             state_dict = (
                 self.properties_in_feed[
-                    self.flowsheet().config.time.first()]
+                    self.flowsheet().time.first()]
                 .define_port_members())
 
             for k in state_dict.keys():
@@ -722,7 +722,7 @@ see property package for documentation.}"""))
             state_args_liq = {}
             state_dict = (
                 self.properties_in_liq[
-                    self.flowsheet().config.time.first()]
+                    self.flowsheet().time.first()]
                 .define_port_members())
 
             for k in state_dict.keys():
@@ -739,7 +739,7 @@ see property package for documentation.}"""))
             state_args_vap = {}
             state_dict = (
                 self.properties_in_vap[
-                    self.flowsheet().config.time.first()]
+                    self.flowsheet().time.first()]
                 .define_port_members())
 
             for k in state_dict.keys():
@@ -790,7 +790,7 @@ see property package for documentation.}"""))
             # will work for most combination of state vars.
             state_dict = (
                 self.properties_in_liq[
-                    self.flowsheet().config.time.first()]
+                    self.flowsheet().time.first()]
                 .define_port_members())
             for k in state_dict.keys():
                 if k == "pressure":

--- a/idaes/generic_models/unit_models/equilibrium_reactor.py
+++ b/idaes/generic_models/unit_models/equilibrium_reactor.py
@@ -235,7 +235,7 @@ see reaction package for documentation.}"""))
 
         if self.config.has_rate_reactions:
             # Add equilibrium reactor performance equation
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.config.reaction_package.rate_reaction_idx,
                              doc="Rate reaction equilibrium constraint")
             def rate_reaction_constraint(b, t, r):

--- a/idaes/generic_models/unit_models/feed.py
+++ b/idaes/generic_models/unit_models/feed.py
@@ -84,7 +84,7 @@ see property package for documentation.}"""))
         # Add State Block
         self.properties = (
                     self.config.property_package.build_state_block(
-                            self.flowsheet().config.time,
+                            self.flowsheet().time,
                             doc="Material properties in feed",
                             default={
                                 "defined_state": True,
@@ -93,7 +93,7 @@ see property package for documentation.}"""))
 
         # Add references to all state vars
         s_vars = self.properties[
-                self.flowsheet().config.time.first()].define_state_vars()
+                self.flowsheet().time.first()].define_state_vars()
         for s in s_vars:
             l_name = s_vars[s].local_name
             if s_vars[s].is_indexed():

--- a/idaes/generic_models/unit_models/feed_flash.py
+++ b/idaes/generic_models/unit_models/feed_flash.py
@@ -127,13 +127,13 @@ see property package for documentation.}"""))
 
         # Add isothermal constraint
         if self.config.flash_type == FlashType.isothermal:
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Isothermal constraint")
             def isothermal(b, t):
                 return (b.control_volume.properties_in[t].temperature ==
                         b.control_volume.properties_out[t].temperature)
         elif self.config.flash_type == FlashType.isenthalpic:
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Isothermal constraint")
             def isenthalpic(b, t):
                 cv = b.control_volume
@@ -147,7 +147,7 @@ see property package for documentation.}"""))
 
         # Add references to all feed state vars
         s_vars = self.control_volume.properties_in[
-                    self.flowsheet().config.time.first()].define_state_vars()
+                    self.flowsheet().time.first()].define_state_vars()
         for s in s_vars:
             l_name = s_vars[s].local_name
             if s_vars[s].is_indexed():

--- a/idaes/generic_models/unit_models/flash.py
+++ b/idaes/generic_models/unit_models/flash.py
@@ -228,7 +228,7 @@ see property package for documentation.}"""))
         if not self.config.ideal_separation:
             def split_frac_rule(b, t, o):
                 return b.split.split_fraction[t, o, o] == 1
-            self.split_fraction_eq = Constraint(self.flowsheet().config.time,
+            self.split_fraction_eq = Constraint(self.flowsheet().time,
                                                 self.split.outlet_idx,
                                                 rule=split_frac_rule)
 

--- a/idaes/generic_models/unit_models/gibbs_reactor.py
+++ b/idaes/generic_models/unit_models/gibbs_reactor.py
@@ -172,7 +172,7 @@ see property package for documentation.}"""))
         # Add Lagrangian multiplier variables
         e_units = self.config.property_package.get_metadata(
             ).get_derived_units("energy_mole")
-        self.lagrange_mult = Var(self.flowsheet().config.time,
+        self.lagrange_mult = Var(self.flowsheet().time,
                                  self.config.property_package.element_list,
                                  domain=Reals,
                                  initialize=100,
@@ -186,7 +186,7 @@ see property package for documentation.}"""))
         # Use RT*lagrange as the Lagrangian multiple such that lagrange is in
         # a similar order of magnitude as log(Yi)
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.control_volume.properties_in.phase_component_set,
                          doc="Gibbs energy minimisation constraint")
         def gibbs_minimization(b, t, p, j):
@@ -202,7 +202,7 @@ see property package for documentation.}"""))
                     for e in b.config.property_package.element_list))
 
         if len(self.config.inert_species) > 0:
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.control_volume.properties_in.phase_list,
                              self.config.inert_species,
                              doc="Inert species balances")

--- a/idaes/generic_models/unit_models/heat_exchanger.py
+++ b/idaes/generic_models/unit_models/heat_exchanger.py
@@ -133,7 +133,7 @@ def delta_temperature_lmtd_callback(b):
     dT1 = b.delta_temperature_in
     dT2 = b.delta_temperature_out
 
-    @b.Expression(b.flowsheet().config.time)
+    @b.Expression(b.flowsheet().time)
     def delta_temperature(b, t):
         return (dT1[t] - dT2[t]) / log(dT1[t] / dT2[t])
 
@@ -148,7 +148,7 @@ def delta_temperature_amtd_callback(b):
     dT1 = b.delta_temperature_in
     dT2 = b.delta_temperature_out
 
-    @b.Expression(b.flowsheet().config.time)
+    @b.Expression(b.flowsheet().time)
     def delta_temperature(b, t):
         return (dT1[t] + dT2[t]) * 0.5
 
@@ -173,7 +173,7 @@ def delta_temperature_underwood_callback(b):
         function="cbrt",
         arg_units=[temp_units])
 
-    @b.Expression(b.flowsheet().config.time)
+    @b.Expression(b.flowsheet().time)
     def delta_temperature(b, t):
         return ((b.cbrt(dT1[t]) + b.cbrt(dT2[t])) / 2.0) ** 3 * temp_units
 
@@ -282,7 +282,7 @@ class HeatExchangerData(UnitModelBlockData):
         temp_units = s1_metadata.get_derived_units("temperature")
 
         u = self.overall_heat_transfer_coefficient = Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             domain=PositiveReals,
             initialize=100.0,
             doc="Overall heat transfer coefficient",
@@ -295,20 +295,20 @@ class HeatExchangerData(UnitModelBlockData):
             units=a_units
         )
         self.delta_temperature_in = Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             initialize=10.0,
             doc="Temperature difference at the hot inlet end",
             units=temp_units
         )
         self.delta_temperature_out = Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             initialize=10.1,
             doc="Temperature difference at the hot outlet end",
             units=temp_units
         )
         if self.config.flow_pattern == HeatExchangerFlowPattern.crossflow:
             self.crossflow_factor = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0,
                 doc="Factor to adjust coutercurrent flow heat "
                 "transfer calculation for cross flow.",
@@ -360,7 +360,7 @@ class HeatExchangerData(UnitModelBlockData):
         # Add end temperature differnece constraints                           #
         ########################################################################
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def delta_temperature_in_equation(b, t):
             if b.config.flow_pattern == HeatExchangerFlowPattern.cocurrent:
                 return (
@@ -377,7 +377,7 @@ class HeatExchangerData(UnitModelBlockData):
                                       to_units=temp_units)
                 )
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def delta_temperature_out_equation(b, t):
             if b.config.flow_pattern == HeatExchangerFlowPattern.cocurrent:
                 return (
@@ -397,7 +397,7 @@ class HeatExchangerData(UnitModelBlockData):
         ########################################################################
         # Add a unit level energy balance                                      #
         ########################################################################
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def unit_heat_balance(b, t):
             return 0 == (hot_side.heat[t] +
                          pyunits.convert(cold_side.heat[t],
@@ -413,7 +413,7 @@ class HeatExchangerData(UnitModelBlockData):
         ########################################################################
         deltaT = self.delta_temperature
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def heat_transfer_equation(b, t):
             if self.config.flow_pattern == HeatExchangerFlowPattern.crossflow:
                 return pyunits.convert(self.heat_duty[t], to_units=q_units) == (

--- a/idaes/generic_models/unit_models/heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/heat_exchanger_1D.py
@@ -511,14 +511,14 @@ thickness of the tube""",
 
         # Performance variables
         self.shell_heat_transfer_coefficient = Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             self.shell.length_domain,
             initialize=50,
             doc="Heat transfer coefficient",
             units=shell_units("heat_transfer_coefficient")
         )
         self.tube_heat_transfer_coefficient = Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             self.tube.length_domain,
             initialize=50,
             doc="Heat transfer coefficient",
@@ -528,7 +528,7 @@ thickness of the tube""",
         # Wall 0D model (Q_shell = Q_tube*N_tubes)
         if self.config.has_wall_conduction == WallConductionType.zero_dimensional:
             self.temperature_wall = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.tube.length_domain,
                 initialize=298.15,
                 units=shell_units("temperature")
@@ -538,7 +538,7 @@ thickness of the tube""",
             # Energy transfer between shell and tube wall
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.shell.length_domain,
                 doc="Heat transfer between shell and tube",
             )
@@ -555,7 +555,7 @@ thickness of the tube""",
 
             # Energy transfer between tube wall and tube
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.tube.length_domain,
                 doc="Convective heat transfer",
             )
@@ -576,7 +576,7 @@ thickness of the tube""",
                 q_units = shell_units("power")/shell_units("length")
             # Wall 0D model
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.shell.length_domain,
                 doc="wall 0D model",
             )
@@ -658,7 +658,7 @@ thickness of the tube""",
         if blk.config.has_wall_conduction == WallConductionType.zero_dimensional:
             shell_units = \
                 blk.config.shell_side.property_package.get_metadata().get_derived_units
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 for z in blk.shell.length_domain:
                     blk.temperature_wall[t, z].fix(
                         value(

--- a/idaes/generic_models/unit_models/mixer.py
+++ b/idaes/generic_models/unit_models/mixer.py
@@ -295,7 +295,7 @@ objects linked to all inlet states and the mixed state,
 
         mb_type = self.config.material_balance_type
         if mb_type == MaterialBalanceType.useDefault:
-            t_ref = self.flowsheet().config.time.first()
+            t_ref = self.flowsheet().time.first()
             mb_type = mixed_block[t_ref].default_material_balance_type()
 
         if mb_type != MaterialBalanceType.none:
@@ -422,7 +422,7 @@ objects linked to all inlet states and the mixed state,
         # Create an instance of StateBlock for all inlets
         for i in inlet_list:
             i_obj = self.config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 doc="Material properties at inlet",
                 default=tmp_dict,
             )
@@ -446,7 +446,7 @@ objects linked to all inlet states and the mixed state,
         tmp_dict["defined_state"] = False
 
         self.mixed_state = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Material properties of mixed stream",
             default=tmp_dict,
         )
@@ -471,7 +471,7 @@ objects linked to all inlet states and the mixed state,
         # Check that the user-provided StateBlock uses the same prop pack
         if (
             self.config.mixed_state_block[
-                self.flowsheet().config.time.first()
+                self.flowsheet().time.first()
             ].config.parameters
             != self.config.property_package
         ):
@@ -498,7 +498,7 @@ objects linked to all inlet states and the mixed state,
         units = pp.get_metadata()
 
         flow_basis = mixed_block[
-            self.flowsheet().config.time.first()].get_material_flow_basis()
+            self.flowsheet().time.first()].get_material_flow_basis()
         if flow_basis == MaterialFlowBasis.molar:
             flow_units = units.get_derived_units("flow_mole")
         elif flow_basis == MaterialFlowBasis.mass:
@@ -512,7 +512,7 @@ objects linked to all inlet states and the mixed state,
             if self.config.has_phase_equilibrium is True:
                 try:
                     self.phase_equilibrium_generation = Var(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         pp.phase_equilibrium_idx,
                         domain=Reals,
                         doc="Amount of generation in unit by phase equilibria",
@@ -560,7 +560,7 @@ objects linked to all inlet states and the mixed state,
 
             # Write phase-component balances
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 pc_set,
                 doc="Material mixing equations",
             )
@@ -580,7 +580,7 @@ objects linked to all inlet states and the mixed state,
         elif mb_type == MaterialBalanceType.componentTotal:
             # Write phase-component balances
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 mixed_block.component_list,
                 doc="Material mixing equations",
             )
@@ -598,7 +598,7 @@ objects linked to all inlet states and the mixed state,
         elif mb_type == MaterialBalanceType.total:
             # Write phase-component balances
             @self.Constraint(
-                self.flowsheet().config.time, doc="Material mixing equations"
+                self.flowsheet().time, doc="Material mixing equations"
             )
             def material_mixing_equations(b, t):
                 return 0 == sum(
@@ -634,7 +634,7 @@ objects linked to all inlet states and the mixed state,
         Add energy mixing equations (total enthalpy balance).
         """
 
-        @self.Constraint(self.flowsheet().config.time, doc="Energy balances")
+        @self.Constraint(self.flowsheet().time, doc="Energy balances")
         def enthalpy_mixing_equations(b, t):
             return 0 == (
                 sum(
@@ -664,7 +664,7 @@ objects linked to all inlet states and the mixed state,
 
         # Add variables
         self.minimum_pressure = Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             self.inlet_idx,
             doc="Variable for calculating minimum inlet pressure",
             units=units.get_derived_units("pressure")
@@ -680,7 +680,7 @@ objects linked to all inlet states and the mixed state,
 
         # Calculate minimum inlet pressure
         @self.Constraint(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             self.inlet_idx,
             doc="Calculation for minimum inlet pressure",
         )
@@ -699,7 +699,7 @@ objects linked to all inlet states and the mixed state,
 
         # Set inlet pressure to minimum pressure
         @self.Constraint(
-            self.flowsheet().config.time, doc="Link pressure to control volume"
+            self.flowsheet().time, doc="Link pressure to control volume"
         )
         def mixture_pressure(b, t):
             return mixed_block[t].pressure == (
@@ -717,7 +717,7 @@ objects linked to all inlet states and the mixed state,
 
         # Create equality constraints
         @self.Constraint(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             self.inlet_idx,
             doc="Calculation for minimum inlet pressure",
         )
@@ -755,7 +755,7 @@ objects linked to all inlet states and the mixed state,
             None
         """
         # Try property block model check
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             try:
                 inlet_list = blk.create_inlet_list()
                 for i in inlet_list:
@@ -868,7 +868,7 @@ objects linked to all inlet states and the mixed state,
 
         o_flags = {}
         # Calculate initial guesses for mixed stream state
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             # Iterate over state vars as defined by property package
             s_vars = mblock[t].define_state_vars()
             for s in s_vars:
@@ -915,7 +915,7 @@ objects linked to all inlet states and the mixed state,
         )
 
         # Revert fixed status of variables to what they were before
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             s_vars = mblock[t].define_state_vars()
             for s in s_vars:
                 for k in s_vars[s]:
@@ -927,7 +927,7 @@ objects linked to all inlet states and the mixed state,
                 and blk.pressure_equality_constraints.active is True
             ):
                 blk.pressure_equality_constraints.deactivate()
-                for t in blk.flowsheet().config.time:
+                for t in blk.flowsheet().time:
                     sys_press = getattr(
                         blk,
                         blk.create_inlet_list()[0] + "_state")[t].pressure
@@ -935,7 +935,7 @@ objects linked to all inlet states and the mixed state,
                 with idaeslog.solver_log(solve_log, idaeslog.DEBUG)as slc:
                     res = opt.solve(blk, tee=slc.tee)
                 blk.pressure_equality_constraints.activate()
-                for t in blk.flowsheet().config.time:
+                for t in blk.flowsheet().time:
                     blk.mixed_state[t].pressure.unfix()
             else:
                 with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
@@ -986,7 +986,7 @@ objects linked to all inlet states and the mixed state,
         super().calculate_scaling_factors()
         mb_type = self.config.material_balance_type
         if mb_type == MaterialBalanceType.useDefault:
-            t_ref = self.flowsheet().config.time.first()
+            t_ref = self.flowsheet().time.first()
             mb_type = self.mixed_state[t_ref].default_material_balance_type()
 
         if hasattr(self, "pressure_equality_constraints"):

--- a/idaes/generic_models/unit_models/plug_flow_reactor.py
+++ b/idaes/generic_models/unit_models/plug_flow_reactor.py
@@ -255,7 +255,7 @@ domain,
         self.add_outlet_port()
 
         # Add PFR performance equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.control_volume.length_domain,
                          self.config.reaction_package.rate_reaction_idx,
                          doc="PFR performance equation")

--- a/idaes/generic_models/unit_models/product.py
+++ b/idaes/generic_models/unit_models/product.py
@@ -102,7 +102,7 @@ see property package for documentation.}""",
 
         # Add State Block
         self.properties = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Material properties in product",
             default={
                 "defined_state": True,
@@ -113,7 +113,7 @@ see property package for documentation.}""",
 
         # Add references to all state vars
         s_vars = self.properties[
-            self.flowsheet().config.time.first()
+            self.flowsheet().time.first()
         ].define_state_vars()
         for s in s_vars:
             l_name = s_vars[s].local_name

--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -416,7 +416,7 @@ objects linked the mixed state and all outlet states,
         # Create an instance of StateBlock for all outlets
         for o in outlet_list:
             o_obj = self.config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 doc="Material properties at outlet",
                 default=tmp_dict,
             )
@@ -440,7 +440,7 @@ objects linked the mixed state and all outlet states,
         tmp_dict["defined_state"] = True
 
         self.mixed_state = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Material properties of mixed stream",
             default=tmp_dict,
         )
@@ -467,7 +467,7 @@ objects linked the mixed state and all outlet states,
         # Check that the user-provided StateBlock uses the same prop pack
         if (
             self.config.mixed_state_block[
-                self.flowsheet().config.time.first()
+                self.flowsheet().time.first()
             ].config.parameters
             != self.config.property_package
         ):
@@ -526,36 +526,36 @@ objects linked the mixed state and all outlet states,
         pc_set = mixed_block.phase_component_set
 
         if self.config.split_basis == SplittingType.totalFlow:
-            sf_idx = [self.flowsheet().config.time, self.outlet_idx]
-            sf_sum_idx = [self.flowsheet().config.time]
+            sf_idx = [self.flowsheet().time, self.outlet_idx]
+            sf_sum_idx = [self.flowsheet().time]
         elif self.config.split_basis == SplittingType.phaseFlow:
             sf_idx = [
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 mixed_block.phase_list,
             ]
             sf_sum_idx = [
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 mixed_block.phase_list,
             ]
         elif self.config.split_basis == SplittingType.componentFlow:
             sf_idx = [
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 mixed_block.component_list,
             ]
             sf_sum_idx = [
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 mixed_block.component_list,
             ]
         elif self.config.split_basis == SplittingType.phaseComponentFlow:
             sf_idx = [
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 pc_set,
             ]
             sf_sum_idx = [
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 pc_set,
             ]
         else:
@@ -593,7 +593,7 @@ objects linked the mixed state and all outlet states,
 
         mb_type = self.config.material_balance_type
         if mb_type == MaterialBalanceType.useDefault:
-            t_ref = self.flowsheet().config.time.first()
+            t_ref = self.flowsheet().time.first()
             mb_type = mixed_block[t_ref].default_material_balance_type()
 
         if mb_type == MaterialBalanceType.componentPhase:
@@ -601,7 +601,7 @@ objects linked the mixed state and all outlet states,
                 # Get units from property package
                 units_meta = self.config.property_package.get_metadata()
                 flow_basis = mixed_block[
-                    self.flowsheet().config.time.first()].get_material_flow_basis()
+                    self.flowsheet().time.first()].get_material_flow_basis()
                 if flow_basis == MaterialFlowBasis.molar:
                     flow_units = units_meta.get_derived_units("flow_mole")
                 elif flow_basis == MaterialFlowBasis.mass:
@@ -612,7 +612,7 @@ objects linked the mixed state and all outlet states,
 
                 try:
                     self.phase_equilibrium_generation = Var(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         self.outlet_idx,
                         self.config.property_package.phase_equilibrium_idx,
                         domain=Reals,
@@ -650,7 +650,7 @@ objects linked the mixed state and all outlet states,
                     return 0
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 pc_set,
                 doc="Material splitting equations",
@@ -665,7 +665,7 @@ objects linked the mixed state and all outlet states,
         elif mb_type == MaterialBalanceType.componentTotal:
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 mixed_block.component_list,
                 doc="Material splitting equations",
@@ -686,7 +686,7 @@ objects linked the mixed state and all outlet states,
         elif mb_type == MaterialBalanceType.total:
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 doc="Material splitting equations",
             )
@@ -733,7 +733,7 @@ objects linked the mixed state and all outlet states,
                 EnergySplittingType.equal_temperature:
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 doc="Temperature equality constraint",
             )
@@ -745,7 +745,7 @@ objects linked the mixed state and all outlet states,
                 EnergySplittingType.equal_molar_enthalpy:
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 doc="Molar enthalpy equality constraint",
             )
@@ -773,7 +773,7 @@ objects linked the mixed state and all outlet states,
                     return self.split_fraction[t, o, p]
 
             @self.Constraint(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 self.outlet_idx,
                 doc="Molar enthalpy splitting constraint",
             )
@@ -802,7 +802,7 @@ objects linked the mixed state and all outlet states,
         """
 
         @self.Constraint(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             self.outlet_idx,
             doc="Pressure equality constraint",
         )
@@ -900,7 +900,7 @@ objects linked the mixed state and all outlet states,
         units_meta = self.config.property_package.get_metadata()
 
         flow_basis = mb[
-            self.flowsheet().config.time.first()].get_material_flow_basis()
+            self.flowsheet().time.first()].get_material_flow_basis()
         if flow_basis == MaterialFlowBasis.molar:
             flow_units = units_meta.get_derived_units("flow_mole")
         elif flow_basis == MaterialFlowBasis.mass:
@@ -913,7 +913,7 @@ objects linked the mixed state and all outlet states,
         self.eps = Param(default=1e-8, mutable=True, units=flow_units)
 
         # Get list of port members
-        s_vars = mb[self.flowsheet().config.time.first()].define_port_members()
+        s_vars = mb[self.flowsheet().time.first()].define_port_members()
 
         # Get phase component list(s)
         pc_set = mb.phase_component_set
@@ -965,7 +965,7 @@ objects linked the mixed state and all outlet states,
                                 )
 
                         e_obj = VarLikeExpression(
-                            self.flowsheet().config.time,
+                            self.flowsheet().time,
                             pc_set,
                             rule=e_rule,
                         )
@@ -1032,7 +1032,7 @@ objects linked the mixed state and all outlet states,
                                 return self.eps
 
                         e_obj = VarLikeExpression(
-                            self.flowsheet().config.time,
+                            self.flowsheet().time,
                             mb.component_list,
                             rule=e_rule,
                         )
@@ -1063,7 +1063,7 @@ objects linked the mixed state and all outlet states,
                             return self.eps
 
                     e_obj = VarLikeExpression(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         pc_set,
                         rule=e_rule,
                     )
@@ -1118,7 +1118,7 @@ objects linked the mixed state and all outlet states,
                             return self.eps
 
                     e_obj = VarLikeExpression(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         mb.phase_list,
                         rule=e_rule,
                     )
@@ -1174,7 +1174,7 @@ objects linked the mixed state and all outlet states,
                             return self.eps
 
                     e_obj = VarLikeExpression(
-                        self.flowsheet().config.time,
+                        self.flowsheet().time,
                         mb.component_list,
                         rule=e_rule,
                     )
@@ -1277,7 +1277,7 @@ objects linked the mixed state and all outlet states,
                                 "equivalent indexed form.".format(self.name, s)
                             )
 
-                    e_obj = VarLikeExpression(self.flowsheet().config.time,
+                    e_obj = VarLikeExpression(self.flowsheet().time,
                                               rule=e_rule)
 
                 # Add Reference/Expression object to Separator model object
@@ -1299,7 +1299,7 @@ objects linked the mixed state and all outlet states,
             None
         """
         # Try property block model check
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             try:
                 if blk.config.mixed_state_block is None:
                     blk.mixed_state[t].model_check()
@@ -1410,7 +1410,7 @@ objects linked the mixed state and all outlet states,
 
             # Create dict to store fixed status of state variables
             o_flags = {}
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
 
                 # Calculate values for state variables
                 s_vars = o_block[t].define_state_vars()
@@ -1564,7 +1564,7 @@ objects linked the mixed state and all outlet states,
             )
 
             # Revert fixed status of variables to what they were before
-            for t in blk.flowsheet().config.time:
+            for t in blk.flowsheet().time:
                 s_vars = o_block[t].define_state_vars()
                 for v in s_vars:
                     for k in s_vars[v]:
@@ -1612,7 +1612,7 @@ objects linked the mixed state and all outlet states,
         mb_type = self.config.material_balance_type
         mixed_state = self.get_mixed_state_block()
         if mb_type == MaterialBalanceType.useDefault:
-            t_ref = self.flowsheet().config.time.first()
+            t_ref = self.flowsheet().time.first()
             mb_type = mixed_state[t_ref].default_material_balance_type()
         super().calculate_scaling_factors()
 

--- a/idaes/generic_models/unit_models/statejunction.py
+++ b/idaes/generic_models/unit_models/statejunction.py
@@ -95,7 +95,7 @@ see property package for documentation.}""",
         super(StateJunctionData, self).build()
 
         self.properties = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Material properties",
             default={
                 "has_phase_equilibrium": False,

--- a/idaes/generic_models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/generic_models/unit_models/tests/test_pressure_changer.py
@@ -877,12 +877,12 @@ class Test_costing(object):
         def perf_callback(b):
             unit_hd = units.J/units.kg
             unit_vflw = units.m**3/units.s
-            @b.Constraint(m.fs.config.time)
+            @b.Constraint(m.fs.time)
             def pc_isen_eff_eqn(b, t):
                 prnt = b.parent_block()
                 vflw = prnt.control_volume.properties_in[t].flow_vol
                 return prnt.efficiency_isentropic[t] == 0.9/3.975*vflw/unit_vflw
-            @b.Constraint(m.fs.config.time)
+            @b.Constraint(m.fs.time)
             def pc_isen_head_eqn(b, t):
                 prnt = b.parent_block()
                 vflw = prnt.control_volume.properties_in[t].flow_vol
@@ -922,12 +922,12 @@ class Test_costing(object):
             "support_isentropic_performance_curves":True})
         unit_hd = units.J/units.kg
         unit_vflw = units.m**3/units.s
-        @m.fs.unit.performance_curve.Constraint(m.fs.config.time)
+        @m.fs.unit.performance_curve.Constraint(m.fs.time)
         def pc_isen_eff_eqn(b, t):
             prnt = b.parent_block()
             vflw = prnt.control_volume.properties_in[t].flow_vol
             return prnt.efficiency_isentropic[t] == 0.9/3.975*vflw/unit_vflw
-        @m.fs.unit.performance_curve.Constraint(m.fs.config.time)
+        @m.fs.unit.performance_curve.Constraint(m.fs.time)
         def pc_isen_head_eqn(b, t):
             prnt = b.parent_block()
             vflw = prnt.control_volume.properties_in[t].flow_vol

--- a/idaes/generic_models/unit_models/translator.py
+++ b/idaes/generic_models/unit_models/translator.py
@@ -165,7 +165,7 @@ see property package for documentation.}""",
 
         # Add State Blocks
         self.properties_in = self.config.inlet_property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Material properties in incoming stream",
             default={
                 "defined_state": True,
@@ -175,7 +175,7 @@ see property package for documentation.}""",
         )
 
         self.properties_out = self.config.outlet_property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Material properties in outgoing stream",
             default={
                 "defined_state": self.config.outlet_state_defined,

--- a/idaes/generic_models/unit_models/valve.py
+++ b/idaes/generic_models/unit_models/valve.py
@@ -48,7 +48,7 @@ def linear_cb(valve):
     """
     Linear opening valve function callback.
     """
-    @valve.Expression(valve.flowsheet().config.time)
+    @valve.Expression(valve.flowsheet().time)
     def valve_function(b, t):
         return b.valve_opening[t]
 
@@ -57,7 +57,7 @@ def quick_cb(valve):
     """
     Quick opening valve function callback.
     """
-    @valve.Expression(valve.flowsheet().config.time)
+    @valve.Expression(valve.flowsheet().time)
     def valve_function(b, t):
         return pyo.sqrt(b.valve_opening[t])
 
@@ -68,7 +68,7 @@ def equal_percentage_cb(valve):
     """
     valve.alpha = pyo.Var(initialize=100, doc="Valve function parameter")
     valve.alpha.fix()
-    @valve.Expression(valve.flowsheet().config.time)
+    @valve.Expression(valve.flowsheet().time)
     def valve_function(b, t):
         return b.alpha ** (b.valve_opening[t] - 1)
 
@@ -90,7 +90,7 @@ def pressure_flow_default_callback(valve):
     valve.flow_var = pyo.Reference(valve.control_volume.properties_in[:].flow_mol)
     valve.pressure_flow_equation_scale = lambda x : x**2
 
-    @valve.Constraint(valve.flowsheet().config.time)
+    @valve.Constraint(valve.flowsheet().time)
     def pressure_flow_equation(b, t):
         Po = b.control_volume.properties_out[t].pressure
         Pi = b.control_volume.properties_in[t].pressure
@@ -145,7 +145,7 @@ variables, expressions, or constraints required can also be added by the callbac
         super().build()
 
         self.valve_opening = pyo.Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             initialize=1,
             doc="Fraction open for valve from 0 to 1",
         )
@@ -184,7 +184,7 @@ variables, expressions, or constraints required can also be added by the callbac
         """
         init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
 
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             if (self.deltaP[t].fixed or self.ratioP[t].fixed or
                 self.outlet.pressure[t].fixed):
                 continue

--- a/idaes/power_generation/carbon_capture/compression_system/compressor.py
+++ b/idaes/power_generation/carbon_capture/compression_system/compressor.py
@@ -61,13 +61,13 @@ class VaneDiffuserType(Enum):
 
 
 def _build_cover_impeller_equations(blk):
-    @blk.Constraint(blk.flowsheet().config.time)
+    @blk.Constraint(blk.flowsheet().time)
     def impeller_work_coeff_eqn(b, t):
         phi = blk.mass_flow_coeff[t]
         return b.impeller_work_coeff[t] * 100 * phi == (
                           0.62 * phi - phi * (phi / 0.4)**3 + 0.0014) * 100
 
-    @blk.Constraint(blk.flowsheet().config.time)
+    @blk.Constraint(blk.flowsheet().time)
     def polytropic_head_coeff_vaned_diffuser_eqn(b, t):
         phi = blk.mass_flow_coeff[t]
         return b.mu_p_v[t] * 100 * phi == (
@@ -75,13 +75,13 @@ def _build_cover_impeller_equations(blk):
 
 
 def _build_open_impeller_equations(blk):
-    @blk.Constraint(blk.flowsheet().config.time)
+    @blk.Constraint(blk.flowsheet().time)
     def impeller_work_coeff_eqn(b, t):
         phi = blk.mass_flow_coeff[t]
         return b.impeller_work_coeff[t] * phi == (
                       0.68 * phi - phi * (phi / 0.37)**3 + 0.002)
 
-    @blk.Constraint(blk.flowsheet().config.time)
+    @blk.Constraint(blk.flowsheet().time)
     def polytropic_head_coeff_vaned_diffuser_eqn(b, t):
         phi = blk.mass_flow_coeff[t]
         return b.mu_p_v[t] * phi == 0.5 * (1 + (phi - 0.065) / abs(
@@ -91,21 +91,21 @@ def _build_open_impeller_equations(blk):
 
 
 def _build_vane_diffuser_equations(blk):
-    @blk.Constraint(blk.flowsheet().config.time)
+    @blk.Constraint(blk.flowsheet().time)
     def polytropic_head_coeff_eqn(b, t):
         return b.mu_p[t] == b.mu_p_v[t]
 
-    @blk.Constraint(blk.flowsheet().config.time)
+    @blk.Constraint(blk.flowsheet().time)
     def polytropic_efficiency_eqn(b, t):
         return b.eff_p[t] == b.eff_p_v[t]
 
 
 def _build_vaneless_diffuser_equations(blk):
-    @blk.Constraint(blk.flowsheet().config.time)
+    @blk.Constraint(blk.flowsheet().time)
     def polytropic_head_coeff_eqn(b, t):
         return b.mu_p[t] == b.impeller_work_coeff[t] * b.eff_p[t]
 
-    @blk.Constraint(blk.flowsheet().config.time)
+    @blk.Constraint(blk.flowsheet().time)
     def polytropic_efficiency_eqn(b, t):
         phi = blk.mass_flow_coeff[t]
         return (b.eff_p[t] - b.eff_p_v[t]) * (
@@ -179,55 +179,55 @@ VaneDiffuserType.custom}""",
         properties_in = self.control_volume.properties_in
         properties_out = self.control_volume.properties_out
 
-        self.mass_flow_coeff = Var(self.flowsheet().config.time,
+        self.mass_flow_coeff = Var(self.flowsheet().time,
                                    initialize=0.07,
                                    doc="Compressor Flow Coefficient",
                                    bounds=(0.01, 0.15))
-        self.rspeed = Var(self.flowsheet().config.time,
+        self.rspeed = Var(self.flowsheet().time,
                           initialize=70.0,
                           doc='Rotation Speed of The Impeller',
                           bounds=(0.5, 8000),
                           units=1 / pyunits.s)
-        self.U2 = Var(self.flowsheet().config.time,
+        self.U2 = Var(self.flowsheet().time,
                       initialize=300,
                       doc="Impeller Tip Speed",
                       bounds=(0, 500),
                       units=pyunits.m / pyunits.s)
-        self.delta_enth_polytropic = Var(self.flowsheet().config.time,
+        self.delta_enth_polytropic = Var(self.flowsheet().time,
                                          initialize=2500,
                                          doc="Polytropic Enthalpy Change",
                                          units=pyunits.J / pyunits.mol,
                                          within=NonNegativeReals)
-        self.impeller_work_coeff = Var(self.flowsheet().config.time,
+        self.impeller_work_coeff = Var(self.flowsheet().time,
                                        initialize=0.60,
                                        doc="Impeller Work Coefficient",
                                        bounds=(0.001, 1))
-        self.mu_p_v = Var(self.flowsheet().config.time,
+        self.mu_p_v = Var(self.flowsheet().time,
                           initialize=0.60,
                           doc="Polytropic Head Coefficient Vaned Diffuser",
                           bounds=(0.001, 1))
-        self.mu_p = Var(self.flowsheet().config.time,
+        self.mu_p = Var(self.flowsheet().time,
                         initialize=0.60,
                         doc="Polytropic Head Coefficient",
                         bounds=(0.001, 1))
-        self.eff_p_v = Var(self.flowsheet().config.time,
+        self.eff_p_v = Var(self.flowsheet().time,
                            initialize=0.85,
                            doc="Polytropic Efficiency Vaned Diffuser",
                            bounds=(0.001, 1))
-        self.eff_p = Var(self.flowsheet().config.time,
+        self.eff_p = Var(self.flowsheet().time,
                          initialize=0.85,
                          doc="Polytropic Efficiency",
                          bounds=(0.001, 1.0))
-        self.Ma = Var(self.flowsheet().config.time,
+        self.Ma = Var(self.flowsheet().time,
                       initialize=0.10,
                       doc='Rotational Mach Number',
                       bounds=(0.5, 1.5))
-        self.psi_3 = Var(self.flowsheet().config.time,
+        self.psi_3 = Var(self.flowsheet().time,
                          initialize=0.01,
                          doc="Dimensionless Exit Flow Coefficient",
                          within=NonNegativeReals,
                          units=pyunits.dimensionless)
-        self.psi_s = Var(self.flowsheet().config.time,
+        self.psi_s = Var(self.flowsheet().time,
                          initialize=0.01,
                          doc="Dimensionless Isentropic Head Coefficient",
                          within=NonNegativeReals,
@@ -255,14 +255,14 @@ VaneDiffuserType.custom}""",
 
         ###########################################################
         # Calculate Mach number and tip impeller speed
-        @self.Constraint(self.flowsheet().config.time, doc="Mach Number")
+        @self.Constraint(self.flowsheet().time, doc="Mach Number")
         def Ma_con(b, t):
             # assume single vapor phase.
             speed_of_sound = self.control_volume.properties_in[
                 t].speed_sound_phase['Vap']
             return b.Ma[t] == b.U2[t] / speed_of_sound
 
-        @self.Constraint(self.flowsheet().config.time, doc="Rotation Speed "
+        @self.Constraint(self.flowsheet().time, doc="Rotation Speed "
                          "of the Impeller")
         def rspeed_con(b, t):
             return b.U2[t] == 2 * const.pi * b.r2 * b.rspeed[t]
@@ -298,32 +298,32 @@ VaneDiffuserType.custom}""",
             icb(self)
 
         # efficiency for vane diffuser
-        @self.Constraint(self.flowsheet().config.time, doc="Polytropic "
+        @self.Constraint(self.flowsheet().time, doc="Polytropic "
                          "Efficiency")
         def eff_p_v_cons(b, t):
             return b.eff_p_v[t] * b.impeller_work_coeff[t] == b.mu_p_v[t]
 
         # Total enthalpy and entropy change through compressor stage
         # Isentropic enthalpy change (hisen - hin)
-        @self.Expression(self.flowsheet().config.time, doc="Specific "
+        @self.Expression(self.flowsheet().time, doc="Specific "
                          "Enthalpy Change of Isentropic Process")
         def delta_enth_isentropic(b, t):
             return b.properties_isentropic[t].enth_mol - \
                 properties_in[t].enth_mol
 
         # Total enthalpy change (ho - hi)
-        @self.Expression(self.flowsheet().config.time, doc="Actual Enthalpy "
+        @self.Expression(self.flowsheet().time, doc="Actual Enthalpy "
                          "Change")
         def delta_enth_actual(b, t):
             return properties_out[t].enth_mol - properties_in[t].enth_mol
 
         # Entropy change
-        @self.Expression(self.flowsheet().config.time, doc="Entropy change in"
+        @self.Expression(self.flowsheet().time, doc="Entropy change in"
                          "Compressor Stage")
         def deltaS(b, t):
             return properties_out[t].entr_mol - properties_in[t].entr_mol
 
-        @self.Constraint(self.flowsheet().config.time, doc="Polytropic "
+        @self.Constraint(self.flowsheet().time, doc="Polytropic "
                          "Enthalpy Correlation")
         def polytropic_correlation(b, t):
             return b.delta_enth_polytropic[t] == b.mu_p[t] * \
@@ -331,7 +331,7 @@ VaneDiffuserType.custom}""",
 
         # Correlation between actual enthalpy and polytropic enthalpy
         # This equation is obtained by Eq. (2.13) from Aungier textbook (2000)
-        @self.Constraint(self.flowsheet().config.time, doc="Equation for"
+        @self.Constraint(self.flowsheet().time, doc="Equation for"
                          "Polytropic Enthalpy")
         def delta_enth_polytropic_con(b, t):
             Tout = properties_out[t].temperature
@@ -341,27 +341,27 @@ VaneDiffuserType.custom}""",
 
         # Maximum impeller speed for individual stage
         @self.Expression(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Maximum Allowable Impeller Tip Speed")
         def U2max(b, t):
             phi = b.mass_flow_coeff[t]
             return sqrt((1984.1 * phi**2 - 616.88 * phi + 215.97) * 0.7 * 830)
 
         # Thermodynamic power
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Thermodynamic Power")
         def fluid_pow(b, t):
             flow = properties_in[t].flow_mol
             return b.delta_enth_actual[t] * flow
 
         # Electricity power
-        @self.Expression(self.flowsheet().config.time, doc="Shaft Power")
+        @self.Expression(self.flowsheet().time, doc="Shaft Power")
         def elec_pow(b, t):
             return b.fluid_pow[t] / (b.efficiency_mech * b.eff_drive)
 
         # -------------------------------------------------------------------
         # Static Volumetric Flow at Suction Inlet
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Static Volumetric Flow at Suction Inlet")
         def Vsdot(b, t):
             flow_in = properties_in[t].flow_mol
@@ -370,13 +370,13 @@ VaneDiffuserType.custom}""",
 
         # Mass flow coefficient
         @self.Constraint(
-            self.flowsheet().config.time, doc="Mass Flow Coefficient")
+            self.flowsheet().time, doc="Mass Flow Coefficient")
         def mass_flow_coeff_eqn(b, t):
             phi = b.mass_flow_coeff[t]
             return phi == b.Vsdot[t] / (const.pi * b.r2**2 * b.U2[t])
 
         # Static volumetric flow at impeller exit
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Static volumetric flow at impeller exit")
         def V3dot(b, t):
             Tin = properties_in[t].temperature
@@ -387,7 +387,7 @@ VaneDiffuserType.custom}""",
             return b.Vsdot[t] * (b.z_d / b.z_s) * (Tout / Tin) * (Ps / Pd)
 
         # Dimensionless Exit Flow Coefficient (Performance Curve)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Dimensionless Exit Flow Coefficient")
         def psi_3_eqn(b, t):
             b2 = 0.076 * 2 * b.r2
@@ -395,7 +395,7 @@ VaneDiffuserType.custom}""",
                 const.pi * 2 * b.r2 * b2 * b.U2[t])
 
         # Isentropic head
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Isentropic Head")
         def ys_model(b, t):
             k_v = self.control_volume.properties_in[t].heat_capacity_ratio
@@ -408,7 +408,7 @@ VaneDiffuserType.custom}""",
             return b.z_s * (gas_const / mw) * Tin * (1 / a) * ((Pd/Ps)**a - 1)
 
         # Dimensionless Isentropic Head Coefficient (Performance Curve)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Dimensionless Isentropic Head Coefficient")
         def psi_s_eqn(b, t):
             return b.psi_s[t] == 2 * b.ys_model[t] / (b.U2[t]**2)
@@ -434,7 +434,7 @@ VaneDiffuserType.custom}""",
         opt = get_solver(solver, optarg)
 
         unfix_ratioP = {}
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             # if there is not a good guess for efficiency or outlet pressure
             # provide something reasonable.
             eff = self.efficiency_isentropic[t]
@@ -483,7 +483,7 @@ VaneDiffuserType.custom}""",
             state_args=state_args, outlvl=outlvl, solver=solver, optarg=optarg)
 
         self.efficiency_isentropic.unfix()
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             if unfix_ratioP.get(t, False):
                 self.ratioP[t].unfix()
         # Activate special constraints

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/column.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/column.py
@@ -393,7 +393,7 @@ documentation for supported schemes,
         # Add object reference - time
         add_object_reference(self,
                              "t",
-                             self.flowsheet().config.time)
+                             self.flowsheet().time)
 
         # Packing  parameters
         self.eps_ref = Param(initialize=self.config.packing_void_fraction,

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/phe.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/phe.py
@@ -339,14 +339,14 @@ class PHEData(UnitModelBlockData):
         def rule_trh(blk, t):
             return (blk.hot_side.properties_out[t].temperature /
                     blk.hot_side.properties_in[t].temperature)
-        self.trh = Expression(self.flowsheet().config.time, rule=rule_trh,
+        self.trh = Expression(self.flowsheet().time, rule=rule_trh,
                               doc='Ratio of hot outlet temperature to hot'
                                   'inlet temperature')
 
         def rule_trc(blk, t):
             return (blk.cold_side.properties_out[t].temperature /
                     blk.cold_side.properties_in[t].temperature)
-        self.trc = Expression(self.flowsheet().config.time, rule=rule_trc,
+        self.trc = Expression(self.flowsheet().time, rule=rule_trc,
                               doc='Ratio of cold outlet temperature to cold'
                                   ' inlet temperature')
 
@@ -366,7 +366,7 @@ class PHEData(UnitModelBlockData):
                 (blk.hot_side.properties_in[t].temperature**4) *
                 (blk.trh[t]**4 + blk.trh[t]**3 + blk.trh[t]**2 + blk.trh[t] + 1))
 
-        self.cp_comp_hot = Expression(self.flowsheet().config.time,
+        self.cp_comp_hot = Expression(self.flowsheet().time,
                                       solvent_list,
                                       rule=rule_cp_comp_hot,
                                       doc='Component mean specific heat capacity'
@@ -377,7 +377,7 @@ class PHEData(UnitModelBlockData):
             return sum(blk.cp_comp_hot[t, j] *
                        blk.hot_side.properties_in[t].mass_frac_co2_free[j]
                        for j in solvent_list)
-        self.cp_hot = Expression(self.flowsheet().config.time, rule=rule_cp_hot,
+        self.cp_hot = Expression(self.flowsheet().time, rule=rule_cp_hot,
                                  doc='Hot-side mean specific heat capacity on'
                                      'free CO2 basis')
 
@@ -397,7 +397,7 @@ class PHEData(UnitModelBlockData):
                 (blk.cold_side.properties_in[t].temperature**4) *
                 (blk.trc[t]**4 + blk.trc[t]**3 + blk.trc[t]**2 + blk.trc[t] + 1))
 
-        self.cp_comp_cold = Expression(self.flowsheet().config.time,
+        self.cp_comp_cold = Expression(self.flowsheet().time,
                                        solvent_list,
                                        rule=rule_cp_comp_cold,
                                        doc='Component mean specific heat capacity'
@@ -408,21 +408,21 @@ class PHEData(UnitModelBlockData):
             return sum(blk.cp_comp_cold[t, j] *
                        blk.cold_side.properties_in[t].mass_frac_co2_free[j]
                        for j in solvent_list)
-        self.cp_cold = Expression(self.flowsheet().config.time, rule=rule_cp_cold,
+        self.cp_cold = Expression(self.flowsheet().time, rule=rule_cp_cold,
                                   doc='Cold-side mean specific heat capacity'
                                       'on free CO2 basis')
 
         # Model Variables
-        self.Th_in = Var(self.flowsheet().config.time,
+        self.Th_in = Var(self.flowsheet().time,
                          self.PH, initialize=393, units=pyunits.K,
                          doc="Hot Temperature IN of pass")
-        self.Th_out = Var(self.flowsheet().config.time,
+        self.Th_out = Var(self.flowsheet().time,
                           self.PH, initialize=325, units=pyunits.K,
                           doc="Hot Temperature OUT of pass")
-        self.Tc_in = Var(self.flowsheet().config.time,
+        self.Tc_in = Var(self.flowsheet().time,
                          self.PH, initialize=320, units=pyunits.K,
                          doc="Cold Temperature IN of pass")
-        self.Tc_out = Var(self.flowsheet().config.time,
+        self.Tc_out = Var(self.flowsheet().time,
                           self.PH, initialize=390, units=pyunits.K,
                           doc="Cold Temperature OUT of pass")
 
@@ -432,13 +432,13 @@ class PHEData(UnitModelBlockData):
         def rule_mh_in(blk, t):
             return blk.hot_side.properties_in[t].flow_mol *\
                 blk.hot_side.properties_in[t].mw
-        self.mh_in = Expression(self.flowsheet().config.time, rule=rule_mh_in,
+        self.mh_in = Expression(self.flowsheet().time, rule=rule_mh_in,
                                 doc='Hotside mass flow rate [kg/s]')
 
         def rule_mc_in(blk, t):
             return blk.cold_side.properties_in[t].flow_mol *\
                 blk.cold_side.properties_in[t].mw
-        self.mc_in = Expression(self.flowsheet().config.time, rule=rule_mc_in,
+        self.mc_in = Expression(self.flowsheet().time, rule=rule_mc_in,
                                 doc='Coldside mass flow rate [kg/s]')
 
         # ----------------------------------------------------------------------
@@ -446,13 +446,13 @@ class PHEData(UnitModelBlockData):
         def rule_Gph(blk, t):
             return (4 * blk.mh_in[t] * 7) / (22 * blk.port_dia**2)
 
-        self.Gph = Expression(self.flowsheet().config.time, rule=rule_Gph,
+        self.Gph = Expression(self.flowsheet().time, rule=rule_Gph,
                               doc='Hotside port mass velocity[kg/m2.s]')
 
         def rule_Gpc(blk, t):
             return (4 * blk.mc_in[t] * 7) / (22 * blk.port_dia**2)
 
-        self.Gpc = Expression(self.flowsheet().config.time, rule=rule_Gpc,
+        self.Gpc = Expression(self.flowsheet().time, rule=rule_Gpc,
                               doc='Coldside port mass velocity[kg/m2.s]')
 
         # ----------------------------------------------------------------------
@@ -461,7 +461,7 @@ class PHEData(UnitModelBlockData):
             return blk.mh_in[t] * blk.channel_dia /\
                 (blk.Np[p] * blk.plate_width *
                  blk.plate_gap * blk.hot_side.properties_in[t].visc_d)
-        self.Re_h = Expression(self.flowsheet().config.time, self.PH,
+        self.Re_h = Expression(self.flowsheet().time, self.PH,
                                rule=rule_Re_h,
                                doc='Hotside Reynolds number')
 
@@ -469,21 +469,21 @@ class PHEData(UnitModelBlockData):
             return blk.mc_in[t] * blk.channel_dia /\
                 (blk.Np[p] * blk.plate_width *
                  blk.plate_gap * blk.cold_side.properties_in[t].visc_d)
-        self.Re_c = Expression(self.flowsheet().config.time, self.PH,
+        self.Re_c = Expression(self.flowsheet().time, self.PH,
                                rule=rule_Re_c,
                                doc='Coldside Reynolds number')
 
         def rule_Pr_h(blk, t):
             return blk.cp_hot[t] * blk.hot_side.properties_in[t].visc_d /\
                 blk.hot_side.properties_in[t].thermal_cond
-        self.Pr_h = Expression(self.flowsheet().config.time,
+        self.Pr_h = Expression(self.flowsheet().time,
                                rule=rule_Pr_h,
                                doc='Hotside Prandtl number')
 
         def rule_Pr_c(blk, t):
             return blk.cp_cold[t] * blk.cold_side.properties_in[t].visc_d /\
                 blk.cold_side.properties_in[t].thermal_cond
-        self.Pr_c = Expression(self.flowsheet().config.time,
+        self.Pr_c = Expression(self.flowsheet().time,
                                rule=rule_Pr_c,
                                doc='Coldside Prandtl number')
         # ----------------------------------------------------------------------
@@ -494,7 +494,7 @@ class PHEData(UnitModelBlockData):
                     blk.param_a * blk.Re_h[t, p]**blk.param_b *
                     blk.Pr_h[t]**blk.param_c)
 
-        self.h_hot = Expression(self.flowsheet().config.time,
+        self.h_hot = Expression(self.flowsheet().time,
                                 self.PH, rule=rule_hotside_transfer_coef,
                                 doc='Hotside heat transfer coefficient')
 
@@ -503,7 +503,7 @@ class PHEData(UnitModelBlockData):
                     blk.param_a * blk.Re_c[t, p]**blk.param_b *
                     blk.Pr_c[t]**blk.param_c)
 
-        self.h_cold = Expression(self.flowsheet().config.time,
+        self.h_cold = Expression(self.flowsheet().time,
                                  self.PH, rule=rule_coldside_transfer_coef,
                                  doc='Coldside heat transfer coefficient')
 
@@ -511,13 +511,13 @@ class PHEData(UnitModelBlockData):
         # Friction factor calculation
         def rule_fric_h(blk, t):
             return 18.29 * blk.Re_h[t, 1]**(-0.652)
-        self.fric_h = Expression(self.flowsheet().config.time,
+        self.fric_h = Expression(self.flowsheet().time,
                                  rule=rule_fric_h,
                                  doc='Hotside friction factor')
 
         def rule_fric_c(blk, t):
             return 1.441 * self.Re_c[t, 1]**(-0.206)
-        self.fric_c = Expression(self.flowsheet().config.time,
+        self.fric_c = Expression(self.flowsheet().time,
                                  rule=rule_fric_c,
                                  doc='Coldside friction factor')
 
@@ -532,7 +532,7 @@ class PHEData(UnitModelBlockData):
                 blk.hot_side.properties_in[t].dens_mass * \
                 9.81 * (blk.plate_length + blk.port_dia)
 
-        self.dP_h = Expression(self.flowsheet().config.time,
+        self.dP_h = Expression(self.flowsheet().time,
                                rule=rule_hotside_dP,
                                doc='Hotside pressure drop  [Pa]')
 
@@ -545,18 +545,18 @@ class PHEData(UnitModelBlockData):
                 blk.cold_side.properties_in[t].dens_mass * \
                 9.81 * (blk.plate_length + blk.port_dia)
 
-        self.dP_c = Expression(self.flowsheet().config.time,
+        self.dP_c = Expression(self.flowsheet().time,
                                rule=rule_coldside_dP,
                                doc='Coldside pressure drop  [Pa]')
 
         def rule_eq_deltaP_hot(blk, t):
             return blk.hot_side.deltaP[t] == -blk.dP_h[t]
-        self.eq_deltaP_hot = Constraint(self.flowsheet().config.time,
+        self.eq_deltaP_hot = Constraint(self.flowsheet().time,
                                         rule=rule_eq_deltaP_hot)
 
         def rule_eq_deltaP_cold(blk, t):
             return blk.cold_side.deltaP[t] == -blk.dP_c[t]
-        self.eq_deltaP_cold = Constraint(self.flowsheet().config.time,
+        self.eq_deltaP_cold = Constraint(self.flowsheet().time,
                                          rule=rule_eq_deltaP_cold)
 
         # ----------------------------------------------------------------------
@@ -565,7 +565,7 @@ class PHEData(UnitModelBlockData):
             return 1.0 /\
                 (1.0 / blk.h_hot[t, p] + blk.plate_gap / blk.plate_thermal_cond +
                  1.0 / blk.h_cold[t, p])
-        self.U = Expression(self.flowsheet().config.time, self.PH,
+        self.U = Expression(self.flowsheet().time, self.PH,
                             rule=rule_U,
                             doc='Overall heat transfer coefficient')
         # ----------------------------------------------------------------------
@@ -573,13 +573,13 @@ class PHEData(UnitModelBlockData):
 
         def rule_Caph(blk, t, p):
             return blk.mh_in[t] * blk.cp_hot[t] / blk.Np[p]
-        self.Caph = Expression(self.flowsheet().config.time, self.PH,
+        self.Caph = Expression(self.flowsheet().time, self.PH,
                                rule=rule_Caph,
                                doc='Hotfluid capacitance rate')
 
         def rule_Capc(blk, t, p):
             return blk.mc_in[t] * blk.cp_cold[t] / blk.Np[p]
-        self.Capc = Expression(self.flowsheet().config.time, self.PH,
+        self.Capc = Expression(self.flowsheet().time, self.PH,
                                rule=rule_Capc,
                                doc='Coldfluid capacitance rate')
 
@@ -588,20 +588,20 @@ class PHEData(UnitModelBlockData):
         def rule_Cmin(blk, t, p):
             return 0.5 * (blk.Caph[t, p] + blk.Capc[t, p] -
                           ((blk.Caph[t, p] - blk.Capc[t, p])**2 + 0.00001)**0.5)
-        self.Cmin = Expression(self.flowsheet().config.time, self.PH,
+        self.Cmin = Expression(self.flowsheet().time, self.PH,
                                rule=rule_Cmin,
                                doc='Minimum capacitance rate')
 
         def rule_Cmax(blk, t, p):
             return 0.5 * (blk.Caph[t, p] + blk.Capc[t, p] +
                           ((blk.Caph[t, p] - blk.Capc[t, p])**2 + 0.00001)**0.5)
-        self.Cmax = Expression(self.flowsheet().config.time, self.PH,
+        self.Cmax = Expression(self.flowsheet().time, self.PH,
                                rule=rule_Cmax,
                                doc='Maximum capacitance rate')
 
         def rule_CR(blk, t, p):
             return blk.Cmin[t, p] / blk.Cmax[t, p]
-        self.CR = Expression(self.flowsheet().config.time, self.PH,
+        self.CR = Expression(self.flowsheet().time, self.PH,
                              rule=rule_CR,
                              doc='Capacitance ratio')
 
@@ -609,7 +609,7 @@ class PHEData(UnitModelBlockData):
         # Number of Transfer units for sub heat exchanger
         def rule_NTU(blk, t, p):
             return blk.U[t, p] * blk.plate_area / blk.Cmin[t, p]
-        self.NTU = Expression(self.flowsheet().config.time, self.PH,
+        self.NTU = Expression(self.flowsheet().time, self.PH,
                               rule=rule_NTU,
                               doc='Number of Transfer Units')
 
@@ -623,7 +623,7 @@ class PHEData(UnitModelBlockData):
             elif blk.P.value % 2 == 1:
                 return (1 - exp(-blk.NTU[t, p] * (1 + blk.CR[t, p]))) / (1 + blk.CR[t, p])
 
-        self.Ecf = Expression(self.flowsheet().config.time, self.PH,
+        self.Ecf = Expression(self.flowsheet().time, self.PH,
                               rule=rule_Ecf,
                               doc='Effectiveness for sub-HX')
 
@@ -634,7 +634,7 @@ class PHEData(UnitModelBlockData):
                 blk.Ecf[t, p] * blk.Cmin[t, p] / blk.Caph[t, p] * \
                 (blk.Th_in[t, p] - blk.Tc_in[t, p])
 
-        self.Ebh_eq = Constraint(self.flowsheet().config.time, self.PH,
+        self.Ebh_eq = Constraint(self.flowsheet().time, self.PH,
                                  rule=rule_Ebh_eq,
                                  doc='Hot fluid sub-heat exchanger energy balance')
 
@@ -643,7 +643,7 @@ class PHEData(UnitModelBlockData):
             return blk.Th_out[t, blk.P.value] ==\
                 blk.hot_side.properties_out[t].temperature
 
-        self.Tout_hot_eq = Constraint(self.flowsheet().config.time,
+        self.Tout_hot_eq = Constraint(self.flowsheet().time,
                                       rule=rule_Tout_hot,
                                       doc='Hot fluid exit temperature')
 
@@ -653,7 +653,7 @@ class PHEData(UnitModelBlockData):
                 blk.Ecf[t, p] * blk.Cmin[t, p] / blk.Capc[t, p] * \
                 (blk.Th_in[t, p] - blk.Tc_in[t, p])
 
-        self.Ebc_eq = Constraint(self.flowsheet().config.time, self.PH,
+        self.Ebc_eq = Constraint(self.flowsheet().time, self.PH,
                                  rule=rule_Ebc_eq,
                                  doc='Cold fluid sub-heat exchanger energy balance')
 
@@ -662,7 +662,7 @@ class PHEData(UnitModelBlockData):
             return blk.Tc_out[t, 1] ==\
                 blk.cold_side.properties_out[t].temperature
 
-        self.Tout_cold_eq = Constraint(self.flowsheet().config.time,
+        self.Tout_cold_eq = Constraint(self.flowsheet().time,
                                        rule=rule_Tout_cold,
                                        doc='Cold fluid exit temperature')
 
@@ -672,14 +672,14 @@ class PHEData(UnitModelBlockData):
             return blk.Th_in[t, 1] == \
                 blk.hot_side.properties_in[t].temperature
 
-        self.hot_BCIN = Constraint(self.flowsheet().config.time,
+        self.hot_BCIN = Constraint(self.flowsheet().time,
                                    rule=rule_hot_BCIN,
                                    doc='Hot fluid inlet boundary conditions')
 
         def rule_cold_BCIN(blk, t):
             return blk.Tc_in[t, blk.P.value] ==\
                 blk.cold_side.properties_in[t].temperature
-        self.cold_BCIN = Constraint(self.flowsheet().config.time,
+        self.cold_BCIN = Constraint(self.flowsheet().time,
                                     rule=rule_cold_BCIN,
                                     doc='Cold fluid inlet boundary conditions')
 
@@ -687,13 +687,13 @@ class PHEData(UnitModelBlockData):
 
         def rule_hot_BC(blk, t, p):
             return blk.Th_out[t, p] == blk.Th_in[t, p + 1]
-        self.hot_BC = Constraint(self.flowsheet().config.time, Pset,
+        self.hot_BC = Constraint(self.flowsheet().time, Pset,
                                  rule=rule_hot_BC,
                                  doc='Hot fluid boundary conditions: change of pass')
 
         def rule_cold_BC(blk, t, p):
             return blk.Tc_out[t, p + 1] == blk.Tc_in[t, p]
-        self.cold_BC = Constraint(self.flowsheet().config.time, Pset,
+        self.cold_BC = Constraint(self.flowsheet().time, Pset,
                                   rule=rule_cold_BC,
                                   doc='Cold fluid boundary conditions: change of pass')
 
@@ -703,14 +703,14 @@ class PHEData(UnitModelBlockData):
             return blk.mh_in[t] * blk.cp_hot[t] *\
                 (blk.hot_side.properties_in[t].temperature -
                  blk.hot_side.properties_out[t].temperature)
-        self.QH = Expression(self.flowsheet().config.time, rule=rule_QH,
+        self.QH = Expression(self.flowsheet().time, rule=rule_QH,
                              doc='Heat lost by hot fluid')
 
         def rule_QC(blk, t):
             return blk.mc_in[t] * blk.cp_cold[t] *\
                 (blk.cold_side.properties_out[t].temperature -
                  blk.cold_side.properties_in[t].temperature)
-        self.QC = Expression(self.flowsheet().config.time, rule=rule_QH,
+        self.QC = Expression(self.flowsheet().time, rule=rule_QH,
                              doc='Heat gain by cold fluid')
 
     def initialize(blk, hotside_state_args=None, coldside_state_args=None,

--- a/idaes/power_generation/control/pid_controller.py
+++ b/idaes/power_generation/control/pid_controller.py
@@ -75,7 +75,7 @@ Default is PI"""))
                 raise ConfigurationError("Controller configuration"
                                          " requires 'mv'")
             # Shorter pointers to time set information
-            time_set = self.flowsheet().config.time
+            time_set = self.flowsheet().time
             self.pv = Reference(self.config.pv)
             self.mv = Reference(self.config.mv)
 
@@ -122,7 +122,7 @@ Default is PI"""))
                                              doc="Integral term")
                 self.error_from_integral = DerivativeVar(
                     self.integral_of_error,
-                    wrt=self.flowsheet().config.time,
+                    wrt=self.flowsheet().time,
                     initialize=0)
 
                 @self.Constraint(time_set,
@@ -134,7 +134,7 @@ Default is PI"""))
             if self.config.type == 'PID' or self.config.type == 'PD':
                 self.derivative_of_error = DerivativeVar(
                     self.error,
-                    wrt=self.flowsheet().config.time,
+                    wrt=self.flowsheet().time,
                     initialize=0)
 
             @self.Expression(time_set, doc="Proportional output")
@@ -177,7 +177,7 @@ Default is PI"""))
             @self.Constraint(time_set,
                              doc="Bounded output of manipulated variable")
             def mv_eqn(b, t):
-                if t == b.flowsheet().config.time.first():
+                if t == b.flowsheet().time.first():
                     return Constraint.Skip
                 else:
                     if self.config.bounded_output is True:

--- a/idaes/power_generation/control/tests/test_pid_pump.py
+++ b/idaes/power_generation/control/tests/test_pid_pump.py
@@ -53,7 +53,7 @@ def set_scaling_factors(m):
             iscale.constraint_scaling_transform(c, 1e-6)
 
     # scaling factor for control valves
-    for t in m.fs.config.time:
+    for t in m.fs.time:
         iscale.set_scaling_factor(
             m.fs.valve.control_volume.properties_in[t].flow_mol, 0.001)
 
@@ -65,7 +65,7 @@ def main():
     m_ss = get_model(dynamic=False)
     m_dyn = get_model(dynamic=True)
     copy_non_time_indexed_values(m_dyn.fs, m_ss.fs, copy_fixed=True)
-    for t in m_dyn.fs.config.time:
+    for t in m_dyn.fs.time:
         copy_values_at_time(m_dyn.fs, m_ss.fs, t, 0.0, copy_fixed=True)
     m_dyn.fs.controller.mv_ref.value = m_dyn.fs.valve.valve_opening[0].value
     # calculate integral error assuming error is zero

--- a/idaes/power_generation/flowsheets/gas_turbine/gas_turbine.py
+++ b/idaes/power_generation/flowsheets/gas_turbine/gas_turbine.py
@@ -180,7 +180,7 @@ def performance_curves(m, flow_scale=0.896):
     # pylint: disable=function-redefined
 
     # Efficiency curves for three stages
-    @m.fs.gts1.performance_curve.Constraint(m.fs.config.time)
+    @m.fs.gts1.performance_curve.Constraint(m.fs.time)
     def eff_isen_eqn(b, t):
         f = fscale*b.parent_block().control_volume.properties_in[t].flow_vol
         return b.parent_block().efficiency_isentropic[t] == 1.02*(
@@ -190,7 +190,7 @@ def performance_curves(m, flow_scale=0.896):
             3.1728E-05*f**2 +
             7.7846E-03*f +
             1.0724E-01)
-    @m.fs.gts2.performance_curve.Constraint(m.fs.config.time)
+    @m.fs.gts2.performance_curve.Constraint(m.fs.time)
     def eff_isen_eqn(b, t):
         f = fscale*b.parent_block().control_volume.properties_in[t].flow_vol
         return b.parent_block().efficiency_isentropic[t] == 1.02*(
@@ -200,7 +200,7 @@ def performance_curves(m, flow_scale=0.896):
             6.4156E-06*f**2 +
             3.5005E-03*f +
             1.0724E-01)
-    @m.fs.gts3.performance_curve.Constraint(m.fs.config.time)
+    @m.fs.gts3.performance_curve.Constraint(m.fs.time)
     def eff_isen_eqn(b, t):
         f = fscale*b.parent_block().control_volume.properties_in[t].flow_vol
         return b.parent_block().efficiency_isentropic[t] == 1.02*(
@@ -211,19 +211,19 @@ def performance_curves(m, flow_scale=0.896):
             1.6310E-03*f +
             1.0724E-01)
     # Head curves for three stages
-    @m.fs.gts1.performance_curve.Constraint(m.fs.config.time)
+    @m.fs.gts1.performance_curve.Constraint(m.fs.time)
     def head_isen_eqn(b, t):
         f = pyo.log(
             fscale*b.parent_block().control_volume.properties_in[t].flow_vol)
         return b.head_isentropic[t] == -(
             -2085.1*f**3 + 38433*f**2 - 150764*f + 422313)
-    @m.fs.gts2.performance_curve.Constraint(m.fs.config.time)
+    @m.fs.gts2.performance_curve.Constraint(m.fs.time)
     def head_isen_eqn(b, t):
         f = pyo.log(
             fscale*b.parent_block().control_volume.properties_in[t].flow_vol)
         return b.head_isentropic[t] == -(
             -1676.3*f**3 + 34916*f**2 - 173801*f + 456957)
-    @m.fs.gts3.performance_curve.Constraint(m.fs.config.time)
+    @m.fs.gts3.performance_curve.Constraint(m.fs.time)
     def head_isen_eqn(b, t):
         f = pyo.log(
             fscale*b.parent_block().control_volume.properties_in[t].flow_vol)
@@ -292,7 +292,7 @@ def main(
         default=get_rxn(m.fs.gas_prop_params, rxns))
     # Variable for mole-fraction of O2 in the flue gas.  To initialize the model
     # will use a fixed value here.
-    m.fs.cmbout_o2_mol_frac = pyo.Var(m.fs.config.time, initialize=0.1157)
+    m.fs.cmbout_o2_mol_frac = pyo.Var(m.fs.time, initialize=0.1157)
     m.fs.cmbout_o2_mol_frac.fix()
     #
     # Unit models
@@ -367,22 +367,22 @@ def main(
     # and forget the opening
     m.fs.vsv.pressure_flow_equation.deactivate()
     # O2 fraction in combustor constraint (to set var)
-    @m.fs.Constraint(m.fs.config.time)
+    @m.fs.Constraint(m.fs.time)
     def o2_flow(b, t):
         return m.fs.cmb1.control_volume.properties_out[t].mole_frac_comp["O2"] \
             == m.fs.cmbout_o2_mol_frac[t]
     # Fuel injector pressure is the air pressure. This lumps in the gas valve
-    @m.fs.inject1.Constraint(m.fs.config.time)
+    @m.fs.inject1.Constraint(m.fs.time)
     def mxpress_eqn(b, t):
         return b.mixed_state[t].pressure == b.air_state[t].pressure
     # The pressure drop in the cumbustor is just a fixed 5%.
-    @m.fs.cmb1.Constraint(m.fs.config.time)
+    @m.fs.cmb1.Constraint(m.fs.time)
     def pressure_drop_eqn(b, t):
         return (0.95 ==
             b.control_volume.properties_out[t].pressure /
             b.control_volume.properties_in[t].pressure)
     # Constraints for complete combustion, use key compoents and 100% conversion
-    @m.fs.cmb1.Constraint(m.fs.config.time, rxns.keys())
+    @m.fs.cmb1.Constraint(m.fs.time, rxns.keys())
     def reaction_extent(b, t, r):
         k = rxns[r]
         prp = b.control_volume.properties_in[t]
@@ -390,7 +390,7 @@ def main(
         extent = b.rate_reaction_extent[t, r]
         return extent == prp.flow_mol*prp.mole_frac_comp[k]/stc
     # Calculate the total gas turnine gross power output.
-    @m.fs.Expression(m.fs.config.time)
+    @m.fs.Expression(m.fs.time)
     def gt_power_expr(b, t):
         return (
             m.fs.cmp1.control_volume.work[t] +
@@ -399,8 +399,8 @@ def main(
             m.fs.gts3.control_volume.work[t])
     # Add a varable and constraint for gross power.  This allows fixing power
     # for simulations where a specific power output is desired.
-    m.fs.gt_power = pyo.Var(m.fs.config.time)
-    @m.fs.Constraint(m.fs.config.time)
+    m.fs.gt_power = pyo.Var(m.fs.time)
+    @m.fs.Constraint(m.fs.time)
     def gt_power_eqn(b, t):
         return b.gt_power[t] == b.gt_power_expr[t]
     #

--- a/idaes/power_generation/flowsheets/subcritical_power_plant/steam_cycle_flowsheet.py
+++ b/idaes/power_generation/flowsheets/subcritical_power_plant/steam_cycle_flowsheet.py
@@ -309,21 +309,21 @@ def add_unit_models(m):
 
     # Important process variables, declared and used in PID controllers
     # Variable for main steam temperature
-    fs.temperature_main_steam = pyo.Var(fs.config.time, initialize=810)
+    fs.temperature_main_steam = pyo.Var(fs.time, initialize=810)
 
     # Constraint to calculate main steam temperature
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def temperature_main_steam_eqn(b, t):
         return b.temperature_main_steam[t] == b.turb.\
             throttle_valve[1].control_volume.properties_in[t].temperature
 
     # Variable for gross power output in MW
-    fs.power_output = pyo.Var(fs.config.time,
+    fs.power_output = pyo.Var(fs.time,
                               initialize=300,
                               doc='gross power output in MW')
 
     # Constraint to calculate gross power output
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def power_output_eqn(b, t):
         return b.power_output[t] == -b.turb.power[t]/1e6
 
@@ -517,14 +517,14 @@ def set_arcs_and_constraints(m):
     #
     # Constraint to set boiler feed water pump work equal to BFPT work
     # Note that there are to unit models for BFPT including an outlet stage
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def constraint_bfp_power(b, t):
         return 0 == (1e-6*fs.bfp.control_volume.work[t]
                      + 1e-6*fs.bfp_turb.control_volume.work[t]
                      + 1e-6*fs.bfp_turb_os.control_volume.work[t])
 
     # Constraint to set IP inlet steam flow equal to HP outlet steam flow
-    @fs.turb.Constraint(fs.config.time)
+    @fs.turb.Constraint(fs.time)
     def constraint_reheat_flow(b, t):
         return b.ip_stages[1].inlet.flow_mol[t] == \
             b.hp_split[14].outlet_1.flow_mol[t]
@@ -537,14 +537,14 @@ def set_arcs_and_constraints(m):
     # Constraint to set the pressure of makeup water to hotwell equal to
     # the pressure of auxiliary condenser, which is usually lower than
     # the pressure of main condenser in this model
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def makeup_water_pressure_constraint(b, t):
         return b.condenser_hotwell.makeup_state[t].pressure*1e-4 == \
             b.condenser_hotwell.aux_condensate_state[t].pressure*1e-4
 
     # Constrait to set the mixed state pressure equal to the pressure of
     # auxiliary condenser
-    @fs.condenser_hotwell.Constraint(fs.config.time)
+    @fs.condenser_hotwell.Constraint(fs.time)
     def mixer_pressure_constraint(b, t):
         return b.aux_condensate_state[t].pressure*1e-4 == \
             b.mixed_state[t].pressure*1e-4
@@ -554,7 +554,7 @@ def set_arcs_and_constraints(m):
     # This constraint determines the steam extraction flow rate and
     # is very important to avoid flash of deaerator tank when load is
     # ramping down, which will causes convergence issue if the flash happens
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def da_outlet_enthalpy_constraint(b, t):
         return 1e-3*b.da_tank.outlet.enth_mol[t] == 1e-3*(
             b.da_tank.control_volume.properties_in[t].
@@ -565,7 +565,7 @@ def set_arcs_and_constraints(m):
     # drain_mix model of the feed water heater is declared with momentum
     # mixing type set to MomentumMixingType.none
     # Constraint for feed water heater 1
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def fwh1_drain_mixer_pressure_eqn(b, t):
         return b.fwh1.drain_mix.drain.pressure[t]*1e-4 == \
             b.fwh1.drain_mix.steam.pressure[t]*1e-4
@@ -575,7 +575,7 @@ def set_arcs_and_constraints(m):
     # drain_mix model of the feed water heater is declared with momentum
     # mixing type set to MomentumMixingType.none
     # Constraint for feed water heater 2
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def fwh2_drain_mixer_pressure_eqn(b, t):
         return b.fwh2.drain_mix.drain.pressure[t]*1e-4 == \
             b.fwh2.drain_mix.steam.pressure[t]*1e-4
@@ -585,14 +585,14 @@ def set_arcs_and_constraints(m):
     # drain_mix model of the feed water heater is declared with momentum
     # mixing type set to MomentumMixingType.none
     # Constraint for feed water heater 5
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def fwh5_drain_mixer_pressure_eqn(b, t):
         return b.fwh5.drain_mix.drain.pressure[t]*1e-5 == \
             b.fwh5.drain_mix.steam.pressure[t]*1e-5
 
     # Add a custom constraint for condensate pump using the pump curve,
     # the relationship between flow rate and pressure increase
-    @fs.cond_pump.Constraint(fs.config.time)
+    @fs.cond_pump.Constraint(fs.time)
     def cond_pump_curve_constraint(b, t):
         return 1e-5*b.deltaP[t] == 1e-5*(
             -5.08e-7*b.inlet.flow_mol[t]**3 + 4.09e-3*b.inlet.flow_mol[t]**2
@@ -600,7 +600,7 @@ def set_arcs_and_constraints(m):
 
     # Add a custom constraint for the booster pump using the pump curve,
     # the relationship between flow rate and pressure increase
-    @fs.booster.Constraint(fs.config.time)
+    @fs.booster.Constraint(fs.time)
     def booster_pump_curve_constraint(b, t):
         return 1e-5*b.deltaP[t] == 1e-5*(
             -2.36e-7*b.inlet.flow_mol[t]**3 + 3.15e-3*b.inlet.flow_mol[t]**2
@@ -610,7 +610,7 @@ def set_arcs_and_constraints(m):
     # steam flow in such that there is makeup flow needed to offset blowdown
     # This constraint will be deactivated when the steam cycle sub-flowsheet
     # is combined with the boiler system sub-flowsheet
-    @fs.Constraint(fs.config.time)
+    @fs.Constraint(fs.time)
     def fw_flow_constraint(b, t):
         return 1e-3*b.da_tank.outlet.flow_mol[t] == \
             1e-3*b.turb.inlet_split.inlet.flow_mol[t]*1.02
@@ -629,11 +629,11 @@ def set_arcs_and_constraints(m):
             - b.cooling.tube.properties_in[t].temperature
         )
 
-    fs.fwh1.dca = pyo.Expression(fs.config.time, rule=rule_dca_no_cool)
-    fs.fwh2.dca = pyo.Expression(fs.config.time, rule=rule_dca)
-    fs.fwh3.dca = pyo.Expression(fs.config.time, rule=rule_dca)
-    fs.fwh5.dca = pyo.Expression(fs.config.time, rule=rule_dca)
-    fs.fwh6.dca = pyo.Expression(fs.config.time, rule=rule_dca)
+    fs.fwh1.dca = pyo.Expression(fs.time, rule=rule_dca_no_cool)
+    fs.fwh2.dca = pyo.Expression(fs.time, rule=rule_dca)
+    fs.fwh3.dca = pyo.Expression(fs.time, rule=rule_dca)
+    fs.fwh5.dca = pyo.Expression(fs.time, rule=rule_dca)
+    fs.fwh6.dca = pyo.Expression(fs.time, rule=rule_dca)
 
     return m
 
@@ -934,7 +934,7 @@ def set_inputs(m):
         fs.spray_ctrl.mv_lb = 0.05
 
         # Set initial conditions for controller errors
-        t0 = fs.config.time.first()
+        t0 = fs.time.first()
         fs.fwh2_ctrl.integral_of_error[t0].fix(0)
         fs.fwh3_ctrl.integral_of_error[t0].fix(0)
         fs.fwh5_ctrl.integral_of_error[t0].fix(0)
@@ -973,7 +973,7 @@ def initialize(m):
     # Set initial condition for dynamic unit models
     t0 = 0
     if m.dynamic is True:
-        t0 = fs.config.time.first()
+        t0 = fs.time.first()
         fs.hotwell_tank.set_initial_condition()
         fs.da_tank.set_initial_condition()
         fs.fwh1.set_initial_condition()
@@ -1533,7 +1533,7 @@ def _add_u_eq(blk, uex=0.8):
     Returns:
         None
     """
-    ti = blk.flowsheet().config.time
+    ti = blk.flowsheet().time
     blk.U0 = pyo.Var(ti)
     blk.f0 = pyo.Var(ti)
     blk.uex = pyo.Var(ti, initialize=uex)
@@ -1617,7 +1617,7 @@ def set_scaling_factors(m):
     iscale.set_scaling_factor(fs.fwh6.condense.side_2.heat, 1e-7)
 
     # scaling factor for control valves
-    for t in m.fs_main.config.time:
+    for t in m.fs_main.time:
         iscale.set_scaling_factor(
             fs.spray_valve.control_volume.properties_in[t].flow_mol, 0.05)
         iscale.set_scaling_factor(
@@ -1655,7 +1655,7 @@ def main_dynamic():
     copy_non_time_indexed_values(m_dyn.fs_main, m_ss.fs_main,
                                  copy_fixed=True,
                                  outlvl=idaeslog.ERROR)
-    for t in m_dyn.fs_main.config.time:
+    for t in m_dyn.fs_main.time:
         copy_values_at_time(m_dyn.fs_main, m_ss.fs_main, t, 0.0,
                             copy_fixed=True, outlvl=idaeslog.ERROR)
     t0 = 0
@@ -1791,7 +1791,7 @@ def main_dynamic():
           m_dyn.fs_main.fs_stc.split_attemp.split_fraction[0, "Spray"].value))
 
     # impose step change for dynamic model
-    for t in m_dyn.fs_main.config.time:
+    for t in m_dyn.fs_main.time:
         if t >= 30:
             m_dyn.fs_main.fs_stc.turb.ip_stages[1].inlet.pressure[t].fix(
                 m_dyn.fs_main.fs_stc.turb.ip_stages[1].
@@ -1825,7 +1825,7 @@ def main_dynamic():
     power_gross = []
     da_level = []
     cond_valve_open = []
-    for t in m_dyn.fs_main.config.time:
+    for t in m_dyn.fs_main.time:
         time.append(t)
         pres_ip.append(
             m_dyn.fs_main.fs_stc.turb.ip_stages[1].inlet.pressure[t].value)

--- a/idaes/power_generation/flowsheets/subcritical_power_plant/subcritical_boiler_flowsheet.py
+++ b/idaes/power_generation/flowsheets/subcritical_power_plant/subcritical_boiler_flowsheet.py
@@ -300,38 +300,38 @@ def set_arcs_and_constraints(m):
     # Follwing are flowsheet level constraints
     #
     # Constraint to set boiler zone heat duty equal to waterwall section duty
-    @fs.Constraint(fs.config.time, fs.ww_zones, doc="boiler zone heat duty")
+    @fs.Constraint(fs.time, fs.ww_zones, doc="boiler zone heat duty")
     def zone_heat_loss_eqn(b, t, izone):
         return 1e-6*b.aBoiler.waterwall_heat[t, izone] == \
                1e-6*b.Waterwalls[izone].heat_fireside[t]
 
     # Constraint to set boiler platen heat duty equal to platen model duty
-    @fs.Constraint(fs.config.time, doc="platen SH heat duty")
+    @fs.Constraint(fs.time, doc="platen SH heat duty")
     def platen_heat_loss_eqn(b, t):
         return 1e-6*b.aBoiler.platen_heat[t] == 1e-6*b.aPlaten.heat_fireside[t]
 
     # Constraint to set boiler roof heat duty equal to roof model duty
-    @fs.Constraint(fs.config.time, doc="roof SH heat duty")
+    @fs.Constraint(fs.time, doc="roof SH heat duty")
     def roof_heat_loss_eqn(b, t):
         return 1e-6*b.aBoiler.roof_heat[t] == 1e-6*b.aRoof.heat_fireside[t]
 
     # Constraint to set boiler slag layer wall temperature equal to
     # waterwall section model slag wall temperature
-    @fs.Constraint(fs.config.time, fs.ww_zones, doc="zone wall temperature")
+    @fs.Constraint(fs.time, fs.ww_zones, doc="zone wall temperature")
     def zone_wall_temp_eqn(b, t, izone):
         return b.aBoiler.wall_temperature_waterwall[t, izone] == \
                b.Waterwalls[izone].temp_slag_boundary[t]
 
     # Constraint to set boiler platen slag wall temperature equal to
     # platen superheater slag wall temperature
-    @fs.Constraint(fs.config.time, doc="platen wall temperature")
+    @fs.Constraint(fs.time, doc="platen wall temperature")
     def platen_wall_temp_eqn(b, t):
         return b.aBoiler.wall_temperature_platen[t] == \
                b.aPlaten.temp_slag_boundary[t]
 
     # Constraint to set boiler roof slag wall temperature equal to
     # roof superheater slag wall temperature
-    @fs.Constraint(fs.config.time, doc="roof wall temperature")
+    @fs.Constraint(fs.time, doc="roof wall temperature")
     def roof_wall_temp_eqn(b, t):
         return b.aBoiler.wall_temperature_roof[t] == \
                b.aRoof.temp_slag_boundary[t]
@@ -339,25 +339,25 @@ def set_arcs_and_constraints(m):
     # Constraint to set RH steam flow as 90% of main steam flow
     # This constraint should be deactivated if this boiler sub-flowsheet
     # is combined with the steam cycle sub-flowsheet to form a full plant model
-    @fs.Constraint(fs.config.time, doc="RH steam flow")
+    @fs.Constraint(fs.time, doc="RH steam flow")
     def flow_mol_steam_rh_eqn(b, t):
         return b.aRH1.tube_inlet.flow_mol[t] == 0.9\
                * b.aPlaten.outlet.flow_mol[t]
 
     # Constraint to set pressure drop of PA equal to that of SA
-    @fs.Constraint(fs.config.time, doc="Pressure drop of PA and SA of APH")
+    @fs.Constraint(fs.time, doc="Pressure drop of PA and SA of APH")
     def pressure_drop_of_APH_eqn(b, t):
         return b.aAPH.deltaP_side_2[t] == b.aAPH.deltaP_side_3[t]
 
     # Constraint to set the temperature of PA before APH equal to
     # the temperature of TA
-    @fs.Constraint(fs.config.time, doc="Same inlet temperature for PA and SA")
+    @fs.Constraint(fs.time, doc="Same inlet temperature for PA and SA")
     def pa_ta_temperature_identical_eqn(b, t):
         return b.aAPH.side_2_inlet.temperature[t] == \
                b.Mixer_PA.TA_inlet.temperature[t]
 
     # Constraint to set blowdown water flow rate equal to 2% of feed water flow
-    @fs.Constraint(fs.config.time, doc="Blowdown water flow fraction")
+    @fs.Constraint(fs.time, doc="Blowdown water flow fraction")
     def blowdown_flow_fraction_eqn(b, t):
         return b.blowdown_split.FW_Blowdown.flow_mol[t] == 0.02\
                * b.aECON.tube_inlet.flow_mol[t]
@@ -365,7 +365,7 @@ def set_arcs_and_constraints(m):
     # Surrogate model of UA (overall heat transfer coefficient times area)
     # for heat transfer from flue gas to primary air in air preheater
     # as a function of raw coal flow rate, which is related to load
-    @fs.Constraint(fs.config.time, doc="UA for APH of PA")
+    @fs.Constraint(fs.time, doc="UA for APH of PA")
     def ua_side_2_eqn(b, t):
         return 1e-4 * b.aAPH.ua_side_2[t] == \
                1e-4 * (-150.0 * b.aBoiler.flowrate_coal_raw[t]**2
@@ -374,7 +374,7 @@ def set_arcs_and_constraints(m):
     # Surrogate model of UA (overall heat transfer coefficient times area)
     # for heat transfer from flue gas to secondary air in air preheater
     # as a function of raw coal flow rate, which is related to load
-    @fs.Constraint(fs.config.time, doc="UA for APH of SA")
+    @fs.Constraint(fs.time, doc="UA for APH of SA")
     def ua_side_3_eqn(b, t):
         return 1e-5 * b.aAPH.ua_side_3[t] == \
                1e-5 * (30000*b.aBoiler.flowrate_coal_raw[t] + 100000)
@@ -387,7 +387,7 @@ def set_arcs_and_constraints(m):
     # This is usually controlled to get a desired mill outlet temperature
     # Currently we don't have a mill model and the controller on the flowsheet
     # Usually more temperatuing air is needed at lower load
-    @fs.Constraint(fs.config.time, prop_gas.component_list,
+    @fs.Constraint(fs.time, prop_gas.component_list,
                    doc="Fraction of tempering air as total PA flow")
     def fraction_of_ta_in_total_pa_eqn(b, t, j):
         return b.Mixer_PA.PA_inlet.flow_mol_comp[t, j] == ((
@@ -399,7 +399,7 @@ def set_arcs_and_constraints(m):
     # Constraint to set total PA flow to coal flow ratio as a function of
     # raw coal flow rate
     # This is related to mill curve and burner out of service scheduling
-    @fs.Constraint(fs.config.time, doc="PA to coal ratio")
+    @fs.Constraint(fs.time, doc="PA to coal ratio")
     def pa_to_coal_ratio_eqn(b, t):
         return b.aBoiler.ratio_PA2coal[t] == (
             0.0018 * b.aBoiler.flowrate_coal_raw[t]**2
@@ -409,7 +409,7 @@ def set_arcs_and_constraints(m):
     # as a function of coal flow rate
     # This is related to scheduling by the controller to adjust to obtain
     # a desired main steam temperature, unburned carbon and NOx
-    @fs.Constraint(fs.config.time, doc="Steady state dry O2 in flue gas")
+    @fs.Constraint(fs.time, doc="Steady state dry O2 in flue gas")
     def dry_o2_in_flue_gas_eqn(b, t):
         return b.aBoiler.fluegas_o2_pct_dry[t] == (
             -0.00075*b.aBoiler.flowrate_coal_raw[t]**3
@@ -417,7 +417,7 @@ def set_arcs_and_constraints(m):
             - 2.0*b.aBoiler.flowrate_coal_raw[t] + 22.95)
 
     # Boiler efficiency based on enthalpy increase of main and RH steams
-    @fs.Expression(fs.config.time, doc="boiler efficiency based on steam")
+    @fs.Expression(fs.time, doc="boiler efficiency based on steam")
     def boiler_efficiency_steam(b, t):
         return (((b.aPlaten.outlet.flow_mol[t]
                  - b.Attemp.Water_inlet.flow_mol[t])
@@ -434,7 +434,7 @@ def set_arcs_and_constraints(m):
                    * b.aBoiler.hhv_coal_dry))
 
     # Boiler efficiency based on heat absorbed
-    @fs.Expression(fs.config.time, doc="boiler efficiency based on heat")
+    @fs.Expression(fs.time, doc="boiler efficiency based on heat")
     def boiler_efficiency_heat(b, t):
         return ((b.aBoiler.heat_total[t] + b.aRH2.total_heat[t]
                 + b.aRH1.total_heat[t] + b.aPSH.total_heat[t]
@@ -1140,7 +1140,7 @@ def main_dynamic():
     m_dyn = get_model(dynamic=True)
     copy_non_time_indexed_values(
         m_dyn.fs_main, m_ss.fs_main, copy_fixed=True, outlvl=idaeslog.ERROR)
-    for t in m_dyn.fs_main.config.time:
+    for t in m_dyn.fs_main.time:
         copy_values_at_time(
             m_dyn.fs_main, m_ss.fs_main, t, 0.0, copy_fixed=True,
             outlvl=idaeslog.ERROR)
@@ -1192,7 +1192,7 @@ def run_dynamic(m):
     fs = m.fs_main.fs_blr
 
     # Create a disturbance
-    for t in m.fs_main.config.time:
+    for t in m.fs_main.time:
         if t >= 30:
             fs.aBoiler.flowrate_coal_raw[t].fix(
                 fs.aBoiler.flowrate_coal_raw[0].value*1.025)
@@ -1218,7 +1218,7 @@ def print_dynamic_results(m):
     fegt = []
     drum_level = []
 
-    for t in m.fs_main.config.time:
+    for t in m.fs_main.time:
         time.append(t)
         coal_flow.append(fs.aBoiler.flowrate_coal_raw[t].value)
         steam_flow.append(fs.aPlaten.outlet.flow_mol[t].value/1000)

--- a/idaes/power_generation/unit_models/boiler_fireside.py
+++ b/idaes/power_generation/unit_models/boiler_fireside.py
@@ -189,17 +189,17 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                 .format(self.name))
 
         self.primary_air = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             default=self.config.property_package_args)
         self.primary_air_moist = self.config.property_package.\
             build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 default=self.config.property_package_args)
         self.secondary_air = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             default=self.config.property_package_args)
         self.flue_gas = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             default=self.config.property_package_args)
 
         self.add_port("primary_air_inlet", self.primary_air)
@@ -227,7 +227,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
 
         # Surrogate model predictions
         # Constraints for heat duty in boiler water wall zones
-        @self.Constraint(self.flowsheet().config.time, self.zones,
+        @self.Constraint(self.flowsheet().time, self.zones,
                          doc="Surrogate model for heat loss"
                          " to water wall zones")
         def eq_surr_waterwall_heat(b, t, z):
@@ -235,7 +235,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                 eval(data_dict[z])
 
         if self.config.has_platen_superheater is True:
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Surrogate model for heat loss"
                              " to platen superheater")
             def eq_surr_platen_heat(b, t):
@@ -243,7 +243,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                     == eval(data_dict['pl'])
 
         if self.config.has_roof_superheater is True:
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Surrogate model for heat loss in "
                              " the roof and backpass heater")
             def eq_surr_roof_heat(b, t):
@@ -251,7 +251,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                     eval(data_dict['roof'])
 
         # Constraints for unburned carbon
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Surrogate model for"
                          " mass fraction of unburned carbon")
         def eq_surr_ln_ubc(b, t):
@@ -259,7 +259,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
 
         # Constraints for NOx in mol fraction, surrogate model in PPM,
         # converted to mass fraction
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="NOx in mol fraction"
                              "surrogate model must be in PPM")
         def eq_surr_nox(b, t):
@@ -301,61 +301,61 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         # Number of waterwall zones is given by config,
         # Optionally the model could contain a platen and a roof superheater
 
-        self.deltaP = Var(self.flowsheet().config.time,
+        self.deltaP = Var(self.flowsheet().time,
                           initialize=1000,
                           doc='Pressure drop of secondary air '
                           'through windbox and burner [Pa]')
 
         self.zones = RangeSet(self.config.number_of_zones)
 
-        self.fcorrection_heat_ww = Var(self.flowsheet().config.time,
+        self.fcorrection_heat_ww = Var(self.flowsheet().time,
                                        initialize=1,
                                        doc='Correction factor '
                                        'for waterwall heat duty')
 
         if self.config.has_platen_superheater is True:
-            self.fcorrection_heat_platen = Var(self.flowsheet().config.time,
+            self.fcorrection_heat_platen = Var(self.flowsheet().time,
                                                initialize=1,
                                                doc='Correction factor for '
                                                'platen SH heat duty')
 
         # wall temperatures of water wall zones
-        self.wall_temperature_waterwall = Var(self.flowsheet().config.time,
+        self.wall_temperature_waterwall = Var(self.flowsheet().time,
                                               self.zones,
                                               initialize=700.0,
                                               doc='Wall temperature [K] in '
                                               'Waterwall zones')
 
         # heat duties for water wall zones
-        self.waterwall_heat = Var(self.flowsheet().config.time, self.zones,
+        self.waterwall_heat = Var(self.flowsheet().time, self.zones,
                                   initialize=2.0e7,
                                   doc='Heat duty [W] or heat loss '
                                   'to waterwall zones')
 
         if self.config.has_platen_superheater is True:
             # heat duty to platen super heater
-            self.platen_heat = Var(self.flowsheet().config.time,
+            self.platen_heat = Var(self.flowsheet().time,
                                    initialize=6.0e7,
                                    doc='Platen superheater heat duty [W]')
             # wall temperature of platen superheater
-            self.wall_temperature_platen = Var(self.flowsheet().config.time,
+            self.wall_temperature_platen = Var(self.flowsheet().time,
                                                initialize=800.0,
                                                doc='Platen superheater'
                                                ' wall temperature [K]')
 
         if self.config.has_roof_superheater is True:
             # heat duty to roof superheater
-            self.roof_heat = Var(self.flowsheet().config.time,
+            self.roof_heat = Var(self.flowsheet().time,
                                  initialize=5e6,
                                  doc='Roof superheater heat duty [W]')
             # wall temperature of roof superheater
-            self.wall_temperature_roof = Var(self.flowsheet().config.time,
+            self.wall_temperature_roof = Var(self.flowsheet().time,
                                              initialize=800.0,
                                              doc='Roof superheater '
                                              'wall temperature [K]')
 
         # PA/coal temperature, usually fixed around 150 F
-        self.temperature_coal = Var(self.flowsheet().config.time,
+        self.temperature_coal = Var(self.flowsheet().time,
                                     initialize=338.7,
                                     doc='Coal temperature in K')
 
@@ -363,12 +363,12 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         # combustion air flowrate
         # If SR is a function of load or raw coal flow rate,
         # specify constraint in flowsheet model
-        self.SR = Var(self.flowsheet().config.time,
+        self.SR = Var(self.flowsheet().time,
                       initialize=1.15,
                       doc='Overall furnace Stoichiometric ratio - SR')
 
         # lower furnace Stoichiometric ratio
-        self.SR_lf = Var(self.flowsheet().config.time,
+        self.SR_lf = Var(self.flowsheet().time,
                          initialize=1.15,
                          doc='Lower furnace Stoichiometric ratio'
                          ' - SR excluding overfire air')
@@ -376,18 +376,18 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         # PA to coal mass flow ratio,
         # typically 2.0 depending on load or mill curve
         # usually this is an input of surrogate model
-        self.ratio_PA2coal = Var(self.flowsheet().config.time,
+        self.ratio_PA2coal = Var(self.flowsheet().time,
                                  initialize=2.0,
                                  doc='Primary air to coal ratio')
 
         # mass flow rate of raw coal fed to mill
         # (raw coal flow without moisture vaporization in mill)
-        self.flowrate_coal_raw = Var(self.flowsheet().config.time,
+        self.flowrate_coal_raw = Var(self.flowsheet().time,
                                      initialize=25.0,
                                      doc='Raw coal mass flowrate [kg/s]')
 
         # mass flow rate of coal to burners after moisture vaporization in mill
-        self.flowrate_coal_burner = Var(self.flowsheet().config.time,
+        self.flowrate_coal_burner = Var(self.flowsheet().time,
                                         initialize=20.0,
                                         doc='Mass flowrate coal to burners '
                                         'with moisture'
@@ -395,27 +395,27 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
 
         # raw coal moisture mass fraction (on as received basis),
         # can change with time to represent HHV change on as received basis
-        self.mf_H2O_coal_raw = Var(self.flowsheet().config.time,
+        self.mf_H2O_coal_raw = Var(self.flowsheet().time,
                                    initialize=0.15,
                                    doc='Raw coal mass fraction of'
                                    ' moisture on as received basis')
 
         # moisture mass fraction of coal to burners after mill,
         # calculated based on fraction of moistures vaporized in mill
-        self.mf_H2O_coal_burner = Var(self.flowsheet().config.time,
+        self.mf_H2O_coal_burner = Var(self.flowsheet().time,
                                       initialize=0.15,
                                       doc='Mass fraction of moisture'
                                       ' on as received basis')
 
         # Fraction of moisture vaporized in mill,
         # set in flowsheet as a function of coal flow rate, default is 0.6
-        self.frac_moisture_vaporized = Var(self.flowsheet().config.time,
+        self.frac_moisture_vaporized = Var(self.flowsheet().time,
                                            initialize=0.6,
                                            doc='Fraction of coal'
                                            ' moisture vaporized in mill')
 
         # Vaporized moisture mass flow rate
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Vaporized moisture mass flowrate [kg/s]")
         def flowrate_moist_vaporized(b, t):
             return b.flowrate_coal_raw[t] * b.mf_H2O_coal_raw[t] \
@@ -450,33 +450,33 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         # flyash, predicted by surrogate model.
         # When generating the surrogate, sum up all elements in
         # flyash from fireside boiler model outputs
-        self.ubc_in_flyash = Var(self.flowsheet().config.time,
+        self.ubc_in_flyash = Var(self.flowsheet().time,
                                  initialize=0.01,
                                  doc='Unburned carbon and'
                                  ' other organic elements in fly ash')
 
         # mole fraction of NO in flue gas, predicted by surrogate model
         # usually mole fraction is very close to mass fraction of NO
-        self.frac_mol_NOx_fluegas = Var(self.flowsheet().config.time,
+        self.frac_mol_NOx_fluegas = Var(self.flowsheet().time,
                                         initialize=1e-4,
                                         doc='Mole fraction of NOx in flue gas')
 
         # NOx in lb/MMBTU, NO is converted to NO2 as NOx
-        @self.Expression(self.flowsheet().config.time, doc="NOx in lb/MMBTU")
+        @self.Expression(self.flowsheet().time, doc="NOx in lb/MMBTU")
         def nox_lb_mmbtu(b, t):
             return b.flue_gas_outlet.flow_mol_comp[t, "NO"] * 0.046 * 2.20462 \
                 / (b.flowrate_coal_raw[t] * (1-b.mf_H2O_coal_raw[t])
                    * b.hhv_coal_dry/1.054e9)
 
         # coal flow rate after mill
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Coal flow rate to burners after mill")
         def flowrate_coal_burner_eqn(b, t):
             return b.flowrate_coal_burner[t] == b.flowrate_coal_raw[t] \
                 - b.flowrate_moist_vaporized[t]
 
         # moisture mass fraction in coal after mill
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Moisture mass fraction for coal after mill")
         def mf_H2O_coal_burner_eqn(b, t):
             return b.flowrate_coal_raw[t] * b.mf_H2O_coal_raw[t] == \
@@ -488,31 +488,31 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         def mf_daf_dry(b):
             return 1-b.mf_Ash_coal_dry
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Ash mass flow rate kg/s")
         def flowrate_ash(b, t):
             return b.flowrate_coal_raw[t] * \
                 (1-b.mf_H2O_coal_raw[t])*b.mf_Ash_coal_dry
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Dry ash free - daf_coal flow rate "
                          "in fuel fed to the boiler kg/s")
         def flowrate_daf_fuel(b, t):
             return b.flowrate_coal_raw[t] * \
                 (1-b.mf_H2O_coal_raw[t]) * b.mf_daf_dry
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Dry ash free (daf) coal flow rate in fly ash")
         def flowrate_daf_flyash(b, t):
             return b.flowrate_ash[t] / (1.0 - b.ubc_in_flyash[t]) \
                 * b.ubc_in_flyash[t]
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Burned daf coal flow rate")
         def flowrate_daf_burned(b, t):
             return b.flowrate_daf_fuel[t] - b.flowrate_daf_flyash[t]
 
-        @self.Expression(self.flowsheet().config.time, doc="Coal burnout")
+        @self.Expression(self.flowsheet().time, doc="Coal burnout")
         def coal_burnout(b, t):
             return b.flowrate_daf_burned[t] / b.flowrate_daf_fuel[t]
 
@@ -564,7 +564,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         def hf_daf(b):
             return b.dhc+b.dhh+b.dhs-b.dhcoal
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Heat of formation of "
                          "moisture-containing coal to burners")
         def hf_coal(b, t):
@@ -580,26 +580,26 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                       + b.mf_N_daf / b.atomic_mass_N
                       + b.mf_S_daf / b.atomic_mass_S)
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Gt1 or Einstein quantum theory function for daf "
                          "coal sensible heat calculation")
         def gt1(b, t):
             return 1/(exp(380/b.temperature_coal[t])-1)
 
         # since flyash and flue gas outlet temperature is not fixed
-        self.gt1_flyash = Var(self.flowsheet().config.time,
+        self.gt1_flyash = Var(self.flowsheet().time,
                               initialize=1,
                               doc='Gt1 or Einstein quantum theory function'
                               ' for daf part of flyash')
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Gt1 or Einstein quantum theory "
                          "for daf part of flyash")
         def gt1_flyash_eqn(b, t):
             return b.gt1_flyash[t] \
                 * (exp(380/b.flue_gas[t].temperature)-1) == 1
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Gt2 or Einstein quantum theory "
                          "function for daf coal "
                          "sensible heat calculation for high temperature")
@@ -608,25 +608,25 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
 
         # declare variable rather than use expression
         # since flyash and flue gas outlet temperature is not fixed
-        self.gt2_flyash = Var(self.flowsheet().config.time,
+        self.gt2_flyash = Var(self.flowsheet().time,
                               initialize=1,
                               doc='Gt2 or Einstein quantum theory function '
                               'for daf part of flyash')
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Gt2 or Einstein quantum theory function "
                          "for daf part of flyash")
         def gt2_flyash_eqn(b, t):
             return b.gt2_flyash[t] \
                 * (exp(1800/b.flue_gas[t].temperature)-1) == 1
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Sensible heat of daf coal")
         def hs_daf(b, t):
             return const.gas_constant/b.am_daf*(380*(b.gt1[t]-0.3880471566)
                                                 + 3600*(b.gt2[t]-0.002393883))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Sensible heat for daf part of flyash")
         def hs_daf_flyash(b, t):
             return const.gas_constant/b.am_daf*(380*(b.gt1_flyash[t]
@@ -634,7 +634,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                                                 + 3600*(b.gt2_flyash[t]
                                                         - 0.002393883))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Sensible heat of coal to burners")
         def hs_coal(b, t):
             return (1-b.mf_H2O_coal_burner[t]) * b.mf_daf_dry * b.hs_daf[t] \
@@ -643,7 +643,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                 * (593 * (b.temperature_coal[t]-298.15)
                    + 0.293*(b.temperature_coal[t]**2 - 298.15**2))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Total enthalpy of "
                          "moisture-containing coal to burners")
         def h_coal(b, t):
@@ -651,39 +651,39 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
 
         # variable for O2 mole fraction in flue gas on dry basis
         # it can be used for data reconciliation and parameter estimation
-        self.fluegas_o2_pct_dry = Var(self.flowsheet().config.time,
+        self.fluegas_o2_pct_dry = Var(self.flowsheet().time,
                                       initialize=3,
                                       doc='Mol percent of O2 on dry basis')
 
     def _make_mass_balance(self):
         # PA flow rate calculated based on PA/coal ratio
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Ratio of PA mass flow to raw coal mass flow")
         def ratio_PA2coal_eqn(b, t):
             return b.primary_air[t].flow_mass == b.flowrate_coal_raw[t] \
                     * b.ratio_PA2coal[t]
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="C molar flow from coal")
         def molflow_C_fuel(b, t):
             return b.flowrate_daf_fuel[t] * b.mf_C_daf / b.atomic_mass_C
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="H molar flow from coal")
         def molflow_H_fuel(b, t):
             return b.flowrate_daf_fuel[t] * b.mf_H_daf / b.atomic_mass_H
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="O molar flow from coal")
         def molflow_O_fuel(b, t):
             return b.flowrate_daf_fuel[t] * b.mf_O_daf / b.atomic_mass_O
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="N molar flow from coal")
         def molflow_N_fuel(b, t):
             return b.flowrate_daf_fuel[t]*b.mf_N_daf/b.atomic_mass_N
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="S molar flow from coal")
         def molflow_S_fuel(b, t):
             return b.flowrate_daf_fuel[t]*b.mf_S_daf/b.atomic_mass_S
@@ -693,7 +693,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
             # specified as model parameter
             # Overwrite the composition from inlets
             # Let N2 molar flow calculated by balance
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.config.property_package.component_list,
                              doc="PA component molar flow")
             def molar_flow_PA_eqn(b, t, j):
@@ -707,7 +707,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
             # specified as model parameter
             # Overwrite the composition from inlets
             # Let N2 molar flow calculated by balance
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.config.property_package.component_list,
                              doc="SA component molar flow")
             def molar_flow_SA_eqn(b, t, j):
@@ -718,7 +718,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                        b.secondary_air[t].flow_mol * b.mole_frac_air[j]
 
         # calculate molar flow of primary_air_moist stream
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.config.property_package.component_list)
         def primary_air_moist_comp_flow_eqn(b, t, j):
             if j == "H2O":
@@ -731,13 +731,13 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                        b.primary_air_moist[t].flow_mol_comp[j]
 
         # total combustion air mass flow rate
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Total combustion air mass flow rate")
         def flow_mass_TCA(b, t):
             return b.primary_air[t].flow_mass + b.secondary_air[t].flow_mass
 
         # overall Stoichiometric ratio (SR)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="SR equation")
         def SR_eqn(b, t):
             return b.SR[t]*(b.molflow_C_fuel[t] + b.molflow_H_fuel[t]/4
@@ -745,14 +745,14 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                 b.primary_air[t].flow_mol_comp["O2"] \
                 + b.secondary_air[t].flow_mol_comp["O2"]
 
-        @self.Expression(self.flowsheet().config.time, doc="C mole flow")
+        @self.Expression(self.flowsheet().time, doc="C mole flow")
         def molflow_C_fluegas(b, t):
             return b.flowrate_daf_burned[t] \
                 * b.mf_C_daf/b.atomic_mass_C \
                 + b.primary_air_moist[t].flow_mol_comp["CO2"] \
                 + b.secondary_air[t].flow_mol_comp["CO2"]
 
-        @self.Expression(self.flowsheet().config.time, doc="H mole flow")
+        @self.Expression(self.flowsheet().time, doc="H mole flow")
         def molflow_H_fluegas(b, t):
             return b.flowrate_daf_burned[t] \
                 * b.mf_H_daf/b.atomic_mass_H \
@@ -761,7 +761,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                 + b.flowrate_coal_burner[t]*b.mf_H2O_coal_burner[t] \
                 / (b.atomic_mass_H*2 + b.atomic_mass_O)*2
 
-        @self.Expression(self.flowsheet().config.time, doc="O mole flow")
+        @self.Expression(self.flowsheet().time, doc="O mole flow")
         def molflow_O_fluegas(b, t):
             return b.flowrate_daf_burned[t] \
                 * b.mf_O_daf/b.atomic_mass_O \
@@ -778,7 +778,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                 + b.flowrate_coal_burner[t]*b.mf_H2O_coal_burner[t] \
                 / (b.atomic_mass_H*2 + b.atomic_mass_O)
 
-        @self.Expression(self.flowsheet().config.time, doc="N mole flow")
+        @self.Expression(self.flowsheet().time, doc="N mole flow")
         def molflow_N_fluegas(b, t):
             return b.flowrate_daf_burned[t] \
                 * b.mf_N_daf/b.atomic_mass_N \
@@ -787,7 +787,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                 + b.secondary_air[t].flow_mol_comp["N2"]*2 \
                 + b.secondary_air[t].flow_mol_comp["NO"]
 
-        @self.Expression(self.flowsheet().config.time, doc="S mole flow")
+        @self.Expression(self.flowsheet().time, doc="S mole flow")
         def molflow_S_fluegas(b, t):
             return b.flowrate_daf_burned[t] \
                 * b.mf_S_daf/b.atomic_mass_S \
@@ -796,39 +796,39 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
 
         # calculate flue gas flow component at flue_gas_outlet
         # NO mole fraction in flue gas is given by NOx surrogate model
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="NO at flue gas outlet")
         def NO_eqn(b, t):
             return b.flue_gas[t].flow_mol_comp["NO"] == \
                 b.frac_mol_NOx_fluegas[t] * b.flue_gas[t].flow_mol
 
         # N2 at outlet
-        @self.Constraint(self.flowsheet().config.time, doc="N2 at outlet")
+        @self.Constraint(self.flowsheet().time, doc="N2 at outlet")
         def N2_eqn(b, t):
             return b.flue_gas_outlet.flow_mol_comp[t, "N2"] == \
                 + b.molflow_N_fluegas[t]/2 \
                 - b.flue_gas_outlet.flow_mol_comp[t, 'NO']/2
 
         # SO2 at outlet
-        @self.Constraint(self.flowsheet().config.time, doc="SO2 at outlet")
+        @self.Constraint(self.flowsheet().time, doc="SO2 at outlet")
         def SO2_eqn(b, t):
             return b.flue_gas_outlet.flow_mol_comp[t, "SO2"] == \
                 b.molflow_S_fluegas[t]
 
         # H2O at outlet
-        @self.Constraint(self.flowsheet().config.time, doc="H2O at outlet")
+        @self.Constraint(self.flowsheet().time, doc="H2O at outlet")
         def H2O_eqn(b, t):
             return b.flue_gas_outlet.flow_mol_comp[t, "H2O"] == \
                 b.molflow_H_fluegas[t]/2
 
         # CO2 at outlet
-        @self.Constraint(self.flowsheet().config.time, doc="CO2 at outlet")
+        @self.Constraint(self.flowsheet().time, doc="CO2 at outlet")
         def CO2_eqn(b, t):
             return b.flue_gas_outlet.flow_mol_comp[t, "CO2"] == \
                 b.molflow_C_fluegas[t]
 
         # O2 at outlet
-        @self.Constraint(self.flowsheet().config.time, doc="O2 at outlet")
+        @self.Constraint(self.flowsheet().time, doc="O2 at outlet")
         def O2_eqn(b, t):
             return b.flue_gas_outlet.flow_mol_comp[t, "O2"] == \
                 (b.molflow_O_fluegas[t] - b.molflow_C_fluegas[t]*2
@@ -836,7 +836,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                  - b.flue_gas_outlet.flow_mol_comp[t, "NO"])/2
 
         # constraint for mol percent of O2 in flue gas on dry basis
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Mol percent of O2 in flue gas on dry basis")
         def fluegas_o2_pct_dry_eqn(b, t):
             return b.fluegas_o2_pct_dry[t] \
@@ -848,7 +848,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                 == b.flue_gas_outlet.flow_mol_comp[t, "O2"]
 
         # mass flow rate of flyash containing unburned fuel
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Flyash mass flow rate  kg/s")
         def flow_mass_flyash(b, t):
             return (b.flowrate_daf_flyash[t] + b.flowrate_ash[t])
@@ -857,14 +857,14 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         # flue gas pressure is secondary air presure
         # - pressure drop through windbox
         # and burner secondary air register
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Flue gas pressure in Pascals")
         def flue_gas_pressure_eqn(b, t):
             return b.flue_gas[t].pressure*1e-5 == (b.secondary_air[t].pressure
                                                    - b.deltaP[t]) * 1e-5
 
         # set pressure of primary air with moisture at mill outlet
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Mill outlet pressure")
         def primary_air_moist_pressure_eqn(b, t):
             return b.primary_air[t].pressure*1e-5 == \
@@ -874,13 +874,13 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         # temperature of primary_air_moist is equal to coal temparature
         # leaving mill, ignore the temperature of primary_air_inlet in energy
         # balance equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Temperature of primary air leaving mill")
         def primary_air_moist_temperature_eqn(b, t):
             return b.primary_air_moist[t].temperature == b.temperature_coal[t]
 
         # overall energy balance to calculate FEGT
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Temperature at flue gas outlet")
         def flue_gas_temp_eqn(b, t):
             return (b.primary_air_moist[t].flow_mol
@@ -903,14 +903,14 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
                  + b.flowrate_daf_flyash[t] * b.hs_daf_flyash[t])
 
         # expression to calculate total heat duty of waterwall
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Total heat duty of all waterwall zones")
         def heat_total_ww(b, t):
             return sum(b.waterwall_heat[t, j] for j in b.zones)
 
         # expression to calculate total heat loss through
         # waterwall, platen SH, and roof SH
-        @self.Expression(self.flowsheet().config.time, doc="Total heat duty")
+        @self.Expression(self.flowsheet().time, doc="Total heat duty")
         def heat_total(b, t):
             return b.heat_total_ww[t] \
                 + (b.platen_heat[t] if self.config.has_platen_superheater is

--- a/idaes/power_generation/unit_models/boiler_heat_exchanger_2D.py
+++ b/idaes/power_generation/unit_models/boiler_heat_exchanger_2D.py
@@ -624,35 +624,35 @@ tube side flows from 1 to 0"""))
         # Performance variables
         if self.config.has_radiation is True:
             # Gas emissivity at mbl
-            self.gas_emissivity = Var(self.flowsheet().config.time,
+            self.gas_emissivity = Var(self.flowsheet().time,
                                       self.shell.length_domain,
                                       initialize=0.5,
                                       doc='Emissivity at Given'
                                       'Mean Beam Length')
 
             # Gas emissivity at mbl/sqrt(2)
-            self.gas_emissivity_div2 = Var(self.flowsheet().config.time,
+            self.gas_emissivity_div2 = Var(self.flowsheet().time,
                                            self.shell.length_domain,
                                            initialize=0.4,
                                            doc='Emissivity at Mean Beam Length'
                                            'Divided by Sqrt of 2')
 
             # Gas emissivity at mbl*sqrt(2)
-            self.gas_emissivity_mul2 = Var(self.flowsheet().config.time,
+            self.gas_emissivity_mul2 = Var(self.flowsheet().time,
                                            self.shell.length_domain,
                                            initialize=0.6,
                                            doc='Emissivity at Mean Beam'
                                            'Length Multiplied by Sqrt Of 2')
 
             # Gray fraction of gas in entire spectrum
-            self.gas_gray_fraction = Var(self.flowsheet().config.time,
+            self.gas_gray_fraction = Var(self.flowsheet().time,
                                          self.shell.length_domain,
                                          initialize=0.5,
                                          doc='Gray Fraction of Gas'
                                          'in Entire Spectrum')
 
             # Gas-surface radiation exchange factor for shell side wall
-            self.frad_gas_shell = Var(self.flowsheet().config.time,
+            self.frad_gas_shell = Var(self.flowsheet().time,
                                       self.shell.length_domain,
                                       initialize=0.5,
                                       doc='Gas-Surface Radiation Exchange'
@@ -660,21 +660,21 @@ tube side flows from 1 to 0"""))
 
             # Shell side equivalent convective heat transfer coefficient
             # due to radiation
-            self.hconv_shell_rad = Var(self.flowsheet().config.time,
+            self.hconv_shell_rad = Var(self.flowsheet().time,
                                        self.shell.length_domain,
                                        initialize=100.0,
                                        doc='Shell Side Convective Heat'
                                        'Transfer Coefficient due to Radiation')
 
         # Tube side convective heat transfer coefficient
-        self.hconv_tube = Var(self.flowsheet().config.time,
+        self.hconv_tube = Var(self.flowsheet().time,
                               self.tube.length_domain,
                               initialize=100.0,
                               doc='Tube Side Convective'
                               'Heat Transfer Coefficient')
 
         # Tube side convective heat transfer coefficient combined with fouling
-        self.hconv_tube_foul = Var(self.flowsheet().config.time,
+        self.hconv_tube_foul = Var(self.flowsheet().time,
                                    self.tube.length_domain,
                                    initialize=100.0,
                                    doc='Tube Side Convective Heat Transfer'
@@ -682,7 +682,7 @@ tube side flows from 1 to 0"""))
 
         # Shell side convective heat transfer coefficient
         # due to convection only
-        self.hconv_shell_conv = Var(self.flowsheet().config.time,
+        self.hconv_shell_conv = Var(self.flowsheet().time,
                                     self.shell.length_domain,
                                     initialize=100.0,
                                     doc='Shell Side Convective Heat Transfer'
@@ -690,7 +690,7 @@ tube side flows from 1 to 0"""))
 
         # Total shell side convective heat transfer coefficient
         # including convection and radiation
-        self.hconv_shell_total = Var(self.flowsheet().config.time,
+        self.hconv_shell_total = Var(self.flowsheet().time,
                                      self.shell.length_domain,
                                      initialize=150.0,
                                      doc='Total Shell Side Convective'
@@ -698,14 +698,14 @@ tube side flows from 1 to 0"""))
 
         # Total shell side convective heat transfer coefficient
         # combined with fouling
-        self.hconv_shell_foul = Var(self.flowsheet().config.time,
+        self.hconv_shell_foul = Var(self.flowsheet().time,
                                     self.shell.length_domain,
                                     initialize=150.0,
                                     doc='Shell Side Convective Heat Transfer'
                                     'Coefficient Combined with Fouling')
 
         # Constraint for hconv_tube_foul
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Tube Side Convective Heat Transfer"
                          "Coefficient with Fouling")
@@ -715,7 +715,7 @@ tube side flows from 1 to 0"""))
                 0.01*b.hconv_tube[t, x]
 
         # Constraint for hconv_shell_foul
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Shell Side Convective Heat"
                          "Transfer Coefficient with Fouling")
@@ -725,19 +725,19 @@ tube side flows from 1 to 0"""))
                 == 0.1*b.hconv_shell_total[t, x]
 
         # Tube metal wall temperature profile across radius
-        self.tube_wall_temperature = Var(self.flowsheet().config.time,
+        self.tube_wall_temperature = Var(self.flowsheet().time,
                                          self.tube.length_domain, self.r,
                                          initialize=500,
                                          doc='Tube Wall Temperature')
 
-        self.shell_wall_temperature = Var(self.flowsheet().config.time,
+        self.shell_wall_temperature = Var(self.flowsheet().time,
                                           self.shell.length_domain,
                                           initialize=500,
                                           doc='Shell Side Fouling Wall'
                                           'Surface Temperature')
 
         # Fouling wall surface temperature on shell side
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Fouling Wall Surface"
                          "Temperature on Shell Side")
@@ -751,7 +751,7 @@ tube side flows from 1 to 0"""))
         # Declare derivatives in the model
         if self.config.dynamic is True:
             self.dTdt = DerivativeVar(self.tube_wall_temperature,
-                                      wrt=self.flowsheet().config.time)
+                                      wrt=self.flowsheet().time)
         self.dTdr = DerivativeVar(self.tube_wall_temperature, wrt=self.r)
         self.d2Tdr2 = DerivativeVar(self.tube_wall_temperature,
                                     wrt=(self.r, self.r))
@@ -761,7 +761,7 @@ tube side flows from 1 to 0"""))
                              wrt=self.r, scheme='CENTRAL')
 
         # Constraint for heat conduction equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain, self.r,
                          doc="1-D Heat Conduction Equation Through Radius")
         def heat_conduction_eqn(b, t, x, r):
@@ -774,7 +774,7 @@ tube side flows from 1 to 0"""))
                 return 0 == b.diff_therm_wall/b.ri_scaling**2 \
                     * (b.d2Tdr2[t, x, r] + b.dTdr[t, x, r]/r)
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Inner Wall Boundary")
         def inner_wall_bc_eqn(b, t, x):
@@ -784,7 +784,7 @@ tube side flows from 1 to 0"""))
                 - 0.01*b.dTdr[t, x, b.r.first()]/b.ri_scaling \
                 * b.therm_cond_wall
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Outer Wall Boundary")
         def outer_wall_bc_eqn(b, t, x):
@@ -794,7 +794,7 @@ tube side flows from 1 to 0"""))
                 - 0.01*b.dTdr[t, x, b.r.last()]/b.ri_scaling*b.therm_cond_wall
 
         # Inner wall BC for dTdt
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Extra Inner Wall Temperature Derivative")
         def extra_at_inner_wall_eqn(b, t, x):
@@ -813,7 +813,7 @@ tube side flows from 1 to 0"""))
                 / b.ri_scaling*(b.tube.properties[t, x].temperature
                                 - b.tube_wall_temperature[t, x, b.r.first()])
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Extra Outer Wall Temperature Derivative")
         def extra_at_outer_wall_eqn(b, t, x):
@@ -834,7 +834,7 @@ tube side flows from 1 to 0"""))
 
         if self.config.has_radiation is True:
             # Constraints for gas emissivity
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.shell.length_domain,
                              doc="Gas Emissivity")
             def gas_emissivity_eqn(b, t, x):
@@ -882,7 +882,7 @@ tube side flows from 1 to 0"""))
                     - 1.27853 * (X2*X5)**2
 
             # Constraints for gas emissivity at mbl/sqrt(2)
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.shell.length_domain,
                              doc="Gas Emissivity at a Lower Mean Beam Length")
             def gas_emissivity_div2_eqn(b, t, x):
@@ -929,7 +929,7 @@ tube side flows from 1 to 0"""))
                     - 1.27853 * (X2*X5)**2
 
             # Constraints for gas emissivity at mbl*sqrt(2)
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.shell.length_domain,
                              doc="Gas Emissivity at a Higher Mean Beam Length")
             def gas_emissivity_mul2_eqn(b, t, x):
@@ -976,7 +976,7 @@ tube side flows from 1 to 0"""))
                     - 1.27853 * (X2*X5)**2
 
             # fraction of gray gas spectrum
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.shell.length_domain,
                              doc="Fraction of Gray Gas Spectrum")
             def gas_gray_fraction_eqn(b, t, x):
@@ -987,7 +987,7 @@ tube side flows from 1 to 0"""))
 
             # Gas-surface radiation exchange factor between
             # gas and shell side wall
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.shell.length_domain,
                              doc="Gas-Surface Radiation Exchange"
                              "Factor between Gas and Shell Side Wall")
@@ -998,7 +998,7 @@ tube side flows from 1 to 0"""))
                     == b.gas_gray_fraction[t, x]*b.gas_emissivity[t, x]
 
             # equivalent convective heat transfer coefficent due to radiation
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.shell.length_domain,
                              doc="Equivalent Convective Heat Transfer"
                              "Coefficient due to Radiation")
@@ -1014,49 +1014,49 @@ tube side flows from 1 to 0"""))
         # Tube side heat transfer coefficient and pressure drop
         # -----------------------------------------------------
         # Velocity on tube side
-        self.tube_velocity = Var(self.flowsheet().config.time,
+        self.tube_velocity = Var(self.flowsheet().time,
                                  self.tube.length_domain,
                                  initialize=1.0,
                                  doc="Velocity on Tube Side")
 
         # Reynalds number on tube side
-        self.tube_N_Re = Var(self.flowsheet().config.time,
+        self.tube_N_Re = Var(self.flowsheet().time,
                              self.tube.length_domain,
                              initialize=10000.0,
                              doc="Reynolds Number on Tube Side")
 
         # Friction factor on tube side
-        self.tube_friction_factor = Var(self.flowsheet().config.time,
+        self.tube_friction_factor = Var(self.flowsheet().time,
                                         self.tube.length_domain,
                                         initialize=1.0,
                                         doc='Friction Factor on Tube Side')
 
         # Pressure drop due to friction on tube side
-        self.deltaP_tube_friction = Var(self.flowsheet().config.time,
+        self.deltaP_tube_friction = Var(self.flowsheet().time,
                                         self.tube.length_domain,
                                         initialize=-10.0,
                                         doc="Pressure Drop due to"
                                         "Friction on Tube Side")
 
         # Pressure drop due to 180 degree turn on tube side
-        self.deltaP_tube_uturn = Var(self.flowsheet().config.time,
+        self.deltaP_tube_uturn = Var(self.flowsheet().time,
                                      self.tube.length_domain,
                                      initialize=-10.0,
                                      doc="Pressure Drop due to U-Turn on"
                                      "Tube Side")
 
         # Prandtl number on tube side
-        self.tube_N_Pr = Var(self.flowsheet().config.time,
+        self.tube_N_Pr = Var(self.flowsheet().time,
                              self.tube.length_domain, initialize=1.0,
                              doc="Prandtl Number on Tube Side")
 
         # Nusselt number on tube side
-        self.tube_N_Nu = Var(self.flowsheet().config.time,
+        self.tube_N_Nu = Var(self.flowsheet().time,
                              self.tube.length_domain, initialize=1,
                              doc="Nusselts Number on Tube Side")
 
         # Velocity equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Tube Side Velocity Equation")
         def v_tube_eqn(b, t, x):
@@ -1065,7 +1065,7 @@ tube side flows from 1 to 0"""))
                 == 0.001 * b.tube.properties[t, x].flow_mol
 
         # Reynolds number
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Reynolds Number Equation on Tube Side")
         def N_Re_tube_eqn(b, t, x):
@@ -1075,7 +1075,7 @@ tube side flows from 1 to 0"""))
                 * b.tube.properties[t, x].dens_mass_phase[phase_s]
 
         # Friction factor
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Darcy Friction Factor on Tube Side")
         def friction_factor_tube_eqn(b, t, x):
@@ -1083,7 +1083,7 @@ tube side flows from 1 to 0"""))
                 0.3164 * b.fcorrection_dp_tube
 
         # Pressure drop due to friction per tube length
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Pressure Drop due to Friction per Tube Length")
         def deltaP_tube_friction_eqn(b, t, x):
@@ -1092,7 +1092,7 @@ tube side flows from 1 to 0"""))
                 * b.tube_velocity[t, x]**2 * b.tube_friction_factor[t, x]
 
         # Pressure drop due to u-turn
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Pressure Drop due to U-Turn on Tube Side")
         def deltaP_tube_uturn_eqn(b, t, x):
@@ -1101,7 +1101,7 @@ tube side flows from 1 to 0"""))
                 * b.tube_velocity[t, x]**2 * b.kloss_uturn
 
         # Total pressure drop on tube side
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Total Pressure Drop on Tube Side")
         def deltaP_tube_eqn(b, t, x):
@@ -1112,7 +1112,7 @@ tube side flows from 1 to 0"""))
                  b.tube_length_seg)
 
         # Prandtl number
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Prandtl Number Equation on Tube Side")
         def N_Pr_tube_eqn(b, t, x):
@@ -1123,7 +1123,7 @@ tube side flows from 1 to 0"""))
                 b.tube.properties[t, x].visc_d_phase[phase_s]
 
         # Nusselts number
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Nusselts Number Equation on Tube Side")
         def N_Nu_tube_eqn(b, t, x):
@@ -1131,7 +1131,7 @@ tube side flows from 1 to 0"""))
                 * b.tube_N_Pr[t, x]**0.4
 
         # Heat transfer coefficient
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Convective Heat Transfer Coefficient"
                          "Equation on Tube Side")
@@ -1153,36 +1153,36 @@ tube side flows from 1 to 0"""))
             raise Exception('Tube Arrangement Not Supported')
 
         # Velocity on shell side
-        self.shell_velocity = Var(self.flowsheet().config.time,
+        self.shell_velocity = Var(self.flowsheet().time,
                                   self.shell.length_domain, initialize=1.0,
                                   doc="Velocity on Shell Side")
 
         # Reynalds number on shell side
-        self.shell_N_Re = Var(self.flowsheet().config.time,
+        self.shell_N_Re = Var(self.flowsheet().time,
                               self.shell.length_domain,
                               initialize=10000.0,
                               doc="Reynolds Number on Shell Side")
 
         # Friction factor on shell side
-        self.shell_friction_factor = Var(self.flowsheet().config.time,
+        self.shell_friction_factor = Var(self.flowsheet().time,
                                          self.shell.length_domain,
                                          initialize=1.0,
                                          doc='Friction Factor on Shell Side')
 
         # Prandtl number on shell side
-        self.shell_N_Pr = Var(self.flowsheet().config.time,
+        self.shell_N_Pr = Var(self.flowsheet().time,
                               self.shell.length_domain,
                               initialize=1,
                               doc="Prandtl Number on Shell Side")
 
         # Nusselt number on shell side
-        self.shell_N_Nu = Var(self.flowsheet().config.time,
+        self.shell_N_Nu = Var(self.flowsheet().time,
                               self.shell.length_domain,
                               initialize=1,
                               doc="Nusselts Number on Shell Side")
 
         # Velocity equation on shell side, using inlet molar flow rate
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Velocity on Shell Side")
         def v_shell_eqn(b, t, x):
@@ -1191,7 +1191,7 @@ tube side flows from 1 to 0"""))
                 b.area_flow_shell_min == b.shell.properties[t, 0].flow_mol
 
         # Reynolds number
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Reynolds Number Equation on Shell Side")
         def N_Re_shell_eqn(b, t, x):
@@ -1202,7 +1202,7 @@ tube side flows from 1 to 0"""))
 
         # Friction factor on shell side
         if self.config.tube_arrangement == "in-line":
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.shell.length_domain,
                              doc="In-Line Friction Factor on Shell Side")
             def friction_factor_shell_eqn(b, t, x):
@@ -1213,7 +1213,7 @@ tube side flows from 1 to 0"""))
                                                  + 1.13 / b.pitch_x_to_do)) \
                     * b.fcorrection_dp_shell
         elif self.config.tube_arrangement == "staggered":
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.shell.length_domain,
                              doc="Staggered Friction Factor on Shell Side")
             def friction_factor_shell_eqn(b, t, x):
@@ -1226,7 +1226,7 @@ tube side flows from 1 to 0"""))
             raise Exception('Tube Arrangement Not Supported')
 
         # Pressure drop on shell side
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Pressure Change on Shell Side")
         def deltaP_shell_eqn(b, t, x):
@@ -1236,7 +1236,7 @@ tube side flows from 1 to 0"""))
                 b.shell.properties[t, x].mw * b.shell_velocity[t, x]**2
 
         # Prandtl number
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Prandtl Number Equation on Shell Side")
         def N_Pr_shell_eqn(b, t, x):
@@ -1246,7 +1246,7 @@ tube side flows from 1 to 0"""))
                 * b.shell.properties[t, x].visc_d
 
         # Nusselt number, currently assume Re > 300
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Nusselts Number Equation on Shell Side")
         def N_Nu_shell_eqn(b, t, x):
@@ -1255,7 +1255,7 @@ tube side flows from 1 to 0"""))
 
         # Convective heat transfer coefficient on shell side
         # due to convection only
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Convective Heat Transfer Coefficient Equation"
                          "on Shell Side due to Convection")
@@ -1265,7 +1265,7 @@ tube side flows from 1 to 0"""))
                 * b.fcorrection_htc_shell
 
         # Total convective heat transfer coefficient on shell side
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Total Convective Heat Transfer Coefficient"
                          "Equation on Shell Side")
@@ -1279,7 +1279,7 @@ tube side flows from 1 to 0"""))
         # Energy balance with tube wall
         # ------------------------------------
         # Heat to wall per length on tube side
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Heat per Length on Tube Side")
         def heat_tube_eqn(b, t, x):
@@ -1289,7 +1289,7 @@ tube side flows from 1 to 0"""))
                  - b.tube.properties[t, x].temperature)
 
         # Heat to wall per length on shell side
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.shell.length_domain,
                          doc="Heat per Length on Shell Side")
         def heat_shell_eqn(b, t, x):
@@ -1309,7 +1309,7 @@ tube side flows from 1 to 0"""))
                             doc="Integer Indexing for Radius Domain")
 
         # Calculate integral point for mean temperature in the wall
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Mean Temperature across the Wall")
         def mean_temperature(b, t, x):
@@ -1322,7 +1322,7 @@ tube side flows from 1 to 0"""))
         for index_r, value_r in enumerate(self.r, 1):
             self.rindex[value_r] = index_r
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Discrete Point Mean Temperature")
@@ -1339,7 +1339,7 @@ tube side flows from 1 to 0"""))
                                 b.tube_wall_temperature[t, x, b.r[j]])
                          for j in range(2, b.rindex[r].value+1)))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Thermal Stress at Radial Direction for Tube")
@@ -1353,7 +1353,7 @@ tube side flows from 1 to 0"""))
                        (b.mean_temperature[t, x]
                         - b.discrete_mean_temperature[t, x, r]))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Thermal Stress at "
@@ -1368,7 +1368,7 @@ tube side flows from 1 to 0"""))
                    b.discrete_mean_temperature[t, x, r] -
                    2 * b.tube_wall_temperature[t, x, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Thermal Stress at Axial Direction for Tube")
@@ -1377,7 +1377,7 @@ tube side flows from 1 to 0"""))
                 / (1-b.Poisson_ratio) * (b.mean_temperature[t, x]
                                          - b.tube_wall_temperature[t, x, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Mechanical Stress at Radial Direction for Tube")
@@ -1399,7 +1399,7 @@ tube side flows from 1 to 0"""))
                                ((r * b.ri_scaling)**2 *
                                 (b.tube_ro**2 - b.tube_ri**2))))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Mechanical Stress at"
@@ -1416,7 +1416,7 @@ tube side flows from 1 to 0"""))
                              / ((r*b.ri_scaling)**2
                                 * (b.tube_ro**2-b.tube_ri**2))))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          doc="Mechanical Stress at Axial Direction for Tube")
         def mech_sigma_z(b, t, x):
@@ -1425,7 +1425,7 @@ tube side flows from 1 to 0"""))
                               * b.tube_ro**2)
                         / (b.tube_ro**2 - b.tube_ri**2))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Principal Structural Stress"
@@ -1438,7 +1438,7 @@ tube side flows from 1 to 0"""))
             else:
                 return b.mech_sigma_r[t, x, r] + b.therm_sigma_r[t, x, r]
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Principal Structural Stress"
@@ -1446,7 +1446,7 @@ tube side flows from 1 to 0"""))
         def sigma_theta(b, t, x, r):
             return b.mech_sigma_theta[t, x, r] + b.therm_sigma_theta[t, x, r]
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc="Principal Structural Stress"
@@ -1454,14 +1454,14 @@ tube side flows from 1 to 0"""))
         def sigma_z(b, t, x, r):
             return b.mech_sigma_z[t, x] + b.therm_sigma_z[t, x, r]
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r, doc='Variation Principal Stress'
                          'between Radial-Circumferential Directions for Tube')
         def delta_sigma_r_theta(b, t, x, r):
             return abs(b.sigma_r[t, x, r] - b.sigma_theta[t, x, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc='Variation Principal Stress'
@@ -1469,7 +1469,7 @@ tube side flows from 1 to 0"""))
         def delta_sigma_theta_z(b, t, x, r):
             return abs(b.sigma_theta[t, x, r]-b.sigma_z[t, x, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain,
                          self.r,
                          doc='Variation Principal Stress'
@@ -1477,7 +1477,7 @@ tube side flows from 1 to 0"""))
         def delta_sigma_z_r(b, t, x, r):
             return abs(b.sigma_z[t, x, r] - b.sigma_r[t, x, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.tube.length_domain, self.r,
                          doc='Equivalent von Mises Stress for Tube')
         def sigma_von_Mises(b, t, x, r):
@@ -1498,7 +1498,7 @@ tube side flows from 1 to 0"""))
         self.creep_d = Param(initialize=-19.62, mutable=True)
         self.creep_e = Param(initialize=348582.80, mutable=True)
 
-        @self.Expression(self.flowsheet().config.time, self.tube.length_domain,
+        @self.Expression(self.flowsheet().time, self.tube.length_domain,
                          self.r, doc='Rupture Time for Tube')
         def rupture_time(b, t, x, r):
             return 10**(b.creep_a + b.creep_b *
@@ -1564,7 +1564,7 @@ tube side flows from 1 to 0"""))
 
             # Variables for heat transfer of header with insulation
             # Ambient temperature
-            self.temperature_ambient = Var(self.flowsheet().config.time,
+            self.temperature_ambient = Var(self.flowsheet().time,
                                            initialize=298.15,
                                            doc="Ambient Temperature")
 
@@ -1575,54 +1575,54 @@ tube side flows from 1 to 0"""))
 
             # Header inside heat transfer coefficient
             self.head_hin = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1,
                 doc="Inside Heat Transfer Coefficient of Header")
 
             # Header outside heat transfer coefficient
             self.head_hout = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1,
                 doc="Outside Heat Transfer Coefficient of Header")
 
             # Insulation free convection heat transfer coefficient
             self.head_h_free_conv = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1,
                 doc="Insulation Free Convection Heat Transfer Coefficient")
 
             # Ra number of free convection
             self.head_N_Ra_root6 = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=80,
                 doc="1/6 Power of Ra Number of Free Convection of Air")
 
             # Nu number of free convection for header shell side
             self.head_N_Nu_shell = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1,
                 doc="Nu Number of Free Convection of Air")
 
             # header tube side velocity
             self.head_velocity_tube = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1,
                 doc="header velocity on tube side")
 
             # Re number on header tube side
             self.head_N_Re_tube = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1,
                 doc="Nu Number on header tube side")
 
             # Nu number of free convection on header tube side
             self.head_N_Nu_tube = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1,
                 doc="Nu Number on header tube side")
 
             # Temperature across header wall thickness
-            self.header_wall_temperature = Var(self.flowsheet().config.time,
+            self.header_wall_temperature = Var(self.flowsheet().time,
                                                self.head_r,
                                                bounds=(500, 900),
                                                initialize=680)
@@ -1648,7 +1648,7 @@ tube side flows from 1 to 0"""))
                 return b.therm_cond_header / (b.dens_header * b.cp_header)
 
             # Constraint for heat conduction equation
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              self.head_r,
                              doc="1-D PDE Heat Conduction for Header")
             def head_heat_conduction_eqn(b, t, r):
@@ -1662,7 +1662,7 @@ tube side flows from 1 to 0"""))
                     return 0 == b.therm_diffus_header / b.head_ri_scaling**2 \
                                 * (b.head_d2Tdr2[t, r] + b.head_dTdr[t, r] / r)
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Inner Wall Boundary")
             def head_inner_wall_bc_eqn(b, t):
                 return 0.01 * b.head_hin[t] *\
@@ -1672,7 +1672,7 @@ tube side flows from 1 to 0"""))
                     - 0.01 * b.head_dTdr[t, b.head_r.first()] \
                     / b.head_ri_scaling * b.therm_cond_header
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Outer Wall Boundary")
             def head_outer_wall_bc_eqn(b, t):
                 return 0.01 * b.head_hout[t] * \
@@ -1682,7 +1682,7 @@ tube side flows from 1 to 0"""))
                     * b.therm_cond_header
 
             # Inner wall BC for dTdt
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Extra Boundary at Inner Wall"
                              "Temperature Derivative")
             def head_extra_at_inner_wall_eqn(b, t):
@@ -1709,7 +1709,7 @@ tube side flows from 1 to 0"""))
                            temperature
                            - b.header_wall_temperature[t, b.head_r.first()]))
 
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Extra Boundary at Outer Wall "
                              "Temperature Derivative")
             def head_extra_at_outer_wall_eqn(b, t):
@@ -1742,14 +1742,14 @@ tube side flows from 1 to 0"""))
 
             # Equation considering conduction through insulation
             # and free convection between insulation and ambient
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Outer Side Heat Transfer Coefficient")
             def head_hout_eqn(b, t):
                 return b.head_hout[t] * (b.resistance_insulation +
                                          1/b.head_h_free_conv[t]) == 1.0
 
             # Expressure for outside insulation wall temperature
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc="Outside Insulation Wall Temperature")
             def head_temp_insulation_outside(b, t):
                 return b.temperature_ambient[t] + (
@@ -1758,7 +1758,7 @@ tube side flows from 1 to 0"""))
                     / b.head_h_free_conv[t]
 
             # Ra number equation
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Ra Number of Free Convection")
             def head_Ra_number_eqn(b, t):
                 return b.head_N_Ra_root6[t] == b.const_head_Ra_root6 * sqrt(
@@ -1767,14 +1767,14 @@ tube side flows from 1 to 0"""))
                         - b.temperature_ambient[t])**0.166667
 
             # Nu number equation
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Nu Number of Free Convection")
             def head_Nu_number_shell_eqn(b, t):
                 return b.head_N_Nu_shell[t] == (0.6 + b.const_head_Nu *
                                                 b.head_N_Ra_root6[t])**2
 
             # Free convection coefficient based on the drum outside diameter
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Free Convection Heat Transfer Coefficient"
                              "between Insulation Wall and Ambient")
             def head_h_free_conv_eqn(b, t):
@@ -1782,7 +1782,7 @@ tube side flows from 1 to 0"""))
                     * b.therm_cond_air / b.head_do
 
             # Calculate header inside heat transfer coefficient
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="velocity inside header")
             def head_velocity_tube_eqn(b, t):
                 return (0.0001 * b.head_velocity_tube[t] * const.pi *
@@ -1792,7 +1792,7 @@ tube side flows from 1 to 0"""))
                         properties[t, b.tube.length_domain.first()].flow_mol)
 
             # Calculate header Re number on tube side
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Reynolds number inside header")
             def head_N_Re_tube_eqn(b, t):
                 return (b.head_N_Re_tube[t]
@@ -1803,14 +1803,14 @@ tube side flows from 1 to 0"""))
                         dens_mass_phase[phase_s])
 
             # Calculate header Nu number
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Nuseldt number inside header")
             def head_N_Nu_tube_eqn(b, t):
                 return b.head_N_Nu_tube[t] == 0.023 * b.head_N_Re_tube[t]**0.8\
                        * b.tube_N_Pr[t, b.tube.length_domain.first()]**0.4
 
             # Calculate header hin
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="inside heat transfer coefficient of header")
             def head_hin_eqn(b, t):
                 return b.head_hin[t] * b.head_di == b.head_N_Nu_tube[t] *\
@@ -1826,7 +1826,7 @@ tube side flows from 1 to 0"""))
                                      doc="Integer Indexing for Radius Domain")
 
             # calculate integral point for mean temperature in the wall
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc="Mean Temperature for Header")
             def mean_temperature_header(b, t):
                 return 2 * (b.head_r[2] - b.head_r[1]) * b.head_ri_scaling**2 \
@@ -1840,7 +1840,7 @@ tube side flows from 1 to 0"""))
             for head_index_r, head_value_r in enumerate(self.head_r, 1):
                 self.head_rindex[head_value_r] = head_index_r
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc="Discrete Point Mean Temperature for Header")
             def discrete_mean_temperature_header(b, t, r):
                 if b.head_rindex[r].value == 1:
@@ -1860,7 +1860,7 @@ tube side flows from 1 to 0"""))
                                     ) for j in range(
                                         2, b.head_rindex[r].value + 1)))
 
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              self.head_r,
                              doc="Thermal Stress at"
                                  "Radial Direction for Header")
@@ -1875,7 +1875,7 @@ tube side flows from 1 to 0"""))
                            * (b.mean_temperature_header[t]
                            - b.discrete_mean_temperature_header[t, r]))
 
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              self.head_r,
                              doc="Thermal Stress at Circumferential"
                                  "Direction for Header")
@@ -1889,7 +1889,7 @@ tube side flows from 1 to 0"""))
                        * b.discrete_mean_temperature_header[t, r]
                        - 2 * b.header_wall_temperature[t, r])
 
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              self.head_r,
                              doc="Thermal Stress at "
                                  " Axial Direction for Header")
@@ -1900,7 +1900,7 @@ tube side flows from 1 to 0"""))
                     * (b.mean_temperature_header[t]
                        - b.header_wall_temperature[t, r])
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc="Mechanical Stress "
                                  "at Radial Direction for Header")
             def mech_sigma_r_header(b, t, r):
@@ -1949,7 +1949,7 @@ tube side flows from 1 to 0"""))
                                                        * (b.head_ro**2
                                                           - b.head_ri**2))))
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc="Mechanical Stress"
                              "at Circumferential Direction for Header")
             def mech_sigma_theta_header(b, t, r):
@@ -1989,7 +1989,7 @@ tube side flows from 1 to 0"""))
                                  / ((r * b.head_ri_scaling)**2 *
                                     (b.head_ro**2 - b.head_ri**2))))
 
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc="Mechanical Stress"
                              "at Axial Direction for Header")
             def mech_sigma_z_header(b, t):
@@ -2012,7 +2012,7 @@ tube side flows from 1 to 0"""))
                                       b.head_ro**2) / (b.head_ro**2
                                                        - b.head_ri**2))
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc="Principal Structural Stress "
                                  "at Radial Direction for Header")
             def sigma_r_header(b, t, r):
@@ -2034,40 +2034,40 @@ tube side flows from 1 to 0"""))
                     return b.mech_sigma_r_header[t, r] + \
                                 b.therm_sigma_r_header[t, r]
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc="Principal Structural Stress"
                              "at Circumferential Direction for Header")
             def sigma_theta_header(b, t, r):
                 return b.mech_sigma_theta_header[t, r] \
                         + b.therm_sigma_theta_header[t, r]
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc="Principal Structural Stress"
                              "at Axial Direction for Header")
             def sigma_z_header(b, t, r):
                 return b.mech_sigma_z_header[t] + b.therm_sigma_z_header[t, r]
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc='Variation Principal Stress'
                              'between Radial - Circumferential Directions'
                              'for Header')
             def delta_sigma_r_theta_header(b, t, r):
                 return abs(b.sigma_r_header[t, r] - b.sigma_theta_header[t, r])
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc='Variation Principal Stress'
                              'between Circumferential-Axial Directions'
                              'for Header')
             def delta_sigma_theta_z_header(b, t, r):
                 return abs(b.sigma_theta_header[t, r]-b.sigma_z_header[t, r])
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc='Variation Principal Stress'
                              'between Axial-Radial Directions for Header')
             def delta_sigma_z_r_header(b, t, r):
                 return abs(b.sigma_z_header[t, r] - b.sigma_r_header[t, r])
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc='Equivalent von Mises Stress for Header')
             def sigma_von_Mises_header(b, t, r):
                 return sqrt(b.sigma_r_header[t, r]**2
@@ -2095,7 +2095,7 @@ tube side flows from 1 to 0"""))
             self.creep_e_header = Param(initialize=20.32884026, mutable=True)
             self.creep_f_header = Param(initialize=280, mutable=True)
 
-            @self.Expression(self.flowsheet().config.time, self.head_r,
+            @self.Expression(self.flowsheet().time, self.head_r,
                              doc='Rupture Time for Header')
             def rupture_time_header(b, t, r):
                 return 10**((b.creep_a_header
@@ -2140,7 +2140,7 @@ tube side flows from 1 to 0"""))
                                * (exp(-7 * k_t_A)-1))**2 + 0.81 * k_t_A**2)
 
             # mechanical stress at circumferential direction
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Mechanical Stress '
                              'at Circumferential Direction'
                              'for Header (EN 12952-3)')
@@ -2160,7 +2160,7 @@ tube side flows from 1 to 0"""))
                                      pressure) * r_ms_head / header_thickness
 
             # thermal stress at circumferential direction
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Thermal Stress at Circumferential'
                                  'Direction for Header (EN 12952-3)')
             def sigma_t(b, t):
@@ -2174,27 +2174,27 @@ tube side flows from 1 to 0"""))
             # stress at crotch corner P1 and location P2
 
             # mechanical stress by pressure at crotch corner
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Mechanical Stress at Crotch Corner'
                              'for Header')
             def sigma_p_P1(b, t):
                 return b.sigma_p[t] * k_m_header
 
             # mechanical stress at location P2
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Mechanical Stress at'
                                  'Critical Point P2 for Header')
             def sigma_p_P2(b, t):
                 return b.sigma_p[t] * k_m_header / 5
 
             # thermal stress at crotch corner
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Thermal Stress at Crotch Corner for Header')
             def sigma_t_P1(b, t):
                 return b.sigma_t[t] * k_t_header
 
             # thermal stress at location P2
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Thermal Stress'
                              'at Critical Point P2 for Header')
             def sigma_t_P2(b, t):
@@ -2202,14 +2202,14 @@ tube side flows from 1 to 0"""))
 
             # total circumferential stress with notch effect
             # crotch corner P1
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Circumferential Stress'
                              'at Crotch Corner for Header')
             def sigma_theta_P1(b, t):
                 return b.sigma_p_P1[t] + b.sigma_t_P1[t]
 
             # location P2
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Circumferential Stress'
                              'at Critical Point P2 for Header')
             def sigma_theta_P2(b, t):
@@ -2217,7 +2217,7 @@ tube side flows from 1 to 0"""))
 
             # total stress with notch effect // f1 - f2
             # crotch corner
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Total Stress at Crotch Corner for Header')
             def sigma_notch_P1(b, t):
                 return b.sigma_theta_P1[t] \
@@ -2226,7 +2226,7 @@ tube side flows from 1 to 0"""))
                                       b.tube.length_domain.first()].pressure
 
             # location P2
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Total Stress at Critial Point P2 for Header')
             def sigma_notch_P2(b, t):
                 return b.sigma_theta_P2[t] \
@@ -2237,7 +2237,7 @@ tube side flows from 1 to 0"""))
 
             # Von Mises equivalent stress
             # VM stress at crotch corner
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Equivalent von Mises Stress'
                                  'at Crotch Corner for Header')
             def sigma_eff_P1(b, t):
@@ -2251,7 +2251,7 @@ tube side flows from 1 to 0"""))
                         * (-1e-6 * p_in)))
 
             # VM stress at location P2
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Equivalent von Mises Stress'
                              'at Critical Point P2 for Header')
             def sigma_eff_P2(b, t):
@@ -2265,7 +2265,7 @@ tube side flows from 1 to 0"""))
                         * (-1e-6 * p_in)))
 
             # rupture time calculation at crotch corner
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Rupture Tme at Crotch Corner for Header')
             def rupture_time_crotch_corner(b, t):
                 if value(b.sigma_eff_P1[t]) > 10:  # MPa
@@ -2283,7 +2283,7 @@ tube side flows from 1 to 0"""))
                     return 10**13
 
             # rupture time calculation at location P2
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc='Rupture Time at Critical Point P2'
                              'for Header')
             def rupture_time_P2(b, t):
@@ -2304,7 +2304,7 @@ tube side flows from 1 to 0"""))
         # total heat released by shell side fluid assuming even discretization.
         # shell side always in forward direction and the first point is skiped
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Total Heat Released from Shell Side")
         def total_heat(b, t):
             return -(sum(b.shell_heat[t, x] for x in b.shell.length_domain)
@@ -2313,7 +2313,7 @@ tube side flows from 1 to 0"""))
 
     def set_initial_condition(self):
         if self.config.dynamic is True:
-            t0 = self.flowsheet().config.time.first()
+            t0 = self.flowsheet().time.first()
             self.dTdt[:, :, :].value = 0
             self.dTdt[t0, :, :].fix(0)
             if self.config.has_header is True:
@@ -2458,7 +2458,7 @@ tube side flows from 1 to 0"""))
                               " Temperature = {}.".format(
                                   temp_out_tube_guess))
 
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for z in blk.tube.length_domain:
                 if blk.config.flow_type == "co_current":
                     blk.tube_wall_temperature[t, z, :].fix(value(
@@ -2481,14 +2481,14 @@ tube side flows from 1 to 0"""))
                                     (1 - z) * temp_out_tube_guess + z * blk.
                                     tube.properties[0, 1].temperature)))
 
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for z in blk.tube.length_domain:
                 blk.tube.properties[t, z].enth_mol.fix(
                     value(blk.tube_inlet.enth_mol[0]))
                 blk.tube.properties[t, z].pressure.fix(
                     value(blk.tube_inlet.pressure[0]))
 
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for z in blk.shell.length_domain:
                 blk.shell.properties[t, z].temperature.fix(
                     value(blk.shell.properties[0, 0].temperature))
@@ -2530,7 +2530,7 @@ tube side flows from 1 to 0"""))
         # (enthalpy/temperature and pressure)
         # keep the inlet state variables fixed,
         # otherwise, the degree of freedom > 0
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for z in blk.tube.length_domain:
                 blk.tube.properties[t, z].enth_mol.unfix()
                 blk.tube.properties[t, z].pressure.unfix()
@@ -2545,7 +2545,7 @@ tube side flows from 1 to 0"""))
                 blk.tube.properties[t, 1].pressure.fix(
                     value(blk.tube_inlet.pressure[0]))
 
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             for z in blk.shell.length_domain:
                 blk.shell.properties[t, z].temperature.unfix()
                 blk.shell.properties[t, z].pressure.unfix()

--- a/idaes/power_generation/unit_models/downcomer.py
+++ b/idaes/power_generation/unit_models/downcomer.py
@@ -213,7 +213,7 @@ see property package for documentation.}"""))
                 doc="Inside diameter of downcomer",
                 units=units_meta.get_derived_units("length"))
         # Volume constraint
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Downcomer volume of all pipes")
         def volume_eqn(b, t):
             return b.volume[t] == 0.25*const.pi*b.diameter**2*b.height \
@@ -228,39 +228,39 @@ see property package for documentation.}"""))
         # Add performance variables
         # Velocity of fluid inside downcomer pipe
         self.velocity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=10.0,
                 doc='Liquid water velocity inside downcomer',
                 units=units_meta.get_derived_units("velocity"))
 
         # Reynolds number
         self.N_Re = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=10000.0,
                 doc='Reynolds number')
 
         # Darcy friction factor (turbulent flow)
         self.friction_factor_darcy = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.005,
                 doc='Darcy friction factor')
 
         # Pressure change due to friction
         self.deltaP_friction = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=-1.0,
                 doc='Pressure change due to friction',
                 units=units_meta.get_derived_units("pressure"))
 
         # Pressure change due to gravity
         self.deltaP_gravity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=100.0,
                 doc='Pressure change due to gravity',
                 units=units_meta.get_derived_units("pressure"))
 
         # Equation for calculating velocity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Velocity of fluid inside downcomer")
         def velocity_eqn(b, t):
             return b.velocity[t]*0.25*const.pi*b.diameter**2 \
@@ -268,7 +268,7 @@ see property package for documentation.}"""))
                 == b.control_volume.properties_in[t].flow_vol
 
         # Equation for calculating Reynolds number
-        @self.Constraint(self.flowsheet().config.time, doc="Reynolds number")
+        @self.Constraint(self.flowsheet().time, doc="Reynolds number")
         def Reynolds_number_eqn(b, t):
             return b.N_Re[t] * \
                    b.control_volume.properties_in[t].visc_d_phase["Liq"] == \
@@ -276,7 +276,7 @@ see property package for documentation.}"""))
                    b.control_volume.properties_in[t].dens_mass_phase["Liq"]
 
         # Friction factor expression depending on laminar or turbulent flow
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Darcy friction factor as "
                          "a function of Reynolds number")
         def friction_factor_darcy_eqn(b, t):
@@ -284,7 +284,7 @@ see property package for documentation.}"""))
 
         # Pressure change equation for friction,
         # -1/2*density*velocity^2*fD/diameter*height
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pressure change due to friction")
         def pressure_change_friction_eqn(b, t):
             return b.deltaP_friction[t] * b.diameter == -0.5 \
@@ -293,7 +293,7 @@ see property package for documentation.}"""))
 
         # Pressure change equation for gravity, density*gravity*height
         g_units = units_meta.get_derived_units("acceleration")
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pressure change due to gravity")
         def pressure_change_gravity_eqn(b, t):
             return b.deltaP_gravity[t] == \
@@ -302,7 +302,7 @@ see property package for documentation.}"""))
                                   to_units=g_units) * b.height
 
         # Total pressure change equation
-        @self.Constraint(self.flowsheet().config.time, doc="Pressure drop")
+        @self.Constraint(self.flowsheet().time, doc="Pressure drop")
         def pressure_change_total_eqn(b, t):
             return b.deltaP[t] == (b.deltaP_friction[t] + b.deltaP_gravity[t])
 
@@ -354,7 +354,7 @@ see property package for documentation.}"""))
                 "Incorrect degrees of freedom when initializing {}: dof = {}".format(
                     blk.name, degrees_of_freedom(blk)))
         # Fix outlet pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].pressure.fix(
                 value(blk.control_volume.properties_in[t].pressure)
             )
@@ -367,7 +367,7 @@ see property package for documentation.}"""))
             )
 
         # Unfix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].pressure.unfix()
         blk.pressure_change_total_eqn.activate()
 

--- a/idaes/power_generation/unit_models/drum.py
+++ b/idaes/power_generation/unit_models/drum.py
@@ -244,7 +244,7 @@ see property package for documentation.}"""))
 
 
         # constraint to make pressures of two inlets of drum mixer the same
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Mixter pressure identical")
         def mixer_pressure_eqn(b, t):
             return b.mixer.SaturatedWater.pressure[t]*1e-6 == \
@@ -259,17 +259,17 @@ see property package for documentation.}"""))
 
         # connect internal units (Mixer to Water Tank Model)
         # Mixer Outlet (mixed_state) to unit control volume.properties_in
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def connection_material_balance(b, t):
             return 1e-4*b.mixer.mixed_state[t].flow_mol == \
                 b.control_volume.properties_in[t].flow_mol*1e-4
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def connection_enthalpy_balance(b, t):
             return b.mixer.mixed_state[t].enth_mol*1e-4 == \
                 b.control_volume.properties_in[t].enth_mol*1e-4
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def connection_pressure_balance(b, t):
             return b.mixer.mixed_state[t].pressure*1e-6 == \
                 b.control_volume.properties_in[t].pressure*1e-6
@@ -327,7 +327,7 @@ see property package for documentation.}"""))
 
         # Add performance variables
         self.drum_level = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 within=pyo.PositiveReals,
                 initialize=1.0,
                 doc='Water level from the bottom of the drum',
@@ -335,21 +335,21 @@ see property package for documentation.}"""))
 
         # Velocity of fluid inside downcomer pipe
         self.downcomer_velocity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=10.0,
                 doc='Liquid water velocity at the top of downcomer',
                 units=units_meta.get_derived_units("velocity"))
 
         # Pressure change due to contraction
         self.deltaP_contraction = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=-1.0,
                 doc='Pressure change due to contraction',
                 units=units_meta.get_derived_units("pressure"))
 
         # Pressure change due to gravity
         self.deltaP_gravity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0,
                 doc='Pressure change due to gravity',
                 units=units_meta.get_derived_units("pressure"))
@@ -361,13 +361,13 @@ see property package for documentation.}"""))
 
         # Expression for the angle from the drum center
         # to the circumference point at water level
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="angle of water level")
         def alpha_drum(b, t):
             return asin((b.drum_level[t]-b.drum_radius)/b.drum_radius)/pyo.units.rad
 
         # Constraint for volume liquid in drum
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="volume of liquid in drum")
         def volume_eqn(b, t):
             return b.volume[t] == \
@@ -377,7 +377,7 @@ see property package for documentation.}"""))
                        * b.drum_length
 
         # Equation for velocity at the entrance of downcomer
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Velocity at entrance of downcomer")
         def velocity_eqn(b, t):
             return b.downcomer_velocity[t] * 0.25 * const.pi \
@@ -386,7 +386,7 @@ see property package for documentation.}"""))
 
         # Pressure change equation for contraction
         # (acceleration pressure change)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="pressure change due to contraction")
         def pressure_change_contraction_eqn(b, t):
             return 1e-3*b.deltaP_contraction[t] == -1e-3*0.75 \
@@ -395,7 +395,7 @@ see property package for documentation.}"""))
 
         # Pressure change equation for gravity, density*gravity*height
         g_units = units_meta.get_derived_units("acceleration")
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="pressure change due to gravity")
         def pressure_change_gravity_eqn(b, t):
             return 1e-3 * b.deltaP_gravity[t] == 1e-3 * \
@@ -404,7 +404,7 @@ see property package for documentation.}"""))
                                     to_units=g_units) * b.drum_level[t]
 
         # Total pressure change equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="pressure drop")
         def pressure_change_total_eqn(b, t):
             return 1e-3 * b.deltaP[t] == 1e-3 * (b.deltaP_contraction[t]

--- a/idaes/power_generation/unit_models/drum1D.py
+++ b/idaes/power_generation/unit_models/drum1D.py
@@ -266,17 +266,17 @@ discretizing length domain (default=3)"""))
 
         # connect internal units (Mixer to Water Tank Model)
         # Mixer Outlet (mixed_state) to unit control volume.properties_in
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def connection_material_balance(b, t):
             return b.mixer.mixed_state[t].flow_mol == \
                 b.control_volume.properties_in[t].flow_mol
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def connection_enthalpy_balance(b, t):
             return b.mixer.mixed_state[t].enth_mol == \
                 b.control_volume.properties_in[t].enth_mol
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def connection_pressure_balance(b, t):
             return b.mixer.mixed_state[t].pressure == \
                 b.control_volume.properties_in[t].pressure
@@ -401,40 +401,40 @@ discretizing length domain (default=3)"""))
         self.pressure_amb = Param(initialize=1.0E5, doc="Ambient Pressure")
 
         # Ambient temperature
-        self.temperature_ambient = Var(self.flowsheet().config.time,
+        self.temperature_ambient = Var(self.flowsheet().time,
                                        initialize=298.15,
                                        doc="Ambient Temperature")
 
         # Inside heat transfer coefficient
-        self.heat_transfer_in = Var(self.flowsheet().config.time,
+        self.heat_transfer_in = Var(self.flowsheet().time,
                                     initialize=1,
                                     doc="Inside Heat Transfer Coefficient")
 
         # Outside heat transfer coefficient
-        self.heat_transfer_out = Var(self.flowsheet().config.time,
+        self.heat_transfer_out = Var(self.flowsheet().time,
                                      initialize=1,
                                      doc="Outside Heat Transfer Coefficient")
 
         # Insulation free convection heat transfer coefficient
-        self.heat_transfer_free_conv = Var(self.flowsheet().config.time,
+        self.heat_transfer_free_conv = Var(self.flowsheet().time,
                                            initialize=1,
                                            doc="Insulation Free Convection"
                                            "Heat Transfer Coefficient")
 
         # Ra number of free convection
-        self.N_Ra_root6 = Var(self.flowsheet().config.time, initialize=80,
+        self.N_Ra_root6 = Var(self.flowsheet().time, initialize=80,
                               doc="1/6 Power of Ra"
                               "Number of Free Convection of Air")
 
         # Nu number  of free convection
-        self.N_Nu = Var(self.flowsheet().config.time, initialize=1,
+        self.N_Nu = Var(self.flowsheet().time, initialize=1,
                         doc="Nu Number of Free Convection of Air")
 
         # Define the continuous domains for model
         self.radial_domain = ContinuousSet(bounds=(self.drum_ri, self.drum_ro))
 
         # Temperature across wall thickness
-        self.drum_wall_temperature = Var(self.flowsheet().config.time,
+        self.drum_wall_temperature = Var(self.flowsheet().time,
                                          self.radial_domain,
                                          bounds=(280, 800),
                                          initialize=550)
@@ -442,7 +442,7 @@ discretizing length domain (default=3)"""))
         # Declare derivatives in the model
         if self.config.dynamic is True:
             self.dTdt = DerivativeVar(self.drum_wall_temperature,
-                                      wrt=self.flowsheet().config.time)
+                                      wrt=self.flowsheet().time)
         self.dTdr = DerivativeVar(self.drum_wall_temperature,
                                   wrt=self.radial_domain)
         self.d2Tdr2 = DerivativeVar(self.drum_wall_temperature,
@@ -457,25 +457,25 @@ discretizing length domain (default=3)"""))
 
         # Add performance variables
         self.level = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0,
                 doc='Water Level from the Bottom of the Drum')
 
         # Velocity of fluid inside downcomer pipe
         self.velocity_downcomer = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=10.0,
                 doc='Liquid Water Velocity at the Top of Downcomer')
 
         # Pressure change due to contraction
         self.deltaP_contraction = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=-1.0,
                 doc='Pressure Change due to Contraction')
 
         # Pressure change due to gravity
         self.deltaP_gravity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0,
                 doc='Pressure Change due to Gravity')
 
@@ -486,19 +486,19 @@ discretizing length domain (default=3)"""))
 
         # Expressure for the angle from the drum center
         # to the circumference point at water level
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Angle of Water Level")
         def alpha_drum(b, t):
             return asin((b.level[t] - b.drum_ri) / b.drum_ri)
 
         # Expressure for the fraction of wet area
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Fraction of Wet Area")
         def frac_wet_area(b, t):
             return (b.alpha_drum[t] + const.pi / 2) / const.pi
 
         # Constraint for volume liquid in drum
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Volume of Liquid in Drum")
         def volume_eqn(b, t):
             return b.volume[t] == \
@@ -507,7 +507,7 @@ discretizing length domain (default=3)"""))
                     * (b.level[t] - b.drum_ri)) * b.drum_length
 
         # Equation for velocity at the entrance of downcomer
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Velocity at Entrance of Downcomer")
         def velocity_eqn(b, t):
             return b.velocity_downcomer[t] * 0.25 * const.pi \
@@ -518,7 +518,7 @@ discretizing length domain (default=3)"""))
         # -0.5*1/2*density*velocity^2 for stagnation head loss
         # plus 1/2*density*velocity^2 dynamic head
         # (acceleration pressure change)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pressure Change due To Contraction")
         def pressure_change_contraction_eqn(b, t):
             return b.deltaP_contraction[t] == \
@@ -527,7 +527,7 @@ discretizing length domain (default=3)"""))
                    b.velocity_downcomer[t]**2
 
         # Pressure change equation for gravity, density*gravity*height
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pressure Change due to Gravity")
         def pressure_change_gravity_eqn(b, t):
             return b.deltaP_gravity[t] == \
@@ -536,12 +536,12 @@ discretizing length domain (default=3)"""))
                    * b.level[t]
 
         # Total pressure change equation
-        @self.Constraint(self.flowsheet().config.time, doc="Pressure Drop")
+        @self.Constraint(self.flowsheet().time, doc="Pressure Drop")
         def pressure_change_total_eqn(b, t):
             return b.deltaP[t] == b.deltaP_contraction[t] + b.deltaP_gravity[t]
 
         # Constraint for heat conduction equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          self.radial_domain,
                          doc="1-D Heat Conduction Equation Through Radius")
         def heat_conduction_eqn(b, t, r):
@@ -554,7 +554,7 @@ discretizing length domain (default=3)"""))
                 return 0 == b.diff_therm_metal * b.d2Tdr2[t, r]\
                             + b.diff_therm_metal * (1 / r) * b.dTdr[t, r]
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Inner Wall Boundary")
         def inner_wall_bc_eqn(b, t):
             return b.heat_transfer_in[t] \
@@ -562,7 +562,7 @@ discretizing length domain (default=3)"""))
                    - b.drum_wall_temperature[t, b.radial_domain.first()]) == \
                 - b.dTdr[t, b.radial_domain.first()] * b.therm_cond_metal
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Outer Wall Boundary")
         def outer_wall_bc_eqn(b, t):
             return b.heat_transfer_out[t] * \
@@ -571,7 +571,7 @@ discretizing length domain (default=3)"""))
                 - b.dTdr[t, b.radial_domain.last()] * b.therm_cond_metal
 
         # Inner wall BC for dTdt
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Extra Inner Wall Temperature Derivative")
         def extra_at_inner_wall_eqn(b, t):
             if self.config.dynamic is True:
@@ -591,7 +591,7 @@ discretizing length domain (default=3)"""))
                 * (b.control_volume.properties_out[t].temperature
                    - b.drum_wall_temperature[t, b.radial_domain.first()])
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Extra Outer Wall Temperature Derivative")
         def extra_at_outer_wall_eqn(b, t):
             if self.config.dynamic is True:
@@ -612,7 +612,7 @@ discretizing length domain (default=3)"""))
                     - b.drum_wall_temperature[t, b.radial_domain.last()])
 
         # Reduced pressure expression
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Reduced Pressure")
         def pres_reduced(b, t):
             return b.control_volume.properties_out[t].pressure / 2.2048e7
@@ -621,7 +621,7 @@ discretizing length domain (default=3)"""))
         # with minimum temperature difference set to sqrt(0.1)
         # multipling wet area fraction to convert it
         # to the value based on total circumference
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Inner Side Heat Transfer Coefficient")
         def h_in_eqn(b, t):
             return b.heat_transfer_in[t] == 2178.6 \
@@ -643,7 +643,7 @@ discretizing length domain (default=3)"""))
 
         # heat_transfer_out equation considering conduction through insulation
         # and free convection between insulation and ambient
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Outer Side Heat Transfer Coefficient")
         def h_out_eqn(b, t):
             return b.heat_transfer_out[t] * (b.resistance_insulation
@@ -651,7 +651,7 @@ discretizing length domain (default=3)"""))
                                              heat_transfer_free_conv[t]) == 1.0
 
         # Expressure for outside insulation wall temperature (skin temperature)
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Outside Insulation Wall Temperature")
         def temp_insulation_outside(b, t):
             return b.temperature_ambient[t] + (
@@ -660,7 +660,7 @@ discretizing length domain (default=3)"""))
                 / b.heat_transfer_free_conv[t]
 
         # Ra number equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Ra Number of Free Convection")
         def Ra_number_eqn(b, t):
            return b.N_Ra_root6[t] == b.const_Ra_root6 * sqrt(
@@ -669,20 +669,20 @@ discretizing length domain (default=3)"""))
                     - b.temperature_ambient[t])**0.166667
 
         # Nu number equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Nu Number of Free Convection")
         def Nu_number_eqn(b, t):
             return b.N_Nu[t] == (0.6 + b.const_Nu * b.N_Ra_root6[t])**2
 
         # Free convection coefficient based on the drum metal outside diameter
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Free Convection Heat Transfer Coefficient"
                          "between Insulation Wall and Ambient")
         def h_free_conv_eqn(b, t):
             return b.heat_transfer_free_conv[t] == b.N_Nu[t] \
                 * b.therm_cond_air / b.drum_do
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Heat Loss of Water")
         def heat_loss_eqn(b, t):
             return b.heat_duty[t] == b.drum_area * b.heat_transfer_in[t] * (
@@ -698,7 +698,7 @@ discretizing length domain (default=3)"""))
                             doc="Integer Indexing for Radius Domain")
 
         # calculate integral point for mean temperature in the wall
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Mean Temperature across the Wall")
         def mean_temperature(b, t):
             return 2 * (b.radial_domain[2] - b.radial_domain[1]) / (
@@ -713,7 +713,7 @@ discretizing length domain (default=3)"""))
         for index_r, value_r in enumerate(self.radial_domain, 1):
             self.rindex[value_r] = index_r
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Discrete Point Mean Temperature")
         def discrete_mean_temperature(b, t, r):
@@ -732,7 +732,7 @@ discretizing length domain (default=3)"""))
                                 ) for j in range(2, b.rindex[r].value
                                                  + 1)))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Thermal Stress at Radial Direction for Drum")
         def therm_sigma_r(b, t, r):
@@ -744,7 +744,7 @@ discretizing length domain (default=3)"""))
                         b.mean_temperature[t]
                         - b.discrete_mean_temperature[t, r]))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Thermal Stress at Circumferential Direction"
                          "for Drum")
@@ -756,7 +756,7 @@ discretizing length domain (default=3)"""))
                                            discrete_mean_temperature[t, r]
                                            - 2 * b.drum_wall_temperature[t, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Thermal Stress at Axial Direction for Drum")
         def therm_sigma_z(b, t, r):
@@ -764,7 +764,7 @@ discretizing length domain (default=3)"""))
                 1 - b.Poisson_ratio) * (b.mean_temperature[t]
                                         - b.drum_wall_temperature[t, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Mechanical Stress at Radial Direction for Drum")
         def mech_sigma_r(b, t, r):
@@ -784,7 +784,7 @@ discretizing length domain (default=3)"""))
                                           * b.drum_ro**2 / (r**2 * (
                                               b.drum_ro**2 - b.drum_ri**2))))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Mechanical Stress at Circumferential Direction"
                          "for Drum")
@@ -798,7 +798,7 @@ discretizing length domain (default=3)"""))
                     ) * b.drum_ri**2 * b.drum_ro**2 / (
                         r**2 * (b.drum_ro**2 - b.drum_ri**2))))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Mechanical Stress at Axial Direction"
                          "for Drum")
         def mech_sigma_z(b, t):
@@ -807,7 +807,7 @@ discretizing length domain (default=3)"""))
                 - b.pressure_amb*b.drum_ro**2
                 ) / (b.drum_ro**2 - b.drum_ri**2))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Principal Structural Stress"
                          "at Radial Direction for Drum")
@@ -820,7 +820,7 @@ discretizing length domain (default=3)"""))
                 return b.mech_sigma_r[t, r] + \
                                 b.therm_sigma_r[t, r]
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Principal Structural Stress"
                              "at Circumferential Direction for Drum")
@@ -828,14 +828,14 @@ discretizing length domain (default=3)"""))
             return b.mech_sigma_theta[t, r] \
                         + b.therm_sigma_theta[t, r]
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc="Principal Structural Stress"
                              "at Axial Direction for Drum")
         def sigma_z(b, t, r):
             return b.mech_sigma_z[t] + b.therm_sigma_z[t, r]
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc='Equivalent von Mises Stress for Drum')
         def sigma_von_Mises(b, t, r):
@@ -849,21 +849,21 @@ discretizing length domain (default=3)"""))
                            + b.sigma_theta[t, r]
                            * b.sigma_z[t, r]))
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc='Variation Principal Stress'
                          'between Radial-Circumferential Directions for Drum')
         def delta_sigma_r_theta(b, t, r):
             return abs(b.sigma_r[t, r] - b.sigma_theta[t, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc='Variation Principal Stress'
                          'between Circumferential-Axial Directions for Drum')
         def delta_sigma_theta_z(b, t, r):
             return abs(b.sigma_theta[t, r]-b.sigma_z[t, r])
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          self.radial_domain,
                          doc='Variation Principal Stress'
                          'between Axial-Radial Directions for Drum')
@@ -904,7 +904,7 @@ discretizing length domain (default=3)"""))
                    + 0.81 * k_t_A**2)
 
         # mechanical stress at circumferential direction
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Mechanical Stress '
                          'at Circumferential Direction'
                          'for Drum (EN 12952-3)')
@@ -913,7 +913,7 @@ discretizing length domain (default=3)"""))
                     pressure * r_ms_drum / self.drum_thickness
 
         # thermal stress at circumferential direction
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Thermal Stress at Circumferential'
                              'Direction for Drum (EN 12952-3)')
         def sigma_t(b, t):
@@ -927,27 +927,27 @@ discretizing length domain (default=3)"""))
         # stress at crotch corner P1 and location P2
 
         # mechanical stress by pressure at crotch corner
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Mechanical Stress at Crotch Corner'
                          'for Drum')
         def sigma_p_P1(b, t):
             return b.sigma_p[t] * k_m
 
         # mechanical stress at location P2
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Mechanical Stress at'
                              'Critical Point P2 for Drum')
         def sigma_p_P2(b, t):
             return b.sigma_p[t] * k_m / 5
 
         # thermal stress at crotch corner
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Thermal Stress at Crotch Corner for Drum')
         def sigma_t_P1(b, t):
             return b.sigma_t[t] * k_t
 
         # thermal stress at location P2
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Thermal Stress'
                          'at Critical Point P2 for Drum')
         def sigma_t_P2(b, t):
@@ -955,14 +955,14 @@ discretizing length domain (default=3)"""))
 
         # total circumferential stress with notch effect
         # crotch corner P1
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Circumferential Stress'
                          'at Crotch Corner for Drum')
         def sigma_theta_P1(b, t):
             return b.sigma_p_P1[t] + b.sigma_t_P1[t]
 
         # location P2
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Circumferential Stress'
                          'at Critical Point P2 for Drum')
         def sigma_theta_P2(b, t):
@@ -970,14 +970,14 @@ discretizing length domain (default=3)"""))
 
         # total stress with notch effect // f1 - f2
         # crotch corner
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Total Stress at Crotch Corner for Drum')
         def sigma_notch_P1(b, t):
             return b.sigma_theta_P1[t] \
                 + 1e-6 * b.control_volume.properties_out[t].pressure
 
         # location P2
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Total Stress at Critial Point P2 for Header')
         def sigma_notch_P2(b, t):
             return b.sigma_theta_P2[t] \
@@ -985,7 +985,7 @@ discretizing length domain (default=3)"""))
 
         # Von Mises equivalent stress
         # VM stress at crotch corner
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Equivalent von Mises Stress'
                              'at Crotch Corner for Drum')
         def sigma_eff_P1(b, t):
@@ -998,7 +998,7 @@ discretizing length domain (default=3)"""))
                     * (-1e-6 * p_in)))
 
         # VM stress at location P2
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc='Equivalent von Mises Stress'
                          'at Critical Point P2 for Drum')
         def sigma_eff_P2(b, t):
@@ -1120,7 +1120,7 @@ discretizing length domain (default=3)"""))
         blk.drum_wall_temperature[:, :].unfix()
 
         # Fix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].pressure.fix(
                 value(blk.control_volume.properties_in[0].pressure) - 5000.0)
             blk.control_volume.properties_out[t].enth_mol.fix(
@@ -1135,7 +1135,7 @@ discretizing length domain (default=3)"""))
                     idaeslog.condition(res)))
 
         # Unfix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].pressure.unfix()
             blk.control_volume.properties_out[t].enth_mol.unfix()
         blk.pressure_change_total_eqn.activate()

--- a/idaes/power_generation/unit_models/feedwater_heater_0D.py
+++ b/idaes/power_generation/unit_models/feedwater_heater_0D.py
@@ -154,13 +154,13 @@ class FWHCondensing0DData(HeatExchangerData):
     def build(self):
         super().build()
         units_meta = self.shell.config.property_package.get_metadata()
-        self.enth_sub = Var(self.flowsheet().config.time,
+        self.enth_sub = Var(self.flowsheet().time,
                             initialize=0,
                             units=units_meta.get_derived_units("energy_mole"))
         self.enth_sub.fix()
 
         @self.Constraint(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Calculate steam extraction rate such that all steam condenses",
         )
         def extraction_rate_constraint(b, t):
@@ -246,7 +246,7 @@ class FWH0DData(UnitModelBlockData):
             }
             self.drain_mix = Mixer(default=mix_cfg)
 
-            @self.drain_mix.Constraint(self.drain_mix.flowsheet().config.time)
+            @self.drain_mix.Constraint(self.drain_mix.flowsheet().time)
             def mixer_pressure_constraint(b, t):
                 """
                 Constraint to set the drain mixer pressure to the pressure of

--- a/idaes/power_generation/unit_models/feedwater_heater_0D_dynamic.py
+++ b/idaes/power_generation/unit_models/feedwater_heater_0D_dynamic.py
@@ -155,7 +155,7 @@ class FWHCondensing0DData(CondenserData):
                                    doc="Inside diameter of FWH tank")
         self.cond_sect_length = Var(initialize=10,
                                     doc="Length of condensing section")
-        self.level = Var(self.flowsheet().config.time,
+        self.level = Var(self.flowsheet().time,
                          initialize=1,
                          doc="Water level in condensing section")
 
@@ -166,13 +166,13 @@ class FWHCondensing0DData(CondenserData):
 
         # Expressure for the angle from the tank cylinder center to
         # the circumference point at water level between -pi/2 and pi/2
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Angle of water level")
         def alpha(b, t):
             return asin((b.level[t]-b.heater_radius)/b.heater_radius)
 
         # Constraint to calculate the shell side liquid volume
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Calculate the volume of "
                          "shell side based on water level")
         def shell_volume_eqn(b, t):
@@ -183,7 +183,7 @@ class FWHCondensing0DData(CondenserData):
                 * b.cond_sect_length*b.vol_frac_shell)
 
         # Total pressure change equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pressure drop")
         def pressure_change_total_eqn(b, t):
             return b.shell.deltaP[t] == const.acceleration_gravity*b.level[t]\
@@ -270,7 +270,7 @@ class FWH0DDynamicData(UnitModelBlockData):
                        }
             self.drain_mix = Mixer(default=mix_cfg)
 
-            @self.drain_mix.Constraint(self.drain_mix.flowsheet().config.time)
+            @self.drain_mix.Constraint(self.drain_mix.flowsheet().time)
             def mixer_pressure_constraint(b, t):
                 """
                 Constraint to set the drain mixer pressure to the pressure of

--- a/idaes/power_generation/unit_models/heat_exchanger_3streams.py
+++ b/idaes/power_generation/unit_models/heat_exchanger_3streams.py
@@ -273,12 +273,12 @@ exchanger (default = 'counter-current' - counter-current flow arrangement"""))
 
         # UA (product of overall heat transfer coefficient and area)
         # between side 1 and side 2
-        self.ua_side_2 = Var(self.flowsheet().config.time, initialize=10.0,
+        self.ua_side_2 = Var(self.flowsheet().time, initialize=10.0,
                              doc='UA between side 1 and side 2')
 
         # UA (product of overall heat transfer coefficient and area)
         # between side 1 and side 3
-        self.ua_side_3 = Var(self.flowsheet().config.time, initialize=10.0,
+        self.ua_side_3 = Var(self.flowsheet().time, initialize=10.0,
                              doc='UA between side 1 and side 3')
 
         # fraction of heat from hot stream as heat loss to ambient
@@ -312,45 +312,43 @@ exchanger (default = 'counter-current' - counter-current flow arrangement"""))
 
         # Performance parameters and variables
         # Temperature driving force
-        self.temperature_driving_force_side_2 = Var(self.flowsheet().config.
-                                                    time,
+        self.temperature_driving_force_side_2 = Var(self.flowsheet().time,
                                                     initialize=1.0,
                                                     doc='Mean driving force '
                                                     'for heat exchange')
 
         # Temperature driving force
-        self.temperature_driving_force_side_3 = Var(self.flowsheet().
-                                                    config.time,
+        self.temperature_driving_force_side_3 = Var(self.flowsheet().time,
                                                     initialize=1.0,
                                                     doc='Mean driving force '
                                                     'for heat exchange')
 
         # Temperature difference at side 2 inlet
-        self.side_2_inlet_dT = Var(self.flowsheet().config.time,
+        self.side_2_inlet_dT = Var(self.flowsheet().time,
                                    initialize=1.0,
                                    doc='Temperature difference '
                                    'at side 2 inlet')
 
         # Temperature difference at side 2 outlet
-        self.side_2_outlet_dT = Var(self.flowsheet().config.time,
+        self.side_2_outlet_dT = Var(self.flowsheet().time,
                                     initialize=1.0,
                                     doc='Temperature difference '
                                     'at side 2 outlet')
 
         # Temperature difference at side 3 inlet
-        self.side_3_inlet_dT = Var(self.flowsheet().config.time,
+        self.side_3_inlet_dT = Var(self.flowsheet().time,
                                    initialize=1.0,
                                    doc='Temperature difference'
                                    ' at side 3 inlet')
 
         # Temperature difference at side 3 outlet
-        self.side_3_outlet_dT = Var(self.flowsheet().config.time,
+        self.side_3_outlet_dT = Var(self.flowsheet().time,
                                     initialize=1.0,
                                     doc='Temperature difference '
                                     'at side 3 outlet')
 
         # Driving force side 2 (Underwood approximation)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Log mean temperature difference calculation "
                          "using Underwood approximation")
         def LMTD_side_2(b, t):
@@ -359,7 +357,7 @@ exchanger (default = 'counter-current' - counter-current flow arrangement"""))
                   + b.side_2_outlet_dT[t]**(1/3))/2)**(3)
 
         # Driving force side 3 (Underwood approximation)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Log mean temperature difference calculation "
                          "using Underwood approximation")
         def LMTD_side_3(b, t):
@@ -368,21 +366,21 @@ exchanger (default = 'counter-current' - counter-current flow arrangement"""))
                   + b.side_3_outlet_dT[t]**(1/3))/2)**(3)
 
         # Heat duty side 2
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Heat transfer rate")
         def heat_duty_side_2_eqn(b, t):
             return b.heat_duty_side_2[t] == \
                 (b.ua_side_2[t] * b.temperature_driving_force_side_2[t])
 
         # Heat duty side 3
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Heat transfer rate")
         def heat_duty_side_3_eqn(b, t):
             return b.heat_duty_side_3[t] == \
                 (b.ua_side_3[t]*b.temperature_driving_force_side_3[t])
 
         # Energy balance equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Energy balance between two sides")
         def heat_duty_side_1_eqn(b, t):
             return -b.heat_duty_side_1[t]*(1-b.frac_heatloss) == \
@@ -395,14 +393,14 @@ exchanger (default = 'counter-current' - counter-current flow arrangement"""))
 
         """
         # Temperature Differences
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Side 2 inlet temperature difference")
         def side_2_inlet_dT_eqn(b, t):
             return b.side_2_inlet_dT[t] == (
                        b.side_1.properties_in[t].temperature -
                        b.side_2.properties_in[t].temperature)
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Side 2 outlet temperature difference")
         def side_2_outlet_dT_eqn(b, t):
             return b.side_2_outlet_dT[t] == (
@@ -414,14 +412,14 @@ exchanger (default = 'counter-current' - counter-current flow arrangement"""))
         Add temperature driving force Constraints for counter-current flow.
         """
         # Temperature Differences
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Side 2 inlet temperature difference")
         def side_2_inlet_dT_eqn(b, t):
             return b.side_2_inlet_dT[t] == (
                        b.side_1.properties_out[t].temperature -
                        b.side_2.properties_in[t].temperature)
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Side 2 outlet temperature difference")
         def side_2_outlet_dT_eqn(b, t):
             return b.side_2_outlet_dT[t] == (
@@ -433,14 +431,14 @@ exchanger (default = 'counter-current' - counter-current flow arrangement"""))
         Add temperature driving force Constraints for co-current flow.
         """
         # Temperature Differences
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Side 3 inlet temperature difference")
         def side_3_inlet_dT_eqn(b, t):
             return b.side_3_inlet_dT[t] == (
                        b.side_1.properties_in[t].temperature -
                        b.side_3.properties_in[t].temperature)
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Side 3 outlet temperature difference")
         def side_3_outlet_dT_eqn(b, t):
             return b.side_3_outlet_dT[t] == (
@@ -452,14 +450,14 @@ exchanger (default = 'counter-current' - counter-current flow arrangement"""))
         Add temperature driving force Constraints for counter-current flow.
         """
         # Temperature Differences
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Side 3 inlet temperature difference")
         def side_3_inlet_dT_eqn(b, t):
             return b.side_3_inlet_dT[t] == (
                        b.side_1.properties_out[t].temperature -
                        b.side_3.properties_in[t].temperature)
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Side 3 outlet temperature difference")
         def side_3_outlet_dT_eqn(b, t):
             return b.side_3_outlet_dT[t] == (

--- a/idaes/power_generation/unit_models/helm/condenser_ntu.py
+++ b/idaes/power_generation/unit_models/helm/condenser_ntu.py
@@ -132,7 +132,7 @@ class HelmNtuCondenserData(UnitModelBlockData):
         super().build()
         self._process_config()
         config = self.config
-        time = self.flowsheet().config.time
+        time = self.flowsheet().time
 
         ########################################################################
         # Add control volumes                                                  #

--- a/idaes/power_generation/unit_models/helm/mixer.py
+++ b/idaes/power_generation/unit_models/helm/mixer.py
@@ -180,13 +180,13 @@ between flow and pressure driven simulations.}""",
         self.add_inlet_state_blocks()
         self.add_mixed_state_block()
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def mass_balance(b, t):
             return self.mixed_state[t].flow_mol == sum(
                 self.inlet_blocks[i][t].flow_mol for i in self.inlet_list
             )
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def energy_balance(b, t):
             return self.mixed_state[t].enth_mol*self.mixed_state[t].flow_mol == \
                 sum(self.inlet_blocks[i][t].enth_mol
@@ -259,7 +259,7 @@ between flow and pressure driven simulations.}""",
         # Create an instance of StateBlock for all inlets
         for i in self.inlet_list:
             i_obj = self.config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 doc="Material properties at inlet",
                 default=tmp_dict,
             )
@@ -279,7 +279,7 @@ between flow and pressure driven simulations.}""",
         tmp_dict["defined_state"] = False
 
         self.mixed_state = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Material properties of mixed stream",
             default=tmp_dict,
         )
@@ -303,7 +303,7 @@ between flow and pressure driven simulations.}""",
 
         # Calculate minimum inlet pressure
         @self.Expression(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             self.inlet_list,
             doc="Calculation for minimum inlet pressure",
         )
@@ -318,7 +318,7 @@ between flow and pressure driven simulations.}""",
 
         # Set inlet pressure to minimum pressure
         @self.Constraint(
-            self.flowsheet().config.time, doc="Link pressure to control volume")
+            self.flowsheet().time, doc="Link pressure to control volume")
         def minimum_pressure_constraint(b, t):
             return self.mixed_state[t].pressure == (
                 self.minimum_pressure[t, self.inlet_list[-1]]
@@ -333,7 +333,7 @@ between flow and pressure driven simulations.}""",
         """
         # Create equality constraints
         @self.Constraint(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             self.inlet_list,
             doc="Calculation for minimum inlet pressure",
         )

--- a/idaes/power_generation/unit_models/helm/phase_separator.py
+++ b/idaes/power_generation/unit_models/helm/phase_separator.py
@@ -83,49 +83,49 @@ see property package for documentation.}"""))
         super(WaterFlashData, self).build()
 
         self.mixed_state = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             default=self.config.property_package_args)
 
         self.add_port("inlet", self.mixed_state)
 
         self.vap_state = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             default=self.config.property_package_args)
 
         self.liq_state = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             default=self.config.property_package_args)
 
         self.add_port("vap_outlet", self.vap_state)
         self.add_port("liq_outlet", self.liq_state)
         # vapor outlet state
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def vap_material_balance(b, t):
             return 1e-4*b.mixed_state[t].flow_mol*b.mixed_state[t].vapor_frac == \
                 b.vap_state[t].flow_mol*1e-4
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def vap_enthalpy_balance(b, t):
             return b.mixed_state[t].enth_mol_phase["Vap"]*1e-4 == \
                 b.vap_state[t].enth_mol*1e-4
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def vap_pressure_balance(b, t):
             return b.mixed_state[t].pressure*1e-6 == \
                 b.vap_state[t].pressure*1e-6
 
         # liquid outlet state
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def liq_material_balance(b, t):
             return 1e-4*b.mixed_state[t].flow_mol*(1 - b.mixed_state[t].vapor_frac)\
                 == b.liq_state[t].flow_mol*1e-4
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def liq_enthalpy_balance(b, t):
             return 1e-4*b.mixed_state[t].enth_mol_phase["Liq"] == \
                 b.liq_state[t].enth_mol*1e-4
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def liq_pressure_balance(b, t):
             return b.mixed_state[t].pressure*1e-6 == \
                 b.liq_state[t].pressure*1e-6
@@ -158,7 +158,7 @@ see property package for documentation.}"""))
                                   state_args_water_steam)
         blk.mixed_state.initialize(solver=solver, optarg=optarg, outlvl=outlvl)
         # initialize outlet states
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.vap_state[t].flow_mol = value(blk.mixed_state[t].
                                               flow_mol*blk.mixed_state[t].
                                               vapor_frac)

--- a/idaes/power_generation/unit_models/helm/splitter.py
+++ b/idaes/power_generation/unit_models/helm/splitter.py
@@ -134,7 +134,7 @@ from 1 to num_outlets).}""",
         Returns:
             None
         """
-        time = self.flowsheet().config.time
+        time = self.flowsheet().time
         super().build()
 
         self._get_property_package()
@@ -176,7 +176,7 @@ from 1 to num_outlets).}""",
         tmp_dict = dict(**self.config.property_package_args)
         tmp_dict["defined_state"] = True
         self.mixed_state = self.config.property_package.build_state_block(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Material properties of mixed (inlet) stream",
             default=tmp_dict,
         )
@@ -236,7 +236,7 @@ from 1 to num_outlets).}""",
         # Create an instance of StateBlock for all outlets
         for o in self.outlet_list:
             o_obj = self.config.property_package.build_state_block(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 doc="Material properties at outlet",
                 default=tmp_dict,
             )
@@ -285,14 +285,14 @@ from 1 to num_outlets).}""",
 
         # check for fixed outlet flows and use them to calculate fixed split
         # fractions
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             for o in self.outlet_list:
                 if self.outlet_blocks[o][t].flow_mol.fixed:
                     self.split_fraction[t, o].fix(
                         value(self.mixed_state[t]/self.outlet_blocks[o][t].flow_mol))
 
         # fix or unfix split fractions so n - 1 are fixed
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             # see how many split fractions are fixed
             n = sum(1 for o in self.outlet_list if self.split_fraction[t, o].fixed)
             # if number of outlets - 1 we're good

--- a/idaes/power_generation/unit_models/helm/tests/test_turbine_multistage.py
+++ b/idaes/power_generation/unit_models/helm/tests/test_turbine_multistage.py
@@ -123,7 +123,7 @@ def test_initialize():
     def reheat_T_rule(b, t):
         return m.fs.reheat.control_volume.properties_out[t].temperature == 880
     m.fs.reheat.temperature_out_equation = pyo.Constraint(
-            m.fs.reheat.flowsheet().config.time,
+            m.fs.reheat.flowsheet().time,
             rule=reheat_T_rule)
 
     pyo.TransformationFactory("network.expand_arcs").apply_to(m)
@@ -203,7 +203,7 @@ def test_initialize_calc_cf():
     def reheat_T_rule(b, t):
         return m.fs.reheat.control_volume.properties_out[t].temperature == 880
     m.fs.reheat.temperature_out_equation = pyo.Constraint(
-            m.fs.reheat.flowsheet().config.time,
+            m.fs.reheat.flowsheet().time,
             rule=reheat_T_rule)
 
     pyo.TransformationFactory("network.expand_arcs").apply_to(m)

--- a/idaes/power_generation/unit_models/helm/turbine.py
+++ b/idaes/power_generation/unit_models/helm/turbine.py
@@ -94,14 +94,14 @@ class HelmIsentropicTurbineData(BalanceBlockData):
         te = ThermoExpr(blk=self, parameters=config.property_package)
 
         eff = self.efficiency_isentropic = pyo.Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             initialize=0.9,
             doc="Isentropic efficiency"
         )
         eff.fix()
 
         pratio = self.ratioP = pyo.Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             initialize=0.7,
             doc="Ratio of outlet to inlet pressure"
         )
@@ -111,21 +111,21 @@ class HelmIsentropicTurbineData(BalanceBlockData):
         properties_out = self.control_volume.properties_out
 
         @self.Expression(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Outlet isentropic enthalpy"
         )
         def h_is(b, t):
             return te.h(s=properties_in[t].entr_mol, p=properties_out[t].pressure)
 
         @self.Expression(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Isentropic enthalpy change"
         )
         def delta_enth_isentropic(b, t):
             return self.h_is[t] - properties_in[t].enth_mol
 
         @self.Expression(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Isentropic work"
         )
         def work_isentropic(b, t):
@@ -133,23 +133,23 @@ class HelmIsentropicTurbineData(BalanceBlockData):
                 properties_in[t].enth_mol - self.h_is[t])
 
         @self.Expression(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             doc="Outlet enthalpy"
         )
         def h_o(b, t): # Early access to the outlet enthalpy and work
             return properties_in[t].enth_mol - eff[t]*(
                 properties_in[t].enth_mol - self.h_is[t])
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def eq_work(b, t): # Work from energy balance
             return properties_out[t].enth_mol == self.h_o[t]
 
-        @self.Constraint(self.flowsheet().config.time)
+        @self.Constraint(self.flowsheet().time)
         def eq_pressure_ratio(b, t):
             return (pratio[t]*properties_in[t].pressure ==
                 properties_out[t].pressure)
 
-        @self.Expression(self.flowsheet().config.time)
+        @self.Expression(self.flowsheet().time)
         def work_mechanical(b, t):
             return b.control_volume.work[t]
 
@@ -182,7 +182,7 @@ class HelmIsentropicTurbineData(BalanceBlockData):
         sp = StoreSpec.value_isfixed_isactive(only_fixed=True)
         istate = to_json(self, return_dict=True, wts=sp)
         # Check for alternate pressure specs
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             if self.outlet.pressure[t].fixed:
                 self.ratioP[t] = pyo.value(
                     self.outlet.pressure[t]/self.inlet.pressure[t])
@@ -199,7 +199,7 @@ class HelmIsentropicTurbineData(BalanceBlockData):
         self.ratioP.fix()
         self.deltaP.unfix()
         self.efficiency_isentropic.fix()
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             self.outlet.pressure[t] = pyo.value(
                 self.inlet.pressure[t]*self.ratioP[t])
             self.deltaP[t] = pyo.value(

--- a/idaes/power_generation/unit_models/helm/turbine_multistage.py
+++ b/idaes/power_generation/unit_models/helm/turbine_multistage.py
@@ -495,8 +495,8 @@ class HelmTurbineMultistageData(UnitModelBlockData):
             )
 
         self.power = pyo.Var(
-            self.flowsheet().config.time, initialize=-1e8, doc="power (W)")
-        @self.Constraint(self.flowsheet().config.time)
+            self.flowsheet().time, initialize=-1e8, doc="power (W)")
+        @self.Constraint(self.flowsheet().time)
         def power_eqn(b, t):
             return (b.power[t] ==
                 b.outlet_stage.control_volume.work[t]*b.outlet_stage.efficiency_mech

--- a/idaes/power_generation/unit_models/helm/turbine_outlet.py
+++ b/idaes/power_generation/unit_models/helm/turbine_outlet.py
@@ -60,7 +60,7 @@ class HelmTurbineOutletStageData(HelmIsentropicTurbineData):
         self.flow_coeff.fix()
         self.efficiency_mech.fix()
 
-        @self.Expression(self.flowsheet().config.time, doc="Eff. fact. correlation")
+        @self.Expression(self.flowsheet().time, doc="Eff. fact. correlation")
         def tel(b, t):
             f = b.control_volume.properties_out[t].flow_vol / b.design_exhaust_flow_vol
             return 1e6 * (
@@ -72,7 +72,7 @@ class HelmTurbineOutletStageData(HelmIsentropicTurbineData):
                 + 0.0064
             )*pyunits.J/pyunits.mol
 
-        @self.Constraint(self.flowsheet().config.time, doc="Stodola eq. choked flow")
+        @self.Constraint(self.flowsheet().time, doc="Stodola eq. choked flow")
         def stodola_equation(b, t):
             flow = b.control_volume.properties_in[t].flow_mol
             mw = b.control_volume.properties_in[t].mw
@@ -84,7 +84,7 @@ class HelmTurbineOutletStageData(HelmIsentropicTurbineData):
             return flow ** 2 * mw ** 2 * (Tin) == (
                 cf ** 2 * Pin ** 2 * (1 - Pr ** 2))
 
-        @self.Constraint(self.flowsheet().config.time, doc="Efficiency correlation")
+        @self.Constraint(self.flowsheet().time, doc="Efficiency correlation")
         def efficiency_correlation(b, t):
             x = b.control_volume.properties_out[t].vapor_frac
             eff = b.efficiency_isentropic[t]
@@ -92,11 +92,11 @@ class HelmTurbineOutletStageData(HelmIsentropicTurbineData):
             tel = b.tel[t]
             return eff == b.eff_dry * x * (1 - 0.65 * (1 - x)) * (1 + tel / dh_isen)
 
-        @self.Expression(self.flowsheet().config.time, doc="Thermodynamic power [J/s]")
+        @self.Expression(self.flowsheet().time, doc="Thermodynamic power [J/s]")
         def power_thermo(b, t):
             return b.control_volume.work[t]
 
-        @self.Expression(self.flowsheet().config.time, doc="Shaft power [J/s]")
+        @self.Expression(self.flowsheet().time, doc="Shaft power [J/s]")
         def power_shaft(b, t):
             return b.power_thermo[t] * b.efficiency_mech
 
@@ -127,7 +127,7 @@ class HelmTurbineOutletStageData(HelmIsentropicTurbineData):
         #   saves value, fixed, and active state, doesn't load originally free
         #   values, this makes sure original problem spec is same but initializes
         #   the values of free vars
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             if self.outlet.pressure[t].fixed:
                 self.ratioP[t] = value(
                     self.outlet.pressure[t]/self.inlet.pressure[t])
@@ -145,7 +145,7 @@ class HelmTurbineOutletStageData(HelmIsentropicTurbineData):
 
         super().initialize(outlvl=outlvl, solver=solver, optarg=optarg)
 
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             mw = self.control_volume.properties_in[t].mw
             Tin = self.control_volume.properties_in[t].temperature
             Pin = self.control_volume.properties_in[t].pressure

--- a/idaes/power_generation/unit_models/helm/turbine_stage.py
+++ b/idaes/power_generation/unit_models/helm/turbine_stage.py
@@ -44,7 +44,7 @@ class HelmTurbineStageData(HelmIsentropicTurbineData):
 
         self.efficiency_mech = Var(initialize=1.0, doc="Turbine mechanical efficiency")
         self.efficiency_mech.fix()
-        time_set = self.flowsheet().config.time
+        time_set = self.flowsheet().time
         self.shaft_speed = Var(time_set,
                                doc="Shaft speed [1/s]",
                                initialize=60.0,
@@ -63,7 +63,7 @@ class HelmTurbineStageData(HelmIsentropicTurbineData):
         def power_thermo(b, t):
             return b.control_volume.work[t]
 
-        @self.Expression(self.flowsheet().config.time, doc="Shaft power [J/s]")
+        @self.Expression(self.flowsheet().time, doc="Shaft power [J/s]")
         def power_shaft(b, t):
             return b.power_thermo[t] * b.efficiency_mech
 

--- a/idaes/power_generation/unit_models/helm/valve_steam.py
+++ b/idaes/power_generation/unit_models/helm/valve_steam.py
@@ -49,13 +49,13 @@ def _assert_properties(pb):
 
 
 def _linear_callback(blk):
-    @blk.Expression(blk.flowsheet().config.time)
+    @blk.Expression(blk.flowsheet().time)
     def valve_function(b, t):
         return b.valve_opening[t]
 
 
 def _quick_open_callback(blk):
-    @blk.Expression(blk.flowsheet().config.time)
+    @blk.Expression(blk.flowsheet().time)
     def valve_function(b, t):
         return pyo.sqrt(b.valve_opening[t])
 
@@ -63,7 +63,7 @@ def _quick_open_callback(blk):
 def _equal_percentage_callback(blk):
     blk.alpha = pyo.Var(initialize=1, doc="Valve function parameter")
     blk.alpha.fix()
-    @blk.Expression(blk.flowsheet().config.time)
+    @blk.Expression(blk.flowsheet().time)
     def valve_function(b, t):
         return b.alpha ** (b.valve_opening[t] - 1)
 
@@ -176,7 +176,7 @@ ValveFunctionType.custom}""",
         te = ThermoExpr(blk=self, parameters=config.property_package)
 
         self.valve_opening = pyo.Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             initialize=1,
             doc="Fraction open for valve from 0 to 1",
         )
@@ -214,7 +214,7 @@ ValveFunctionType.custom}""",
             rule = _vapor_pressure_flow_rule
 
         self.pressure_flow_equation = pyo.Constraint(
-            self.flowsheet().config.time, rule=rule
+            self.flowsheet().time, rule=rule
         )
 
 
@@ -247,7 +247,7 @@ ValveFunctionType.custom}""",
         sp = StoreSpec.value_isfixed_isactive(only_fixed=True)
         istate = to_json(self, return_dict=True, wts=sp)
         # Check for alternate pressure specs
-        for t in self.flowsheet().config.time:
+        for t in self.flowsheet().time:
             if self.outlet.pressure[t].fixed:
                 self.deltaP[t].fix(pyo.value(
                     self.outlet.pressure[t] - self.inlet.pressure[t]))

--- a/idaes/power_generation/unit_models/steamheater.py
+++ b/idaes/power_generation/unit_models/steamheater.py
@@ -234,7 +234,7 @@ see property package for documentation.}"""))
                 doc="Length of fin")
         # Thickness of slag layer
         self.slag_thickness = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.001,
                 doc="thickness of slag layer")
 
@@ -254,7 +254,7 @@ see property package for documentation.}"""))
         def alpha_tube(b):
             return asin(0.5*b.fin_thickness/b.radius_out)
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Angle at joint of tube "
                          "and fin at outside slag layer")
         def alpha_slag(b, t):
@@ -274,7 +274,7 @@ see property package for documentation.}"""))
         def perimeter_ts(b):
             return const.pi*b.diameter_in
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Perimeter on the outer slag side")
         def perimeter_ss(b, t):
             if self.config.single_side_only:
@@ -296,13 +296,13 @@ see property package for documentation.}"""))
                 + b.fin_thickness * b.fin_length
 
         # Cross section area of slag layer
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Cross section area of slag layer per tube")
         def area_cross_slag(b, t):
             return b.perimeter_if * b.slag_thickness[t]
 
         # Volume constraint
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="waterwall fluid volume of all tubes")
         def volume_eqn(b, t):
             return b.volume[t] == 0.25 * const.pi * b.diameter_in**2 \
@@ -355,39 +355,39 @@ see property package for documentation.}"""))
         # Add performance variables
         # Heat from fire side boiler model
         self.heat_fireside = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1e7,
                 doc='total heat from fire side model for the section')
         # Tube boundary wall temperature
         self.temp_tube_boundary = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=400.0,
                 doc='Temperature of tube boundary wall')
         # Tube center point wall temperature
         self.temp_tube_center = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=450.0,
                 doc='Temperature of tube center wall')
         # Slag boundary wall temperature
         self.temp_slag_boundary = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=600.0,
                 doc='Temperature of slag boundary wall')
         # Slag center point slag wall temperature
         self.temp_slag_center = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=500.0,
                 doc='Temperature of slag layer center point')
 
         # Energy holdup for slag layer
         self.energy_holdup_slag = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0,
                 doc='Energy holdup of slag layer')
 
         # Energy holdup for metal (tube + fin)
         self.energy_holdup_metal = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0,
                 doc='Energy holdup of metal')
 
@@ -395,11 +395,11 @@ see property package for documentation.}"""))
         if self.config.dynamic is True:
             self.energy_accumulation_slag = DerivativeVar(
                     self.energy_holdup_slag,
-                    wrt=self.flowsheet().config.time,
+                    wrt=self.flowsheet().time,
                     doc='Energy accumulation of slag layer')
             self.energy_accumulation_metal = DerivativeVar(
                     self.energy_holdup_metal,
-                    wrt=self.flowsheet().config.time,
+                    wrt=self.flowsheet().time,
                     doc='Energy accumulation of tube and fin metal')
 
         def energy_accumulation_term_slag(b, t):
@@ -410,55 +410,55 @@ see property package for documentation.}"""))
 
         # Velocity of steam
         self.velocity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=3.0,
                 doc='Velocity of steam')
 
         # Reynolds number based on liquid only flow
         self.N_Re = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0e6,
                 doc='Reynolds number')
 
         # Prandtl number of liquid phase
         self.N_Pr = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=2.0,
                 doc='Reynolds number')
 
         # Darcy friction factor
         self.friction_factor_darcy = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.01,
                 doc='Darcy friction factor')
 
         # Convective heat transfer coefficient on tube side,
         # typically in range (1000, 5e5)
         self.hconv = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=30000.0,
                 doc='Convective heat transfer coefficient')
 
         # Convective heat flux to fluid
         self.heat_flux_conv = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=7e4,
                 doc='Convective heat flux to fluid')
 
         # Fire-side heat flux
         self.heat_flux_fireside = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=100000.0,
                 doc='Fireside heat flux to slag boundary')
 
         # Slag-tube interface heat flux
         self.heat_flux_interface = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=100000.0,
                 doc='Slag-tube interface heat flux')
 
         # Equation to calculate heat flux to slag boundary
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="heat flux at slag outer layer")
         def heat_flux_fireside_from_boiler_eqn(b, t):
             if self.config.single_side_only:
@@ -469,7 +469,7 @@ see property package for documentation.}"""))
                     * b.perimeter_ss[t] == b.heat_fireside[t] * b.pitch * 2.0
 
         # Equation to calculate slag layer boundary temperature
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="slag layer boundary temperature")
         def slag_layer_boundary_temperature_eqn(b, t):
             return b.heat_flux_fireside[t] * 0.5 * b.slag_thickness[t] == \
@@ -477,7 +477,7 @@ see property package for documentation.}"""))
                                                      - b.temp_slag_center[t])
 
         # Equation to calculate heat flux at the slag-metal interface
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="heat flux at slag-tube interface")
         def heat_flux_interface_eqn(b, t):
             return b.heat_flux_interface[t] * 0.5 * \
@@ -486,7 +486,7 @@ see property package for documentation.}"""))
                    b.temp_slag_center[t] - b.temp_tube_center[t]
 
         # Equation to calculate heat flux at tube boundary
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="convective heat flux at tube boundary")
         def heat_flux_conv_eqn(b, t):
             return b.heat_flux_conv[t] == \
@@ -497,7 +497,7 @@ see property package for documentation.}"""))
                                     temperature)/2.0)
 
         # Equation to calculate tube boundary wall temperature
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="tube bounary wall temperature")
         def temperature_tube_boundary_eqn(b, t):
             return b.heat_flux_conv[t] * 0.5 * b.tube_thickness == \
@@ -505,7 +505,7 @@ see property package for documentation.}"""))
                 * (b.temp_tube_center[t] - b.temp_tube_boundary[t])
 
         # Equation to calculate energy holdup for slag layer per tube length
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="energy holdup for slag layer")
         def energy_holdup_slag_eqn(b, t):
             return b.energy_holdup_slag[t] == \
@@ -514,14 +514,14 @@ see property package for documentation.}"""))
 
         # Equation to calculate energy holdup for metal
         # (tube + fin) per tube length
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="energy holdup for metal")
         def energy_holdup_metal_eqn(b, t):
             return b.energy_holdup_metal[t] == b.temp_tube_center[t] \
                 * b.cp_metal * b.dens_metal * b.area_cross_metal
 
         # Energy balance for slag layer
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="energy balance for slag layer")
         def energy_balance_slag_eqn(b, t):
             return energy_accumulation_term_slag(b, t) == \
@@ -529,7 +529,7 @@ see property package for documentation.}"""))
                  - b.heat_flux_interface[t] * b.perimeter_if)
 
         # Energy balance for metal
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="energy balance for metal")
         def energy_balance_metal_eqn(b, t):
             return energy_accumulation_term_metal(b, t) == (
@@ -537,7 +537,7 @@ see property package for documentation.}"""))
                    b.heat_flux_conv[t] * b.perimeter_ts)
 
         # Expression to calculate slag/tube metal interface wall temperature
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Slag tube interface wall temperature")
         def temp_interface(b, t):
             return b.temp_tube_center[t] + b.heat_flux_interface[t] * 0.5 \
@@ -546,14 +546,14 @@ see property package for documentation.}"""))
         # Equations for calculate pressure drop
         # and convective heat transfer coefficient
         # Equation for calculating velocity
-        @self.Constraint(self.flowsheet().config.time, doc="Vecolity of fluid")
+        @self.Constraint(self.flowsheet().time, doc="Vecolity of fluid")
         def velocity_eqn(b, t):
             return 1e-3*b.velocity[t]*b.area_cross_fluid_total * \
                    b.control_volume.properties_in[t].dens_mol_phase["Vap"] \
                    == 1e-3*b.control_volume.properties_in[t].flow_mol
 
         # Equation for calculating Reynolds number if liquid only
-        @self.Constraint(self.flowsheet().config.time, doc="Reynolds number")
+        @self.Constraint(self.flowsheet().time, doc="Reynolds number")
         def Reynolds_number_eqn(b, t):
             return b.N_Re[t] * \
                    b.control_volume.properties_in[t].visc_d_phase["Vap"] == \
@@ -561,7 +561,7 @@ see property package for documentation.}"""))
                    b.control_volume.properties_in[t].dens_mass
 
         # Friction factor depending on laminar or turbulent flow
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Darcy friction factor")
         def friction_factor_darcy_eqn(b, t):
             return Expr_if(b.N_Re[t] < 1187.384, b.friction_factor_darcy[t]
@@ -570,7 +570,7 @@ see property package for documentation.}"""))
 
         # Pressure change equation due to friction,
         # -1/2*density*velocity^2*fD/diameter*length
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="pressure change due to friction")
         def pressure_change_eqn(b, t):
             return b.deltaP[t] * b.diameter_in == \
@@ -579,14 +579,14 @@ see property package for documentation.}"""))
                 * b.tube_length
 
         # Total heat added to control_volume
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="total heat added to fluid control_volume")
         def heat_eqn(b, t):
             return b.heat_duty[t] == b.number_tubes * b.heat_flux_conv[t] \
                 * b.tube_length * b.perimeter_ts
 
         # Prandtl number of steam
-        @self.Constraint(self.flowsheet().config.time, doc="Prandtl number")
+        @self.Constraint(self.flowsheet().time, doc="Prandtl number")
         def N_Pr_eqn(b, t):
             return b.N_Pr[t] \
                 * b.control_volume.properties_in[t].therm_cond_phase["Vap"] \
@@ -595,7 +595,7 @@ see property package for documentation.}"""))
                 b.control_volume.properties_in[t].visc_d_phase["Vap"]
 
         # Forced convection heat transfer coefficient for liquid only
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="forced convection heat transfer"
                          " coefficient for liquid only")
         def hconv_eqn(b, t):
@@ -655,7 +655,7 @@ see property package for documentation.}"""))
         init_log.info_high("Initialization Step 1 Complete.")
 
         # Fix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].enth_mol.fix(
                 value(blk.control_volume.properties_in[t].enth_mol) +
                 value(blk.heat_fireside[t]) /
@@ -675,7 +675,7 @@ see property package for documentation.}"""))
             )
 
         # Unfix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].enth_mol.unfix()
             blk.control_volume.properties_out[t].pressure.unfix()
         blk.heat_eqn.activate()

--- a/idaes/power_generation/unit_models/waterpipe.py
+++ b/idaes/power_generation/unit_models/waterpipe.py
@@ -217,7 +217,7 @@ mixed phase not supported'''))
                 doc="Cross section area ratio of exit end to pipe")
 
         # Volume constraint
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Total volume of all pipes")
         def volume_eqn(b, t):
             return b.volume[t] == 0.25 * const.pi * b.diameter**2 \
@@ -232,19 +232,19 @@ mixed phase not supported'''))
         # Add performance variables
         # Velocity of fluid inside pipe
         self.velocity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=10.0,
                 doc='Fluid velocity inside pipe')
 
         # Reynolds number
         self.N_Re = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=10000.0,
                 doc='Reynolds number')
 
         # Darcy friction factor
         self.friction_factor_darcy = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.005,
                 doc='Darcy friction factor')
 
@@ -254,24 +254,24 @@ mixed phase not supported'''))
 
         # Pressure change due to friction
         self.deltaP_friction = Var(
-            self.flowsheet().config.time,
+            self.flowsheet().time,
             initialize=-1.0,
             doc='Pressure change due to friction')
 
         # Pressure change due to gravity
         self.deltaP_gravity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.0,
                 doc='Pressure change due to gravity')
 
         # Pressure change due to area change at end
         self.deltaP_area_change = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.0,
                 doc='Pressure change due to area change')
 
         # Equation for calculating velocity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Velocity of fluid inside pipe")
         def velocity_eqn(b, t):
             return b.velocity[t]*0.25*const.pi*b.diameter**2\
@@ -279,7 +279,7 @@ mixed phase not supported'''))
                 b.control_volume.properties_in[t].flow_vol
 
         # Equation for calculating Reynolds number
-        @self.Constraint(self.flowsheet().config.time, doc="Reynolds number")
+        @self.Constraint(self.flowsheet().time, doc="Reynolds number")
         def Reynolds_number_eqn(b, t):
             return b.N_Re[t] * \
                    b.control_volume.properties_in[t].visc_d_phase[phase] == \
@@ -287,7 +287,7 @@ mixed phase not supported'''))
                    b.control_volume.properties_in[t].dens_mass_phase[phase]
 
         # Friction factor expression depending on laminar or turbulent flow
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Darcy friction factor as"
                          " a function of Reynolds number")
         def friction_factor_darcy_eqn(b, t):
@@ -295,7 +295,7 @@ mixed phase not supported'''))
                 0.3164 * b.fcorrection_dp
 
         # Pressure change equation for friction
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pressure change due to friction")
         def pressure_change_friction_eqn(b, t):
             return b.deltaP_friction[t] * b.diameter == \
@@ -304,7 +304,7 @@ mixed phase not supported'''))
                    b.velocity[t]**2 * b.friction_factor_darcy[t] * b.length
 
         # Pressure change equation for gravity
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pressure change due to gravity")
         def pressure_change_gravity_eqn(b, t):
             return b.deltaP_gravity[t] == -const.acceleration_gravity * \
@@ -312,7 +312,7 @@ mixed phase not supported'''))
                 * b.elevation_change
 
         # Pressure change equation for contraction or expansion
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pressure change due to gravity")
         def pressure_change_area_change_eqn(b, t):
             if self.config.contraction_expansion_at_end == "contraction":
@@ -331,7 +331,7 @@ mixed phase not supported'''))
                 return b.deltaP_area_change[t] == 0
 
         # Total pressure change equation
-        @self.Constraint(self.flowsheet().config.time, doc="Pressure drop")
+        @self.Constraint(self.flowsheet().time, doc="Pressure drop")
         def pressure_change_total_eqn(b, t):
             return b.deltaP[t] == (b.deltaP_friction[t]
                                    + b.deltaP_gravity[t]
@@ -378,7 +378,7 @@ mixed phase not supported'''))
         )
         init_log.info_high("Initialization Step 1 Complete.")
         # Fix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].pressure.fix(
                 value(blk.control_volume.properties_in[t].pressure)
             )
@@ -391,7 +391,7 @@ mixed phase not supported'''))
             )
 
         # Unfix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].pressure.unfix()
         blk.pressure_change_total_eqn.activate()
 

--- a/idaes/power_generation/unit_models/watertank.py
+++ b/idaes/power_generation/unit_models/watertank.py
@@ -239,7 +239,7 @@ see property package for documentation.}"""))
         """
 
         # Add performance variables
-        self.tank_level = Var(self.flowsheet().config.time,
+        self.tank_level = Var(self.flowsheet().time,
                               initialize=1.0,
                               doc="Water level from in the tank")
 
@@ -270,13 +270,13 @@ see property package for documentation.}"""))
                 return b.tank_diameter/2
             # Angle of the circular sector used to calculate the area
 
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc="Angle of the circular"
                              " sector of liquid level")
             def alpha_tank(b, t):
                 return 2*acos((b.tank_radius-b.tank_level[t])/b.tank_radius)
 
-            @self.Expression(self.flowsheet().config.time,
+            @self.Expression(self.flowsheet().time,
                              doc="Area covered by the liquid level"
                              " at one end of the tank")
             def tank_area(b, t):
@@ -286,7 +286,7 @@ see property package for documentation.}"""))
                        - b.tank_level[t]**2)**0.5
 
         # Constraint for volume of the liquid in tank
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="volume of liquid in the tank")
         def volume_eqn(b, t):
             if self.config.tank_type == "horizontal_cylindrical_tank":
@@ -295,7 +295,7 @@ see property package for documentation.}"""))
                 return b.volume[t] == b.tank_level[t]*b.tank_cross_sect_area
 
         # Pressure change equation due gravity
-        @self.Constraint(self.flowsheet().config.time, doc="pressure drop")
+        @self.Constraint(self.flowsheet().time, doc="pressure drop")
         def pressure_change_eqn(b, t):
             return b.deltaP[t] == \
                 b.control_volume.properties_in[t].dens_mass_phase["Liq"] * \
@@ -349,7 +349,7 @@ see property package for documentation.}"""))
         init_log.info_high("Initialization Step 1 Complete.")
 
         # Fix outlet pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].pressure.\
                 fix(value(blk.control_volume.properties_in[t].pressure))
         blk.pressure_change_eqn.deactivate()
@@ -362,7 +362,7 @@ see property package for documentation.}"""))
             )
 
         # Unfix outlet pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].pressure.unfix()
         blk.pressure_change_eqn.activate()
 

--- a/idaes/power_generation/unit_models/waterwall_section.py
+++ b/idaes/power_generation/unit_models/waterwall_section.py
@@ -284,7 +284,7 @@ constructed,
                 units=units_meta.get_derived_units("length"))
         # Thickness of slag layer
         self.slag_thickness = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 bounds=(0.0001, 0.009),
                 initialize=0.001,
                 doc="Thickness of slag layer",
@@ -304,7 +304,7 @@ constructed,
         def alpha_tube(b):
             return asin(b.fin_thickness_half/b.radius_outer)
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Angle at joint of tube and "
                          "fin at outside slag layer")
         def alpha_slag(b, t):
@@ -320,7 +320,7 @@ constructed,
         def perimeter_ts(b):
             return const.pi*b.tube_diameter
 
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Perimeter on the outer slag side")
         def perimeter_ss(b, t):
             return (const.pi - 2 * b.alpha_slag[t]) * (b.radius_outer
@@ -335,13 +335,13 @@ constructed,
                 + b.fin_thickness*b.fin_length
 
         # Cross section area of slag layer
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Cross section area of slag layer per tube")
         def area_cross_slag(b, t):
             return b.perimeter_interface*b.slag_thickness[t]
 
         # Volume constraint
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="waterwall fluid volume of all tubes")
         def volume_eqn(b, t):
             return b.volume[t] == 0.25 * const.pi * b.tube_diameter**2\
@@ -421,7 +421,7 @@ constructed,
 
         # Heat conduction resistance of half of slag thickness
         # based on mid slag layer perimeter
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="half slag layer conduction resistance")
         def half_resistance_slag(b, t):
             return b.slag_thickness[t]/2/b.therm_cond_slag * b.fshape_slag \
@@ -430,38 +430,38 @@ constructed,
         # Add performance variables
         # Heat from fire side boiler model
         self.heat_fireside = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1e7,
                 doc='total heat from fire side model for the section',
                 units=units_meta.get_derived_units("power"))
         # Tube boundary wall temperature
         self.temp_tube_boundary = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=400.0,
                 doc='Temperature of tube boundary wall',
                 units=units_meta.get_derived_units("temperature"))
         # Tube center point wall temperature
         self.temp_tube_center = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=450.0,
                 doc='Temperature of tube center wall',
                 units=units_meta.get_derived_units("temperature"))
         # Slag boundary wall temperature
         self.temp_slag_boundary = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=600.0,
                 doc='Temperature of slag boundary wall',
                 units=units_meta.get_derived_units("temperature"))
         # Slag center point wall temperature
         self.temp_slag_center = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=500.0,
                 doc='Temperature of slag layer center point',
                 units=units_meta.get_derived_units("temperature"))
 
         # Energy holdup for slag layer
         self.energy_holdup_slag = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1e4,
                 doc='Energy holdup of slag layer',
                 units=(units_meta.get_derived_units("energy") *
@@ -469,7 +469,7 @@ constructed,
 
         # Energy holdup for metal (tube + fin)
         self.energy_holdup_metal = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1e6,
                 doc='Energy holdup of metal',
                 units=(units_meta.get_derived_units("energy") *
@@ -479,11 +479,11 @@ constructed,
         if self.config.dynamic is True:
             self.energy_accumulation_slag = DerivativeVar(
                 self.energy_holdup_slag,
-                wrt=self.flowsheet().config.time,
+                wrt=self.flowsheet().time,
                 doc='Energy accumulation of slag layer')
             self.energy_accumulation_metal = DerivativeVar(
                 self.energy_holdup_metal,
-                wrt=self.flowsheet().config.time,
+                wrt=self.flowsheet().time,
                 doc='Energy accumulation of tube and fin metal')
 
         def energy_accumulation_term_slag(b, t):
@@ -494,88 +494,88 @@ constructed,
 
         # Velocity of liquid only
         self.velocity_liquid = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=3.0,
                 doc='Velocity of liquid only',
                 units=units_meta.get_derived_units("velocity"))
 
         # Reynolds number based on liquid only flow
         self.N_Re = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0e6,
                 doc='Reynolds number')
 
         # Prandtl number of liquid phase
         self.N_Pr = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=2.0,
                 doc='Reynolds number')
 
         # Darcy friction factor
         self.friction_factor_darcy = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.01,
                 doc='Darcy friction factor')
 
         # Vapor fraction at inlet
         self.vapor_fraction = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.0,
                 doc='Vapor fractoin of vapor-liquid mixture')
 
         # Liquid fraction at inlet
         self.liquid_fraction = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0,
                 doc='Liquid fractoin of vapor-liquid mixture')
 
         # Density ratio of liquid to vapor
         self.ratio_density = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.0,
                 doc='Liquid to vapor density ratio')
 
         # Void fraction at inlet
         self.void_fraction = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.0,
                 doc='void fraction at inlet')
 
         # Exponent n for gamma at inlet, typical range in (0.75,0.8294)
         self.n_exp = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.82,
                 doc='exponent for gamma at inlet')
 
         # Gamma for velocity slip at inlet
         self.gamma = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=3.0,
                 doc='gamma for velocity slip at inlet')
 
         # Mass flux
         self.mass_flux = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1000.0,
                 doc='mass flux',
                 units=units_meta.get_derived_units("flux_mass"))
 
         # Reduced pressure
         self.reduced_pressure = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.85,
                 doc='reduced pressure')
 
         # Two-phase correction factor
         self.phi_correction = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.01,
                 doc='Two-phase flow correction factor')
 
         # Convective heat transfer coefficient on tube side,
         # typically in range (1000, 5e5)
         self.hconv = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=30000.0,
                 doc='Convective heat transfer coefficient',
                 units=units_meta.get_derived_units(
@@ -584,7 +584,7 @@ constructed,
         # Convective heat transfer coefficient for liquid only,
         # typically in range (1000.0, 1e5)
         self.hconv_liquid = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=20000.0,
                 doc='Convective heat transfer coefficient of liquid only',
                 units=units_meta.get_derived_units(
@@ -592,7 +592,7 @@ constructed,
 
         # Pool boiling heat transfer coefficient, typically in range (1e4, 5e5)
         self.hpool = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1e5,
                 doc='Pool boiling heat transfer coefficient',
                 units=units_meta.get_derived_units(
@@ -601,66 +601,66 @@ constructed,
         # Boiling number, typical range in (1e-7, 5e-4) in original formula.
         # we define here as boiling_number_scaled == 1e6*boiling_number
         self.boiling_number_scaled = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1,
                 doc='Scaled boiling number')
 
         # Enhancement factor, typical range in (1.0, 3.0)
         self.enhancement_factor = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=1.3,
                 doc='Enhancement factor')
 
         # Suppression factor, typical range in (0.005, 1.0)
         self.suppression_factor = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=0.03,
                 doc='Suppression factor')
 
         # Convective heat flux to fluid
         self.heat_flux_conv = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=7e4,
                 doc='Convective heat flux to fluid',
                 units=units_meta.get_derived_units("flux_energy"))
 
         # Slag-tube interface heat flux
         self.heat_flux_interface = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=100000.0,
                 doc='Slag-tube interface heat flux',
                 units=units_meta.get_derived_units("flux_energy"))
 
         # Pressure change due to friction
         self.deltaP_friction = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=-1000.0,
                 doc='Pressure change due to friction',
                 units=units_meta.get_derived_units("pressure"))
 
         # Pressure change due to gravity
         self.deltaP_gravity = Var(
-                self.flowsheet().config.time,
+                self.flowsheet().time,
                 initialize=-1000.0,
                 doc='Pressure change due to gravity',
                 units=units_meta.get_derived_units("pressure"))
 
         # Equation to calculate heat flux to slag boundary
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="heat flux at slag outer layer")
         def heat_flux_fireside(b, t):
             return (b.heat_fireside[t] * b.pitch /
                     (b.projected_area * b.perimeter_ss[t]))
 
         # Equation to calculate slag layer boundary temperature
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="slag layer boundary temperature")
         def slag_layer_boundary_temperature_eqn(b, t):
             return b.heat_flux_fireside[t] * b.half_resistance_slag[t] == \
                    (b.temp_slag_boundary[t] - b.temp_slag_center[t])
 
         # Equation to calculate heat flux at the slag-metal interface
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="heat flux at slag-tube interface")
         def heat_flux_interface_eqn(b, t):
             return b.heat_flux_interface[t] \
@@ -668,7 +668,7 @@ constructed,
                 (b.temp_slag_center[t] - b.temp_tube_center[t])
 
         # Equation to calculate heat flux at tube boundary
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="convective heat flux at tube boundary")
         def heat_flux_conv_eqn(b, t):
             return b.heat_flux_conv[t] * b.fshape_conv * b.perimeter_ts ==\
@@ -677,7 +677,7 @@ constructed,
                    - b.control_volume.properties_in[t].temperature)
 
         # Equation to calculate tube boundary wall temperature
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="tube bounary wall temperature")
         def temperature_tube_boundary_eqn(b, t):
             return b.heat_flux_conv[t] * b.half_resistance_metal \
@@ -686,7 +686,7 @@ constructed,
                                          - b.temp_tube_boundary[t])
 
         # Equation to calculate energy holdup for slag layer per tube length
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="energy holdup for slag layer")
         def energy_holdup_slag_eqn(b, t):
             return b.energy_holdup_slag[t] == \
@@ -695,14 +695,14 @@ constructed,
 
         # Equation to calculate energy holdup for metal
         # (tube + fin) per tube length
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="energy holdup for metal")
         def energy_holdup_metal_eqn(b, t):
             return b.energy_holdup_metal[t] == b.temp_tube_center[t] \
                 * b.cp_metal * b.dens_metal * b.area_cross_metal
 
         # Energy balance for slag layer
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="energy balance for slag layer")
         def energy_balance_slag_eqn(b, t):
             return energy_accumulation_term_slag(b, t) == \
@@ -710,7 +710,7 @@ constructed,
                 b.heat_flux_interface[t]*b.perimeter_interface
 
         # Energy balance for metal
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="energy balance for metal")
         def energy_balance_metal_eqn(b, t):
             return energy_accumulation_term_metal(b, t) == \
@@ -718,7 +718,7 @@ constructed,
                    b.heat_flux_conv[t]*b.perimeter_ts
 
         # Expression to calculate slag/tube metal interface wall temperature
-        @self.Expression(self.flowsheet().config.time,
+        @self.Expression(self.flowsheet().time,
                          doc="Slag tube interface wall temperature")
         def temp_interface(b, t):
             return b.temp_tube_center[t] + b.heat_flux_interface[t] \
@@ -727,7 +727,7 @@ constructed,
         # Equations for calculate pressure drop
         # and convective heat transfer coefficient for 2-phase flow
         # Equation to calculate liquid to vapor density ratio
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="liquid to vapor density ratio")
         def ratio_density_eqn(b, t):
             return 0.01*b.ratio_density[t] \
@@ -735,7 +735,7 @@ constructed,
                 0.01*b.control_volume.properties_in[t].dens_mol_phase["Liq"]
 
         # Equation for calculating velocity if the flow is liquid only
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Vecolity of fluid if liquid only")
         def velocity_lo_eqn(b, t):
             return 1e-4*b.velocity_liquid[t]*b.area_cross_fluid_total * \
@@ -743,7 +743,7 @@ constructed,
                    == 1e-4*b.control_volume.properties_in[t].flow_mol
 
         # Equation for calculating Reynolds number if liquid only
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Reynolds number if liquid only")
         def Reynolds_number_eqn(b, t):
             return b.N_Re[t] * \
@@ -753,33 +753,33 @@ constructed,
 
         # Friction factor depending on laminar or turbulent flow,
         # usually always turbulent (>1187.385)
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Darcy friction factor")
         def friction_factor_darcy_eqn(b, t):
             return b.friction_factor_darcy[t]*b.N_Re[t]**0.25/0.3164 == 1.0
 
         # Vapor fractoin equation at inlet,
         # add 1e-5 such that vapor fraction is always positive
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Vapor fractoin at inlet")
         def vapor_fraction_eqn(b, t):
             return 100*b.vapor_fraction[t] == \
                 100*(b.control_volume.properties_in[t].vapor_frac + 1e-5)
 
         # n-exponent equation for inlet
-        @self.Constraint(self.flowsheet().config.time, doc="n-exponent")
+        @self.Constraint(self.flowsheet().time, doc="n-exponent")
         def n_exp_eqn(b, t):
             return (0.001*(0.8294 - b.n_exp[t]) *
                     b.control_volume.properties_in[t].pressure ==
                     8.0478*units_meta.get_derived_units("pressure"))
 
         # Gamma equation for inlet
-        @self.Constraint(self.flowsheet().config.time, doc="Gamma at inlet")
+        @self.Constraint(self.flowsheet().time, doc="Gamma at inlet")
         def gamma_eqn(b, t):
             return b.gamma[t] == b.ratio_density[t]**b.n_exp[t]
 
         # void faction at inlet equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Void fractoin at inlet")
         def void_fraction_eqn(b, t):
             return b.void_fraction[t] * (1.0 + b.vapor_fraction[t]
@@ -787,7 +787,7 @@ constructed,
                 b.vapor_fraction[t] * b.gamma[t]
 
         # Two-phase flow correction factor equation
-        @self.Constraint(self.flowsheet().config.time, doc="Correction factor")
+        @self.Constraint(self.flowsheet().time, doc="Correction factor")
         def correction_factor_eqn(b, t):
             return (b.phi_correction[t] - 0.027*b.liquid_fraction[t])**2 == \
                 (0.973*b.liquid_fraction[t] + b.vapor_fraction[t]
@@ -796,7 +796,7 @@ constructed,
 
         # Pressure change equation due to friction,
         # -1/2*density*velocity^2*fD/diameter*length*phi^2
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="pressure change due to friction")
         def pressure_change_friction_eqn(b, t):
             return 0.01 * b.deltaP_friction[t] * b.tube_diameter == \
@@ -807,7 +807,7 @@ constructed,
 
         # Pressure change equation due to gravity,
         # density_mixture*gravity*height
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="pressure change due to gravity")
         def pressure_change_gravity_eqn(b, t):
             return 1e-3 * b.deltaP_gravity[t] == -1e-3 \
@@ -819,38 +819,38 @@ constructed,
 
         # Mass flux of vapor-liquid mixture
         # (density*velocity or mass_flow/area)
-        @self.Constraint(self.flowsheet().config.time, doc="mass flux")
+        @self.Constraint(self.flowsheet().time, doc="mass flux")
         def mass_flux_eqn(b, t):
             return b.mass_flux[t] * b.area_cross_fluid_total == \
                    b.control_volume.properties_in[t].flow_mol * \
                    b.control_volume.properties_in[0].mw
 
         # Liquid fraction at inlet
-        @self.Constraint(self.flowsheet().config.time, doc="liquid fraction")
+        @self.Constraint(self.flowsheet().time, doc="liquid fraction")
         def liquid_fraction_eqn(b, t):
             return b.liquid_fraction[t] + b.vapor_fraction[t] == 1.0
 
         # Total pressure change equation
-        @self.Constraint(self.flowsheet().config.time, doc="pressure drop")
+        @self.Constraint(self.flowsheet().time, doc="pressure drop")
         def pressure_change_total_eqn(b, t):
             return b.deltaP[t] == b.deltaP_friction[t] + b.deltaP_gravity[t]
 
         # Total heat added to control_volume
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="total heat added to fluid control_volume")
         def heat_eqn(b, t):
             return b.heat_duty[t] == b.number_tubes * b.heat_flux_conv[t] \
                 * b.tube_length * b.perimeter_ts
 
         # Reduced pressure
-        @self.Constraint(self.flowsheet().config.time, doc="reduced pressure")
+        @self.Constraint(self.flowsheet().time, doc="reduced pressure")
         def reduced_pressure_eqn(b, t):
             return b.reduced_pressure[t] \
                 * self.config.property_package.pressure_crit == \
                 b.control_volume.properties_in[t].pressure
 
         # Prandtl number of liquid
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="liquid Prandtl number")
         def N_Pr_eqn(b, t):
             return b.N_Pr[t] \
@@ -860,7 +860,7 @@ constructed,
                 b.control_volume.properties_in[t].visc_d_phase["Liq"]
 
         # Forced convection heat transfer coefficient for liquid only
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="forced convection heat transfer "
                          "coefficient for liquid only")
         def hconv_lo_eqn(b, t):
@@ -869,7 +869,7 @@ constructed,
                 b.control_volume.properties_in[t].therm_cond_phase["Liq"]
 
         # Pool boiling heat transfer coefficient
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="pool boiling heat transfer coefficient")
         def hpool_eqn(b, t):
             return (1e-4*b.hpool[t]*sqrt(pyunits.convert(
@@ -880,7 +880,7 @@ constructed,
                     b.heat_flux_conv[t]**0.67)
 
         # Boiling number scaled by a factor of 1e6
-        @self.Constraint(self.flowsheet().config.time, doc="boiling number")
+        @self.Constraint(self.flowsheet().time, doc="boiling number")
         def boiling_number_eqn(b, t):
             return 1e-10*b.boiling_number_scaled[t] \
                 * b.control_volume.properties_in[t].dh_vap_mol \
@@ -897,13 +897,13 @@ constructed,
             # Reciprocal of Martinelli parameter to the power of 0.86,
             # typical range in (1e-3, 1.0)
             self.martinelli_reciprocal_p86 = Var(
-                    self.flowsheet().config.time,
+                    self.flowsheet().time,
                     initialize=0.2,
                     doc='Reciprocal of Martinelli parameter '
                     'to the power of 0.86')
 
             # Reciprocal of Martinelli parameter to the power of 0.86
-            @self.Constraint(self.flowsheet().config.time,
+            @self.Constraint(self.flowsheet().time,
                              doc="Reciprocal of Martineli parameter "
                              "to the power of 0.86")
             def martinelli_reciprocal_p86_eqn(b, t):
@@ -918,7 +918,7 @@ constructed,
         # Enhancement factor
         # due to low contribution the reciprocal Martinalli parameter,
         # it can be removed from the enhancement factor equation
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Forced convection enhancement factor")
         def enhancement_factor_eqn(b, t):
             if self.config.rigorous_boiling is True:
@@ -931,14 +931,14 @@ constructed,
                     * (b.boiling_number_scaled[t]/1e6)**1.16
 
         # Suppression factor
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="Pool boiler suppression factor")
         def suppression_factor_eqn(b, t):
             return b.suppression_factor[t] \
                 * (1.0 + 1.15e-6*b.enhancement_factor[t]**2
                    * b.N_Re[t]**1.17) == 1.0
 
-        @self.Constraint(self.flowsheet().config.time,
+        @self.Constraint(self.flowsheet().time,
                          doc="convective heat transfer coefficient")
         def hconv_eqn(b, t):
             return 1e-3*b.hconv[t] == 1e-3 * b.hconv_liquid[t] \
@@ -990,7 +990,7 @@ constructed,
                                               state_args=state_args)
         init_log.info_high("Initialization Step 1 Complete.")
         # Fix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].enth_mol.fix(
                 value(blk.control_volume.properties_in[t].enth_mol) +
                 value(blk.heat_fireside[t]) /
@@ -1009,7 +1009,7 @@ constructed,
             )
 
         # Unfix outlet enthalpy and pressure
-        for t in blk.flowsheet().config.time:
+        for t in blk.flowsheet().time:
             blk.control_volume.properties_out[t].enth_mol.unfix()
             blk.control_volume.properties_out[t].pressure.unfix()
         blk.heat_eqn.activate()


### PR DESCRIPTION
## Follow on from #399


## Summary/Motivation:
Now that `time` is a property of flowsheets, this PR updates all references to the time domain in the code base to use the property instead of the config block.

## Changes proposed in this PR:
- Replace all instances of `config.time` with `.time`
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
