### PR TITLE
Pin pylint version used in CI checks to avoid unexpected check failures

### DIFF
--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -10,11 +10,13 @@ runs:
         PIP_INSTALL="pip --no-cache-dir install --progress-bar off"
         echo "::group::Output of pip install commands"
         $PIP_INSTALL --upgrade pip setuptools wheel
-        # TODO the pylint version will have to be pinned
         # TODO installing idaes is necessary in our case because we import some idaes code in pylint plugins
+        # don't think we need to install the extensions, though
         $PIP_INSTALL -r requirements-dev.txt
         echo "::endgroup::"
-        # don't think we need to install the extensions, though
+        echo "::group::Display pylint version"
+        pip show pylint astroid
+        echo "::endgroup::"
     - name: Run pylint (errors only)
       # use custom options for bash since the default causes the step to fail immediately for any non-zero return code of intermediate commands
       shell: bash --noprofile --norc {0}

--- a/.pylint/idaes_transform.py
+++ b/.pylint/idaes_transform.py
@@ -4,6 +4,7 @@ dynamically created through the `declare_process_block_class()` decorator.
 
 See #1159 for more information.
 """
+import sys
 import functools
 import logging
 import time
@@ -18,6 +19,23 @@ _logger = logging.getLogger('pylint.ideas_plugin')
 
 # TODO figure out a better way to integrate this with pylint logging and/or verbosity settings
 _display = _notify = lambda *a, **kw: None
+
+
+REFERENCE_PYLINT_VERSION = '2.8.3'
+
+
+def _check_version_compatibility():
+
+    from pylint import __version__
+    if __version__ != REFERENCE_PYLINT_VERSION:
+        cmd_to_install = f"pip install pylint=={REFERENCE_PYLINT_VERSION}"
+        msg = (
+            f"WARNING: this plugin's reference version is {REFERENCE_PYLINT_VERSION}, "
+            f"but the currently installed pylint version is {__version__}. "
+            "This is not necessarily a problem; "
+            f"however, in case of issues, try installing the reference version using {cmd_to_install}"
+        )
+        print(msg, file=sys.stderr)
 
 
 def has_declare_block_class_decorator(cls_node, decorator_name="declare_process_block_class"):
@@ -171,3 +189,4 @@ astroid.MANAGER.register_transform(
 
 def register(linter):
     "This function needs to be defined for the plugin to be picked up by pylint"
+    _check_version_compatibility()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,8 @@ sphinx-argparse
 pytest
 coverage
 pytest-cov
-pylint
+# @lbianchi-lbl: pinned pylint version after update to 2.9.1 broke previously passing checks
+pylint==2.8.3
 flake8
 
 ### other/misc


### PR DESCRIPTION
## Fixes #407 

## Summary/Motivation
- From experience in the past months, pylint checks are highly sensitive to changes made in pylint
- Having a pinned version allows us IDAES maintainers to review and possibly update it *in a proactive way*, as opposed to having to be *reactive* when a pylint update is released
- Conceptually, as we're using pylint to check for changes *within IDAES*, it makes sense to treat the pylint version as a "test constant"

## Changes proposed in this PR:
- Pin pylint version in `requirements-dev.txt`
- Add version compatibility check to IDAES transform plugin
  - The checks compares the pylint version used at runtime with a "reference version" defined in the plugin, and displays a warning if the two don't match (specifying that this is not necessarily a problem to reduce confusion/"warning fatigue" for the IDAES developer running the check locally)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
