### PR TITLE
Fixing issue with IndexedArcs in propagate_state

### DIFF
--- a/idaes/core/util/initialization.py
+++ b/idaes/core/util/initialization.py
@@ -16,7 +16,7 @@ This module contains utility functions for initialization of IDAES models.
 """
 
 from pyomo.environ import Block, Var, TerminationCondition, Constraint
-from pyomo.network import Arc
+from pyomo.network.arc import _ArcData
 from pyomo.dae import ContinuousSet
 from pyomo.core.expr.visitor import identify_variables
 
@@ -135,7 +135,7 @@ def propagate_state(stream, direction="forward"):
     Returns:
         None
     """
-    if not isinstance(stream, Arc):
+    if not isinstance(stream, _ArcData):
         raise TypeError("Unexpected type of stream argument. Value must be "
                         "a Pyomo Arc.")
 
@@ -151,12 +151,12 @@ def propagate_state(stream, direction="forward"):
                          .format(direction))
 
     for v in value_source.vars:
+        if not isinstance(value_dest.vars[v], Var):
+            raise TypeError("Port contains one or more members which are "
+                            "not Vars. propogate_state works by assigning "
+                            "to the value attribute, thus can only be "
+                            "when Port members are Pyomo Vars.")
         for i in value_source.vars[v]:
-            if not isinstance(value_dest.vars[v], Var):
-                raise TypeError("Port contains one or more members which are "
-                                "not Vars. propogate_state works by assigning "
-                                "to the value attribute, thus can only be "
-                                "when Port members are Pyomo Vars.")
             if not value_dest.vars[v][i].fixed:
                 value_dest.vars[v][i].value = value_source.vars[v][i].value
 

--- a/idaes/core/util/initialization.py
+++ b/idaes/core/util/initialization.py
@@ -22,6 +22,7 @@ from pyomo.core.expr.visitor import identify_variables
 
 from idaes.core import FlowsheetBlock
 from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.misc import copy_port_values
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.dyn_utils import (
     get_activity_dict,
@@ -140,25 +141,13 @@ def propagate_state(stream, direction="forward"):
                         "a Pyomo Arc.")
 
     if direction == "forward":
-        value_source = stream.source
-        value_dest = stream.destination
+        copy_port_values(destination=stream.destination, source=stream.source)
     elif direction == "backward":
-        value_source = stream.destination
-        value_dest = stream.source
+        copy_port_values(destination=stream.source, source=stream.destination)
     else:
         raise ValueError("Unexpected value for direction argument: ({}). "
                          "Value must be either 'forward' or 'backward'."
                          .format(direction))
-
-    for v in value_source.vars:
-        if not isinstance(value_dest.vars[v], Var):
-            raise TypeError("Port contains one or more members which are "
-                            "not Vars. propogate_state works by assigning "
-                            "to the value attribute, thus can only be "
-                            "when Port members are Pyomo Vars.")
-        for i in value_source.vars[v]:
-            if not value_dest.vars[v][i].fixed:
-                value_dest.vars[v][i].value = value_source.vars[v][i].value
 
 
 # HACK, courtesy of J. Siirola

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -23,8 +23,6 @@ from pyomo.core.base.indexed_component import (
     UnindexedComponent_set, )
 from pyomo.core.base.util import disable_methods
 from pyomo.common.config import ConfigBlock
-from pyomo.network.arc import _ArcData
-from pyomo.network.port import _PortData
 
 import idaes.logger as idaeslog
 import idaes.core.solvers
@@ -228,57 +226,18 @@ def svg_tag(
 
 
 # Author: John Eslick
-def copy_port_values(destination=None, source=None, arc=None):
+def copy_port_values(destination=None, source=None, arc=None,
+        direction="forward"):
     """
-    Copy the variable values in the source port to the destination port. The
-    ports must containt the same variables.
-
-    Args:
-        destination (Port): Port to copy values to or None if specifying arc
-        source (Port): Port to copy values from or None if specifying arc
-        arc (Arc): If arc is provided, use arc to define source and destination
-
-    Returns:
-        None
+    Moved to idaes.core.util.initialization.propagate_state.
+    Leaving redirection function here for deprecation warning.
     """
-    # Allow an arc to be passed as a positional arg
-    if destination is not None and source is None and isinstance(destination, _ArcData):
-        arc = destination
-        destination = None
-    # Check that only arc or source and destination are passed
-    if arc is None and (destination is None or source is None):
-        raise RuntimeError(
-            "In copy_port_values(), must provide source and destination or arc")
-    if arc is not None:
-        if not isinstance(arc, _ArcData):
-            raise RuntimeError(
-                "In copy_port_values(), arc argument is not an instance of an Arc")
-        if destination is not None or source is not None:
-            raise RuntimeError(
-                "In copy_port_values(), provide only arc or source and destination")
-    if destination is not None:
-        if not isinstance(destination, _PortData):
-            raise RuntimeError(
-                "In copy_port_values(), destination is not an instance of Port")
-        if not isinstance(source, _PortData):
-            raise RuntimeError(
-                "In copy_port_values(), source is not an instance of Port")
-
-    # Arc provided so get source and destination from arc
-    if arc is not None:
-        source = arc.source
-        destination = arc.dest
-
-    # Copy values
-    for k, v in destination.vars.items():
-        if not isinstance(v, pyo.Var):
-            raise TypeError("Port contains one or more members which are "
-                            "not Vars. propogate_state works by assigning "
-                            "to the value attribute, thus can only be "
-                            "when Port members are Pyomo Vars.")
-        for i in v:
-            if not v[i].fixed:
-                v[i].value = pyo.value(source.vars[k][i])
+    _log.warning("DEPRECATED: copy_port_values has been deprecated. "
+            "The same functionality can be found in "
+            "idaes.core.util.initialization.propagate_state.")
+    from idaes.core.util.initialization import propagate_state
+    propagate_state(destination=destination, source=source, arc=arc,
+            direction=direction)
 
 
 def set_param_from_config(b, param, config=None, index=None):

--- a/idaes/core/util/tests/test_initialization.py
+++ b/idaes/core/util/tests/test_initialization.py
@@ -724,7 +724,7 @@ def test_propagate_state_indexed():
         return {'source': m.b1.p[i], 'destination':m.b2.p[i]}
     m.s1 = Arc([1,2], rule=arc_rule)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeError):
         propagate_state(m.s1)
 
 
@@ -749,7 +749,7 @@ def test_propagate_state_Expression():
 
     m.s1 = Arc(source=m.b1.p, destination=m.b2.p)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         propagate_state(m.s1)
 
 
@@ -757,7 +757,7 @@ def test_propagate_state_Expression():
 def test_propagate_state_invalid_stream():
     m = ConcreteModel()
 
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         propagate_state(m)
 
 

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -106,7 +106,7 @@ def test_port_copy():
     assert_copied_right()
     reset()
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(AttributeError):
         copy_port_values(arc=m.b1.port)
 
     with pytest.raises(RuntimeError):
@@ -115,7 +115,7 @@ def test_port_copy():
     with pytest.raises(RuntimeError):
         copy_port_values(source=m.b1.port, arc=m.arc)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(AttributeError):
         copy_port_values(source=m.b1.port, destination=m.arc)
 
 


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
`idaes.core.util.initialization.propagate_state` currently handles indexed arcs incorrectly. This PR corrects this issue.

## Changes proposed in this PR:
- Deprecate and move the functionality of `idaes.core.util.misc.copy_port_values` to `propagate_state`. `propagate_state` should be able to replace all instances of `copy_port_values` without issue.
- More forgiving duck-typing in `propagate_state` to handle indexed Arcs/Ports
- Tests now check indexed arcs and ports

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
