### PR TITLE
Added Cp, Cv, speed of sound equations to the generic CEOS

### DIFF
--- a/idaes/generic_models/properties/core/eos/eos_base.py
+++ b/idaes/generic_models/properties/core/eos/eos_base.py
@@ -105,8 +105,7 @@ class EoSBase():
 
     @staticmethod
     def heat_capacity_ratio_phase(b, p):
-        return (b.cp_mol_phase[p] /
-                b.cv_mol_phase[p])
+        raise NotImplementedError(_msg(b, "heat_capacity_ratio_phase"))
 
     @staticmethod
     def cv_mol_ig_comp_pure(b, j):
@@ -281,6 +280,14 @@ class EoSBase():
     @staticmethod
     def gibbs_mol_phase_comp(b, p, j):
         raise NotImplementedError(_msg(b, "gibbs_mol_phase_comp"))
+
+    @staticmethod
+    def isentropic_speed_sound_phase(b, p):
+        raise NotImplementedError(_msg(b, "isentropic_speed_sound_phase"))
+
+    @staticmethod
+    def isothermal_speed_sound_phase(b, p):
+        raise NotImplementedError(_msg(b, "isothermal_speed_sound_phase"))
 
 
 def _msg(b, attr):

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -905,6 +905,8 @@ class GenericParameterData(PhysicalParameterBlock):
              'gibbs_mol': {'method': '_gibbs_mol'},
              'gibbs_mol_phase': {'method': '_gibbs_mol_phase'},
              'gibbs_mol_phase_comp': {'method': '_gibbs_mol_phase_comp'},
+             'isentropic_speed_sound_phase': {'method': '_isentropic_speed_sound_phase'},
+             'isothermal_speed_sound_phase': {'method': '_isothermal_speed_sound_phase'},
              'mw': {'method': '_mw'},
              'mw_phase': {'method': '_mw_phase'},
              'pressure_bubble': {'method': '_pressure_bubble'},
@@ -2484,6 +2486,32 @@ class GenericStateBlockData(StateBlockData):
                 rule=rule_gibbs_mol_phase_comp)
         except AttributeError:
             self.del_component(self.gibbs_mol_phase_comp)
+            raise
+
+    def _isentropic_speed_sound_phase(self):
+        try:
+            def rule_isentropic_speed_sound_phase(b, p):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.isentropic_speed_sound_phase(b, p)
+            self.isentropic_speed_sound_phase = Expression(
+                    self.phase_list,
+                    doc="Isentropic speed of sound in each phase",
+                    rule=rule_isentropic_speed_sound_phase)
+        except AttributeError:
+            self.del_component(self.isentropic_speed_sound_phase)
+            raise
+
+    def _isothermal_speed_sound_phase(self):
+        try:
+            def rule_isothermal_speed_sound_phase(b, p):
+                p_config = b.params.get_phase(p).config
+                return p_config.equation_of_state.isothermal_speed_sound_phase(b, p)
+            self.isothermal_speed_sound_phase = Expression(
+                    self.phase_list,
+                    doc="Isothermal speed of sound in each phase",
+                    rule=rule_isothermal_speed_sound_phase)
+        except AttributeError:
+            self.del_component(self.isothermal_speed_sound_phase)
             raise
 
     def _mw(self):

--- a/idaes/power_generation/properties/natural_gas_PR.py
+++ b/idaes/power_generation/properties/natural_gas_PR.py
@@ -134,6 +134,7 @@ _component_params = {
         'elemental_composition': {'H': 2, 'O': 1},
         'enth_mol_ig_comp': NIST,
         'entr_mol_ig_comp': NIST,
+        'cp_mol_ig_comp': NIST,
         'pressure_sat_comp': NIST,
         'parameter_data': {
             'mw': (0.01801528, pyunits.kg/pyunits.mol),
@@ -161,6 +162,7 @@ _component_params = {
         'elemental_composition': {'C': 1, 'O': 2},
         'enth_mol_ig_comp': NIST,
         'entr_mol_ig_comp': NIST,
+        'cp_mol_ig_comp': NIST,
         'parameter_data': {
             'mw': (0.04401, pyunits.kg/pyunits.mol),
             'pressure_crit': (73.8e5, pyunits.Pa),


### PR DESCRIPTION
## Changes proposed in this PR:
- Added equations for computing cp_mol_phase, cv_mol_phase, heat_capacity_ratio_phase
- Added new methods for computing isentropic_speed_sound_phase and isothermal_speed_sound_phase

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
