### PR TITLE
Get-extensions add "extra" option and bump to 2.4.4 release 

### DIFF
--- a/idaes/commands/extensions.py
+++ b/idaes/commands/extensions.py
@@ -101,6 +101,10 @@ def print_extensions_version(library_only=False):
     "--extras-only",
     is_flag=True,
     help="Only install extras")
+@click.option(
+    "--to",
+    default=None,
+    help="Put extrensions in a alternate location")
 @click.option("--verbose", help="Show details", is_flag=True)
 def get_extensions(
     release,
@@ -116,7 +120,8 @@ def get_extensions(
     show_platforms,
     show_extras,
     extras_only,
-    extra):
+    extra,
+    to):
 
     if show_platforms:
         click.echo("\nSupported platforms for IDAES binary extensions.")
@@ -153,7 +158,8 @@ def get_extensions(
                 library_only,
                 no_download,
                 extras_only,
-                extra)
+                extra,
+                alt_path=to)
             click.echo("Done")
         except idaes.util.download_bin.UnsupportedPlatformError as e:
             click.echo("")

--- a/idaes/commands/extensions.py
+++ b/idaes/commands/extensions.py
@@ -199,7 +199,7 @@ def hash_extensions(release, path):
     if path is not None:
         hfile = os.path.join(path, hfile)
 
-    def _w(fp, pack, plat):
+    def _write_hash(fp, pack, plat):
         f = f"idaes-{pack}-{plat}-64.tar.gz"
         if path is not None:
             h = idaes.util.download_bin.hash_file_sha256(os.path.join(path, f))
@@ -213,9 +213,9 @@ def hash_extensions(release, path):
     with open(hfile, "w") as f:
         for plat in idaes.config.basic_platforms():
             for pack in ["solvers", "lib"]:
-                _w(f, pack, plat)
+                _write_hash(f, pack, plat)
         for plat in idaes.config.basic_platforms():
             for pack, sp in idaes.config.extra_binaries.items():
                 if plat not in sp:
                     continue
-                _w(f, pack, plat)
+                _write_hash(f, pack, plat)

--- a/idaes/commands/extensions.py
+++ b/idaes/commands/extensions.py
@@ -201,12 +201,13 @@ def hash_extensions(release, path):
 
     def _w(fp, pack, plat):
         f = f"idaes-{pack}-{plat}-64.tar.gz"
-        fp.write(f)
-        fp.write("  ")
         if path is not None:
-            f = os.path.join(path, f)
-        h = idaes.util.download_bin.hash_file_sha256(f)
+            h = idaes.util.download_bin.hash_file_sha256(os.path.join(path, f))
+        else:
+            h = idaes.util.download_bin.hash_file_sha256(f)
         fp.write(h)
+        fp.write("  ")
+        fp.write(f)
         fp.write("\n")
 
     with open(hfile, "w") as f:

--- a/idaes/commands/extensions.py
+++ b/idaes/commands/extensions.py
@@ -104,7 +104,7 @@ def print_extensions_version(library_only=False):
 @click.option(
     "--to",
     default=None,
-    help="Put extrensions in a alternate location")
+    help="Put extensions in a alternate location")
 @click.option("--verbose", help="Show details", is_flag=True)
 def get_extensions(
     release,
@@ -126,7 +126,7 @@ def get_extensions(
     if show_platforms:
         click.echo("\nSupported platforms for IDAES binary extensions.")
         for key, mes in sorted(idaes.config.known_binary_platform.items()):
-            click.echo("    {}: {}".format(key, mes))
+            click.echo(f"    {key}: {mes}")
         click.echo("\nBinaries compiled on these platforms:")
         for k in sorted(idaes.config.basic_platforms()):
             click.echo(f"    {k}")

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -19,7 +19,7 @@ import importlib
 
 _log = logging.getLogger(__name__)
 # Default release version if no options provided for get-extensions
-default_binary_release = "2.4.3"
+default_binary_release = "2.4.4"
 # Where to download releases from get-extensions
 release_base_url = "https://github.com/IDAES/idaes-ext/releases/download"
 # Where to get release checksums

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -32,6 +32,8 @@ binary_platform_map = {
     "ubuntu1810": "ubuntu1804",
     "ubuntu1904": "ubuntu1804",
     "ubuntu1910": "ubuntu1804",
+    "ubuntu2010": "ubuntu2004",
+    "ubuntu2104": "ubuntu2004",
     "linux": "centos7",
 }
 # Set of known platforms with available binaries and descriptions of them
@@ -52,6 +54,14 @@ known_binary_platform = {
     "ubuntu1904": "Ubuntu 19.04",
     "ubuntu1910": "Ubuntu 19.10",
     "ubuntu2004": "Ubuntu 20.04",
+    "ubuntu2010": "Ubuntu 20.10",
+    "ubuntu2104": "Ubuntu 21.04",
+}
+# Unsupported platforms
+unsupported_binary_platform = ["darwin"]
+# Set of extra binary packages and platforms where they are available
+extra_binaries = {
+    "petsc": ["centos7", "centos8", "ubuntu1804", "ubuntu2004"],
 }
 
 # Store the original environment variable values so we can revert changes
@@ -60,6 +70,14 @@ orig_environ = {
     "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
     "DYLD_LIBRARY_PATH": os.environ.get("DYLD_LIBRARY_PATH", ""),
 }
+
+def basic_platforms():
+    """Return a set of platforms that binaries should be available for.
+    """
+    kp = set(known_binary_platform.keys()) - set(["auto", "linux"])
+    kp -= set(unsupported_binary_platform)
+    kp -= set([k for k, v in binary_platform_map.items() if k != v])
+    return kp
 
 class ConfigBlockJSONEncoder(json.JSONEncoder):
     """ This class handles non-serializable objects that may appear in the IDAES

--- a/idaes/util/download_bin.py
+++ b/idaes/util/download_bin.py
@@ -136,6 +136,7 @@ def download_binaries(
     extras_only=False,
     extra=(),
     to_path=None,
+    alt_path=None,
     ):
     """
     Download IDAES solvers and libraries and put them in the right location. Need
@@ -157,6 +158,8 @@ def download_binaries(
     # this function without interfereing with anything else.  It's a subdirectory
     # of the data directory because that should be a safe place to store some
     # test files.
+    if alt_path is not None:
+        to_path = os.path.abspath(alt_path)
     if to_path is None:
         to_path = idaes.bin_directory
     else:


### PR DESCRIPTION
## Fixes
This cleans up the get-extensions download function, and lets you specify extra packages.  It also adds a tool to calculate the binary release hashes.  This is to prep for adding the Petsc solver extra.  It's big, and also not something a lot of people want.  So I don't want to add it to solvers.  The size of it may also make it hard to use GitHub actions to calculate the hashes like I have been doing.  It will probably complain about the amount of stuff I download.

You'd use something like:

```sh
idaes get-extensions --extra petsc
```

You can use the ```--extra``` options multiple times to install multiple extras, but at this point we have only petsc

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
