### PR TITLE
HX1D: updting linter errors and removing old  pytest markers

### DIFF
--- a/idaes/generic_models/unit_models/heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/heat_exchanger_1D.py
@@ -1,15 +1,15 @@
-#################################################################################
+###############################################################################
 # The Institute for the Design of Advanced Energy Systems Integrated Platform
 # Framework (IDAES IP) was produced under the DOE Institute for the
 # Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
 # by the software owners: The Regents of the University of California, through
 # Lawrence Berkeley National Laboratory,  National Technology & Engineering
-# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
-# Research Corporation, et al.  All rights reserved.
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
+# University Research Corporation, et al.  All rights reserved.
 #
 # Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
 # license information.
-#################################################################################
+###############################################################################
 """
 Basic IDAES 1D Heat Exchanger Model.
 
@@ -39,7 +39,8 @@ from idaes.core import (
     FlowDirection,
     useDefault,
 )
-from idaes.generic_models.unit_models.heat_exchanger import HeatExchangerFlowPattern
+from idaes.generic_models.unit_models.heat_exchanger \
+    import HeatExchangerFlowPattern
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.misc import add_object_reference
 from idaes.core.util.exceptions import ConfigurationError
@@ -140,7 +141,8 @@ balance type
             default=MomentumBalanceType.pressureTotal,
             domain=In(MomentumBalanceType),
             description="Momentum balance construction flag",
-            doc="""Indicates what type of momentum balance should be constructed,
+            doc="""Indicates what type of momentum balance should
+            be constructed,
 **default** - MomentumBalanceType.pressureTotal.
 **Valid values:** {
 **MomentumBalanceType.none** - exclude momentum balances,
@@ -181,7 +183,8 @@ constructed,
             default=None,
             domain=is_physical_parameter_block,
             description="Property package to use for control volume",
-            doc="""Property parameter object used to define property calculations
+            doc="""Property parameter object used to define property
+            calculations
 (default = 'use_parent_value')
 - 'use_parent_value' - get package from parent (default = None)
 - a ParameterBlock object""",
@@ -206,8 +209,8 @@ and used when constructing these
         ConfigValue(
             default=useDefault,
             description="Discretization method to use for DAE transformation",
-            doc="""Discretization method to use for DAE transformation. See Pyomo
-documentation for supported transformations.""",
+            doc="""Discretization method to use for DAE transformation. See
+            Pyomo documentation for supported transformations.""",
         ),
     )
     _SideTemplate.declare(
@@ -221,8 +224,10 @@ Pyomo documentation for supported schemes.""",
     )
 
     # Create individual config blocks for shell and tube side
-    CONFIG.declare("shell_side", _SideTemplate(doc="shell side config arguments"))
-    CONFIG.declare("tube_side", _SideTemplate(doc="tube side config arguments"))
+    CONFIG.declare(
+        "shell_side", _SideTemplate(doc="shell side config arguments"))
+    CONFIG.declare(
+        "tube_side", _SideTemplate(doc="tube side config arguments"))
 
     # Common config args for both sides
     CONFIG.declare(
@@ -311,7 +316,8 @@ thickness of the tube""",
                     "Defaulting to finite "
                     "difference method on the shell side."
                 )
-                self.config.shell_side.transformation_method = "dae.finite_difference"
+                self.config.shell_side.transformation_method = \
+                    "dae.finite_difference"
             if self.config.tube_side.transformation_method is useDefault:
                 _log.warning(
                     "Discretization method was "
@@ -320,7 +326,8 @@ thickness of the tube""",
                     "Defaulting to finite "
                     "difference method on the tube side."
                 )
-                self.config.tube_side.transformation_method = "dae.finite_difference"
+                self.config.tube_side.transformation_method = \
+                    "dae.finite_difference"
             if self.config.shell_side.transformation_scheme is useDefault:
                 _log.warning(
                     "Discretization scheme was "
@@ -350,7 +357,8 @@ thickness of the tube""",
                     "Defaulting to finite "
                     "difference method on the shell side."
                 )
-                self.config.shell_side.transformation_method = "dae.finite_difference"
+                self.config.shell_side.transformation_method = \
+                    "dae.finite_difference"
             if self.config.tube_side.transformation_method is useDefault:
                 _log.warning(
                     "Discretization method was "
@@ -359,7 +367,8 @@ thickness of the tube""",
                     "Defaulting to finite "
                     "difference method on the tube side."
                 )
-                self.config.tube_side.transformation_method = "dae.finite_difference"
+                self.config.tube_side.transformation_method = \
+                    "dae.finite_difference"
             if self.config.shell_side.transformation_scheme is useDefault:
                 _log.warning(
                     "Discretization scheme was "
@@ -382,7 +391,8 @@ thickness of the tube""",
             raise ConfigurationError(
                 "{} HeatExchanger1D only supports cocurrent and "
                 "countercurrent flow patterns, but flow_type configuration"
-                " argument was set to {}.".format(self.name, self.config.flow_type)
+                " argument was set to {}."
+                .format(self.name, self.config.flow_type)
             )
 
         # Control volume 1D for shell
@@ -391,9 +401,12 @@ thickness of the tube""",
                 "dynamic": self.config.shell_side.dynamic,
                 "has_holdup": self.config.shell_side.has_holdup,
                 "property_package": self.config.shell_side.property_package,
-                "property_package_args": self.config.shell_side.property_package_args,
-                "transformation_method": self.config.shell_side.transformation_method,
-                "transformation_scheme": self.config.shell_side.transformation_scheme,
+                "property_package_args":
+                self.config.shell_side.property_package_args,
+                "transformation_method":
+                self.config.shell_side.transformation_method,
+                "transformation_scheme":
+                self.config.shell_side.transformation_scheme,
                 "finite_elements": self.config.finite_elements,
                 "collocation_points": self.config.collocation_points,
             }
@@ -404,9 +417,12 @@ thickness of the tube""",
                 "dynamic": self.config.tube_side.dynamic,
                 "has_holdup": self.config.tube_side.has_holdup,
                 "property_package": self.config.tube_side.property_package,
-                "property_package_args": self.config.tube_side.property_package_args,
-                "transformation_method": self.config.tube_side.transformation_method,
-                "transformation_scheme": self.config.tube_side.transformation_scheme,
+                "property_package_args":
+                self.config.tube_side.property_package_args,
+                "transformation_method":
+                self.config.tube_side.transformation_method,
+                "transformation_scheme":
+                self.config.tube_side.transformation_scheme,
                 "finite_elements": self.config.finite_elements,
                 "collocation_points": self.config.collocation_points,
             }
@@ -486,10 +502,10 @@ thickness of the tube""",
         Returns:
             None
         """
-        shell_units = \
-            self.config.shell_side.property_package.get_metadata().get_derived_units
-        tube_units = \
-            self.config.tube_side.property_package.get_metadata().get_derived_units
+        shell_units = self.config.shell_side.property_package.\
+            get_metadata().get_derived_units
+        tube_units = self.config.tube_side.property_package.\
+            get_metadata().get_derived_units
 
         # Unit model variables
         # HX dimensions
@@ -526,7 +542,8 @@ thickness of the tube""",
         )
 
         # Wall 0D model (Q_shell = Q_tube*N_tubes)
-        if self.config.has_wall_conduction == WallConductionType.zero_dimensional:
+        if self.config.has_wall_conduction == \
+                WallConductionType.zero_dimensional:
             self.temperature_wall = Var(
                 self.flowsheet().time,
                 self.tube.length_domain,
@@ -560,7 +577,8 @@ thickness of the tube""",
                 doc="Convective heat transfer",
             )
             def tube_heat_transfer_eq(self, t, x):
-                return self.tube.heat[t, x] == self.tube_heat_transfer_coefficient[
+                return self.tube.heat[t, x] == \
+                    self.tube_heat_transfer_coefficient[
                     t, x
                 ] * c.pi * pyunits.convert(self.d_tube_inner,
                                            to_units=tube_units("length")) * (
@@ -604,7 +622,7 @@ thickness of the tube""",
         )
 
     def initialize(
-        blk,
+        self,
         shell_state_args=None,
         tube_state_args=None,
         outlvl=idaeslog.NOTSET,
@@ -628,22 +646,22 @@ thickness of the tube""",
         Returns:
             None
         """
-        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
-        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+        init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
+        solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
 
         # Create solver
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
         # Initialize shell block
-        flags_shell = blk.shell.initialize(
+        flags_shell = self.shell.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
             state_args=shell_state_args,
         )
 
-        flags_tube = blk.tube.initialize(
+        flags_tube = self.tube.initialize(
             outlvl=outlvl,
             optarg=optarg,
             solver=solver,
@@ -655,53 +673,54 @@ thickness of the tube""",
         # ---------------------------------------------------------------------
         # Solve unit
         # Wall 0D
-        if blk.config.has_wall_conduction == WallConductionType.zero_dimensional:
-            shell_units = \
-                blk.config.shell_side.property_package.get_metadata().get_derived_units
-            for t in blk.flowsheet().time:
-                for z in blk.shell.length_domain:
-                    blk.temperature_wall[t, z].fix(
+        if self.config.has_wall_conduction == \
+            WallConductionType.zero_dimensional:
+            shell_units = self.config.shell_side.property_package.\
+                get_metadata().get_derived_units
+            for t in self.flowsheet().time:
+                for z in self.shell.length_domain:
+                    self.temperature_wall[t, z].fix(
                         value(
                             0.5
                             * (
-                                blk.shell.properties[t, 0].temperature
+                                self.shell.properties[t, 0].temperature
                                 + pyunits.convert(
-                                    blk.tube.properties[t, 0].temperature,
+                                    self.tube.properties[t, 0].temperature,
                                     to_units=shell_units('temperature'))
                             )
                         )
                     )
 
-            blk.tube.deactivate()
-            blk.tube_heat_transfer_eq.deactivate()
-            blk.wall_0D_model.deactivate()
+            self.tube.deactivate()
+            self.tube_heat_transfer_eq.deactivate()
+            self.wall_0D_model.deactivate()
 
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                res = opt.solve(blk, tee=slc.tee)
+                res = opt.solve(self, tee=slc.tee)
             init_log.info_high(
                 "Initialization Step 2 {}.".format(idaeslog.condition(res))
             )
 
-            blk.tube.activate()
-            blk.tube_heat_transfer_eq.activate()
+            self.tube.activate()
+            self.tube_heat_transfer_eq.activate()
 
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                res = opt.solve(blk, tee=slc.tee)
+                res = opt.solve(self, tee=slc.tee)
             init_log.info_high(
                 "Initialization Step 3 {}.".format(idaeslog.condition(res))
             )
 
-            blk.wall_0D_model.activate()
-            blk.temperature_wall.unfix()
+            self.wall_0D_model.activate()
+            self.temperature_wall.unfix()
 
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                res = opt.solve(blk, tee=slc.tee)
+                res = opt.solve(self, tee=slc.tee)
             init_log.info_high(
                 "Initialization Step 4 {}.".format(idaeslog.condition(res))
             )
 
-        blk.shell.release_state(flags_shell)
-        blk.tube.release_state(flags_tube)
+        self.shell.release_state(flags_shell)
+        self.tube.release_state(flags_tube)
 
         init_log.info("Initialization Complete.")
 

--- a/idaes/generic_models/unit_models/heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/heat_exchanger_1D.py
@@ -1,15 +1,15 @@
-###############################################################################
+#################################################################################
 # The Institute for the Design of Advanced Energy Systems Integrated Platform
 # Framework (IDAES IP) was produced under the DOE Institute for the
 # Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
 # by the software owners: The Regents of the University of California, through
 # Lawrence Berkeley National Laboratory,  National Technology & Engineering
-# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
-# University Research Corporation, et al.  All rights reserved.
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
 #
 # Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
 # license information.
-###############################################################################
+#################################################################################
 """
 Basic IDAES 1D Heat Exchanger Model.
 
@@ -142,7 +142,7 @@ balance type
             domain=In(MomentumBalanceType),
             description="Momentum balance construction flag",
             doc="""Indicates what type of momentum balance should
-            be constructed,
+be constructed,
 **default** - MomentumBalanceType.pressureTotal.
 **Valid values:** {
 **MomentumBalanceType.none** - exclude momentum balances,
@@ -184,7 +184,7 @@ constructed,
             domain=is_physical_parameter_block,
             description="Property package to use for control volume",
             doc="""Property parameter object used to define property
-            calculations
+calculations
 (default = 'use_parent_value')
 - 'use_parent_value' - get package from parent (default = None)
 - a ParameterBlock object""",
@@ -210,7 +210,7 @@ and used when constructing these
             default=useDefault,
             description="Discretization method to use for DAE transformation",
             doc="""Discretization method to use for DAE transformation. See
-            Pyomo documentation for supported transformations.""",
+Pyomo documentation for supported transformations.""",
         ),
     )
     _SideTemplate.declare(

--- a/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
@@ -1,15 +1,15 @@
-#################################################################################
+###############################################################################
 # The Institute for the Design of Advanced Energy Systems Integrated Platform
 # Framework (IDAES IP) was produced under the DOE Institute for the
 # Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
 # by the software owners: The Regents of the University of California, through
 # Lawrence Berkeley National Laboratory,  National Technology & Engineering
-# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
-# Research Corporation, et al.  All rights reserved.
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
+# University Research Corporation, et al.  All rights reserved.
 #
 # Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
 # license information.
-#################################################################################
+###############################################################################
 """
 Tests for Heat Exchanger 1D unit model.
 
@@ -185,7 +185,6 @@ class TestBTX_cocurrent(object):
         return m
 
     @pytest.mark.unit
-    @pytest.mark.build
     def test_build(self, btx):
         assert hasattr(btx.fs.unit, "shell_inlet")
         assert len(btx.fs.unit.shell_inlet.vars) == 4
@@ -261,12 +260,10 @@ class TestBTX_cocurrent(object):
         assert degrees_of_freedom(btx) == 0
 
     @pytest.mark.component
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     def test_initialize(self, btx):
         initialization_tester(btx)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, btx):
@@ -277,7 +274,6 @@ class TestBTX_cocurrent(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, btx):
@@ -295,7 +291,6 @@ class TestBTX_cocurrent(object):
         assert (pytest.approx(101325, abs=1e-3) ==
                 value(btx.fs.unit.tube_outlet.pressure[0]))
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_conservation(self, btx):
@@ -358,7 +353,6 @@ class TestBTX_countercurrent(object):
         return m
 
     @pytest.mark.unit
-    @pytest.mark.build
     def test_build(self, btx):
         assert hasattr(btx.fs.unit, "shell_inlet")
         assert len(btx.fs.unit.shell_inlet.vars) == 4
@@ -433,7 +427,6 @@ class TestBTX_countercurrent(object):
     def test_dof(self, btx):
         assert degrees_of_freedom(btx) == 0
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, btx):
@@ -447,7 +440,6 @@ class TestBTX_countercurrent(object):
                                  "temperature": 331.5,
                                  "pressure": 101325})
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, btx):
@@ -458,7 +450,6 @@ class TestBTX_countercurrent(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, btx):
@@ -476,7 +467,6 @@ class TestBTX_countercurrent(object):
         assert (pytest.approx(101325, abs=1e-3) ==
                 value(btx.fs.unit.tube_outlet.pressure[0]))
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_conservation(self, btx):
@@ -539,7 +529,6 @@ class TestIAPWS_cocurrent(object):
         return m
 
     @pytest.mark.unit
-    @pytest.mark.build
     def test_build(self, iapws):
         assert len(iapws.fs.unit.shell_inlet.vars) == 3
         assert hasattr(iapws.fs.unit.shell_inlet, "flow_mol")
@@ -608,14 +597,11 @@ class TestIAPWS_cocurrent(object):
     def test_dof(self, iapws):
         assert degrees_of_freedom(iapws) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, iapws):
         initialization_tester(iapws)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.unit
     def test_solve(self, iapws):
@@ -626,7 +612,6 @@ class TestIAPWS_cocurrent(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, iapws):
@@ -645,7 +630,6 @@ class TestIAPWS_cocurrent(object):
         assert pytest.approx(101325, abs=1e2) == \
             value(iapws.fs.unit.tube_outlet.pressure[0])
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_conservation(self, iapws):
@@ -708,7 +692,6 @@ class TestIAPWS_countercurrent(object):
         return m
 
     @pytest.mark.unit
-    @pytest.mark.build
     def test_build(self, iapws):
         assert len(iapws.fs.unit.shell_inlet.vars) == 3
         assert hasattr(iapws.fs.unit.shell_inlet, "flow_mol")
@@ -777,14 +760,11 @@ class TestIAPWS_countercurrent(object):
     def test_dof(self, iapws):
         assert degrees_of_freedom(iapws) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, iapws):
         initialization_tester(iapws)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, iapws):
@@ -795,7 +775,6 @@ class TestIAPWS_countercurrent(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, iapws):
@@ -814,7 +793,6 @@ class TestIAPWS_countercurrent(object):
         assert pytest.approx(101325, abs=1e2) == \
             value(iapws.fs.unit.tube_outlet.pressure[0])
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_conservation(self, iapws):
@@ -882,7 +860,6 @@ class TestSaponification_cocurrent(object):
 
         return m
 
-    @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, sapon):
         assert len(sapon.fs.unit.shell_inlet.vars) == 4
@@ -954,14 +931,11 @@ class TestSaponification_cocurrent(object):
     def test_dof(self, sapon):
         assert degrees_of_freedom(sapon) == 0
 
-    @pytest.mark.initialization
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, sapon):
         initialization_tester(sapon)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, sapon):
@@ -972,7 +946,6 @@ class TestSaponification_cocurrent(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, sapon):
@@ -1013,7 +986,6 @@ class TestSaponification_cocurrent(object):
         assert pytest.approx(101325, abs=1e2) == \
             value(sapon.fs.unit.tube_outlet.pressure[0])
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_conservation(self, sapon):
@@ -1078,7 +1050,6 @@ class TestSaponification_countercurrent(object):
 
         return m
 
-    @pytest.mark.build
     @pytest.mark.unit
     def test_build(self, sapon):
         assert len(sapon.fs.unit.shell_inlet.vars) == 4
@@ -1150,13 +1121,11 @@ class TestSaponification_countercurrent(object):
     def test_dof(self, sapon):
         assert degrees_of_freedom(sapon) == 0
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, sapon):
         initialization_tester(sapon)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, sapon):
@@ -1167,7 +1136,6 @@ class TestSaponification_countercurrent(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solution(self, sapon):
@@ -1208,7 +1176,6 @@ class TestSaponification_countercurrent(object):
         assert pytest.approx(101325, abs=1e2) == \
             value(sapon.fs.unit.tube_outlet.pressure[0])
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_conservation(self, sapon):
@@ -1353,7 +1320,6 @@ class TestBT_Generic_cocurrent(object):
         return m
 
     @pytest.mark.component
-    @pytest.mark.build
     def test_build(self, btx):
         assert hasattr(btx.fs.unit, "shell_inlet")
         assert len(btx.fs.unit.shell_inlet.vars) == 4
@@ -1428,13 +1394,11 @@ class TestBT_Generic_cocurrent(object):
     def test_dof(self, btx):
         assert degrees_of_freedom(btx) == 0
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.integration
     def test_initialize(self, btx):
         initialization_tester(btx)
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.integration
     def test_solve(self, btx):
@@ -1445,7 +1409,6 @@ class TestBT_Generic_cocurrent(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.integration
     def test_solution(self, btx):
@@ -1463,7 +1426,6 @@ class TestBT_Generic_cocurrent(object):
         assert (pytest.approx(101.325, abs=1e-3) ==
                 value(btx.fs.unit.tube_outlet.pressure[0]))
 
-    @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.integration
     def test_conservation(self, btx):

--- a/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
@@ -1,15 +1,15 @@
-###############################################################################
+#################################################################################
 # The Institute for the Design of Advanced Energy Systems Integrated Platform
 # Framework (IDAES IP) was produced under the DOE Institute for the
 # Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
 # by the software owners: The Regents of the University of California, through
 # Lawrence Berkeley National Laboratory,  National Technology & Engineering
-# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
-# University Research Corporation, et al.  All rights reserved.
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
 #
 # Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
 # license information.
-###############################################################################
+#################################################################################
 """
 Tests for Heat Exchanger 1D unit model.
 


### PR DESCRIPTION
## Fixes


## Summary/Motivation:


## Changes proposed in this PR:
- Fixing linter errors
- Removing old pytest markers from `test_heat_exchanger_1D.py`


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
