### PR TITLE
Improvements to Properties Interrogator

### DIFF
--- a/docs/technical_specs/model_libraries/generic/property_models/interrogator.rst
+++ b/docs/technical_specs/model_libraries/generic/property_models/interrogator.rst
@@ -18,7 +18,7 @@ An example of how Property Interrogator tool is used is shown below:
     from idaes.generic_models.properties.interrogator import PropertyInterrogatorBlock, ReactionInterrogatorBlock
 
     m = pyo.ConcreteModel()
-    m.fs = FlowsheetBlock(default={"dynamic": True})
+    m.fs = FlowsheetBlock(default={"dynamic": True, "time_units": pyo.units.s})
 
     m.fs.params = PropertyInterrogatorBlock()
     m.fs.rxn_params = ReactionInterrogatorBlock(

--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -233,7 +233,7 @@ class ComponentData(ProcessBlockData):
 
 # TODO : What about LLE systems where a species is a solvent in one liquid
 # phase, but a solute in another?
-@declare_process_block_class("Solute")
+@declare_process_block_class("Solute", block_class=Component)
 class SoluteData(ComponentData):
     """
     Component type for species which should be considered as solutes in
@@ -262,7 +262,7 @@ class SoluteData(ComponentData):
 
 # TODO : What about LLE systems where a species is a solvent in one liquid
 # phase, but a solute in another?
-@declare_process_block_class("Solvent")
+@declare_process_block_class("Solvent", block_class=Component)
 class SolventData(ComponentData):
     """
     Component type for species which should be considered as solvents in
@@ -289,7 +289,7 @@ class SolventData(ComponentData):
         parent.solvent_set.add(self.local_name)
 
 
-@declare_process_block_class("Ion")
+@declare_process_block_class("Ion", block_class=Component)
 class IonData(SoluteData):
     """
     Component type for ionic species. These can exist only in AqueousPhases,
@@ -328,7 +328,7 @@ class IonData(SoluteData):
             "directly".format(self.name))
 
 
-@declare_process_block_class("Anion")
+@declare_process_block_class("Anion", block_class=Component)
 class AnionData(IonData):
     """
     Component type for anionic species. These can exist only in AqueousPhases,
@@ -360,7 +360,7 @@ class AnionData(IonData):
         parent.anion_set.add(self.local_name)
 
 
-@declare_process_block_class("Cation")
+@declare_process_block_class("Cation", block_class=Component)
 class CationData(IonData):
     """
     Component type for cationic species. These can exist only in AqueousPhases,
@@ -392,7 +392,7 @@ class CationData(IonData):
         parent.cation_set.add(self.local_name)
 
 
-@declare_process_block_class("Apparent")
+@declare_process_block_class("Apparent", block_class=Component)
 class ApparentData(SoluteData):
     """
     Component type for apparent species. Apparent species are those compunds

--- a/idaes/core/phases.py
+++ b/idaes/core/phases.py
@@ -114,7 +114,7 @@ class PhaseData(ProcessBlockData):
                                     ordered=True)
 
 
-@declare_process_block_class("LiquidPhase")
+@declare_process_block_class("LiquidPhase", block_class=Phase)
 class LiquidPhaseData(PhaseData):
     def is_liquid_phase(self):
         return True
@@ -126,7 +126,7 @@ class LiquidPhaseData(PhaseData):
         return False
 
 
-@declare_process_block_class("SolidPhase")
+@declare_process_block_class("SolidPhase", block_class=Phase)
 class SolidPhaseData(PhaseData):
     def is_liquid_phase(self):
         return False
@@ -138,7 +138,7 @@ class SolidPhaseData(PhaseData):
         return False
 
 
-@declare_process_block_class("VaporPhase")
+@declare_process_block_class("VaporPhase", block_class=Phase)
 class VaporPhaseData(PhaseData):
     def is_liquid_phase(self):
         return False
@@ -150,7 +150,7 @@ class VaporPhaseData(PhaseData):
         return True
 
 
-@declare_process_block_class("AqueousPhase")
+@declare_process_block_class("AqueousPhase", block_class=Phase)
 class AqueousPhaseData(LiquidPhaseData):
     # Special phase type for liquid phases involving electrolytes
     # This is used to determine if we need to do the more complex component

--- a/idaes/generic_models/properties/interrogator/properties_interrogator.py
+++ b/idaes/generic_models/properties/interrogator/properties_interrogator.py
@@ -79,7 +79,7 @@ class PropertyInterrogatorData(PhysicalParameterBlock):
                 if t is None:
                     t = Phase
                 elif not issubclass(
-                        t, (Phase, LiquidPhase, SolidPhase, VaporPhase)):
+                        t, Phase):
                     raise Exception()
                 self.add_component(p, t())
 

--- a/idaes/generic_models/properties/interrogator/reactions_interrogator.py
+++ b/idaes/generic_models/properties/interrogator/reactions_interrogator.py
@@ -17,7 +17,7 @@ required to simulate it.
 import sys
 
 # Import Pyomo libraries
-from pyomo.environ import Set, Var
+from pyomo.environ import Set, Var, units as pyunits
 
 # Import IDAES cores
 from idaes.core import (declare_process_block_class,
@@ -54,11 +54,16 @@ class ReactionInterrogatorData(ReactionParameterBlock):
         self._reaction_block_class = InterrogatorReactionBlock
 
         # List of valid phases in property package
-        # TODO : Allow users to define a phase list
-        self.phase_list = Set(initialize=['Liq', 'Vap'])
+        p_list = []
+        for p in self.config.property_package.phase_list:
+            p_list.append(p)
+        self.phase_list = Set(initialize=p_list)
 
         # Component list - a list of component identifiers
-        self.component_list = Set(initialize=['A', 'B'])
+        c_list = []
+        for j in self.config.property_package.component_list:
+            c_list.append(j)
+        self.component_list = Set(initialize=c_list)
 
         # Set up dict to record property calls
         self.required_properties = {}
@@ -67,11 +72,11 @@ class ReactionInterrogatorData(ReactionParameterBlock):
         # Reaction Index
         self.rate_reaction_idx = Set(initialize=["R1"])
 
-        # Reaction Stoichiometry
-        self.rate_reaction_stoichiometry = {("R1", "Liq", "A"): -1,
-                                            ("R1", "Liq", "B"): -1,
-                                            ("R1", "Vap", "A"): 1,
-                                            ("R1", "Vap", "B"): 1}
+        # Reaction Stoichiometry - fake the dict with all 1's
+        self.rate_reaction_stoichiometry = {}
+        for p in p_list:
+            for j in c_list:
+                self.rate_reaction_stoichiometry[("R1", p, j)] = 1
 
     def list_required_properties(self):
         """
@@ -220,13 +225,11 @@ class ReactionInterrogatorData(ReactionParameterBlock):
 
     @classmethod
     def define_metadata(cls, obj):
-        obj.add_default_units({'time': 's',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.s,
+                               'length': pyunits.m,
+                               'mass': pyunits.kg,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
 
 
 class _InterrogatorReactionBlock(ReactionBlockBase):

--- a/idaes/generic_models/properties/interrogator/tests/test_properties_interrogator.py
+++ b/idaes/generic_models/properties/interrogator/tests/test_properties_interrogator.py
@@ -22,7 +22,7 @@ import pytest
 from pyomo.environ import ConcreteModel, units as pyunits
 from pyomo.util.check_units import assert_units_equivalent
 
-from idaes.core import FlowsheetBlock, MaterialBalanceType, LiquidPhase
+from idaes.core import FlowsheetBlock, MaterialBalanceType, LiquidPhase, Solute
 from idaes.generic_models.unit_models import Flash, HeatExchanger1D
 from idaes.generic_models.unit_models.pressure_changer import \
     PressureChanger, ThermodynamicAssumption
@@ -482,7 +482,7 @@ def test_interrogator_parameter_block_custom_phase_comps():
 
     m.fs.params = PropertyInterrogatorBlock(default={
         "phase_list": {"P1": LiquidPhase, "P2": None},
-        "component_list": {"c1": None, "c2": None}})
+        "component_list": {"c1": Solute, "c2": None}})
 
     # Check that parameter block has expected attributes
     assert isinstance(m.fs.params.required_properties, dict)
@@ -497,8 +497,8 @@ def test_interrogator_state_block_methods_custom_phase_comps():
     m.fs = FlowsheetBlock(default={"dynamic": False})
 
     m.fs.params = PropertyInterrogatorBlock(default={
-        "phase_list": {"P1": None, "P2": None},
-        "component_list": {"c1": None, "c2": None}})
+        "phase_list": {"P1": LiquidPhase, "P2": None},
+        "component_list": {"c1": Solute, "c2": None}})
 
     m.fs.props = m.fs.params.build_state_block([0])
 

--- a/idaes/generic_models/properties/interrogator/tests/test_properties_interrogator.py
+++ b/idaes/generic_models/properties/interrogator/tests/test_properties_interrogator.py
@@ -19,14 +19,16 @@ Tests for Property Interrogator Tool
 """
 import pytest
 
-from pyomo.environ import ConcreteModel
+from pyomo.environ import ConcreteModel, units as pyunits
 
 from idaes.core import FlowsheetBlock, MaterialBalanceType
 from idaes.generic_models.unit_models import Flash, HeatExchanger1D
-from idaes.generic_models.unit_models.pressure_changer import (PressureChanger,
-                                                ThermodynamicAssumption)
-from idaes.generic_models.unit_models.separator import Separator, SplittingType
-from idaes.generic_models.properties.interrogator import PropertyInterrogatorBlock
+from idaes.generic_models.unit_models.pressure_changer import \
+    PressureChanger, ThermodynamicAssumption
+from idaes.generic_models.unit_models.separator import \
+    Separator, SplittingType
+from idaes.generic_models.properties.interrogator import \
+    PropertyInterrogatorBlock
 
 
 @pytest.mark.unit
@@ -188,7 +190,8 @@ def test_interrogator_initialize_method():
 @pytest.fixture(scope="module")
 def model():
     m = ConcreteModel()
-    m.fs = FlowsheetBlock(default={"dynamic": True})
+    m.fs = FlowsheetBlock(default={"dynamic": True,
+                                   "time_units": pyunits.s})
 
     m.fs.params = PropertyInterrogatorBlock()
 
@@ -456,3 +459,48 @@ def test_ideal_Separator_3():
     # Ideal Separator should require no property calls
     # Only dummy state variables are required
     assert len(m.fs.params.required_properties) == 0
+
+
+@pytest.mark.unit
+def test_interrogator_parameter_block_custom_phase_comps():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = PropertyInterrogatorBlock(default={
+        "phase_list": ["P1", "P2"],
+        "component_list": ["c1", "c2"]})
+
+    # Check that parameter block has expected attributes
+    assert isinstance(m.fs.params.required_properties, dict)
+    assert len(m.fs.params.required_properties) == 0
+    assert m.fs.params.phase_list == ["P1", "P2"]
+    assert m.fs.params.component_list == ["c1", "c2"]
+
+
+@pytest.mark.unit
+def test_interrogator_state_block_methods_custom_phase_comps():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = PropertyInterrogatorBlock(default={
+        "phase_list": ["P1", "P2"],
+        "component_list": ["c1", "c2"]})
+
+    m.fs.props = m.fs.params.build_state_block([0])
+
+    # Check get_term methods return an unindexed dummy var
+    assert m.fs.props[0].get_material_flow_terms("P1", "c1") is \
+        m.fs.props[0]._dummy_var
+    assert m.fs.props[0].get_enthalpy_flow_terms("P1") is \
+        m.fs.props[0]._dummy_var
+    assert m.fs.props[0].get_material_density_terms("P1", "c1") is \
+        m.fs.props[0]._dummy_var
+    assert m.fs.props[0].get_energy_density_terms("P1") is \
+        m.fs.props[0]._dummy_var
+
+    # Check that get_term calls were logged correctly
+    assert m.fs.params.required_properties == {
+            "material flow terms": ["fs.props"],
+            "material density terms": ["fs.props"],
+            "enthalpy flow terms": ["fs.props"],
+            "energy density terms": ["fs.props"]}

--- a/idaes/generic_models/properties/interrogator/tests/test_properties_interrogator.py
+++ b/idaes/generic_models/properties/interrogator/tests/test_properties_interrogator.py
@@ -20,8 +20,9 @@ Tests for Property Interrogator Tool
 import pytest
 
 from pyomo.environ import ConcreteModel, units as pyunits
+from pyomo.util.check_units import assert_units_equivalent
 
-from idaes.core import FlowsheetBlock, MaterialBalanceType
+from idaes.core import FlowsheetBlock, MaterialBalanceType, LiquidPhase
 from idaes.generic_models.unit_models import Flash, HeatExchanger1D
 from idaes.generic_models.unit_models.pressure_changer import \
     PressureChanger, ThermodynamicAssumption
@@ -41,6 +42,19 @@ def test_interrogator_parameter_block():
     # Check that parameter block has expected attributes
     assert isinstance(m.fs.params.required_properties, dict)
     assert len(m.fs.params.required_properties) == 0
+
+
+@pytest.mark.unit
+def test_units_metadata():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = PropertyInterrogatorBlock()
+
+    units_meta = m.fs.params.get_metadata().get_derived_units
+
+    assert_units_equivalent(units_meta('length'), pyunits.m)
+    assert_units_equivalent(units_meta('pressure'), pyunits.Pa)
 
 
 @pytest.mark.unit
@@ -467,8 +481,8 @@ def test_interrogator_parameter_block_custom_phase_comps():
     m.fs = FlowsheetBlock(default={"dynamic": False})
 
     m.fs.params = PropertyInterrogatorBlock(default={
-        "phase_list": ["P1", "P2"],
-        "component_list": ["c1", "c2"]})
+        "phase_list": {"P1": LiquidPhase, "P2": None},
+        "component_list": {"c1": None, "c2": None}})
 
     # Check that parameter block has expected attributes
     assert isinstance(m.fs.params.required_properties, dict)
@@ -483,8 +497,8 @@ def test_interrogator_state_block_methods_custom_phase_comps():
     m.fs = FlowsheetBlock(default={"dynamic": False})
 
     m.fs.params = PropertyInterrogatorBlock(default={
-        "phase_list": ["P1", "P2"],
-        "component_list": ["c1", "c2"]})
+        "phase_list": {"P1": None, "P2": None},
+        "component_list": {"c1": None, "c2": None}})
 
     m.fs.props = m.fs.params.build_state_block([0])
 

--- a/idaes/generic_models/properties/interrogator/tests/test_reactions_interrogator.py
+++ b/idaes/generic_models/properties/interrogator/tests/test_reactions_interrogator.py
@@ -19,7 +19,7 @@ Tests for Reaction Interrogator Tool
 """
 import pytest
 
-from pyomo.environ import ConcreteModel
+from pyomo.environ import ConcreteModel, units as pyunits
 
 from idaes.core import FlowsheetBlock
 from idaes.generic_models.unit_models import CSTR, PFR
@@ -212,7 +212,8 @@ def test_interrogator_initialize_method():
 @pytest.fixture(scope="module")
 def model():
     m = ConcreteModel()
-    m.fs = FlowsheetBlock(default={"dynamic": True})
+    m.fs = FlowsheetBlock(default={"dynamic": True,
+                                   "time_units": pyunits.s})
 
     m.fs.params = PropertyInterrogatorBlock()
     m.fs.rxn_params = ReactionInterrogatorBlock(
@@ -343,3 +344,35 @@ The following reaction properties are required by model fs.R01:
     dh_rxn
     reaction_rate
 """
+
+
+@pytest.mark.unit
+def test_interrogator_rxn_block_unindexed_call_custom_phase_comp():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+
+    m.fs.params = PropertyInterrogatorBlock(default={
+        "phase_list": ["P1", "P2"],
+        "component_list": ["c1", "c2"]})
+    m.fs.rxn_params = ReactionInterrogatorBlock(
+            default={"property_package": m.fs.params})
+
+    m.fs.props = m.fs.params.build_state_block([0])
+    m.fs.rxns = m.fs.rxn_params.build_reaction_block(
+            [0], default={"state_block": m.fs.props})
+
+    # Check phase and component lists
+    assert m.fs.rxn_params.phase_list == ["P1", "P2"]
+    assert m.fs.rxn_params.component_list == ["c1", "c2"]
+
+    # Check get_term methods return an unindexed dummy var
+    assert m.fs.rxns[0].prop_unindexed is \
+        m.fs.rxns[0]._dummy_var
+
+    # Call again to make sure duplicates are skipped in required_properties
+    assert m.fs.rxns[0].prop_unindexed is \
+        m.fs.rxns[0]._dummy_var
+
+    # Check that get_term calls were logged correctly
+    assert m.fs.rxn_params.required_properties == {
+            "prop_unindexed": ["fs.rxns"]}

--- a/idaes/generic_models/properties/interrogator/tests/test_reactions_interrogator.py
+++ b/idaes/generic_models/properties/interrogator/tests/test_reactions_interrogator.py
@@ -21,7 +21,7 @@ import pytest
 
 from pyomo.environ import ConcreteModel, units as pyunits
 
-from idaes.core import FlowsheetBlock
+from idaes.core import FlowsheetBlock, LiquidPhase, Solute
 from idaes.generic_models.unit_models import CSTR, PFR
 from idaes.generic_models.properties.interrogator import (
         PropertyInterrogatorBlock, ReactionInterrogatorBlock)
@@ -352,8 +352,8 @@ def test_interrogator_rxn_block_unindexed_call_custom_phase_comp():
     m.fs = FlowsheetBlock(default={"dynamic": False})
 
     m.fs.params = PropertyInterrogatorBlock(default={
-        "phase_list": ["P1", "P2"],
-        "component_list": ["c1", "c2"]})
+        "phase_list": {"P1": LiquidPhase, "P2": None},
+        "component_list": {"c1": Solute, "c2": None}})
     m.fs.rxn_params = ReactionInterrogatorBlock(
             default={"property_package": m.fs.params})
 


### PR DESCRIPTION
## Fixes https://github.com/nawi-hub/proteuslib/issues/153


## Summary/Motivation:
A couple of short comings have been identified in the properties interrogator tools:

1. Tools do not work with Unit Models which define specific phase lists that are not ["Liq", "Vap"]
2. Interrogator tools need to be updated to use the Pyomo UnitsContainer


## Changes proposed in this PR:
- Updates units in interrogator tools
- Adds ability for users to (manually) define custom phase and components sets

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
