### PR TITLE
Fix report() in valve.py

### DIFF
--- a/idaes/generic_models/unit_models/valve.py
+++ b/idaes/generic_models/unit_models/valve.py
@@ -262,6 +262,6 @@ variables, expressions, or constraints required can also be added by the callbac
             pc["vars"]["Valve Coefficient"] = self.Cv
         except AttributeError:
             pass
-        if self.config.valve_function == ValveFunctionType.equal_percentage:
+        if self.config.valve_function_callback == ValveFunctionType.equal_percentage:
             pc["vars"]["alpha"] = self.alpha
         return pc


### PR DESCRIPTION
## Fixes
For the valve unit model, the `report` fxn is broken because it's looking for a config entry of `valve_function`, where it should be looking for `valve_function_callback`.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
