### PR TITLE
Bump Pyomo tag for pre-release testing

### DIFF
--- a/idaes/apps/caprese/tests/test_controller.py
+++ b/idaes/apps/caprese/tests/test_controller.py
@@ -325,5 +325,5 @@ class TestControllerBlock(object):
             pwc_expr = controller.pwc_constraint[i,t].expr
             tn = time.next(t)
             inputs = controller.vectors.input
-            pred_expr = (inputs[i, tn] - inputs[i, t] == 0.)
+            pred_expr = (inputs[i, tn] == inputs[i, t])
             assert pwc_expr.to_string() == pred_expr.to_string()

--- a/idaes/core/process_base.py
+++ b/idaes/core/process_base.py
@@ -21,7 +21,7 @@ import textwrap
 from pandas import DataFrame
 
 from pyomo.core.base.block import _BlockData
-from pyomo.core.base.misc import tabular_writer
+from pyomo.common.formatting import tabular_writer
 from pyomo.environ import Block, value
 from pyomo.gdp import Disjunct
 from pyomo.common.config import ConfigBlock

--- a/idaes/core/property_base.py
+++ b/idaes/core/property_base.py
@@ -21,7 +21,7 @@ from pyomo.environ import Set, value, Var, Expression, Constraint
 from pyomo.core.base.var import _VarData
 from pyomo.core.base.expression import _ExpressionData
 from pyomo.common.config import ConfigBlock, ConfigValue, In
-from pyomo.core.base.misc import tabular_writer
+from pyomo.common.formatting import tabular_writer
 
 # Import IDAES cores
 from idaes.core.process_block import ProcessBlock

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -21,7 +21,7 @@ from pyomo.core.base.expression import _GeneralExpressionData
 from pyomo.core.base.component import ModelComponentFactory
 from pyomo.core.base.indexed_component import (
     UnindexedComponent_set, )
-from pyomo.core.base.util import disable_methods
+from pyomo.core.base.disable_methods import disable_methods
 from pyomo.common.config import ConfigBlock
 from pyomo.network import Port, Arc
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.1.idaes.2021.06.04.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.0.1.idaes.2021.08.13.zip",
 ]
 
 


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
This PR bumps the Pyomo tag for testing IDAES in order to start testing the latest version of Pyomo prior to the its next release.

## Changes proposed in this PR:
- Had to make one minor change to fix a test in capresse.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
