### PR TITLE
Relaxing requirement for generic reactions to have rate form

### DIFF
--- a/idaes/generic_models/properties/core/generic/generic_reaction.py
+++ b/idaes/generic_models/properties/core/generic/generic_reaction.py
@@ -278,10 +278,12 @@ class GenericReactionParameterData(ReactionParameterBlock):
 
                 # Check that a method was provided for the rate form
                 if rxn.rate_form is None:
-                    raise ConfigurationError(
+                    _log.debug(
                         "{} rate reaction {} was not provided with a "
-                        "rate_form configuration argument."
-                        .format(self.name, r))
+                        "rate_form configuration argument. This is suitable "
+                        "for processes using stoichiometric reactors, but not "
+                        "for those using unit operations which rely on "
+                        "reaction rate.".format(self.name, r))
 
         # Construct equilibrium reaction attributes if required
         if len(self.config.equilibrium_reactions) > 0:
@@ -611,6 +613,11 @@ class GenericReactionBlockData(ReactionBlockDataBase):
             rblock = getattr(b.params, "reaction_"+r)
 
             carg = b.params.config.rate_reactions[r]
+
+            if carg["rate_form"] is None:
+                raise ConfigurationError(
+                    f"{b.name} Generic Reaction {r} was not provided with a "
+                    f"rate_form configuration argument.")
 
             return carg["rate_form"].return_expression(
                 b, rblock, r, b.state_ref.temperature)

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_reaction.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_reaction.py
@@ -43,6 +43,7 @@ from idaes.core.util.testing import PhysicalParameterTestBlock
 from idaes.core.util.constants import Constants as constants
 
 from idaes.core.util.exceptions import ConfigurationError
+import idaes.logger as idaeslog
 
 
 # -----------------------------------------------------------------------------
@@ -208,19 +209,26 @@ class TestGenericReactionParameterBlock(object):
                            "rate_form": "foo"}}})
 
     @pytest.mark.unit
-    def test_rate_build_no_form(self, m):
-        with pytest.raises(ConfigurationError,
-                           match="rxn_params rate reaction r1 was not "
-                           "provided with a rate_form configuration "
-                           "argument."):
-            m.rxn_params = GenericReactionParameterBlock(default={
-                "property_package": m.params,
-                "base_units": base_units,
-                "rate_reactions": {
-                    "r1": {"stoichiometry": {("p1", "c1"): -1,
-                                             ("p1", "c2"): 2},
-                           "heat_of_reaction": "foo"}}})
-            
+    def test_rate_build_no_form(self, m, caplog):
+        caplog.set_level(
+            idaeslog.DEBUG,
+            logger=("idaes.generic_models.properties.core."
+                    "generic.generic_reaction"))
+
+        m.rxn_params = GenericReactionParameterBlock(default={
+            "property_package": m.params,
+            "base_units": base_units,
+            "rate_reactions": {
+                "r1": {"stoichiometry": {("p1", "c1"): -1,
+                                         ("p1", "c2"): 2},
+                       "heat_of_reaction": "foo"}}})
+
+        assert ("rxn_params rate reaction r1 was not provided with a "
+                "rate_form configuration argument. This is suitable for "
+                "processes using stoichiometric reactors, but not for those "
+                "using unit operations which rely on reaction rate."
+                in caplog.text)
+
     @pytest.mark.unit
     def test_equil_build(self, m):
         m.rxn_params = GenericReactionParameterBlock(default={
@@ -500,6 +508,16 @@ class TestGenericReactionBlock(object):
         assert value(model.rblock[1].reaction_rate["r1"]) == value(
             model.rblock[1].k_rxn["r1"] *
             model.sblock[1].mole_frac_phase_comp["p1", "c1"]**1)
+
+    @pytest.mark.unit
+    def test_reaction_rate_None(self, model):
+        model.rxn_params.config.rate_reactions.r1.rate_form = None
+
+        with pytest.raises(ConfigurationError,
+                           match="rblock\[1\] Generic Reaction r1 was not "
+                           "provided with a rate_form configuration "
+                           "argument."):
+            model.rblock[1].reaction_rate
 
     @pytest.mark.unit
     def test_equilibrium_constant(self, model):


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
A collaborator from NAWI noted that the generic reaction framework insist that rate-based reactions have a rate form specified, even though this is not required for stoichiometric reactors. This PR relaxes that requirement to allow rate-based reactions to not be specified with a form, and to only raise an exception if reaction rate is required.

## Changes proposed in this PR:
- Replace ConfiguragtionError in initial check for rate form with ha DEBUG message
- Add new ConfigurationError as part of constructing `reaction_rate` to catch cases where rate form was not specified.
- Update tests accordingly

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
