### PR TITLE
Expanding Generic Property Framework

### DIFF
--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -52,10 +52,22 @@ class ComponentData(ProcessBlockData):
             doc="Dict indicating phases in which component follows Henry's "
                 "Law (keys) with values indicating form of law."))
 
+    CONFIG.declare("vol_mol_liq_comp", ConfigValue(
+        description="Method to use to calculate liquid phase molar volume",
+        doc="Method to use to calculate liquid phase molar volume. Users "
+        "need only define one of vol_mol_liq_comp and dens_mol_liq_comp."))
+    CONFIG.declare("vol_mol_sol_comp", ConfigValue(
+        description="Method to use to calculate solid phase molar volume",
+        doc="Method to use to calculate solid phase molar volume. Users "
+        "need only define one of vol_mol_sol_comp and dens_mol_sol_comp."))
     CONFIG.declare("dens_mol_liq_comp", ConfigValue(
-        description="Method to use to calculate liquid phase molar density"))
+        description="Method to use to calculate liquid phase molar density",
+        doc="Method to use to calculate liquid phase molar density. Users "
+        "need only define one of vol_mol_liq_comp and dens_mol_liq_comp."))
     CONFIG.declare("dens_mol_sol_comp", ConfigValue(
-        description="Method to use to calculate solid phase molar density"))
+        description="Method to use to calculate solid phase molar density",
+        doc="Method to use to calculate solid phase molar density. Users "
+        "need only define one of vol_mol_sol_comp and dens_mol_sol_comp."))
 
     CONFIG.declare("cp_mol_liq_comp", ConfigValue(
         description="Method to calculate liquid component specific heats"))

--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -55,7 +55,7 @@ class ComponentData(ProcessBlockData):
     CONFIG.declare("vol_mol_liq_comp", ConfigValue(
         description="Method to use to calculate liquid phase molar volume",
         doc="Method to use to calculate liquid phase molar volume. Users "
-        "need only define one of vol_mol_liq_comp and dens_mol_liq_comp."))
+        "need only define either vol_mol_liq_comp or dens_mol_liq_comp."))
     CONFIG.declare("vol_mol_sol_comp", ConfigValue(
         description="Method to use to calculate solid phase molar volume",
         doc="Method to use to calculate solid phase molar volume. Users "

--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -59,7 +59,7 @@ class ComponentData(ProcessBlockData):
     CONFIG.declare("vol_mol_sol_comp", ConfigValue(
         description="Method to use to calculate solid phase molar volume",
         doc="Method to use to calculate solid phase molar volume. Users "
-        "need only define one of vol_mol_sol_comp and dens_mol_sol_comp."))
+        "need only define either vol_mol_sol_comp or dens_mol_sol_comp."))
     CONFIG.declare("dens_mol_liq_comp", ConfigValue(
         description="Method to use to calculate liquid phase molar density",
         doc="Method to use to calculate liquid phase molar density. Users "

--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -63,11 +63,11 @@ class ComponentData(ProcessBlockData):
     CONFIG.declare("dens_mol_liq_comp", ConfigValue(
         description="Method to use to calculate liquid phase molar density",
         doc="Method to use to calculate liquid phase molar density. Users "
-        "need only define one of vol_mol_liq_comp and dens_mol_liq_comp."))
+        "need only define either vol_mol_liq_comp or dens_mol_liq_comp."))
     CONFIG.declare("dens_mol_sol_comp", ConfigValue(
         description="Method to use to calculate solid phase molar density",
         doc="Method to use to calculate solid phase molar density. Users "
-        "need only define one of vol_mol_sol_comp and dens_mol_sol_comp."))
+        "need only define either vol_mol_sol_comp or dens_mol_sol_comp."))
 
     CONFIG.declare("cp_mol_liq_comp", ConfigValue(
         description="Method to calculate liquid component specific heats"))

--- a/idaes/core/phases.py
+++ b/idaes/core/phases.py
@@ -65,6 +65,11 @@ class PhaseData(ProcessBlockData):
             doc="Internal config argument indicating whether phase_list "
             "needs to be populated."))
 
+    CONFIG.declare("diffus_phase_comp", ConfigValue(
+        description="Method to calculate component diffusivities in phase"))
+    CONFIG.declare("visc_d_phase", ConfigValue(
+        description="Method to calculate dynamic viscosity of phase"))
+
     def build(self):
         super(PhaseData, self).build()
 

--- a/idaes/core/tests/test_phases.py
+++ b/idaes/core/tests/test_phases.py
@@ -36,7 +36,6 @@ def test_config():
 
     m.phase = Phase()
 
-    assert len(m.phase.config) == 5
     for k, v in m.phase.config.items():
         if k == "_phase_list_exists":
             assert not v

--- a/idaes/generic_models/properties/core/eos/ceos.py
+++ b/idaes/generic_models/properties/core/eos/ceos.py
@@ -812,6 +812,16 @@ class Cubic(EoSBase):
                 b.entr_mol_phase_comp[p, j] *
                 b.temperature)
 
+    @staticmethod
+    def vol_mol_phase(b, p):
+        pobj = b.params.get_phase(p)
+        if pobj.is_vapor_phase() or pobj.is_liquid_phase():
+            return (Cubic.gas_constant(b)*b.temperature *
+                    b.compress_fact_phase[p] /
+                    b.pressure)
+        else:
+            raise PropertyNotSupportedError(_invalid_phase_msg(b.name, p))
+
 
 def _invalid_phase_msg(name, phase):
     return ("{} received unrecognized phase name {}. Ideal property "

--- a/idaes/generic_models/properties/core/eos/eos_base.py
+++ b/idaes/generic_models/properties/core/eos/eos_base.py
@@ -52,6 +52,27 @@ class EoSBase():
         raise NotImplementedError(_msg(b, "build_parameters"))
 
     @staticmethod
+    def get_vol_mol_pure(b, phase, comp, temperature):
+        try:
+            vol_mol = get_method(b, "vol_mol_"+phase+"_comp", comp)(
+                                 b, cobj(b, comp), temperature)
+        except (AttributeError, ConfigurationError):
+            # vol_mol not defined, try for dens_mol instead
+            try:
+                vol_mol = 1/get_method(b, "dens_mol_"+phase+"_comp", comp)(
+                                       b, cobj(b, comp), temperature)
+            except (AttributeError, ConfigurationError):
+                # Does not have either vol_mol or dens_mol
+                suffix = "_"+phase+"_comp"
+                raise ConfigurationError(
+                    f"{b.name} does not have a method defined to use "
+                    f"when calculating molar volume and density for "
+                    f"component {comp} in phase {phase}. Each component "
+                    f"must define a method for either vol_mol{suffix} or "
+                    f"dens_mol{suffix}.")
+        return vol_mol
+
+    @staticmethod
     def act_phase_comp(b, p, j):
         raise NotImplementedError(_msg(b, "act_phase_comp"))
 

--- a/idaes/generic_models/properties/core/eos/eos_base.py
+++ b/idaes/generic_models/properties/core/eos/eos_base.py
@@ -286,6 +286,10 @@ class EoSBase():
     def pressure_osm_phase(b, p):
         raise NotImplementedError(_msg(b, "pressure_osm_phase"))
 
+    @staticmethod
+    def vol_mol_phase(b, p):
+        raise NotImplementedError(_msg(b, "vol_mol_phase"))
+
 
 def _msg(b, attr):
     return ("{} Equation of State module has not implemented a method for {}. "

--- a/idaes/generic_models/properties/core/eos/tests/test_ceos_PR.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_ceos_PR.py
@@ -678,3 +678,17 @@ def test_gibbs_mol_phase_comp(m):
                     m.props[1].enth_mol_phase_comp[p, j] -
                     m.props[1].entr_mol_phase_comp[p, j] *
                     m.props[1].temperature)
+
+
+@pytest.mark.unit
+def test_vol_mol_phase(m):
+    assert value(Cubic.vol_mol_phase(m.props[1], "Vap")) == pytest.approx(
+            1/44.800, rel=1e-3)
+    assert value(Cubic.vol_mol_phase(m.props[1], "Liq")) == pytest.approx(
+            1/41.157, rel=1e-3)
+
+
+@pytest.mark.unit
+def test_vol_mol_phase_invalid_phase(m_sol):
+    with pytest.raises(PropertyNotSupportedError):
+        Cubic.vol_mol_phase(m_sol.props[1], "Sol")

--- a/idaes/generic_models/properties/core/eos/tests/test_enrtl.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_enrtl.py
@@ -850,14 +850,14 @@ class TestProperties(object):
 
     @pytest.mark.unit
     def test_pressure_osm_phase(self, model):
-        model.state[1].dens_mol_phase = Var(model.params.phase_list,
-                                            initialize=55e3,
-                                            units=pyunits.mol/pyunits.m**3)
+        model.state[1].vol_mol_phase = Var(model.params.phase_list,
+                                           initialize=18e-6,
+                                           units=pyunits.m**3/pyunits.mol)
 
         assert_units_equivalent(model.state[1].pressure_osm_phase["Liq"],
                                 pyunits.Pa)
         assert len(model.state[1].pressure_osm_phase) == 1
         assert pytest.approx(value(
-            -Constants.gas_constant*300*log(0.1670306)*55e3),
+            -Constants.gas_constant*300*log(0.1670306)/18e-6),
             rel=1e-6) == value(
                 model.state[1].pressure_osm_phase["Liq"])

--- a/idaes/generic_models/properties/core/eos/tests/test_enrtl_verification_NaCl.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_enrtl_verification_NaCl.py
@@ -28,6 +28,7 @@ import pytest
 from math import exp, log
 
 from pyomo.environ import (ConcreteModel,
+                           Param,
                            units as pyunits,
                            value)
 
@@ -46,21 +47,28 @@ from idaes.generic_models.properties.core.pure.electrolyte import \
     relative_permittivity_constant
 
 
-def dummy_method(b, *args, **kwargs):
-    return 1000/18e-3*pyunits.mol/pyunits.m**3
+class ConstantVolMol():
+    def build_parameters(b):
+        b.vol_mol_pure = Param(initialize=18e-6,
+                               units=pyunits.m**3/pyunits.mol,
+                               mutable=True)
+
+    def return_expression(b, cobj, T):
+        return cobj.vol_mol_pure
 
 
 configuration = {
     "components": {
         "H2O": {"type": Solvent,
-                "dens_mol_liq_comp": dummy_method,
+                "vol_mol_liq_comp": ConstantVolMol,
                 "relative_permittivity_liq_comp":
                     relative_permittivity_constant,
                 "parameter_data": {
                     "mw": (18E-3, pyunits.kg/pyunits.mol),
                     "relative_permittivity_liq_comp": 78.54}},
         "NaCl": {"type": Apparent,
-                 "dissociation_species": {"Na+": 1, "Cl-": 1}},
+                 "dissociation_species": {"Na+": 1, "Cl-": 1},
+                 "vol_mol_liq_comp": ConstantVolMol},
         "Na+": {"type": Cation,
                 "charge": +1},
         "Cl-": {"type": Anion,

--- a/idaes/generic_models/properties/core/eos/tests/test_ideal.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_ideal.py
@@ -505,6 +505,7 @@ def test_pressure_osm_phase(m):
             m.props[1].conc_mol_phase_comp["Liq", "c"])))
     assert len(m.props[1].pressure_osm_phase) == 1
 
+
 @pytest.mark.unit
 def test_pressure_osm_phase_w_apparent_component():
     m = ConcreteModel()
@@ -562,11 +563,10 @@ def test_pressure_osm_phase_w_apparent_component():
 @pytest.mark.unit
 def test_vol_mol_phase_no_methods(m):
     with pytest.raises(ConfigurationError,
-                       match="props\[1\] does not have a method defined to "
-                       "use when calculating molar volume and density for "
-                       "component a in phase Liq. Each component must "
-                       "define a method for either vol_mol_liq_comp or "
-                       "dens_mol_liq_comp."):
+                       match="does not have a method defined to use when "
+                       "calculating molar volume and density for component a "
+                       "in phase liq. Each component must define a method for "
+                       "either vol_mol_liq_comp or dens_mol_liq_comp."):
         Ideal.vol_mol_phase(m.props[1], "Liq")
 
 

--- a/idaes/generic_models/properties/core/eos/tests/test_ideal.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_ideal.py
@@ -226,8 +226,9 @@ def test_dens_mol_phase_liq(m):
         m.params.get_component(j).config.dens_mol_liq_comp = dummy_call
 
     assert str(Ideal.dens_mol_phase(m.props[1], "Liq")) == str(
-        sum(m.props[1].mole_frac_phase_comp["Liq", j]*42
-            for j in m.params.component_list))
+                1/(1/42*m.props[1].mole_frac_phase_comp["Liq", "a"] +
+                   1/42*m.props[1].mole_frac_phase_comp["Liq", "b"] +
+                   1/42*m.props[1].mole_frac_phase_comp["Liq", "c"]))
 
 
 @pytest.mark.unit
@@ -241,10 +242,11 @@ def test_dens_mol_phase_vap(m):
 def test_dens_mol_phase_sol(m_sol):
     for j in m_sol.params.component_list:
         m_sol.params.get_component(j).config.dens_mol_sol_comp = dummy_call
+        m_sol.params.get_component(j).config.dens_mol_liq_comp = dummy_call
 
     assert str(Ideal.dens_mol_phase(m_sol.props[1], "Sol")) == str(
-        sum(m_sol.props[1].mole_frac_phase_comp["Sol", j]*42
-            for j in m_sol.params.component_list))
+        1/sum(m_sol.props[1].mole_frac_phase_comp["Sol", j]/42
+              for j in m_sol.params.component_list))
 
 
 @pytest.mark.unit
@@ -555,3 +557,62 @@ def test_pressure_osm_phase_w_apparent_component():
             m.props[1].conc_mol_phase_comp["Liq", "b"] +
             2*m.props[1].conc_mol_phase_comp["Liq", "c"])))
     assert len(m.props[1].pressure_osm_phase) == 1
+
+
+@pytest.mark.unit
+def test_vol_mol_phase_no_methods(m):
+    with pytest.raises(ConfigurationError,
+                       match="props\[1\] does not have a method defined to "
+                       "use when calculating molar volume and density for "
+                       "component a in phase Liq. Each component must "
+                       "define a method for either vol_mol_liq_comp or "
+                       "dens_mol_liq_comp."):
+        Ideal.vol_mol_phase(m.props[1], "Liq")
+
+
+@pytest.mark.unit
+def test_vol_mol_phase():
+    m = ConcreteModel()
+
+    # Dummy params block
+    m.params = DummyParameterBlock(default={
+                "components": {
+                    "a": {"dens_mol_liq_comp": dummy_call},
+                    "b": {"dens_mol_liq_comp": dummy_call},
+                    "c": {"vol_mol_liq_comp": dummy_call}},
+                "phases": {
+                    "Vap": {"type": VaporPhase,
+                            "equation_of_state": Ideal},
+                    "Liq": {"type": LiquidPhase,
+                            "equation_of_state": Ideal}},
+                "base_units": {"time": pyunits.s,
+                               "length": pyunits.m,
+                               "mass": pyunits.kg,
+                               "amount": pyunits.mol,
+                               "temperature": pyunits.K},
+                "state_definition": modules[__name__],
+                "pressure_ref": 1e5,
+                "temperature_ref": 300})
+
+    m.props = m.params.state_block_class([1],
+                                         default={"defined_state": False,
+                                         "parameters": m.params})
+
+    # Add common variables
+    m.props[1].pressure = Var(initialize=101325)
+    m.props[1].temperature = Var(initialize=300, units=pyunits.K)
+    m.props[1]._teq = Var([("Vap", "Liq")], initialize=300)
+    m.props[1].mole_frac_phase_comp = Var(m.params.phase_list,
+                                          m.params.component_list,
+                                          initialize=0.5)
+
+    for p in m.params.phase_list:
+        if p == "Vap":
+            assert str(Ideal.vol_mol_phase(m.props[1], p)) == (
+                "kg*m**2/J/s**2*(8.314462618*(J)/mol/K)*"
+                "props[1].temperature/props[1].pressure")
+        else:
+            assert str(Ideal.vol_mol_phase(m.props[1], p)) == str(
+                1/42*m.props[1].mole_frac_phase_comp["Liq", "a"] +
+                1/42*m.props[1].mole_frac_phase_comp["Liq", "b"] +
+                42*m.props[1].mole_frac_phase_comp["Liq", "c"])

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -910,10 +910,11 @@ class GenericParameterData(PhysicalParameterBlock):
              'mw_phase': {'method': '_mw_phase'},
              'pressure_bubble': {'method': '_pressure_bubble'},
              'pressure_dew': {'method': '_pressure_dew'},
+             'pressure_osm_phase': {'method': '_pressure_osm_phase'},
              'pressure_sat_comp': {'method': '_pressure_sat_comp'},
              'temperature_bubble': {'method': '_temperature_bubble'},
              'temperature_dew': {'method': '_temperature_dew'},
-             'pressure_osm_phase': {'method': '_pressure_osm_phase'},
+             'vol_mol_phase': {'method': '_vol_mol_phase'},
              'dh_rxn': {'method': '_dh_rxn'}})
 
 
@@ -2664,6 +2665,19 @@ class GenericStateBlockData(StateBlockData):
                 rule=rule_pressure_sat_comp)
         except AttributeError:
             self.del_component(self.pressure_sat_comp)
+            raise
+
+    def _vol_mol_phase(self):
+        try:
+            def rule_vol_mol_phase(b, p):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.vol_mol_phase(b, p)
+            self.vol_mol_phase = Expression(
+                    self.phase_list,
+                    doc="Molar volume of each phase",
+                    rule=rule_vol_mol_phase)
+        except AttributeError:
+            self.del_component(self.vol_mol_phase)
             raise
 
     def _dh_rxn(self):

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -1071,3 +1071,27 @@ class TestGenericStateBlock(object):
             pytest.approx(100*0.75*(2*0.1 + 3*0.2 + 4*0.7), rel=1e-4)
         assert value(frame.props[1].flow_mass_phase["p2"]) == \
             pytest.approx(100*0.25*(2*0.7 + 3*0.2 + 4*0.1), rel=1e-4)
+
+    class dummy_prop():
+        def return_expression(*args, **kwargs):
+            return 4
+
+    @pytest.mark.unit
+    def test_diffus_phase_comp(self, frame):
+        frame.params.p1.config.diffus_phase_comp = \
+            TestGenericStateBlock.dummy_prop
+        frame.params.p2.config.diffus_phase_comp = \
+            TestGenericStateBlock.dummy_prop
+
+        for p, j in frame.props[1].phase_component_set:
+            assert value(frame.props[1].diffus_phase_comp[p, j]) == 4
+
+    @pytest.mark.unit
+    def test_vics_d_phase(self, frame):
+        frame.params.p1.config.visc_d_phase = \
+            TestGenericStateBlock.dummy_prop
+        frame.params.p2.config.visc_d_phase = \
+            TestGenericStateBlock.dummy_prop
+
+        for p in frame.props[1].phase_list:
+            assert value(frame.props[1].visc_d_phase[p]) == 4

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -1087,7 +1087,7 @@ class TestGenericStateBlock(object):
             assert value(frame.props[1].diffus_phase_comp[p, j]) == 4
 
     @pytest.mark.unit
-    def test_vics_d_phase(self, frame):
+    def test_visc_d_phase(self, frame):
         frame.params.p1.config.visc_d_phase = \
             TestGenericStateBlock.dummy_prop
         frame.params.p2.config.visc_d_phase = \

--- a/idaes/generic_models/properties/core/generic/tests/test_utility.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_utility.py
@@ -1,0 +1,251 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+"""
+Tests for common methods used by generic framework
+
+Author: A Lee
+"""
+import pytest
+
+from types import MethodType
+
+from idaes.generic_models.properties.core.generic.utility import (
+    GenericPropertyPackageError, get_method, get_phase_method,
+    get_component_object, get_bounds_from_config)
+
+from pyomo.environ import Block, units as pyunits
+from pyomo.common.config import ConfigBlock, ConfigValue
+from idaes.core.util.exceptions import ConfigurationError, PropertyPackageError
+
+
+@pytest.fixture
+def frame():
+    m = Block(concrete=True)
+    m.params = Block()
+    m.params.config = ConfigBlock()
+    m.params.config.declare("test_arg", ConfigValue())
+    m.params.config.declare("state_bounds", ConfigValue())
+
+    def get_component(self, comp):
+        return getattr(self, comp)
+    m.params.get_component = MethodType(get_component, m.params)
+    m.params.get_phase = MethodType(get_component, m.params)
+
+    m.params.comp = Block()
+    m.params.comp.config = ConfigBlock()
+    m.params.comp.config.declare("test_arg_2", ConfigValue())
+
+    return m
+
+
+@pytest.mark.unit
+def test_generic_property_package_error():
+    with pytest.raises(
+            PropertyPackageError,
+            match="Generic Property Package instance block called for "
+            "prop, but was not provided with a method "
+            "for this property. Please add a method for this property "
+            "in the property parameter configuration."):
+        raise GenericPropertyPackageError("block", "prop")
+
+
+@pytest.mark.unit
+def test_get_component_object(frame):
+    assert get_component_object(frame, "comp") is frame.params.comp
+
+
+class TestGetMethod():
+    @pytest.mark.unit
+    def test_get_method_invalid_name(self, frame):
+        with pytest.raises(
+                AttributeError,
+                match="ScalarBlock Generic Property Package called for "
+                "invalid configuration option foo. Please contact the "
+                "developer of the property package."):
+            get_method(frame, "foo")
+
+    @pytest.mark.unit
+    def test_get_method_none(self, frame):
+        with pytest.raises(
+                GenericPropertyPackageError,
+                match="Generic Property Package instance ScalarBlock "
+                "called for test_arg, but was not provided with a "
+                "method for this property. Please add a method for "
+                "this property in the property parameter "
+                "configuration."):
+            get_method(frame, "test_arg")
+
+    @pytest.mark.unit
+    def test_get_method_not_callable(self, frame):
+        frame.params.config.test_arg = "foo"
+        with pytest.raises(
+                ConfigurationError,
+                match="ScalarBlock Generic Property Package received "
+                "invalid value for argument test_arg. Value must be a "
+                "method, a class with a method named expression or a "
+                "module containing one of the previous."):
+            get_method(frame, "test_arg")
+
+    @pytest.mark.unit
+    def test_get_method_simple(self, frame):
+        def test_arg():
+            return "bar"
+
+        frame.params.config.test_arg = test_arg
+
+        mthd = get_method(frame, "test_arg")
+        assert mthd() == "bar"
+
+    @pytest.mark.unit
+    def test_get_method_class_w_method(self, frame):
+        class TestClass():
+            def test_arg():
+                return "bar"
+
+        frame.params.config.test_arg = TestClass
+
+        mthd = get_method(frame, "test_arg")
+        assert mthd() == "bar"
+
+    @pytest.mark.unit
+    def test_get_method_class_w_return_expression(self, frame):
+        class TestClass():
+            def return_expression(*args, **kwargs):
+                return "bar"
+
+        frame.params.config.test_arg = TestClass
+
+        mthd = get_method(frame, "test_arg")
+        assert mthd() == "bar"
+
+    @pytest.mark.unit
+    def test_get_method_phase(self, frame):
+        def test_arg():
+            return "bar"
+
+        frame.params.config.test_arg = {"test_phase": test_arg}
+
+        mthd = get_method(frame, "test_arg", phase="test_phase")
+        assert mthd() == "bar"
+
+    @pytest.mark.unit
+    def test_get_method_comp(self, frame):
+        def test_arg():
+            return "bar"
+
+        frame.params.comp.config.test_arg_2 = test_arg
+
+        mthd = get_method(frame, "test_arg_2", comp="comp")
+        assert mthd() == "bar"
+
+    @pytest.mark.unit
+    def test_get_method_phase_comp(self, frame):
+        def test_arg():
+            return "bar"
+
+        frame.params.comp.config.test_arg_2 = {"test_phase": test_arg}
+
+        mthd = get_method(frame, "test_arg_2", comp="comp", phase="test_phase")
+        assert mthd() == "bar"
+
+
+class TestGetPhaseMethod():
+    @pytest.mark.unit
+    def test_get_phase_method_invalid_name(self, frame):
+        with pytest.raises(
+                AttributeError,
+                match="ScalarBlock Generic Property Package called for "
+                "invalid configuration option foo. Please contact the "
+                "developer of the property package."):
+            get_phase_method(frame, "foo", "comp")
+
+    @pytest.mark.unit
+    def test_get_phase_method_none(self, frame):
+        with pytest.raises(
+                GenericPropertyPackageError,
+                match="Generic Property Package instance ScalarBlock "
+                "called for test_arg_2, but was not provided with a "
+                "method for this property. Please add a method for "
+                "this property in the property parameter "
+                "configuration."):
+            get_phase_method(frame, "test_arg_2", "comp")
+
+    @pytest.mark.unit
+    def test_get_phase_method_not_callable(self, frame):
+        frame.params.comp.config.test_arg_2 = "foo"
+        with pytest.raises(
+                ConfigurationError,
+                match="ScalarBlock Generic Property Package received "
+                "invalid value for argument test_arg_2. Value must be a "
+                "method, a class with a method named expression or a "
+                "module containing one of the previous."):
+            get_phase_method(frame, "test_arg_2", "comp")
+
+    @pytest.mark.unit
+    def test_get_phase_method_simple(self, frame):
+        def test_arg():
+            return "bar"
+
+        frame.params.comp.config.test_arg_2 = test_arg
+
+        mthd = get_phase_method(frame, "test_arg_2", "comp")
+        assert mthd() == "bar"
+
+    @pytest.mark.unit
+    def test_get_phase_method_class_w_method(self, frame):
+        class TestClass():
+            def test_arg_2():
+                return "bar"
+
+        frame.params.comp.config.test_arg_2 = TestClass
+
+        mthd = get_phase_method(frame, "test_arg_2", "comp")
+        assert mthd() == "bar"
+
+    @pytest.mark.unit
+    def test_get_phase_method_class_w_return_expression(self, frame):
+        class TestClass():
+            def return_expression():
+                return "bar"
+
+        frame.params.comp.config.test_arg_2 = TestClass
+
+        mthd = get_phase_method(frame, "test_arg_2", "comp")
+        assert mthd() == "bar"
+
+
+class TestGetBoundsFromConfig():
+    @pytest.mark.unit
+    def test_no_state_bounds(self, frame):
+        bounds, value = get_bounds_from_config(frame, "foo", "bar")
+
+        assert bounds == (None, None)
+        assert value is None
+
+    @pytest.mark.unit
+    def test_no_state_bounds_3(self, frame):
+        frame.params.config.state_bounds = {
+            "test_state": (1, 2, 3)}
+        bounds, value = get_bounds_from_config(frame, "test_state", "bar")
+
+        assert bounds == (1, 3)
+        assert value == 2
+
+    @pytest.mark.unit
+    def test_no_state_bounds_4(self, frame):
+        frame.params.config.state_bounds = {
+            "test_state": (1, 2, 3, pyunits.km)}
+        bounds, value = get_bounds_from_config(frame, "test_state", pyunits.m)
+
+        assert bounds == (1000, 3000)
+        assert value == 2000

--- a/idaes/generic_models/properties/core/generic/utility.py
+++ b/idaes/generic_models/properties/core/generic/utility.py
@@ -98,6 +98,56 @@ def get_method(self, config_arg, comp=None, phase=None):
                 "previous.".format(self.name, config_arg))
 
 
+def get_phase_method(self, config_arg, phase):
+    """
+    General method for finding and returning phase-specific configuration
+    arguments.
+
+    Args:
+        config_arg : argument to find in Config block
+        phase : phase in which to search for config_arg
+
+    Returns:
+        Pointer to method in Config block
+    """
+    p_config = self.params.get_phase(phase).config
+
+    try:
+        c_arg = getattr(p_config, config_arg)
+    except AttributeError:
+        raise AttributeError("{} Generic Property Package called for invalid "
+                             "configuration option {}. Please contact the "
+                             "developer of the property package."
+                             .format(self.name, config_arg))
+
+    if c_arg is None:
+        raise GenericPropertyPackageError(self, config_arg)
+
+    # Check to see if c_arg has an attribute with the name of the config_arg
+    # If so, assume c_arg is a class or module holding property subclasses
+    if hasattr(c_arg, config_arg):
+        c_arg = getattr(c_arg, config_arg)
+
+    # Try to get the return_expression method from c_arg
+    # Otherwise assume c_arg is the return_expression method
+    try:
+        mthd = c_arg.return_expression
+    except AttributeError:
+        mthd = c_arg
+
+    # Check if method is callable
+    if callable(mthd):
+        return mthd
+    else:
+        raise ConfigurationError(
+                "{} Generic Property Package received invalid value "
+                "for argument {}. Value must be a method, a class with a "
+                "method named expression or a module containing one of the "
+                "previous.".format(self.name, config_arg))
+
+    return mthd
+
+
 def get_component_object(self, comp):
     """
     Utility method to get a component object from the property parameter block.


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
This PR adds support for a number of properties required by IDAES and NAWI work.


## Changes proposed in this PR:
- Adds support for molar volume and updates molar density to be calculated from molar volume
- Adds general mixing rules for molar volume to all equations of state and activity coefficient models
- Adds support for defining models for diffusivity and dynamic viscosity
- Adds tests for utility methods that were missing

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
