### PR TITLE
Fix typos in PySMO import statements (documentation)

### DIFF
--- a/docs/user_guide/modeling_extensions/surrogate/pysmo/pysmo_kriging.rst
+++ b/docs/user_guide/modeling_extensions/surrogate/pysmo/pysmo_kriging.rst
@@ -31,7 +31,7 @@ and then the function *training* is called on the initialized object:
 .. code:: python
 
    # Required imports
-   >>> from idaes.surrogates.pysmo import kriging
+   >>> from idaes.surrogate.pysmo import kriging
    >>> import pandas as pd
 
    # Load dataset from a csv file

--- a/docs/user_guide/modeling_extensions/surrogate/pysmo/pysmo_polyregression.rst
+++ b/docs/user_guide/modeling_extensions/surrogate/pysmo/pysmo_polyregression.rst
@@ -9,7 +9,7 @@ orders and basis function forms.
 *pysmo.polynomial_regression* considers three types of basis functions
 
 * univariate polynomials,
-* second-degree bivariate pilynomials, and
+* second-degree bivariate polynomials, and
 * user-specified basis functions.
 
 Thus, for a problem with :math:`m` sample points and :math:`n` input variables, the resulting polynomial is of the form
@@ -27,7 +27,7 @@ and then the method ``training`` is called on the initialized object:
 .. code:: python
 
    # Required imports
-   >>> from idaes.surrogates.pysmo import polynomial_regression
+   >>> from idaes.surrogate.pysmo import polynomial_regression
    >>> import pandas as pd
 
    # Load dataset from a csv file
@@ -86,7 +86,7 @@ an objective:
 
    # Required imports
    >>> import pyomo.environ as pyo
-   >>> from idaes.surrogates.pysmo import polynomial_regression
+   >>> from idaes.surrogate.pysmo import polynomial_regression
    >>> import pandas as pd
 
    # Create a Pyomo model

--- a/docs/user_guide/modeling_extensions/surrogate/pysmo/pysmo_radialbasisfunctions.rst
+++ b/docs/user_guide/modeling_extensions/surrogate/pysmo/pysmo_radialbasisfunctions.rst
@@ -53,7 +53,7 @@ and then the function *training* is called on the initialized object:
 .. code:: python
 
    # Required imports
-   >>> from idaes.surrogates.pysmo import radial_basis_function
+   >>> from idaes.surrogate.pysmo import radial_basis_function
    >>> import pandas as pd
 
    # Load dataset from a csv file

--- a/docs/user_guide/modeling_extensions/surrogate/pysmo/pysmo_sampling_properties.rst
+++ b/docs/user_guide/modeling_extensions/surrogate/pysmo/pysmo_sampling_properties.rst
@@ -14,7 +14,7 @@ The following code snippet shows basic usage of the package for generating sampl
 .. code:: python
 
    # Required imports
-   >>> from idaes.surrogates.pysmo import sampling as sp
+   >>> from idaes.surrogate.pysmo import sampling as sp
 
    # Declaration of lower and upper bounds of 3D space to be sampled
    >>> bounds = [[0, 0, 0], [1.2, 0.1, 1]]
@@ -29,7 +29,7 @@ The following code snippet shows basic usage of the package for selecting sample
 .. code:: python
 
    # Required imports
-   >>> from idaes.surrogates.pysmo import sampling as sp
+   >>> from idaes.surrogate.pysmo import sampling as sp
    >>> import pandas as pd
 
    # Load dataset from a csv file


### PR DESCRIPTION
## Fixes
#401 

## Summary/Motivation:
The name of the file containing the surrogate tools was changed from "surrogates" to "surrogate" a while back - this PR seeks to correct the docs to reflect that.

## Changes proposed in this PR:
- change `idaes.surrogates.pysmo` to ` idaes.surrogate.pysmo` in docs


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
