### PR TITLE
Adding energy scaling to mixer unit model

### DIFF
--- a/idaes/generic_models/unit_models/mixer.py
+++ b/idaes/generic_models/unit_models/mixer.py
@@ -1022,3 +1022,14 @@ objects linked to all inlet states and the mixed state,
                             _s = iscale.get_scaling_factor(ft, default=1)
                             s = _s if _s < s else s
                     iscale.constraint_scaling_transform(c, s, overwrite=False)
+
+        if hasattr(self, "enthalpy_mixing_equations"):
+            for (t), c in self.enthalpy_mixing_equations.items():
+                def scale_gen():
+                    for v in self.mixed_state[t].phase_list:
+                        yield self.mixed_state[t].get_enthalpy_flow_terms(p)
+
+                s = iscale.min_scaling_factor(
+                    scale_gen(),
+                    default=1)
+                iscale.constraint_scaling_transform(c, s, overwrite=False)

--- a/idaes/generic_models/unit_models/mixer.py
+++ b/idaes/generic_models/unit_models/mixer.py
@@ -1024,7 +1024,7 @@ objects linked to all inlet states and the mixed state,
                     iscale.constraint_scaling_transform(c, s, overwrite=False)
 
         if hasattr(self, "enthalpy_mixing_equations"):
-            for (t), c in self.enthalpy_mixing_equations.items():
+            for t, c in self.enthalpy_mixing_equations.items():
                 def scale_gen():
                     for v in self.mixed_state[t].phase_list:
                         yield self.mixed_state[t].get_enthalpy_flow_terms(p)

--- a/idaes/generic_models/unit_models/tests/test_mixer.py
+++ b/idaes/generic_models/unit_models/tests/test_mixer.py
@@ -1122,6 +1122,10 @@ class TestSaponification(object):
     def test_initialize(self, sapon):
         initialization_tester(sapon)
 
+    @pytest.mark.component
+    def test_saling(self, sapon):
+        sapon.fs.unit.calculate_scaling_factors()
+
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_solve(self, sapon):

--- a/idaes/generic_models/unit_models/tests/test_mixer.py
+++ b/idaes/generic_models/unit_models/tests/test_mixer.py
@@ -1123,7 +1123,7 @@ class TestSaponification(object):
         initialization_tester(sapon)
 
     @pytest.mark.component
-    def test_saling(self, sapon):
+    def test_scaling(self, sapon):
         sapon.fs.unit.calculate_scaling_factors()
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")


### PR DESCRIPTION
## Fixes #458 


## Summary/Motivation:
The core Mixer model currently lacks code to perform constraint scaling on the energy balance.

## Changes proposed in this PR:
- Add code to do constraint scaling on the Mixer energy balance if it exists
- Add a basic test for Mixer scaling

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
