### PR TITLE
Stop using deprecated ConfigEnum class in Caprese

### DIFF
--- a/idaes/apps/caprese/common/config.py
+++ b/idaes/apps/caprese/common/config.py
@@ -17,43 +17,42 @@ A module of functions and classes for configuring NMPC/MHE problems
 import enum
 from pyomo.environ import SolverFactory
 from pyomo.core.base.var import _GeneralVarData
-from pyomo.common.config import ConfigEnum
 
 
-class ControlInitOption(ConfigEnum):
+class ControlInitOption(enum.Enum):
     FROM_PREVIOUS = 11
     BY_TIME_ELEMENT = 12
     FROM_INITIAL_CONDITIONS = 13
     SETPOINT = 14
 
 
-class ElementInitializationInputOption(ConfigEnum):
+class ElementInitializationInputOption(enum.Enum):
     SETPOINT = 21
     INITIAL = 22
     CURRENT_VALUES = 23
 
 
-class InputOption(ConfigEnum):
+class InputOption(enum.Enum):
     CURRENT = 20
     INITIAL = 21
     SETPOINT = 22
     # TODO: PREVIOUS = 23
 
 
-class TimeResolutionOption(ConfigEnum):
+class TimeResolutionOption(enum.Enum):
     COLLOCATION_POINTS = 31
     FINITE_ELEMENTS = 32
     SAMPLE_POINTS = 33
     INITIAL_POINT = 34
 
 
-class ControlPenaltyType(ConfigEnum):
+class ControlPenaltyType(enum.Enum):
     ERROR = 41
     ACTION = 42
     NONE = 43
 
 
-class VariableCategory(ConfigEnum):
+class VariableCategory(enum.Enum):
     DIFFERENTIAL = 51
     ALGEBRAIC = 52
     DERIVATIVE = 53
@@ -64,13 +63,13 @@ class VariableCategory(ConfigEnum):
     MEASUREMENT = 57
 
 
-class NoiseBoundOption(ConfigEnum):
+class NoiseBoundOption(enum.Enum):
     FAIL = 60
     DISCARD = 61
     PUSH = 62
 
 
-class PlantHorizonType(ConfigEnum):
+class PlantHorizonType(enum.Enum):
     FULL = 71
     ROLLING = 72
 


### PR DESCRIPTION
## Summary/Motivation:
Was using an Enum subclass for config arguments that has been deprecated. Have removed this class, replacing it with enum.Enum to get rid of deprecation warnings.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
