### PR TITLE
Add a command to print a bunch of environment info

### DIFF
--- a/docs/user_guide/commands/env_info.rst
+++ b/docs/user_guide/commands/env_info.rst
@@ -1,0 +1,52 @@
+idaes environment-info: Get information about the IDAES environment
+===================================================================
+
+The idaes "environment-info" command return information about IDAES, Pyomo,
+dependencies, and solvers. This information is particularly useful for
+debugging.
+
+This page lists the options for the idaes "environment-info" subcommand.
+This is invoked like::
+
+    idaes [general options] environment-info [subcommand options]
+
+
+.. program:: idaes
+
+general options
+---------------
+The following general options from the `idaes` base command
+affect the get-extensions subcommand. They should be placed *before* the
+"get-extensions" subcommand, on the command-line.
+
+* -v/--verbose
+* -q/--quiet
+
+See :ref:`idaes-base-command` for details.
+
+idaes environment-info
+----------------------
+
+This subcommand gets the compiled solvers and libraries
+from a remote repository, and installs them locally.
+
+.. program:: environment-info
+
+options
+^^^^^^^
+
+.. option:: --help
+
+    Show the help message and exit.
+
+.. option:: --solver <Pyomo solver name>
+
+    The environment-info command returns version for a set of known solvers. You
+    can use the "--solver" option to specify additional solvers that are not
+    part of the IDAES binary distribution.  The solver option can be supplied
+    multiple times to add multiple solvers.
+
+.. option:: --file <file path>
+
+    Write the command output to a text file rather than displaying to the
+    screen.

--- a/docs/user_guide/commands/env_info.rst
+++ b/docs/user_guide/commands/env_info.rst
@@ -48,4 +48,4 @@ options
 
 .. option:: --json <file path>
 
-    Write output to the specified json file.
+    Write output to the specified json file, instead of to the screen.

--- a/docs/user_guide/commands/env_info.rst
+++ b/docs/user_guide/commands/env_info.rst
@@ -46,7 +46,6 @@ options
     part of the IDAES binary distribution.  The solver option can be supplied
     multiple times to add multiple solvers.
 
-.. option:: --file <file path>
+.. option:: --json <file path>
 
-    Write the command output to a text file rather than displaying to the
-    screen.
+    Write output to the specified json file.

--- a/docs/user_guide/commands/get_extensions.rst
+++ b/docs/user_guide/commands/get_extensions.rst
@@ -35,6 +35,61 @@ options
 
     Show the help message and exit.
 
-.. option:: --url
+.. option:: --release <release number e.g. 2.4.4>
 
-    URL from which to download the solvers/libraries.
+    Specify an official binary release version number to download.  If this is
+    not specified the default release will be used.
+
+.. option:: --url <url>
+
+    URL from which to download the solvers/libraries.  If this is not
+    provided the URL of the default release will be used.
+
+.. option:: --insecure
+
+    Don't verify download location
+
+.. option:: --cacert <ca>
+
+    Specify certificate file to verify download location
+
+.. option:: --nochecksum
+
+    Don't verify the file checksum
+
+.. option:: --library-only
+
+    Only install shared physical property function libraries, and any specified
+    extras not solvers.
+
+.. option:: --no-download
+
+    Don't download anything, but report what would be done
+
+.. option:: --show-current-version
+
+    Just show the version information if any for the currently installed solvers
+    and libraries.
+
+.. option:: --show-platforms
+
+    Just show the platform options
+
+.. option:: --show-extras
+
+    Just show list of binary extras
+
+.. option:: --extra <extra>
+
+    Add an extra binary package to the things to install. You can specify the
+    extra option multiple times for multiple extras.
+
+.. option:: --to <path>
+
+    Put extensions in a alternate location.  This can be used to just download
+    and extract the binaries. It lets you download the files without putting
+    them in IDAES's bin directory.
+
+.. option:: --verbose
+
+    Show details

--- a/docs/user_guide/commands/index.rst
+++ b/docs/user_guide/commands/index.rst
@@ -2,8 +2,8 @@ Command-line interface
 ======================
 The IDAES PSE Toolkit includes a command-line tool that can be invoked
 by typing `idaes` in a UNIX or Mac OSX shell, or Windows Powershell,
-that is in an installed IDAES environment. For the most part, this means
-that wherever you installed IDAES will have this command available.
+that is in an installed IDAES environment. Generally, the `idaes` command
+is available where you install IDAES.
 
 This section of the documentation describes the capabilities of this
 command-line program.
@@ -12,7 +12,7 @@ command-line program.
 
 idaes command
 -------------
-The base `idaes` command does not do anything by itself, besides set some
+The base `idaes` command does not do anything by itself, beside set some
 shared configuration values. All the real work is done by one of the subcommands,
 each of which is described on a separate page below.
 
@@ -23,6 +23,7 @@ each of which is described on a separate page below.
     bin_directory
     copyright
     data_directory
+    env_info
     get_examples
     get_extensions
     lib_directory

--- a/docs/user_guide/commands/index.rst
+++ b/docs/user_guide/commands/index.rst
@@ -12,7 +12,7 @@ command-line program.
 
 idaes command
 -------------
-The base `idaes` command does not do anything by itself, beside set some
+The base `idaes` command does not do anything by itself, besides set some
 shared configuration values. All the real work is done by one of the subcommands,
 each of which is described on a separate page below.
 

--- a/idaes/commands/convergence.py
+++ b/idaes/commands/convergence.py
@@ -112,7 +112,7 @@ def convergence_eval(
 @click.option('-r', '--regex', default=None, type=str,
     help="Optional regular expression to filter registered convergence classes")
 @click.option('-m', '--convergence_module', default=None, type=str, required=False,
-    help="Optional addtional module that registers convergence classes")
+    help="Optional additional module that registers convergence classes")
 def convergence_search(regex, convergence_module):
     import idaes.convergence
     if convergence_module is not None:

--- a/idaes/commands/env_info.py
+++ b/idaes/commands/env_info.py
@@ -1,0 +1,31 @@
+##############################################################################
+# Institute for the Design of Advanced Energy Systems Process Systems
+# Engineering Framework (IDAES PSE Framework) Copyright (c) 2018-2020, by the
+# software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
+# University Research Corporation, et al. All rights reserved.
+#
+# Please see the files COPYRIGHT.txt and LICENSE.txt for full copyright and
+# license information, respectively. Both files are also available online
+# at the URL "https://github.com/IDAES/idaes-pse".
+##############################################################################
+"""Get info about the environment IDAES is running in and the IDAES version
+"""
+
+__author__ = "John Eslick"
+
+import click
+from idaes.core.util.env_info import EnvironmentInfo
+from idaes.commands import cb
+
+@cb.command(
+    name="environment-info",
+    help="Print information about idaes, OS, dependencies...")
+def environment_info():
+    info = EnvironmentInfo().display_dict()
+    for k, v in info.items():
+        click.echo("")
+        click.echo(f"{k}")
+        for l, q in v.items():
+            click.echo(f"    {l}: {q}")

--- a/idaes/commands/env_info.py
+++ b/idaes/commands/env_info.py
@@ -29,22 +29,18 @@ from idaes.commands import cb
     help="Add solvers to list of solvers to check"
 )
 @click.option(
-    "--file",
+    "--json",
     default=None,
     help="Write output ot a file"
 )
-def environment_info(solver, file):
-    info = EnvironmentInfo(additional_solvers=solver).display_dict()
-    if file is None:
-        for k, v in info.items():
+def environment_info(solver, json):
+    info = EnvironmentInfo(additional_solvers=solver)
+    d = info.to_dict()
+    if json is None:
+        for k, v in d.items():
             click.echo("")
             click.echo(f"{k}")
             for l, q in v.items():
                 click.echo(f"    {l}: {q}")
     else:
-        with open(file, "w") as f:
-            for k, v in info.items():
-                f.write("\n")
-                f.write(f"{k}\n")
-                for l, q in v.items():
-                    f.write(f"    {l}: {q}\n")
+        info.to_json(json)

--- a/idaes/commands/env_info.py
+++ b/idaes/commands/env_info.py
@@ -34,7 +34,7 @@ from idaes.commands import cb
     help="Write output ot a file"
 )
 def environment_info(solver, file):
-    info = EnvironmentInfo(addtional_solvers=solver).display_dict()
+    info = EnvironmentInfo(additional_solvers=solver).display_dict()
     if file is None:
         for k, v in info.items():
             click.echo("")

--- a/idaes/commands/env_info.py
+++ b/idaes/commands/env_info.py
@@ -19,13 +19,32 @@ import click
 from idaes.core.util.env_info import EnvironmentInfo
 from idaes.commands import cb
 
+
 @cb.command(
     name="environment-info",
     help="Print information about idaes, OS, dependencies...")
-def environment_info():
-    info = EnvironmentInfo().display_dict()
-    for k, v in info.items():
-        click.echo("")
-        click.echo(f"{k}")
-        for l, q in v.items():
-            click.echo(f"    {l}: {q}")
+@click.option(
+    "--solver",
+    multiple=True,
+    help="Add solvers to list of solvers to check"
+)
+@click.option(
+    "--file",
+    default=None,
+    help="Write output ot a file"
+)
+def environment_info(solver, file):
+    info = EnvironmentInfo(addtional_solvers=solver).display_dict()
+    if file is None:
+        for k, v in info.items():
+            click.echo("")
+            click.echo(f"{k}")
+            for l, q in v.items():
+                click.echo(f"    {l}: {q}")
+    else:
+        with open(file, "w") as f:
+            for k, v in info.items():
+                f.write("\n")
+                f.write(f"{k}\n")
+                for l, q in v.items():
+                    f.write(f"    {l}: {q}\n")

--- a/idaes/commands/tests/test_commands.py
+++ b/idaes/commands/tests/test_commands.py
@@ -665,3 +665,13 @@ def test_conf_set(runner):
     _tst(["--global", "--file", fname, "--file_as_global"])
     _tst(["--local", "--file", fname, "--file_as_local"])
     _tst(["--file", fname])
+
+
+##############
+# env info   #
+##############
+
+@pytest.mark.unit
+def test_env_info1(runner):
+    result = runner.invoke(env_info.environment_info)
+    assert result.exit_code == 0

--- a/idaes/commands/tests/test_commands.py
+++ b/idaes/commands/tests/test_commands.py
@@ -28,7 +28,7 @@ from click.testing import CliRunner
 import pytest
 
 # package
-from idaes.commands import examples, extensions, convergence, config
+from idaes.commands import examples, extensions, convergence, config, env_info
 from idaes.util.system import TemporaryDirectory
 from . import create_module_scratch, rmtree_scratch
 import idaes

--- a/idaes/commands/wrap_solver_wsl.py
+++ b/idaes/commands/wrap_solver_wsl.py
@@ -28,7 +28,7 @@ from idaes.commands import cb
 @cb.command(
     name="solver-wsl",
     context_settings={"ignore_unknown_options": True},
-    help="Run a linux solver on Windows using WSL")
+    help="Run a Linux solver on Windows using WSL")
 @click.option("--distribution", required=True, help="Linux distribution")
 @click.option("--user", required=True, help="User")
 @click.option("--executable", required=True, help="Executable path on WSL")

--- a/idaes/commands/wrap_solver_wsl.py
+++ b/idaes/commands/wrap_solver_wsl.py
@@ -29,11 +29,12 @@ from idaes.commands import cb
     name="solver-wsl",
     context_settings={"ignore_unknown_options": True},
     help="Run a linux solver on Windows using WSL")
-@click.option("--distribution", "-d", required=True, help="Linux distribution")
-@click.option("--user", "-u", required=True, help="User")
-@click.option("--executable", "-e", required=True, help="Executable path on WSL")
+@click.option("--distribution", required=True, help="Linux distribution")
+@click.option("--user", required=True, help="User")
+@click.option("--executable", required=True, help="Executable path on WSL")
+@click.option("-v", default=None, help="Get solver version")
 @click.argument('args', nargs=-1)
-def solver_wsl(distribution, user, executable, args):
+def solver_wsl(distribution, user, executable, v, args):
     al = [None]*len(args)
     for i, a in enumerate(args):
         r = re.match(r"^([A-Za-z]):\\(.*$)", a)
@@ -43,5 +44,8 @@ def solver_wsl(distribution, user, executable, args):
             l = r.group(1).lower()
             a = f"/mnt/{l}/{p}"
         al[i] = a
+    # expand the -v arg (-v doen't work on PETSc, but --version works on everything)
+    if v is not None:
+        al.append("--version")
     r = subprocess.run(["wsl", "-d", distribution, "-u", user, executable] + al)
     return r.returncode

--- a/idaes/commands/wrap_solver_wsl.py
+++ b/idaes/commands/wrap_solver_wsl.py
@@ -32,9 +32,8 @@ from idaes.commands import cb
 @click.option("--distribution", required=True, help="Linux distribution")
 @click.option("--user", required=True, help="User")
 @click.option("--executable", required=True, help="Executable path on WSL")
-@click.option("-v", default=None, help="Get solver version")
 @click.argument('args', nargs=-1)
-def solver_wsl(distribution, user, executable, v, args):
+def solver_wsl(distribution, user, executable, args):
     al = [None]*len(args)
     for i, a in enumerate(args):
         r = re.match(r"^([A-Za-z]):\\(.*$)", a)
@@ -44,8 +43,5 @@ def solver_wsl(distribution, user, executable, v, args):
             l = r.group(1).lower()
             a = f"/mnt/{l}/{p}"
         al[i] = a
-    # expand the -v arg (-v doen't work on PETSc, but --version works on everything)
-    if v is not None:
-        al.append("--version")
     r = subprocess.run(["wsl", "-d", distribution, "-u", user, executable] + al)
     return r.returncode

--- a/idaes/core/util/env_info.py
+++ b/idaes/core/util/env_info.py
@@ -88,7 +88,10 @@ class EnvironmentInfo():
             if not a:
                 self.solver_versions[s] = None
             else:
-                self.solver_versions[s] = ".".join([f"{x}" for x in slv.version()])
+                v = slv.version()
+                if v is None:
+                    v = "Unknown Version Installed"
+                self.solver_versions[s] = ".".join([f"{x}" for x in v])
 
 
     def display_dict(self):
@@ -118,10 +121,10 @@ class EnvironmentInfo():
             ("Extras", OrderedDict()),
             ("Solvers", OrderedDict()),
         ])
-        for k, v in self.dependency_versions.items():
+        for k, v in sorted(self.dependency_versions.items()):
             d["Dependencies"][k] = v if v is not None else "Not Installed"
-        for k, v in self.extra_versions.items():
+        for k, v in sorted(self.extra_versions.items()):
             d["Extras"][k] = v if v is not None else "Not Installed"
-        for k, v in self.solver_versions.items():
+        for k, v in sorted(self.solver_versions.items()):
             d["Solvers"][k] = v if v is not None else "Not Installed"
         return d

--- a/idaes/core/util/env_info.py
+++ b/idaes/core/util/env_info.py
@@ -137,7 +137,7 @@ class EnvironmentInfo:
                 k: v if v is not None else "Not Installed"
                 for k, v in sorted(self.extra_versions.items())
             },
-            "Sovlers": {
+            "Solvers": {
                 k: v if v is not None else "Not Installed"
                 for k, v in sorted(self.solver_versions.items())
             },

--- a/idaes/core/util/env_info.py
+++ b/idaes/core/util/env_info.py
@@ -1,0 +1,93 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+
+__Author__ = "John Eslick"
+
+import sys
+import platform
+from collections import OrderedDict
+import pkg_resources
+
+import pyomo
+
+import idaes.ver as ver
+
+class EnvironmentInfo():
+    """Get information about IDAES and the environment IDAES is running in,
+    including OS and Critial dependency versions."""
+
+    def __init__(self):
+        # Get idaes version from ver module.  This works even if you just
+        # check a new version our from github, have IDAES installed in-place
+        # and don't reinstall, which is likely mode for a lot of developers
+        self.git_hash = ver.gh
+        self.package_version = ver.package_version
+        self.version_string = ver.__version__
+        # Get Python info
+        self.python_version = sys.version
+        # Get os info
+        self.os_platform = platform.system()
+        self.os_release = platform.release()
+        self.os_version = platform.version()
+        # Get pyomo
+        self.pyomo_version = pyomo.version.__version__
+        # Get dependency info
+        self.dependency_versions = OrderedDict()
+        reqs = pkg_resources.get_distribution("idaes-pse").requires()
+        for dep in [x.name for x in reqs]:
+            if dep == "pyomo":
+                continue # pyomo is special
+            try:
+                self.dependency_versions[dep] = \
+                    pkg_resources.get_distribution(dep).version
+            except pkg_resources.DistributionNotFound:
+                self.dependency_versions[dep] = None
+        # Extra packages, users must install these for esoteric features
+        self.extra_versions = OrderedDict()
+        extras = ["seaborn"]
+        for dep in extras:
+            try:
+                self.extra_versions[dep] = \
+                    pkg_resources.get_distribution(dep).version
+            except pkg_resources.DistributionNotFound:
+                self.extra_versions[dep] = None
+
+
+    def display_dict(self):
+        """Return a dictionary that is in a format that allows easy printing"""
+        d = OrderedDict([
+            ("IDAES", OrderedDict([
+                # for version, I'm breaking off the +label, which is the git hash
+                ("IDAES Version", self.version_string.split("+")[0]),
+                # and displaying it here
+                ("IDAES Git Hash", self.git_hash),
+            ])),
+            ("Pyomo", OrderedDict([
+                ("Pyomo Version", self.pyomo_version)
+            ])),
+            ("OS", OrderedDict([
+                ("Platform", self.os_platform),
+                ("Release", self.os_release),
+                ("Version", self.os_version),
+            ])),
+            ("Python", OrderedDict([
+                ("Python Version", self.python_version)
+            ])),
+            ("Dependencies", OrderedDict()),
+            ("Extras", OrderedDict()),
+        ])
+        for k, v in self.dependency_versions.items():
+            d["Dependencies"][k] = v if v is not None else "Not Installed"
+        for k, v in self.extra_versions.items():
+            d["Extras"][k] = v if v is not None else "Not Installed"
+        return d

--- a/idaes/core/util/env_info.py
+++ b/idaes/core/util/env_info.py
@@ -18,7 +18,9 @@ import platform
 from collections import OrderedDict
 import pkg_resources
 
+import idaes
 import pyomo
+import pyomo.environ as pyo
 
 import idaes.ver as ver
 
@@ -26,13 +28,28 @@ class EnvironmentInfo():
     """Get information about IDAES and the environment IDAES is running in,
     including OS and Critial dependency versions."""
 
-    def __init__(self):
+    known_solvers = [
+        "ipopt",
+        "ipopt_sens",
+        "ipopt_l1",
+        "bonmin",
+        "couenne",
+        "cbc",
+        "k_aug",
+        "dot_sens",
+    ]
+
+    def __init__(self, addtional_solvers=()):
         # Get idaes version from ver module.  This works even if you just
         # check a new version our from github, have IDAES installed in-place
         # and don't reinstall, which is likely mode for a lot of developers
         self.git_hash = ver.gh
         self.package_version = ver.package_version
         self.version_string = ver.__version__
+        self.bin_directory = idaes.bin_directory
+        self.data_directory = idaes.data_directory
+        self.global_config = idaes._global_config_file
+        self.local_config = idaes._local_config_file
         # Get Python info
         self.python_version = sys.version
         # Get os info
@@ -61,6 +78,17 @@ class EnvironmentInfo():
                     pkg_resources.get_distribution(dep).version
             except pkg_resources.DistributionNotFound:
                 self.extra_versions[dep] = None
+        self.solver_versions = {}
+        for s in self.known_solvers + list(addtional_solvers):
+            slv = pyo.SolverFactory(s, validate=False)
+            try:
+                a = slv.available()
+            except AttributeError:
+                a = False
+            if not a:
+                self.solver_versions[s] = None
+            else:
+                self.solver_versions[s] = ".".join([f"{x}" for x in slv.version()])
 
 
     def display_dict(self):
@@ -68,9 +96,12 @@ class EnvironmentInfo():
         d = OrderedDict([
             ("IDAES", OrderedDict([
                 # for version, I'm breaking off the +label, which is the git hash
-                ("IDAES Version", self.version_string.split("+")[0]),
+                ("Version", self.version_string.split("+")[0]),
                 # and displaying it here
-                ("IDAES Git Hash", self.git_hash),
+                ("Git Hash", self.git_hash),
+                ("Binary Directory", self.bin_directory),
+                ("Data Directory", self.data_directory),
+                ("Global Config", self.global_config),
             ])),
             ("Pyomo", OrderedDict([
                 ("Pyomo Version", self.pyomo_version)
@@ -85,9 +116,12 @@ class EnvironmentInfo():
             ])),
             ("Dependencies", OrderedDict()),
             ("Extras", OrderedDict()),
+            ("Solvers", OrderedDict()),
         ])
         for k, v in self.dependency_versions.items():
             d["Dependencies"][k] = v if v is not None else "Not Installed"
         for k, v in self.extra_versions.items():
             d["Extras"][k] = v if v is not None else "Not Installed"
+        for k, v in self.solver_versions.items():
+            d["Solvers"][k] = v if v is not None else "Not Installed"
         return d

--- a/idaes/core/util/env_info.py
+++ b/idaes/core/util/env_info.py
@@ -122,7 +122,7 @@ class EnvironmentInfo:
             },
             "Python": {
                 "Version": self.python_version,
-                "Executable": self.python_version,
+                "Executable": self.python_executable,
             },
             "OS": {
                 "Platform": self.os_platform,

--- a/idaes/core/util/env_info.py
+++ b/idaes/core/util/env_info.py
@@ -39,7 +39,7 @@ class EnvironmentInfo():
         "dot_sens",
     ]
 
-    def __init__(self, addtional_solvers=()):
+    def __init__(self, additional_solvers=()):
         # Get idaes version from ver module.  This works even if you just
         # check a new version our from github, have IDAES installed in-place
         # and don't reinstall, which is likely mode for a lot of developers
@@ -79,7 +79,7 @@ class EnvironmentInfo():
             except pkg_resources.DistributionNotFound:
                 self.extra_versions[dep] = None
         self.solver_versions = {}
-        for s in self.known_solvers + list(addtional_solvers):
+        for s in self.known_solvers + list(additional_solvers):
             slv = pyo.SolverFactory(s, validate=False)
             try:
                 a = slv.available()

--- a/idaes/core/util/env_info.py
+++ b/idaes/core/util/env_info.py
@@ -11,7 +11,7 @@
 # license information.
 #################################################################################
 
-__Author__ = "John Eslick"
+__author__ = "John Eslick"
 
 import sys
 import platform

--- a/idaes/core/util/model_serializer.py
+++ b/idaes/core/util/model_serializer.py
@@ -560,11 +560,11 @@ def to_json(o, fname=None, human_read=False, wts=None, metadata=None, gz=None,
         human_read: if True, add indents and spacing to make the json file more
             readable, if false cut out whitespace and make as compact as
             possilbe
-        metadata: A dictionary of addtional metadata to add.
+        metadata: A dictionary of additional metadata to add.
         wts: is What To Save, this is a StoreSpec object that specifies what
             object types and attributes to save.  If None, the default is used
             which saves the state of the compelte model state.
-        metadata: addtional metadata to save beyond the standard format_version,
+        metadata: additional metadata to save beyond the standard format_version,
             date, and time.
         return_dict: default is False if true returns a dictionary representation
         return_json_string: default is False returns a json string

--- a/idaes/core/util/tests/test_env_info.py
+++ b/idaes/core/util/tests/test_env_info.py
@@ -13,7 +13,7 @@
 """
 Tests get environment info
 """
-
+import json
 import pytest
 import idaes.ver as ver
 from idaes.core.util.env_info import EnvironmentInfo
@@ -21,9 +21,14 @@ from idaes.core.util.env_info import EnvironmentInfo
 @pytest.mark.unit
 def test_env_info():
     x = EnvironmentInfo()
-    d = EnvironmentInfo().display_dict()
+    d = x.to_dict()
     assert "IDAES" in d
     assert "Pyomo" in d
     assert "OS" in d
     assert hasattr(x, "package_version")
     assert x.version_string == ver.__version__
+    s = x.to_json()
+    d = json.loads(s)
+    assert "IDAES" in d
+    assert "Pyomo" in d
+    assert "OS" in d

--- a/idaes/core/util/tests/test_env_info.py
+++ b/idaes/core/util/tests/test_env_info.py
@@ -1,0 +1,29 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+"""
+Tests get environment info
+"""
+
+import pytest
+import idaes.ver as ver
+from idaes.core.util.env_info import EnvironmentInfo
+
+@pytest.mark.unit
+def test_env_info():
+    x = EnvironmentInfo()
+    d = EnvironmentInfo().display_dict()
+    assert "IDAES" in d
+    assert "Pyomo" in d
+    assert "OS" in d
+    assert hasattr(x, "package_version")
+    assert x.version_string == ver.__version__

--- a/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py
+++ b/idaes/power_generation/flowsheets/supercritical_steam_cycle/supercritical_steam_cycle.py
@@ -211,7 +211,7 @@ def create_model():
         }
     )
 
-    
+
     # Add NTU condenser model
     m.fs.condenser = Condenser(
         default={"dynamic": False,
@@ -219,8 +219,8 @@ def create_model():
                            "property_package": m.fs.prop_water},
                  "tube": {"has_pressure_change": False,
                           "property_package": m.fs.prop_water}
-                 })    
-    
+                 })
+
     # Add the condenser hotwell.  In steady state a mixer will work.  This is
     # where makeup water is added if needed.
     m.fs.hotwell = HelmMixer(
@@ -463,11 +463,11 @@ def create_model():
     m.fs.EXHST_MAIN = Arc(
         source=m.fs.turb.outlet_stage.outlet, destination=m.fs.condenser_mix.main
     )
-    
+
     m.fs.condenser_mix_to_condenser = Arc(
         source=m.fs.condenser_mix.outlet, destination=m.fs.condenser.inlet_1
     )
-    
+
     m.fs.COND_01 = Arc(
         source=m.fs.condenser.outlet_1, destination=m.fs.hotwell.condensate
     )
@@ -770,19 +770,19 @@ def initialize(m, fileinput=None, outlvl=idaeslog.NOTSET):
 
     iscale.set_scaling_factor(m.fs.fwh4.condense.side_1.heat, 1e-7)
     iscale.set_scaling_factor(m.fs.fwh4.condense.side_2.heat, 1e-7)
-    
+
     iscale.set_scaling_factor(m.fs.fwh6.condense.side_1.heat, 1e-7)
     iscale.set_scaling_factor(m.fs.fwh6.condense.side_2.heat, 1e-7)
-    
+
     iscale.set_scaling_factor(m.fs.fwh7.condense.side_1.heat, 1e-7)
     iscale.set_scaling_factor(m.fs.fwh7.condense.side_2.heat, 1e-7)
-    
+
     iscale.set_scaling_factor(m.fs.fwh8.condense.side_1.heat, 1e-7)
     iscale.set_scaling_factor(m.fs.fwh8.condense.side_2.heat, 1e-7)
 
     iscale.calculate_scaling_factors(m)
-    
-    
+
+
     solver = get_solver()
 
     if fileinput is not None:
@@ -853,10 +853,10 @@ def initialize(m, fileinput=None, outlvl=idaeslog.NOTSET):
     _set_port(m.fs.condenser.inlet_1, m.fs.condenser_mix.outlet)
     _set_port(m.fs.condenser.outlet_2, m.fs.condenser.inlet_2)
     m.fs.condenser.initialize(outlvl=outlvl, optarg=solver.options)
-    
+
     # initialize hotwell
     _set_port(m.fs.hotwell.condensate, m.fs.condenser.outlet_1)
-    
+
     m.fs.hotwell.initialize(outlvl=outlvl, optarg=solver.options)
     m.fs.hotwell.condensate.unfix()
     # initialize condensate pump
@@ -959,7 +959,7 @@ def pfd_result(m, df, svg):
         tags[i + "_T"] = df.loc[i, "T (K)"]
         tags[i + "_P"] = df.loc[i, "P (Pa)"]
         tags[i + "_X"] = df.loc[i, "Vapor Fraction"]
-    # Add some addtional quntities from the model to report
+    # Add some additional quntities from the model to report
     tags["gross_power"] = -pyo.value(m.fs.turb.power[0])
     tags["gross_power_mw"] = -pyo.value(m.fs.turb.power[0]) * 1e-6
     tags["steam_mass_flow"] = df.loc["STEAM_MAIN", "Mass Flow (kg/s)"]

--- a/idaes/power_generation/unit_models/helm/turbine_multistage.py
+++ b/idaes/power_generation/unit_models/helm/turbine_multistage.py
@@ -189,7 +189,7 @@ ValveFunctionType.custom}""",
             domain=int,
             description="HP Turbine stages to not connect to next with an arc.",
             doc="HP Turbine stages to not connect to next with an arc. This is "
-                "usually used to insert addtional units between stages on a "
+                "usually used to insert additional units between stages on a "
                 "flowsheet, such as a reheater",
         ),
     )
@@ -200,7 +200,7 @@ ValveFunctionType.custom}""",
             domain=int,
             description="IP Turbine stages to not connect to next with an arc.",
             doc="IP Turbine stages to not connect to next with an arc. This is "
-            "usually used to insert addtional units between stages on a "
+            "usually used to insert additional units between stages on a "
             "flowsheet, such as a reheater",
         ),
     )
@@ -211,7 +211,7 @@ ValveFunctionType.custom}""",
             domain=int,
             description="LP Turbine stages to not connect to next with an arc.",
             doc="LP Turbine stages to not connect to next with an arc. This is "
-            "usually used to insert addtional units between stages on a "
+            "usually used to insert additional units between stages on a "
             "flowsheet, such as a reheater",
         ),
     )

--- a/idaes/tests/test_solvers.py
+++ b/idaes/tests/test_solvers.py
@@ -72,12 +72,7 @@ def test_sipopt_available():
         raise Exception("Could not find ipopt_sens.")
 
 @pytest.mark.unit
-def test_clp_available():
-    if not SolverFactory('clp').available():
-        raise Exception("Could not find clp.")
-
-@pytest.mark.unit
-def test_clp_available():
+def test_cbc_available():
     if not SolverFactory('cbc').available():
         raise Exception("Could not find cbc.")
 
@@ -112,18 +107,6 @@ def test_couenne_idaes_solve():
     m, x = minlp()
     solver = SolverFactory('couenne')
     solver.solve(m)
-    assert pytest.approx(x) == pyo.value(m.x)
-
-@pytest.mark.unit
-def test_clp_idaes_solve():
-    """
-    Make sure there is no issue with the solver class or default settings that
-    break the solver object.  Passing a bad solver option will result in failure
-    """
-    m, x = lp()
-    solver = SolverFactory('clp')
-    solver.solve(m)
-    m.display()
     assert pytest.approx(x) == pyo.value(m.x)
 
 @pytest.mark.unit


### PR DESCRIPTION
## Fixes issue #313

## Summary

Not sure I took the best approach here, so don't feel bad about making suggestions.

## Changes proposed in this PR:
Adds a command to print info about
-  IDAES version
- Python version
- OS version
- Pyomo version
- Dependency versions
- Extra package versions (by this I mean packages users have to install to use some things)

## Sample Output

```sh
(idaes-pse) C:\Users\EslickJ\git\idaes-pse\idaes\core\util>idaes environment-info

IDAES
    IDAES Version: 1.11.0.dev0
    IDAES Git Hash: 9ca7252853c51b04b9b2c265c73b581104e923fc

Pyomo
    Pyomo Version: 6.0.2.dev0

OS
    Platform: Windows
    Release: 10
    Version: 10.0.19041

Python
    Python Version: 3.9.4 (default, Apr  9 2021, 11:43:21) [MSC v.1916 64 bit (AMD64)]

Dependencies
    backports.shutil_get_terminal_size: 1.0.0
    bunch: 1.0.1
    click: 7.1.2
    colorama: 0.4.4
    flask: 2.0.0
    flask-cors: 3.0.10
    jupyter: 1.0.0
    lxml: 4.6.3
    matplotlib: 3.4.2
    nbconvert: 6.0.7
    nbformat: 5.1.3
    numpy: 1.20.3
    networkx: 2.5.1
    pandas: 1.2.4
    pint: 0.17
    psutil: 5.8.0
    pytest: 6.2.4
    pyyaml: 5.4.1
    requests: 2.25.1
    python-slugify: 5.0.2
    scipy: 1.6.3
    sympy: 1.8
    tinydb: 4.4.0
    rbfopt: 4.2.2
    pywin32: 225

Extras
    seaborn: Not Installed
```

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
