### PR TITLE
Adding units to stream_table

### DIFF
--- a/idaes/core/util/tables.py
+++ b/idaes/core/util/tables.py
@@ -253,13 +253,13 @@ def create_stream_table_dataframe(
                 if i is None:
                     stream_attributes[key][k] = value(disp_dict[k][i])
                     if add_units:
-                        stream_attributes['Units'][k] = units.get_units(disp_dict[k][i])
+                        stream_attributes['Units'][k] = str(units.get_units(disp_dict[k][i]))
                     if k not in full_keys:
                         full_keys.append(k)
                 else:
                     stream_attributes[key][f"{k} {i}"] = value(disp_dict[k][i])
                     if add_units:
-                        stream_attributes['Units'][f"{k} {i}"] = units.get_units(disp_dict[k][i])
+                        stream_attributes['Units'][f"{k} {i}"] = str(units.get_units(disp_dict[k][i]))
                     if f"{k} {i}" not in full_keys:
                         full_keys.append(f"{k} {i}")
 

--- a/idaes/core/util/tables.py
+++ b/idaes/core/util/tables.py
@@ -229,8 +229,8 @@ def create_stream_table_dataframe(
         orient : orientation of stream table. Accepted values are 'columns'
             (default) where streams are displayed as columns, or 'index' where
             stream are displayed as rows.
-        add_units : Add a Units column to the dataframe representing the
-            stream values.
+        add_units : Add a Units column to the dataframe representing the units
+            of the stream values.
 
     Returns:
         A pandas DataFrame containing the stream table data.

--- a/idaes/core/util/tables.py
+++ b/idaes/core/util/tables.py
@@ -239,7 +239,7 @@ def create_stream_table_dataframe(
     stream_states = stream_states_dict(streams=streams, time_point=time_point)
     full_keys = []  # List of all rows in dataframe to fill in missing data
 
-    if add_units and stream_states.items():
+    if add_units and stream_states:
         stream_attributes['Units'] = {}
 
     for key, sb in stream_states.items():

--- a/idaes/core/util/tables.py
+++ b/idaes/core/util/tables.py
@@ -239,7 +239,7 @@ def create_stream_table_dataframe(
     stream_states = stream_states_dict(streams=streams, time_point=time_point)
     full_keys = []  # List of all rows in dataframe to fill in missing data
 
-    if add_units:
+    if add_units and stream_states.items():
         stream_attributes['Units'] = {}
 
     for key, sb in stream_states.items():

--- a/idaes/ui/flowsheet.py
+++ b/idaes/ui/flowsheet.py
@@ -433,12 +433,14 @@ class FlowsheetSerializer:
     def _construct_model_json(self):
         from idaes.core.util.tables import (
             create_stream_table_dataframe,
+            create_stream_table_dataframe_with_units
         )  # deferred to avoid circular import
 
         # Get the stream table and add it to the model json
         # Change the index of the pandas dataframe to not be the variables
         self._stream_table_df = (
-            create_stream_table_dataframe(self.arcs)
+            # create_stream_table_dataframe(self.arcs)
+            create_stream_table_dataframe_with_units(self.arcs)
             # Change the index of the pandas dataframe to not be the variables
             .reset_index()
             .rename(columns={"index": "Variable"})

--- a/idaes/ui/flowsheet.py
+++ b/idaes/ui/flowsheet.py
@@ -449,25 +449,25 @@ class FlowsheetSerializer:
             )
         )
 
-        if ('Units' in self._stream_table_df and
-            'Variable' in self._stream_table_df):
-            # Styling the units for display
-            def apply_html(value, style=''):
-                if value is not None:
-                    return '<span class="' + style + '">' + str(value) + '</span>'
-                else:
-                    return '<span class="' + style + '">&ndash;</span>'
+        # if ('Units' in self._stream_table_df and
+        #     'Variable' in self._stream_table_df):
+        #     # Styling the units for display
+        #     def apply_html(value, style=''):
+        #         if value is not None:
+        #             return '<span class="' + style + '">' + str(value) + '</span>'
+        #         else:
+        #             return '<span class="' + style + '">&ndash;</span>'
 
-            self._stream_table_df['Units'] = self._stream_table_df.apply(
-                lambda x: apply_html(x.Units, 'units'),
-                axis=1
-            )
+        #     self._stream_table_df['Units'] = self._stream_table_df.apply(
+        #         lambda x: apply_html(x.Units, 'streamtable-units'),
+        #         axis=1
+        #     )
 
-            # Append the Units to the Variables columns and drop the Units column
-            self._stream_table_df['Variable'] = (
-                self._stream_table_df['Variable'] + self._stream_table_df['Units']
-            )
-            self._stream_table_df = self._stream_table_df.drop(['Units'], axis=1)
+        #     # Append the Units to the Variables columns and drop the Units column
+        #     self._stream_table_df['Variable'] = (
+        #         self._stream_table_df['Variable'] + self._stream_table_df['Units']
+        #     )
+        #     self._stream_table_df = self._stream_table_df.drop(['Units'], axis=1)
 
         # Change NaNs to None for JSON
         self._stream_table_df = self._stream_table_df.where(

--- a/idaes/ui/flowsheet.py
+++ b/idaes/ui/flowsheet.py
@@ -449,26 +449,6 @@ class FlowsheetSerializer:
             )
         )
 
-        # if ('Units' in self._stream_table_df and
-        #     'Variable' in self._stream_table_df):
-        #     # Styling the units for display
-        #     def apply_html(value, style=''):
-        #         if value is not None:
-        #             return '<span class="' + style + '">' + str(value) + '</span>'
-        #         else:
-        #             return '<span class="' + style + '">&ndash;</span>'
-
-        #     self._stream_table_df['Units'] = self._stream_table_df.apply(
-        #         lambda x: apply_html(x.Units, 'streamtable-units'),
-        #         axis=1
-        #     )
-
-        #     # Append the Units to the Variables columns and drop the Units column
-        #     self._stream_table_df['Variable'] = (
-        #         self._stream_table_df['Variable'] + self._stream_table_df['Units']
-        #     )
-        #     self._stream_table_df = self._stream_table_df.drop(['Units'], axis=1)
-
         # Change NaNs to None for JSON
         self._stream_table_df = self._stream_table_df.where(
             (pd.notnull(self._stream_table_df)), None

--- a/idaes/ui/flowsheet.py
+++ b/idaes/ui/flowsheet.py
@@ -449,23 +449,25 @@ class FlowsheetSerializer:
             )
         )
 
-        # Styling the units for display
-        def apply_html(value, style=''):
-            if value is not None:
-                return '<span class="' + style + '">' + str(value) + '</span>'
-            else:
-                return '<span class="' + style + '">&ndash;</span>'
+        if ('Units' in self._stream_table_df and
+            'Variable' in self._stream_table_df):
+            # Styling the units for display
+            def apply_html(value, style=''):
+                if value is not None:
+                    return '<span class="' + style + '">' + str(value) + '</span>'
+                else:
+                    return '<span class="' + style + '">&ndash;</span>'
 
-        self._stream_table_df['Units'] = self._stream_table_df.apply(
-            lambda x: apply_html(x.Units, 'units'),
-            axis=1
-        )
+            self._stream_table_df['Units'] = self._stream_table_df.apply(
+                lambda x: apply_html(x.Units, 'units'),
+                axis=1
+            )
 
-        # Append the Units to the Variables columns and drop the Units column
-        self._stream_table_df['Variable'] = (
-            self._stream_table_df['Variable']+ self._stream_table_df['Units']
-        )
-        self._stream_table_df = self._stream_table_df.drop(['Units'], axis=1)
+            # Append the Units to the Variables columns and drop the Units column
+            self._stream_table_df['Variable'] = (
+                self._stream_table_df['Variable'] + self._stream_table_df['Units']
+            )
+            self._stream_table_df = self._stream_table_df.drop(['Units'], axis=1)
 
         # Change NaNs to None for JSON
         self._stream_table_df = self._stream_table_df.where(

--- a/idaes/ui/fsvis/static/css/main.css
+++ b/idaes/ui/fsvis/static/css/main.css
@@ -336,3 +336,12 @@ input:checked + .slider:before {
 .dropdown-item:active {
   background-color: white;
 }
+
+.variable {
+  display: block;
+}
+
+.units {
+  opacity: 0.6;
+  float: right;
+}

--- a/idaes/ui/fsvis/static/css/main.css
+++ b/idaes/ui/fsvis/static/css/main.css
@@ -337,11 +337,13 @@ input:checked + .slider:before {
   background-color: white;
 }
 
-.variable {
+/* Styling the Variables column in the Stream Table */
+.streamtable-variable {
   display: block;
 }
 
-.units {
+/* Styling the units in the Variables column in the Stream Table */
+.streamtable-units {
   opacity: 0.6;
   float: right;
 }

--- a/idaes/ui/fsvis/static/js/stream_table.js
+++ b/idaes/ui/fsvis/static/js/stream_table.js
@@ -32,8 +32,9 @@ export class StreamTable {
         for (let col in columns) {
             // There is an empty column because of the way that the pandas dataframe was oriented so 
             // only add the columns that don't have an empty column header
+            // Also ignore the "Units" column header
             let column_header = columns[col]
-            if (column_header !== "") {
+            if (column_header !== "" && column_header !== "Units") {
                 // If the column_header is Variable then we don't want the column to be right-aligned and we want the column to be pinned to the left so when the user scrolls the column scrolls with them
                 if (column_header === "Variable") {
                     column_defs.push({
@@ -44,7 +45,7 @@ export class StreamTable {
                         resizable: true,
                         pinned: 'left',
                         cellRenderer: (params) => {
-                            return '<span class="variable">' + params.value + '</span>';
+                            return '<span class="streamtable-variable">' + params.value + '</span>';
                         }
                     });
                 }
@@ -66,11 +67,22 @@ export class StreamTable {
         let variables = stream_table_data["index"];
         let data_arrays = stream_table_data["data"];
         let row_data = [];
+        let variable_col = "Variable";
         for (let var_index in variables) {
             let row_object = {};
             let data = data_arrays[var_index];
             for (let col_index in columns) {
-                row_object[columns[col_index]] = data[col_index];
+                if (columns[col_index] === "Units") {
+                    if (data[col_index]) {
+                        row_object[variable_col] = row_object[variable_col] + '<span class="streamtable-units">' + data[col_index] + '</span>';
+                    }
+                    else {
+                        row_object[variable_col] = row_object[variable_col] + '<span class="streamtable-units">&ndash;</span>';
+                    }
+                }
+                else {
+                    row_object[columns[col_index]] = data[col_index];
+                }
             };
             row_data.push(row_object);
         };

--- a/idaes/ui/fsvis/static/js/stream_table.js
+++ b/idaes/ui/fsvis/static/js/stream_table.js
@@ -73,7 +73,8 @@ export class StreamTable {
             let data = data_arrays[var_index];
             for (let col_index in columns) {
                 if (columns[col_index] === "Units") {
-                    if (data[col_index]) {
+                    console.log("data[col_index]:", data[col_index]);
+                    if (data[col_index] && data[col_index] !== 'None') {
                         row_object[variable_col] = row_object[variable_col] + '<span class="streamtable-units">' + data[col_index] + '</span>';
                     }
                     else {

--- a/idaes/ui/fsvis/static/js/stream_table.js
+++ b/idaes/ui/fsvis/static/js/stream_table.js
@@ -36,14 +36,17 @@ export class StreamTable {
             if (column_header !== "") {
                 // If the column_header is Variable then we don't want the column to be right-aligned and we want the column to be pinned to the left so when the user scrolls the column scrolls with them
                 if (column_header === "Variable") {
-                    column_defs.push({headerName: column_header, field: column_header, filter: 'agTextColumnFilter', sortable: true, resizable: true, pinned: 'left',});
-                }
-                else if (column_header === "Units") {
-                    column_defs.push({headerName: column_header, field: column_header,
+                    column_defs.push({
+                        headerName: column_header,
+                        field: column_header,
+                        filter: 'agTextColumnFilter',
+                        sortable: true,
+                        resizable: true,
+                        pinned: 'left',
                         cellRenderer: (params) => {
-                            console.log("cellRenderer - params:", params);
-                            return '<span style="opacity: 0.6;">' + params.value + '</span>';
-                        }});
+                            return '<span class="variable">' + params.value + '</span>';
+                        }
+                    });
                 }
                 // If the column header isn't "Variable" then we assume that the contents of the column are numbers so they should be right aligned
                 else {

--- a/idaes/ui/fsvis/static/js/stream_table.js
+++ b/idaes/ui/fsvis/static/js/stream_table.js
@@ -38,6 +38,13 @@ export class StreamTable {
                 if (column_header === "Variable") {
                     column_defs.push({headerName: column_header, field: column_header, filter: 'agTextColumnFilter', sortable: true, resizable: true, pinned: 'left',});
                 }
+                else if (column_header === "Units") {
+                    column_defs.push({headerName: column_header, field: column_header,
+                        cellRenderer: (params) => {
+                            console.log("cellRenderer - params:", params);
+                            return '<span style="opacity: 0.6;">' + params.value + '</span>';
+                        }});
+                }
                 // If the column header isn't "Variable" then we assume that the contents of the column are numbers so they should be right aligned
                 else {
                     column_defs.push({headerName: column_header, field: column_header, filter: 'agTextColumnFilter', sortable: true, resizable: true, cellStyle: {"text-align": "right"}});

--- a/idaes/ui/fsvis/static/js/stream_table.js
+++ b/idaes/ui/fsvis/static/js/stream_table.js
@@ -75,7 +75,7 @@ export class StreamTable {
                 if (columns[col_index] === "Units") {
                     console.log("data[col_index]:", data[col_index]);
                     if (data[col_index] && data[col_index] !== 'None') {
-                        row_object[variable_col] = row_object[variable_col] + '<span class="streamtable-units">' + data[col_index] + '</span>';
+                        row_object[variable_col] = row_object[variable_col] + '<span class="streamtable-units">' + data[col_index].html + '</span>';
                     }
                     else {
                         row_object[variable_col] = row_object[variable_col] + '<span class="streamtable-units">&ndash;</span>';

--- a/idaes/ui/tests/demo_flowsheet.json
+++ b/idaes/ui/tests/demo_flowsheet.json
@@ -11,37 +11,43 @@
             "columns": [
                 "",
                 "Variable",
+                "Units",
                 "s01",
                 "s02"
             ],
             "data": [
                 [
                     0,
-                    "flow_mol<span class=\"units\">mol/s</span>",
+                    "flow_mol",
+                    "mol/s",
                     1.0,
                     1.0
                 ],
                 [
                     1,
-                    "mole_frac_comp benzene<span class=\"units\">&ndash;</span>",
+                    "mole_frac_comp benzene",
+                    "None",
                     0.5,
                     0.5
                 ],
                 [
                     2,
-                    "mole_frac_comp toluene<span class=\"units\">&ndash;</span>",
+                    "mole_frac_comp toluene",
+                    "None",
                     0.5,
                     0.5
                 ],
                 [
                     3,
-                    "temperature<span class=\"units\">K</span>",
+                    "temperature",
+                    "K",
                     298.15,
                     298.15
                 ],
                 [
                     4,
-                    "pressure<span class=\"units\">Pa</span>",
+                    "pressure",
+                    "Pa",
                     101325.0,
                     101325.0
                 ]

--- a/idaes/ui/tests/demo_flowsheet.json
+++ b/idaes/ui/tests/demo_flowsheet.json
@@ -1,7 +1,848 @@
 {
+    "model": {
+        "stream_table": {
+            "index": [
+                0,
+                1,
+                2,
+                3,
+                4
+            ],
+            "columns": [
+                "",
+                "Variable",
+                "s01",
+                "s02"
+            ],
+            "data": [
+                [
+                    0,
+                    "flow_mol<span class=\"units\">mol/s</span>",
+                    1.0,
+                    1.0
+                ],
+                [
+                    1,
+                    "mole_frac_comp benzene<span class=\"units\">&ndash;</span>",
+                    0.5,
+                    0.5
+                ],
+                [
+                    2,
+                    "mole_frac_comp toluene<span class=\"units\">&ndash;</span>",
+                    0.5,
+                    0.5
+                ],
+                [
+                    3,
+                    "temperature<span class=\"units\">K</span>",
+                    298.15,
+                    298.15
+                ],
+                [
+                    4,
+                    "pressure<span class=\"units\">Pa</span>",
+                    101325.0,
+                    101325.0
+                ]
+            ]
+        },
+        "id": "demo",
+        "unit_models": {
+            "M01": {
+                "type": "mixer",
+                "image": "/images/icons/mixer.svg",
+                "performance_contents": {},
+                "stream_contents": {
+                    "0": {
+                        "Variable": "flow_mol",
+                        "inlet_1": 1.0,
+                        "inlet_2": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "mole_frac_comp benzene",
+                        "inlet_1": 0.5,
+                        "inlet_2": 0.5,
+                        "Outlet": 0.5
+                    },
+                    "2": {
+                        "Variable": "mole_frac_comp toluene",
+                        "inlet_1": 0.5,
+                        "inlet_2": 0.5,
+                        "Outlet": 0.5
+                    },
+                    "3": {
+                        "Variable": "temperature",
+                        "inlet_1": 298.15,
+                        "inlet_2": 298.15,
+                        "Outlet": 298.15
+                    },
+                    "4": {
+                        "Variable": "pressure",
+                        "inlet_1": 101325.0,
+                        "inlet_2": 101325.0,
+                        "Outlet": 101325.0
+                    }
+                }
+            },
+            "H02": {
+                "type": "heater",
+                "image": "/images/icons/heater_2.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "flow_mol",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "mole_frac_comp benzene",
+                        "Inlet": 0.5,
+                        "Outlet": 0.5
+                    },
+                    "2": {
+                        "Variable": "mole_frac_comp toluene",
+                        "Inlet": 0.5,
+                        "Outlet": 0.5
+                    },
+                    "3": {
+                        "Variable": "temperature",
+                        "Inlet": 298.15,
+                        "Outlet": 298.15
+                    },
+                    "4": {
+                        "Variable": "pressure",
+                        "Inlet": 101325.0,
+                        "Outlet": 101325.0
+                    }
+                }
+            },
+            "F03": {
+                "type": "flash",
+                "image": "/images/icons/flash.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
+                    },
+                    "1": {
+                        "Variable": "Pressure Change",
+                        "Value": 0.0
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "flow_mol",
+                        "Inlet": 1.0,
+                        "Vapor Outlet": 0.5,
+                        "Liquid Outlet": 0.5
+                    },
+                    "1": {
+                        "Variable": "mole_frac_comp benzene",
+                        "Inlet": 0.5,
+                        "Vapor Outlet": 0.5,
+                        "Liquid Outlet": 0.5
+                    },
+                    "2": {
+                        "Variable": "mole_frac_comp toluene",
+                        "Inlet": 0.5,
+                        "Vapor Outlet": 0.5,
+                        "Liquid Outlet": 0.5
+                    },
+                    "3": {
+                        "Variable": "temperature",
+                        "Inlet": 298.15,
+                        "Vapor Outlet": 298.15,
+                        "Liquid Outlet": 298.15
+                    },
+                    "4": {
+                        "Variable": "pressure",
+                        "Inlet": 101325.0,
+                        "Vapor Outlet": 101325.0,
+                        "Liquid Outlet": 101325.0
+                    }
+                }
+            },
+            "main_compressor": {
+                "type": "pressure_changer",
+                "image": "/images/icons/compressor.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Mechanical Work",
+                        "Value": 0.0
+                    },
+                    "1": {
+                        "Variable": "Pressure Change",
+                        "Value": 0.0
+                    },
+                    "2": {
+                        "Variable": "Pressure Ratio",
+                        "Value": 1.0
+                    },
+                    "3": {
+                        "Variable": "Isentropic Efficiency",
+                        "Value": 0.8
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.04401,
+                        "Outlet": 0.04401
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 325.52764,
+                        "Outlet": 325.52764
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "bypass_compressor": {
+                "type": "pressure_changer",
+                "image": "/images/icons/compressor.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Mechanical Work",
+                        "Value": 0.0
+                    },
+                    "1": {
+                        "Variable": "Pressure Change",
+                        "Value": 0.0
+                    },
+                    "2": {
+                        "Variable": "Pressure Ratio",
+                        "Value": 1.0
+                    },
+                    "3": {
+                        "Variable": "Isentropic Efficiency",
+                        "Value": 0.8
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.04401,
+                        "Outlet": 0.04401
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 325.52764,
+                        "Outlet": 325.52764
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "turbine": {
+                "type": "pressure_changer",
+                "image": "/images/icons/compressor.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Mechanical Work",
+                        "Value": 0.0
+                    },
+                    "1": {
+                        "Variable": "Pressure Change",
+                        "Value": 0.0
+                    },
+                    "2": {
+                        "Variable": "Pressure Ratio",
+                        "Value": 1.0
+                    },
+                    "3": {
+                        "Variable": "Isentropic Efficiency",
+                        "Value": 0.8
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.04401,
+                        "Outlet": 0.04401
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 325.52764,
+                        "Outlet": 325.52764
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "boiler": {
+                "type": "heater",
+                "image": "/images/icons/heater_2.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.04401,
+                        "Outlet": 0.04401
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 325.52764,
+                        "Outlet": 325.52764
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "FG_cooler": {
+                "type": "heater",
+                "image": "/images/icons/heater_2.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.04401,
+                        "Outlet": 0.04401
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 325.52764,
+                        "Outlet": 325.52764
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "pre_boiler": {
+                "type": "heater",
+                "image": "/images/icons/heater_2.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.04401,
+                        "Outlet": 0.04401
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 325.52764,
+                        "Outlet": 325.52764
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "HTR_pseudo_tube": {
+                "type": "heater",
+                "image": "/images/icons/heater_2.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.04401,
+                        "Outlet": 0.04401
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 325.52764,
+                        "Outlet": 325.52764
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "LTR_pseudo_tube": {
+                "type": "heater",
+                "image": "/images/icons/heater_2.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
+                    }
+                },
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.04401,
+                        "Outlet": 0.04401
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 325.52764,
+                        "Outlet": 325.52764
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "liq_outlet_1": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "vap_outlet_1": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "inlet_1": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "outlet_1": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "inlet_2": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "outlet_2": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "inlet_3": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "outlet_3": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "inlet_1_1": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "inlet_2_1": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "inlet_4": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "outlet_4": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "inlet_5": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "outlet_5": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "inlet_6": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "outlet_6": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "inlet_7": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "outlet_7": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "inlet_8": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "outlet_8": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            }
+        },
+        "arcs": {
+            "s01": {
+                "source": "M01",
+                "dest": "H02",
+                "label": "Flow_mol 1.0\nMole_frac_comp benzene 0.5\nMole_frac_comp toluene 0.5\nTemperature 298.15\nPressure 10132"
+            },
+            "s02": {
+                "source": "H02",
+                "dest": "F03",
+                "label": "Flow_mol 1.0\nMole_frac_comp benzene 0.5\nMole_frac_comp toluene 0.5\nTemperature 298.15\nPressure 10132"
+            },
+            "s_liq_outlet_1": {
+                "source": "F03",
+                "dest": "liq_outlet_1",
+                "label": "product info"
+            },
+            "s_vap_outlet_1": {
+                "source": "F03",
+                "dest": "vap_outlet_1",
+                "label": "product info"
+            },
+            "s_inlet_1": {
+                "source": "inlet_1",
+                "dest": "FG_cooler",
+                "label": "feed info"
+            },
+            "s_outlet_1": {
+                "source": "FG_cooler",
+                "dest": "outlet_1",
+                "label": "product info"
+            },
+            "s_inlet_2": {
+                "source": "inlet_2",
+                "dest": "HTR_pseudo_tube",
+                "label": "feed info"
+            },
+            "s_outlet_2": {
+                "source": "HTR_pseudo_tube",
+                "dest": "outlet_2",
+                "label": "product info"
+            },
+            "s_inlet_3": {
+                "source": "inlet_3",
+                "dest": "LTR_pseudo_tube",
+                "label": "feed info"
+            },
+            "s_outlet_3": {
+                "source": "LTR_pseudo_tube",
+                "dest": "outlet_3",
+                "label": "product info"
+            },
+            "s_inlet_1_1": {
+                "source": "inlet_1_1",
+                "dest": "M01",
+                "label": "feed info"
+            },
+            "s_inlet_2_1": {
+                "source": "inlet_2_1",
+                "dest": "M01",
+                "label": "feed info"
+            },
+            "s_inlet_4": {
+                "source": "inlet_4",
+                "dest": "boiler",
+                "label": "feed info"
+            },
+            "s_outlet_4": {
+                "source": "boiler",
+                "dest": "outlet_4",
+                "label": "product info"
+            },
+            "s_inlet_5": {
+                "source": "inlet_5",
+                "dest": "bypass_compressor",
+                "label": "feed info"
+            },
+            "s_outlet_5": {
+                "source": "bypass_compressor",
+                "dest": "outlet_5",
+                "label": "product info"
+            },
+            "s_inlet_6": {
+                "source": "inlet_6",
+                "dest": "main_compressor",
+                "label": "feed info"
+            },
+            "s_outlet_6": {
+                "source": "main_compressor",
+                "dest": "outlet_6",
+                "label": "product info"
+            },
+            "s_inlet_7": {
+                "source": "inlet_7",
+                "dest": "pre_boiler",
+                "label": "feed info"
+            },
+            "s_outlet_7": {
+                "source": "pre_boiler",
+                "dest": "outlet_7",
+                "label": "product info"
+            },
+            "s_inlet_8": {
+                "source": "inlet_8",
+                "dest": "turbine",
+                "label": "feed info"
+            },
+            "s_outlet_8": {
+                "source": "turbine",
+                "dest": "outlet_8",
+                "label": "product info"
+            }
+        }
+    },
     "cells": [
         {
+            "type": "standard.Image",
+            "position": {
+                "x": 10,
+                "y": 10
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
             "angle": 0,
+            "id": "M01",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/mixer.svg"
@@ -12,49 +853,62 @@
                 "root": {
                     "title": "mixer"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 110,
+                "y": 110
             },
-            "id": "M01",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "H02",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 6,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 43,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -68,19 +922,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 10,
-                "y": 10
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/heater_2.svg"
@@ -91,148 +932,82 @@
                 "root": {
                     "title": "heater"
                 }
-            },
-            "id": "H02",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 6,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 43,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 110,
-                "y": 110
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
+            }
         },
         {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/flash.svg"
-                },
-                "label": {
-                    "text": "F03"
-                },
-                "root": {
-                    "title": "flash"
-                }
+            "type": "standard.Image",
+            "position": {
+                "x": 210,
+                "y": 210
             },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
             "id": "F03",
+            "z": 1,
             "ports": {
                 "groups": {
                     "bottom": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "bottom",
+                            "args": {
+                                "x": 25,
+                                "y": 50,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 25,
-                                "y": 50
-                            },
-                            "name": "bottom"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 8,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 8,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "top": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "top",
+                            "args": {
+                                "x": 25,
+                                "y": 0,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 25,
-                                "y": 0
-                            },
-                            "name": "top"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -250,19 +1025,85 @@
                     }
                 ]
             },
-            "position": {
-                "x": 210,
-                "y": 210
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/flash.svg"
+                },
+                "label": {
+                    "text": "F03"
+                },
+                "root": {
+                    "title": "flash"
+                }
+            }
         },
         {
+            "type": "standard.Image",
+            "position": {
+                "x": 310,
+                "y": 310
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
             "angle": 0,
+            "id": "main_compressor",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/compressor.svg"
@@ -273,49 +1114,62 @@
                 "root": {
                     "title": "pressure_changer"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 410,
+                "y": 410
             },
-            "id": "main_compressor",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "bypass_compressor",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -329,19 +1183,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 310,
-                "y": 310
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/compressor.svg"
@@ -352,49 +1193,62 @@
                 "root": {
                     "title": "pressure_changer"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 510,
+                "y": 510
             },
-            "id": "bypass_compressor",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "turbine",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -408,19 +1262,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 410,
-                "y": 410
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/compressor.svg"
@@ -431,49 +1272,62 @@
                 "root": {
                     "title": "pressure_changer"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 610,
+                "y": 610
             },
-            "id": "turbine",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "boiler",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 6,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 43,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -487,19 +1341,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 510,
-                "y": 510
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/heater_2.svg"
@@ -510,49 +1351,62 @@
                 "root": {
                     "title": "heater"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 710,
+                "y": 710
             },
-            "id": "boiler",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "FG_cooler",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 6,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 6,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 43,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 43,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -566,19 +1420,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 610,
-                "y": 610
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/heater_2.svg"
@@ -589,49 +1430,62 @@
                 "root": {
                     "title": "heater"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 100,
+                "y": 10
             },
-            "id": "FG_cooler",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "pre_boiler",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 6,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 6,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 43,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 43,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -645,19 +1499,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 710,
-                "y": 710
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/heater_2.svg"
@@ -668,49 +1509,62 @@
                 "root": {
                     "title": "heater"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 200,
+                "y": 110
             },
-            "id": "pre_boiler",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "HTR_pseudo_tube",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 6,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 6,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 43,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 43,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -724,19 +1578,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 100,
-                "y": 10
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/heater_2.svg"
@@ -747,49 +1588,62 @@
                 "root": {
                     "title": "heater"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 300,
+                "y": 210
             },
-            "id": "HTR_pseudo_tube",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "LTR_pseudo_tube",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 6,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 6,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     },
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 43,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 43,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -803,19 +1657,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 200,
-                "y": 110
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/heater_2.svg"
@@ -826,75 +1667,51 @@
                 "root": {
                     "title": "heater"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 400,
+                "y": 310
             },
-            "id": "LTR_pseudo_tube",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "liq_outlet_1",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 6,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
                         "attrs": {
                             "rect": {
-                                "height": 0,
                                 "stroke": "#000000",
                                 "stroke-width": 0,
-                                "width": 0
+                                "width": 0,
+                                "height": 0
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 43,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
                         "group": "in",
                         "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 300,
-                "y": 210
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -905,29 +1722,42 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 500,
+                "y": 410
             },
-            "id": "liq_outlet_1",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "vap_outlet_1",
+            "z": 1,
             "ports": {
                 "groups": {
                     "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -937,19 +1767,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 400,
-                "y": 310
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -960,51 +1777,51 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 600,
+                "y": 510
             },
-            "id": "vap_outlet_1",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_1",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "in",
-                        "id": "in"
+                        "group": "out",
+                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 500,
-                "y": 410
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1015,51 +1832,51 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 700,
+                "y": 610
             },
-            "id": "inlet_1",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_1",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "out",
-                        "id": "out"
+                        "group": "in",
+                        "id": "in"
                     }
                 ]
             },
-            "position": {
-                "x": 600,
-                "y": 510
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -1070,51 +1887,51 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 100,
+                "y": 110
             },
-            "id": "outlet_1",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_2",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "in",
-                        "id": "in"
+                        "group": "out",
+                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 700,
-                "y": 610
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1125,51 +1942,51 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 200,
+                "y": 210
             },
-            "id": "inlet_2",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_2",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "out",
-                        "id": "out"
+                        "group": "in",
+                        "id": "in"
                     }
                 ]
             },
-            "position": {
-                "x": 100,
-                "y": 110
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -1180,51 +1997,51 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 300,
+                "y": 310
             },
-            "id": "outlet_2",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_3",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "in",
-                        "id": "in"
+                        "group": "out",
+                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 200,
-                "y": 210
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1235,51 +2052,51 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 400,
+                "y": 410
             },
-            "id": "inlet_3",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_3",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "out",
-                        "id": "out"
+                        "group": "in",
+                        "id": "in"
                     }
                 ]
             },
-            "position": {
-                "x": 300,
-                "y": 310
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -1290,51 +2107,51 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 500,
+                "y": 510
             },
-            "id": "outlet_3",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_1_1",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "in",
-                        "id": "in"
+                        "group": "out",
+                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 400,
-                "y": 410
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1345,29 +2162,42 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 600,
+                "y": 610
             },
-            "id": "inlet_1_1",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_2_1",
+            "z": 1,
             "ports": {
                 "groups": {
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -1377,19 +2207,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 500,
-                "y": 510
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1400,29 +2217,42 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 700,
+                "y": 710
             },
-            "id": "inlet_2_1",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_4",
+            "z": 1,
             "ports": {
                 "groups": {
                     "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
@@ -1432,19 +2262,6 @@
                     }
                 ]
             },
-            "position": {
-                "x": 600,
-                "y": 610
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1455,51 +2272,51 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 100,
+                "y": 210
             },
-            "id": "inlet_4",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_4",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "out",
-                        "id": "out"
+                        "group": "in",
+                        "id": "in"
                     }
                 ]
             },
-            "position": {
-                "x": 700,
-                "y": 710
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -1510,51 +2327,51 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 200,
+                "y": 310
             },
-            "id": "outlet_4",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_5",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "in",
-                        "id": "in"
+                        "group": "out",
+                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 100,
-                "y": 210
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1565,51 +2382,51 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 300,
+                "y": 410
             },
-            "id": "inlet_5",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_5",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "out",
-                        "id": "out"
+                        "group": "in",
+                        "id": "in"
                     }
                 ]
             },
-            "position": {
-                "x": 200,
-                "y": 310
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -1620,51 +2437,51 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 400,
+                "y": 510
             },
-            "id": "outlet_5",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_6",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "in",
-                        "id": "in"
+                        "group": "out",
+                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 300,
-                "y": 410
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1675,51 +2492,51 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 500,
+                "y": 610
             },
-            "id": "inlet_6",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_6",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "out",
-                        "id": "out"
+                        "group": "in",
+                        "id": "in"
                     }
                 ]
             },
-            "position": {
-                "x": 400,
-                "y": 510
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -1730,51 +2547,51 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 600,
+                "y": 710
             },
-            "id": "outlet_6",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_7",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "in",
-                        "id": "in"
+                        "group": "out",
+                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 500,
-                "y": 610
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1785,51 +2602,51 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 700,
+                "y": 810
             },
-            "id": "inlet_7",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_7",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "out",
-                        "id": "out"
+                        "group": "in",
+                        "id": "in"
                     }
                 ]
             },
-            "position": {
-                "x": 600,
-                "y": 710
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -1840,51 +2657,51 @@
                 "root": {
                     "title": "product"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 100,
+                "y": 310
             },
-            "id": "outlet_7",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "inlet_8",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "in",
-                        "id": "in"
+                        "group": "out",
+                        "id": "out"
                     }
                 ]
             },
-            "position": {
-                "x": 700,
-                "y": 810
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/feed.svg"
@@ -1895,51 +2712,51 @@
                 "root": {
                     "title": "feed"
                 }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 200,
+                "y": 410
             },
-            "id": "inlet_8",
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_8",
+            "z": 1,
             "ports": {
                 "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
                             }
                         },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
                     }
                 },
                 "items": [
                     {
-                        "group": "out",
-                        "id": "out"
+                        "group": "in",
+                        "id": "in"
                     }
                 ]
             },
-            "position": {
-                "x": 100,
-                "y": 310
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
             "attrs": {
                 "image": {
                     "xlinkHref": "/images/icons/product.svg"
@@ -1950,57 +2767,29 @@
                 "root": {
                     "title": "product"
                 }
-            },
-            "id": "outlet_8",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    }
-                ]
-            },
-            "position": {
-                "x": 200,
-                "y": 410
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
+            }
         },
         {
+            "type": "standard.Link",
+            "source": {
+                "id": "M01",
+                "port": "out"
+            },
+            "target": {
+                "id": "H02",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s01",
             "labels": [
@@ -2008,15 +2797,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "Flow_mol 1.0\nMole_frac_comp benzene 0.5\nMole_frac_comp toluene 0.5\nTemperature 298.15\nPressure 10132",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2032,29 +2821,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "H02",
+                "port": "out"
+            },
+            "target": {
+                "id": "F03",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "M01",
-                "port": "out"
-            },
-            "target": {
-                "id": "H02",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s02",
             "labels": [
@@ -2062,15 +2851,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "Flow_mol 1.0\nMole_frac_comp benzene 0.5\nMole_frac_comp toluene 0.5\nTemperature 298.15\nPressure 10132",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2086,29 +2875,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "F03",
+                "port": "out"
+            },
+            "target": {
+                "id": "liq_outlet_1",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "H02",
-                "port": "out"
-            },
-            "target": {
-                "id": "F03",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_liq_outlet_1",
             "labels": [
@@ -2116,15 +2905,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2140,29 +2929,29 @@
                     }
                 }
             ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
             "source": {
                 "id": "F03",
                 "port": "out"
             },
             "target": {
-                "id": "liq_outlet_1",
+                "id": "vap_outlet_1",
                 "port": "in"
             },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_vap_outlet_1",
             "labels": [
@@ -2170,15 +2959,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2194,29 +2983,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_1",
+                "port": "out"
+            },
+            "target": {
+                "id": "FG_cooler",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "F03",
-                "port": "out"
-            },
-            "target": {
-                "id": "vap_outlet_1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_1",
             "labels": [
@@ -2224,15 +3013,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2248,29 +3037,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "FG_cooler",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_1",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_1",
-                "port": "out"
-            },
-            "target": {
-                "id": "FG_cooler",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_outlet_1",
             "labels": [
@@ -2278,15 +3067,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2302,29 +3091,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_2",
+                "port": "out"
+            },
+            "target": {
+                "id": "HTR_pseudo_tube",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "FG_cooler",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_2",
             "labels": [
@@ -2332,15 +3121,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2356,29 +3145,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "HTR_pseudo_tube",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_2",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_2",
-                "port": "out"
-            },
-            "target": {
-                "id": "HTR_pseudo_tube",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_outlet_2",
             "labels": [
@@ -2386,15 +3175,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2410,29 +3199,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_3",
+                "port": "out"
+            },
+            "target": {
+                "id": "LTR_pseudo_tube",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "HTR_pseudo_tube",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_2",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_3",
             "labels": [
@@ -2440,15 +3229,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2464,29 +3253,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "LTR_pseudo_tube",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_3",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_3",
-                "port": "out"
-            },
-            "target": {
-                "id": "LTR_pseudo_tube",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_outlet_3",
             "labels": [
@@ -2494,15 +3283,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2518,29 +3307,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_1_1",
+                "port": "out"
+            },
+            "target": {
+                "id": "M01",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "LTR_pseudo_tube",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_3",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_1_1",
             "labels": [
@@ -2548,15 +3337,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2572,29 +3361,29 @@
                     }
                 }
             ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
             "source": {
-                "id": "inlet_1_1",
+                "id": "inlet_2_1",
                 "port": "out"
             },
             "target": {
                 "id": "M01",
                 "port": "in"
             },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_2_1",
             "labels": [
@@ -2602,15 +3391,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2626,29 +3415,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_4",
+                "port": "out"
+            },
+            "target": {
+                "id": "boiler",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_2_1",
-                "port": "out"
-            },
-            "target": {
-                "id": "M01",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_4",
             "labels": [
@@ -2656,15 +3445,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2680,29 +3469,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "boiler",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_4",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_4",
-                "port": "out"
-            },
-            "target": {
-                "id": "boiler",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_outlet_4",
             "labels": [
@@ -2710,15 +3499,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2734,29 +3523,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_5",
+                "port": "out"
+            },
+            "target": {
+                "id": "bypass_compressor",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "boiler",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_4",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_5",
             "labels": [
@@ -2764,15 +3553,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2788,29 +3577,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "bypass_compressor",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_5",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_5",
-                "port": "out"
-            },
-            "target": {
-                "id": "bypass_compressor",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_outlet_5",
             "labels": [
@@ -2818,15 +3607,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2842,29 +3631,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_6",
+                "port": "out"
+            },
+            "target": {
+                "id": "main_compressor",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "bypass_compressor",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_5",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_6",
             "labels": [
@@ -2872,15 +3661,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2896,29 +3685,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "main_compressor",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_6",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_6",
-                "port": "out"
-            },
-            "target": {
-                "id": "main_compressor",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_outlet_6",
             "labels": [
@@ -2926,15 +3715,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -2950,29 +3739,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_7",
+                "port": "out"
+            },
+            "target": {
+                "id": "pre_boiler",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "main_compressor",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_6",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_7",
             "labels": [
@@ -2980,15 +3769,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -3004,29 +3793,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "pre_boiler",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_7",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_7",
-                "port": "out"
-            },
-            "target": {
-                "id": "pre_boiler",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_outlet_7",
             "labels": [
@@ -3034,15 +3823,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -3058,29 +3847,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "inlet_8",
+                "port": "out"
+            },
+            "target": {
+                "id": "turbine",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "pre_boiler",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_7",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_inlet_8",
             "labels": [
@@ -3088,15 +3877,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "feed info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -3112,29 +3901,29 @@
                     }
                 }
             ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "turbine",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_8",
+                "port": "in"
+            },
             "router": {
                 "name": "orthogonal",
                 "padding": 10
             },
-            "source": {
-                "id": "inlet_8",
-                "port": "out"
-            },
-            "target": {
-                "id": "turbine",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
             "connector": {
+                "name": "jumpover",
                 "attrs": {
                     "line": {
                         "stroke": "#5c9adb"
                     }
-                },
-                "name": "jumpover"
+                }
             },
             "id": "s_outlet_8",
             "labels": [
@@ -3142,15 +3931,15 @@
                     "attrs": {
                         "rect": {
                             "fill": "#d7dce0",
-                            "fill-opacity": 0,
                             "stroke": "white",
-                            "stroke-width": 0
+                            "stroke-width": 0,
+                            "fill-opacity": 0
                         },
                         "text": {
-                            "display": "none",
-                            "fill": "black",
                             "text": "product info",
-                            "text-anchor": "left"
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
                         }
                     },
                     "position": {
@@ -3166,796 +3955,7 @@
                     }
                 }
             ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "turbine",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_8",
-                "port": "in"
-            },
-            "type": "standard.Link",
             "z": 2
         }
-    ],
-    "model": {
-        "arcs": {
-            "s01": {
-                "dest": "H02",
-                "label": "Flow_mol 1.0\nMole_frac_comp benzene 0.5\nMole_frac_comp toluene 0.5\nTemperature 298.15\nPressure 10132",
-                "source": "M01"
-            },
-            "s02": {
-                "dest": "F03",
-                "label": "Flow_mol 1.0\nMole_frac_comp benzene 0.5\nMole_frac_comp toluene 0.5\nTemperature 298.15\nPressure 10132",
-                "source": "H02"
-            },
-            "s_inlet_1": {
-                "dest": "FG_cooler",
-                "label": "feed info",
-                "source": "inlet_1"
-            },
-            "s_inlet_1_1": {
-                "dest": "M01",
-                "label": "feed info",
-                "source": "inlet_1_1"
-            },
-            "s_inlet_2": {
-                "dest": "HTR_pseudo_tube",
-                "label": "feed info",
-                "source": "inlet_2"
-            },
-            "s_inlet_2_1": {
-                "dest": "M01",
-                "label": "feed info",
-                "source": "inlet_2_1"
-            },
-            "s_inlet_3": {
-                "dest": "LTR_pseudo_tube",
-                "label": "feed info",
-                "source": "inlet_3"
-            },
-            "s_inlet_4": {
-                "dest": "boiler",
-                "label": "feed info",
-                "source": "inlet_4"
-            },
-            "s_inlet_5": {
-                "dest": "bypass_compressor",
-                "label": "feed info",
-                "source": "inlet_5"
-            },
-            "s_inlet_6": {
-                "dest": "main_compressor",
-                "label": "feed info",
-                "source": "inlet_6"
-            },
-            "s_inlet_7": {
-                "dest": "pre_boiler",
-                "label": "feed info",
-                "source": "inlet_7"
-            },
-            "s_inlet_8": {
-                "dest": "turbine",
-                "label": "feed info",
-                "source": "inlet_8"
-            },
-            "s_liq_outlet_1": {
-                "dest": "liq_outlet_1",
-                "label": "product info",
-                "source": "F03"
-            },
-            "s_outlet_1": {
-                "dest": "outlet_1",
-                "label": "product info",
-                "source": "FG_cooler"
-            },
-            "s_outlet_2": {
-                "dest": "outlet_2",
-                "label": "product info",
-                "source": "HTR_pseudo_tube"
-            },
-            "s_outlet_3": {
-                "dest": "outlet_3",
-                "label": "product info",
-                "source": "LTR_pseudo_tube"
-            },
-            "s_outlet_4": {
-                "dest": "outlet_4",
-                "label": "product info",
-                "source": "boiler"
-            },
-            "s_outlet_5": {
-                "dest": "outlet_5",
-                "label": "product info",
-                "source": "bypass_compressor"
-            },
-            "s_outlet_6": {
-                "dest": "outlet_6",
-                "label": "product info",
-                "source": "main_compressor"
-            },
-            "s_outlet_7": {
-                "dest": "outlet_7",
-                "label": "product info",
-                "source": "pre_boiler"
-            },
-            "s_outlet_8": {
-                "dest": "outlet_8",
-                "label": "product info",
-                "source": "turbine"
-            },
-            "s_vap_outlet_1": {
-                "dest": "vap_outlet_1",
-                "label": "product info",
-                "source": "F03"
-            }
-        },
-        "id": "demo",
-        "stream_table": {
-            "columns": [
-                "",
-                "Variable",
-                "s01",
-                "s02"
-            ],
-            "data": [
-                [
-                    0,
-                    "flow_mol",
-                    1.0,
-                    1.0
-                ],
-                [
-                    1,
-                    "mole_frac_comp benzene",
-                    0.5,
-                    0.5
-                ],
-                [
-                    2,
-                    "mole_frac_comp toluene",
-                    0.5,
-                    0.5
-                ],
-                [
-                    3,
-                    "temperature",
-                    298.15,
-                    298.15
-                ],
-                [
-                    4,
-                    "pressure",
-                    101325.0,
-                    101325.0
-                ]
-            ],
-            "index": [
-                0,
-                1,
-                2,
-                3,
-                4
-            ]
-        },
-        "unit_models": {
-            "F03": {
-                "image": "/images/icons/flash.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
-                    },
-                    "1": {
-                        "Value": 0.0,
-                        "Variable": "Pressure Change"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Liquid Outlet": 0.5,
-                        "Vapor Outlet": 0.5,
-                        "Variable": "flow_mol"
-                    },
-                    "1": {
-                        "Inlet": 0.5,
-                        "Liquid Outlet": 0.5,
-                        "Vapor Outlet": 0.5,
-                        "Variable": "mole_frac_comp benzene"
-                    },
-                    "2": {
-                        "Inlet": 0.5,
-                        "Liquid Outlet": 0.5,
-                        "Vapor Outlet": 0.5,
-                        "Variable": "mole_frac_comp toluene"
-                    },
-                    "3": {
-                        "Inlet": 298.15,
-                        "Liquid Outlet": 298.15,
-                        "Vapor Outlet": 298.15,
-                        "Variable": "temperature"
-                    },
-                    "4": {
-                        "Inlet": 101325.0,
-                        "Liquid Outlet": 101325.0,
-                        "Vapor Outlet": 101325.0,
-                        "Variable": "pressure"
-                    }
-                },
-                "type": "flash"
-            },
-            "FG_cooler": {
-                "image": "/images/icons/heater_2.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.04401,
-                        "Outlet": 0.04401,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 325.52764,
-                        "Outlet": 325.52764,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "heater"
-            },
-            "H02": {
-                "image": "/images/icons/heater_2.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "flow_mol"
-                    },
-                    "1": {
-                        "Inlet": 0.5,
-                        "Outlet": 0.5,
-                        "Variable": "mole_frac_comp benzene"
-                    },
-                    "2": {
-                        "Inlet": 0.5,
-                        "Outlet": 0.5,
-                        "Variable": "mole_frac_comp toluene"
-                    },
-                    "3": {
-                        "Inlet": 298.15,
-                        "Outlet": 298.15,
-                        "Variable": "temperature"
-                    },
-                    "4": {
-                        "Inlet": 101325.0,
-                        "Outlet": 101325.0,
-                        "Variable": "pressure"
-                    }
-                },
-                "type": "heater"
-            },
-            "HTR_pseudo_tube": {
-                "image": "/images/icons/heater_2.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.04401,
-                        "Outlet": 0.04401,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 325.52764,
-                        "Outlet": 325.52764,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "heater"
-            },
-            "LTR_pseudo_tube": {
-                "image": "/images/icons/heater_2.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.04401,
-                        "Outlet": 0.04401,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 325.52764,
-                        "Outlet": 325.52764,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "heater"
-            },
-            "M01": {
-                "image": "/images/icons/mixer.svg",
-                "performance_contents": {},
-                "stream_contents": {
-                    "0": {
-                        "Outlet": 1.0,
-                        "Variable": "flow_mol",
-                        "inlet_1": 1.0,
-                        "inlet_2": 1.0
-                    },
-                    "1": {
-                        "Outlet": 0.5,
-                        "Variable": "mole_frac_comp benzene",
-                        "inlet_1": 0.5,
-                        "inlet_2": 0.5
-                    },
-                    "2": {
-                        "Outlet": 0.5,
-                        "Variable": "mole_frac_comp toluene",
-                        "inlet_1": 0.5,
-                        "inlet_2": 0.5
-                    },
-                    "3": {
-                        "Outlet": 298.15,
-                        "Variable": "temperature",
-                        "inlet_1": 298.15,
-                        "inlet_2": 298.15
-                    },
-                    "4": {
-                        "Outlet": 101325.0,
-                        "Variable": "pressure",
-                        "inlet_1": 101325.0,
-                        "inlet_2": 101325.0
-                    }
-                },
-                "type": "mixer"
-            },
-            "boiler": {
-                "image": "/images/icons/heater_2.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.04401,
-                        "Outlet": 0.04401,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 325.52764,
-                        "Outlet": 325.52764,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "heater"
-            },
-            "bypass_compressor": {
-                "image": "/images/icons/compressor.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Mechanical Work"
-                    },
-                    "1": {
-                        "Value": 0.0,
-                        "Variable": "Pressure Change"
-                    },
-                    "2": {
-                        "Value": 1.0,
-                        "Variable": "Pressure Ratio"
-                    },
-                    "3": {
-                        "Value": 0.8,
-                        "Variable": "Isentropic Efficiency"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.04401,
-                        "Outlet": 0.04401,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 325.52764,
-                        "Outlet": 325.52764,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "pressure_changer"
-            },
-            "inlet_1": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_1_1": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_2": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_2_1": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_3": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_4": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_5": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_6": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_7": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "inlet_8": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "liq_outlet_1": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "main_compressor": {
-                "image": "/images/icons/compressor.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Mechanical Work"
-                    },
-                    "1": {
-                        "Value": 0.0,
-                        "Variable": "Pressure Change"
-                    },
-                    "2": {
-                        "Value": 1.0,
-                        "Variable": "Pressure Ratio"
-                    },
-                    "3": {
-                        "Value": 0.8,
-                        "Variable": "Isentropic Efficiency"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.04401,
-                        "Outlet": 0.04401,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 325.52764,
-                        "Outlet": 325.52764,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "pressure_changer"
-            },
-            "outlet_1": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "outlet_2": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "outlet_3": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "outlet_4": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "outlet_5": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "outlet_6": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "outlet_7": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "outlet_8": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "pre_boiler": {
-                "image": "/images/icons/heater_2.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.04401,
-                        "Outlet": 0.04401,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 325.52764,
-                        "Outlet": 325.52764,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "heater"
-            },
-            "turbine": {
-                "image": "/images/icons/compressor.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Mechanical Work"
-                    },
-                    "1": {
-                        "Value": 0.0,
-                        "Variable": "Pressure Change"
-                    },
-                    "2": {
-                        "Value": 1.0,
-                        "Variable": "Pressure Ratio"
-                    },
-                    "3": {
-                        "Value": 0.8,
-                        "Variable": "Isentropic Efficiency"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.04401,
-                        "Outlet": 0.04401,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 325.52764,
-                        "Outlet": 325.52764,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "pressure_changer"
-            },
-            "vap_outlet_1": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            }
-        }
-    }
+    ]
 }

--- a/idaes/ui/tests/demo_flowsheet.json
+++ b/idaes/ui/tests/demo_flowsheet.json
@@ -19,35 +19,47 @@
                 [
                     0,
                     "flow_mol",
-                    "mol/s",
+                    {
+                        "raw": "mol/s",
+                        "html": "mol/s",
+                        "latex": "\\frac{\\mathrm{mol}}{\\mathrm{s}}"
+                    },
                     1.0,
                     1.0
                 ],
                 [
                     1,
                     "mole_frac_comp benzene",
-                    "None",
+                    null,
                     0.5,
                     0.5
                 ],
                 [
                     2,
                     "mole_frac_comp toluene",
-                    "None",
+                    null,
                     0.5,
                     0.5
                 ],
                 [
                     3,
                     "temperature",
-                    "K",
+                    {
+                        "raw": "K",
+                        "html": "K",
+                        "latex": "\\mathrm{K}"
+                    },
                     298.15,
                     298.15
                 ],
                 [
                     4,
                     "pressure",
-                    "Pa",
+                    {
+                        "raw": "Pa",
+                        "html": "Pa",
+                        "latex": "\\mathrm{Pa}"
+                    },
                     101325.0,
                     101325.0
                 ]

--- a/idaes/ui/tests/serialized_boiler_flowsheet.json
+++ b/idaes/ui/tests/serialized_boiler_flowsheet.json
@@ -1,2055 +1,23 @@
 {
-    "cells": [
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/default.svg"
-                },
-                "label": {
-                    "text": "ECON"
-                },
-                "root": {
-                    "title": "boiler_heat_exchanger"
-                }
-            },
-            "id": "ECON",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 0
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 50
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 10,
-                "y": 10
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/default.svg"
-                },
-                "label": {
-                    "text": "PrSH"
-                },
-                "root": {
-                    "title": "boiler_heat_exchanger"
-                }
-            },
-            "id": "PrSH",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 0
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 50
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 110,
-                "y": 110
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/default.svg"
-                },
-                "label": {
-                    "text": "FSH"
-                },
-                "root": {
-                    "title": "boiler_heat_exchanger"
-                }
-            },
-            "id": "FSH",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 0
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 50
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 210,
-                "y": 210
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/default.svg"
-                },
-                "label": {
-                    "text": "RH"
-                },
-                "root": {
-                    "title": "boiler_heat_exchanger"
-                }
-            },
-            "id": "RH",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 0
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 50
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 310,
-                "y": 310
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/heater_2.svg"
-                },
-                "label": {
-                    "text": "PlSH"
-                },
-                "root": {
-                    "title": "heater"
-                }
-            },
-            "id": "PlSH",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 6,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 43,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 410,
-                "y": 410
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/heater_2.svg"
-                },
-                "label": {
-                    "text": "Water_wall"
-                },
-                "root": {
-                    "title": "heater"
-                }
-            },
-            "id": "Water_wall",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 6,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 43,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 510,
-                "y": 510
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/splitter.svg"
-                },
-                "label": {
-                    "text": "Spl1"
-                },
-                "root": {
-                    "title": "separator"
-                }
-            },
-            "id": "Spl1",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "right"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 610,
-                "y": 610
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/mixer.svg"
-                },
-                "label": {
-                    "text": "mix1"
-                },
-                "root": {
-                    "title": "mixer"
-                }
-            },
-            "id": "mix1",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 710,
-                "y": 710
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/mixer.svg"
-                },
-                "label": {
-                    "text": "ATMP1"
-                },
-                "root": {
-                    "title": "mixer"
-                }
-            },
-            "id": "ATMP1",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    },
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    },
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 100,
-                "y": 10
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/product.svg"
-                },
-                "label": {
-                    "text": "outlet_1"
-                },
-                "root": {
-                    "title": "product"
-                }
-            },
-            "id": "outlet_1",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    }
-                ]
-            },
-            "position": {
-                "x": 200,
-                "y": 110
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/feed.svg"
-                },
-                "label": {
-                    "text": "side_1_inlet_1"
-                },
-                "root": {
-                    "title": "feed"
-                }
-            },
-            "id": "side_1_inlet_1",
-            "ports": {
-                "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 300,
-                "y": 210
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/product.svg"
-                },
-                "label": {
-                    "text": "side_2_outlet_1"
-                },
-                "root": {
-                    "title": "product"
-                }
-            },
-            "id": "side_2_outlet_1",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    }
-                ]
-            },
-            "position": {
-                "x": 400,
-                "y": 310
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/feed.svg"
-                },
-                "label": {
-                    "text": "side_2_inlet_1"
-                },
-                "root": {
-                    "title": "feed"
-                }
-            },
-            "id": "side_2_inlet_1",
-            "ports": {
-                "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 500,
-                "y": 410
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/feed.svg"
-                },
-                "label": {
-                    "text": "side_1_inlet_2"
-                },
-                "root": {
-                    "title": "feed"
-                }
-            },
-            "id": "side_1_inlet_2",
-            "ports": {
-                "groups": {
-                    "out": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 48,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "out",
-                        "id": "out"
-                    }
-                ]
-            },
-            "position": {
-                "x": 600,
-                "y": 510
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "angle": 0,
-            "attrs": {
-                "image": {
-                    "xlinkHref": "/images/icons/product.svg"
-                },
-                "label": {
-                    "text": "side_1_outlet_1"
-                },
-                "root": {
-                    "title": "product"
-                }
-            },
-            "id": "side_1_outlet_1",
-            "ports": {
-                "groups": {
-                    "in": {
-                        "attrs": {
-                            "rect": {
-                                "height": 0,
-                                "stroke": "#000000",
-                                "stroke-width": 0,
-                                "width": 0
-                            }
-                        },
-                        "markup": "<g><rect/></g>",
-                        "position": {
-                            "args": {
-                                "dx": 1,
-                                "dy": 1,
-                                "x": 2,
-                                "y": 25
-                            },
-                            "name": "left"
-                        }
-                    }
-                },
-                "items": [
-                    {
-                        "group": "in",
-                        "id": "in"
-                    }
-                ]
-            },
-            "position": {
-                "x": 700,
-                "y": 610
-            },
-            "size": {
-                "height": 50,
-                "width": 50
-            },
-            "type": "standard.Image",
-            "z": 1
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "econ2ww",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "econ2ww"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "ECON",
-                "port": "out"
-            },
-            "target": {
-                "id": "Water_wall",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "ww2prsh",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "ww2prsh"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "Water_wall",
-                "port": "out"
-            },
-            "target": {
-                "id": "PrSH",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "prsh2plsh",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "prsh2plsh"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "PrSH",
-                "port": "out"
-            },
-            "target": {
-                "id": "PlSH",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "plsh2fsh",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "plsh2fsh"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "PlSH",
-                "port": "out"
-            },
-            "target": {
-                "id": "FSH",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "FSHtoATMP1",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "FSHtoATMP1"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "FSH",
-                "port": "out"
-            },
-            "target": {
-                "id": "ATMP1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "fg_fsh2_separator",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "fg_fsh2_separator"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "FSH",
-                "port": "out"
-            },
-            "target": {
-                "id": "Spl1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "fg_fsh2rh",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "fg_fsh2rh"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "Spl1",
-                "port": "out"
-            },
-            "target": {
-                "id": "RH",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "fg_fsh2PrSH",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "fg_fsh2PrSH"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "Spl1",
-                "port": "out"
-            },
-            "target": {
-                "id": "PrSH",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "fg_rhtomix",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "fg_rhtomix"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "RH",
-                "port": "out"
-            },
-            "target": {
-                "id": "mix1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "fg_prsh2mix",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "fg_prsh2mix"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "PrSH",
-                "port": "out"
-            },
-            "target": {
-                "id": "mix1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "fg_mix2econ",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "fg_mix2econ"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "mix1",
-                "port": "out"
-            },
-            "target": {
-                "id": "ECON",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "s_outlet_1",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "product info",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "s_outlet_1"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "ATMP1",
-                "port": "out"
-            },
-            "target": {
-                "id": "outlet_1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "s_side_1_inlet_1",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "feed info",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "s_side_1_inlet_1"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "side_1_inlet_1",
-                "port": "out"
-            },
-            "target": {
-                "id": "ECON",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "s_side_2_outlet_1",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "product info",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "s_side_2_outlet_1"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "ECON",
-                "port": "out"
-            },
-            "target": {
-                "id": "side_2_outlet_1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "s_side_2_inlet_1",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "feed info",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "s_side_2_inlet_1"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "side_2_inlet_1",
-                "port": "out"
-            },
-            "target": {
-                "id": "FSH",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "s_side_1_inlet_2",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "feed info",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "s_side_1_inlet_2"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "side_1_inlet_2",
-                "port": "out"
-            },
-            "target": {
-                "id": "RH",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        },
-        {
-            "connector": {
-                "attrs": {
-                    "line": {
-                        "stroke": "#5c9adb"
-                    }
-                },
-                "name": "jumpover"
-            },
-            "id": "s_side_1_outlet_1",
-            "labels": [
-                {
-                    "attrs": {
-                        "rect": {
-                            "fill": "#d7dce0",
-                            "fill-opacity": 0,
-                            "stroke": "white",
-                            "stroke-width": 0
-                        },
-                        "text": {
-                            "display": "none",
-                            "fill": "black",
-                            "text": "product info",
-                            "text-anchor": "left"
-                        }
-                    },
-                    "position": {
-                        "distance": 0.66,
-                        "offset": -40
-                    }
-                },
-                {
-                    "attrs": {
-                        "text": {
-                            "text": "s_side_1_outlet_1"
-                        }
-                    }
-                }
-            ],
-            "router": {
-                "name": "orthogonal",
-                "padding": 10
-            },
-            "source": {
-                "id": "RH",
-                "port": "out"
-            },
-            "target": {
-                "id": "side_1_outlet_1",
-                "port": "in"
-            },
-            "type": "standard.Link",
-            "z": 2
-        }
-    ],
     "model": {
-        "arcs": {
-            "FSHtoATMP1": {
-                "dest": "ATMP1",
-                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                "source": "FSH"
-            },
-            "econ2ww": {
-                "dest": "Water_wall",
-                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                "source": "ECON"
-            },
-            "fg_fsh2PrSH": {
-                "dest": "PrSH",
-                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                "source": "Spl1"
-            },
-            "fg_fsh2_separator": {
-                "dest": "Spl1",
-                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                "source": "FSH"
-            },
-            "fg_fsh2rh": {
-                "dest": "RH",
-                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                "source": "Spl1"
-            },
-            "fg_mix2econ": {
-                "dest": "ECON",
-                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                "source": "mix1"
-            },
-            "fg_prsh2mix": {
-                "dest": "mix1",
-                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                "source": "PrSH"
-            },
-            "fg_rhtomix": {
-                "dest": "mix1",
-                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
-                "source": "RH"
-            },
-            "plsh2fsh": {
-                "dest": "FSH",
-                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                "source": "PlSH"
-            },
-            "prsh2plsh": {
-                "dest": "PlSH",
-                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                "source": "PrSH"
-            },
-            "s_outlet_1": {
-                "dest": "outlet_1",
-                "label": "product info",
-                "source": "ATMP1"
-            },
-            "s_side_1_inlet_1": {
-                "dest": "ECON",
-                "label": "feed info",
-                "source": "side_1_inlet_1"
-            },
-            "s_side_1_inlet_2": {
-                "dest": "RH",
-                "label": "feed info",
-                "source": "side_1_inlet_2"
-            },
-            "s_side_1_outlet_1": {
-                "dest": "side_1_outlet_1",
-                "label": "product info",
-                "source": "RH"
-            },
-            "s_side_2_inlet_1": {
-                "dest": "FSH",
-                "label": "feed info",
-                "source": "side_2_inlet_1"
-            },
-            "s_side_2_outlet_1": {
-                "dest": "side_2_outlet_1",
-                "label": "product info",
-                "source": "ECON"
-            },
-            "ww2prsh": {
-                "dest": "PrSH",
-                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
-                "source": "Water_wall"
-            }
-        },
-        "id": "boiler",
         "stream_table": {
+            "index": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14
+            ],
             "columns": [
                 "",
                 "Variable",
@@ -2068,7 +36,7 @@
             "data": [
                 [
                     0,
-                    "Molar Flow (mol/s)",
+                    "Molar Flow (mol/s)<span class=\"units\">mol/s</span>",
                     1,
                     1,
                     1,
@@ -2083,7 +51,7 @@
                 ],
                 [
                     1,
-                    "Mass Flow (kg/s)",
+                    "Mass Flow (kg/s)<span class=\"units\">kg/s</span>",
                     0.01802,
                     0.01802,
                     0.01802,
@@ -2098,7 +66,7 @@
                 ],
                 [
                     2,
-                    "T (K)",
+                    "T (K)<span class=\"units\">K</span>",
                     286.34379,
                     286.34379,
                     286.34379,
@@ -2113,7 +81,7 @@
                 ],
                 [
                     3,
-                    "P (Pa)",
+                    "P (Pa)<span class=\"units\">Pa</span>",
                     100000.0,
                     100000.0,
                     100000.0,
@@ -2128,7 +96,7 @@
                 ],
                 [
                     4,
-                    "Vapor Fraction",
+                    "Vapor Fraction<span class=\"units\">&ndash;</span>",
                     0.0,
                     0.0,
                     0.0,
@@ -2143,7 +111,7 @@
                 ],
                 [
                     5,
-                    "Molar Enthalpy (J/mol) Vap",
+                    "Molar Enthalpy (J/mol) Vap<span class=\"units\">J/mol</span>",
                     2168.59605,
                     2168.59605,
                     2168.59605,
@@ -2158,7 +126,7 @@
                 ],
                 [
                     6,
-                    "Molar Enthalpy (J/mol) Liq",
+                    "Molar Enthalpy (J/mol) Liq<span class=\"units\">J/mol</span>",
                     1000.0,
                     1000.0,
                     1000.0,
@@ -2173,7 +141,7 @@
                 ],
                 [
                     7,
-                    "flow_mol_comp N2",
+                    "flow_mol_comp N2<span class=\"units\">mol/s</span>",
                     "-",
                     "-",
                     "-",
@@ -2188,7 +156,7 @@
                 ],
                 [
                     8,
-                    "flow_mol_comp O2",
+                    "flow_mol_comp O2<span class=\"units\">mol/s</span>",
                     "-",
                     "-",
                     "-",
@@ -2203,7 +171,7 @@
                 ],
                 [
                     9,
-                    "flow_mol_comp NO",
+                    "flow_mol_comp NO<span class=\"units\">mol/s</span>",
                     "-",
                     "-",
                     "-",
@@ -2218,7 +186,7 @@
                 ],
                 [
                     10,
-                    "flow_mol_comp CO2",
+                    "flow_mol_comp CO2<span class=\"units\">mol/s</span>",
                     "-",
                     "-",
                     "-",
@@ -2233,7 +201,7 @@
                 ],
                 [
                     11,
-                    "flow_mol_comp H2O",
+                    "flow_mol_comp H2O<span class=\"units\">mol/s</span>",
                     "-",
                     "-",
                     "-",
@@ -2248,7 +216,7 @@
                 ],
                 [
                     12,
-                    "flow_mol_comp SO2",
+                    "flow_mol_comp SO2<span class=\"units\">mol/s</span>",
                     "-",
                     "-",
                     "-",
@@ -2263,7 +231,7 @@
                 ],
                 [
                     13,
-                    "temperature",
+                    "temperature<span class=\"units\">K</span>",
                     "-",
                     "-",
                     "-",
@@ -2278,7 +246,7 @@
                 ],
                 [
                     14,
-                    "pressure",
+                    "pressure<span class=\"units\">Pa</span>",
                     "-",
                     "-",
                     "-",
@@ -2291,316 +259,2348 @@
                     101325.0,
                     101325.0
                 ]
-            ],
-            "index": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14
             ]
         },
+        "id": "boiler",
         "unit_models": {
-            "ATMP1": {
-                "image": "/images/icons/mixer.svg",
-                "performance_contents": {},
-                "stream_contents": {
-                    "0": {
-                        "Outlet": 1.0,
-                        "SprayWater": 1.0,
-                        "Steam": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Outlet": 0.01802,
-                        "SprayWater": 0.01802,
-                        "Steam": 0.01802,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Outlet": 286.34379,
-                        "SprayWater": 286.34379,
-                        "Steam": 286.34379,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Outlet": 100000.0,
-                        "SprayWater": 100000.0,
-                        "Steam": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Outlet": 0.0,
-                        "SprayWater": 0.0,
-                        "Steam": 0.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Outlet": 2168.59605,
-                        "SprayWater": 2168.59605,
-                        "Steam": 2168.59605,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Outlet": 1000.0,
-                        "SprayWater": 1000.0,
-                        "Steam": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "mixer"
-            },
             "ECON": {
+                "type": "boiler_heat_exchanger",
                 "image": "/images/icons/default.svg",
                 "performance_contents": {},
-                "stream_contents": {},
-                "type": "boiler_heat_exchanger"
+                "stream_contents": {}
+            },
+            "PrSH": {
+                "type": "boiler_heat_exchanger",
+                "image": "/images/icons/default.svg",
+                "performance_contents": {},
+                "stream_contents": {}
             },
             "FSH": {
+                "type": "boiler_heat_exchanger",
                 "image": "/images/icons/default.svg",
                 "performance_contents": {},
-                "stream_contents": {},
-                "type": "boiler_heat_exchanger"
+                "stream_contents": {}
+            },
+            "RH": {
+                "type": "boiler_heat_exchanger",
+                "image": "/images/icons/default.svg",
+                "performance_contents": {},
+                "stream_contents": {}
             },
             "PlSH": {
+                "type": "heater",
                 "image": "/images/icons/heater_2.svg",
                 "performance_contents": {
                     "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
                     }
                 },
                 "stream_contents": {
                     "0": {
+                        "Variable": "Molar Flow (mol/s)",
                         "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
+                        "Outlet": 1.0
                     },
                     "1": {
+                        "Variable": "Mass Flow (kg/s)",
                         "Inlet": 0.01802,
-                        "Outlet": 0.01802,
-                        "Variable": "Mass Flow (kg/s)"
+                        "Outlet": 0.01802
                     },
                     "2": {
+                        "Variable": "T (K)",
                         "Inlet": 286.34379,
-                        "Outlet": 286.34379,
-                        "Variable": "T (K)"
+                        "Outlet": 286.34379
                     },
                     "3": {
+                        "Variable": "P (Pa)",
                         "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
+                        "Outlet": 100000.0
                     },
                     "4": {
+                        "Variable": "Vapor Fraction",
                         "Inlet": 0.0,
-                        "Outlet": 0.0,
-                        "Variable": "Vapor Fraction"
+                        "Outlet": 0.0
                     },
                     "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
                         "Inlet": 2168.59605,
-                        "Outlet": 2168.59605,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
+                        "Outlet": 2168.59605
                     },
                     "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
                         "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
+                        "Outlet": 1000.0
+                    }
+                }
+            },
+            "Water_wall": {
+                "type": "heater",
+                "image": "/images/icons/heater_2.svg",
+                "performance_contents": {
+                    "0": {
+                        "Variable": "Heat Duty",
+                        "Value": 0.0
                     }
                 },
-                "type": "heater"
-            },
-            "PrSH": {
-                "image": "/images/icons/default.svg",
-                "performance_contents": {},
-                "stream_contents": {},
-                "type": "boiler_heat_exchanger"
-            },
-            "RH": {
-                "image": "/images/icons/default.svg",
-                "performance_contents": {},
-                "stream_contents": {},
-                "type": "boiler_heat_exchanger"
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Inlet": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Inlet": 0.01802,
+                        "Outlet": 0.01802
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Inlet": 286.34379,
+                        "Outlet": 286.34379
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Inlet": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Inlet": 0.0,
+                        "Outlet": 0.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Inlet": 2168.59605,
+                        "Outlet": 2168.59605
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Inlet": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
             },
             "Spl1": {
+                "type": "separator",
                 "image": "/images/icons/splitter.svg",
                 "performance_contents": {
                     "0": {
-                        "Value": 0.5,
-                        "Variable": "Split Fraction [('outlet_2',)]"
+                        "Variable": "Split Fraction [('outlet_2',)]",
+                        "Value": 0.5
                     }
                 },
                 "stream_contents": {
                     "0": {
-                        "Inlet": 1.0,
-                        "Variable": "flow_mol_comp CO2"
+                        "Variable": "flow_mol_comp CO2",
+                        "Inlet": 1.0
                     },
                     "1": {
-                        "Inlet": 1.0,
-                        "Variable": "flow_mol_comp H2O"
+                        "Variable": "flow_mol_comp H2O",
+                        "Inlet": 1.0
                     },
                     "2": {
-                        "Inlet": 1.0,
-                        "Variable": "flow_mol_comp N2"
+                        "Variable": "flow_mol_comp N2",
+                        "Inlet": 1.0
                     },
                     "3": {
-                        "Inlet": 1.0,
-                        "Variable": "flow_mol_comp NO"
+                        "Variable": "flow_mol_comp NO",
+                        "Inlet": 1.0
                     },
                     "4": {
-                        "Inlet": 1.0,
-                        "Variable": "flow_mol_comp O2"
+                        "Variable": "flow_mol_comp O2",
+                        "Inlet": 1.0
                     },
                     "5": {
-                        "Inlet": 1.0,
-                        "Variable": "flow_mol_comp SO2"
+                        "Variable": "flow_mol_comp SO2",
+                        "Inlet": 1.0
                     },
                     "6": {
-                        "Inlet": 101325.0,
-                        "Variable": "pressure"
+                        "Variable": "pressure",
+                        "Inlet": 101325.0
                     },
                     "7": {
-                        "Inlet": 500.0,
-                        "Variable": "temperature"
+                        "Variable": "temperature",
+                        "Inlet": 500.0
                     }
-                },
-                "type": "separator"
-            },
-            "Water_wall": {
-                "image": "/images/icons/heater_2.svg",
-                "performance_contents": {
-                    "0": {
-                        "Value": 0.0,
-                        "Variable": "Heat Duty"
-                    }
-                },
-                "stream_contents": {
-                    "0": {
-                        "Inlet": 1.0,
-                        "Outlet": 1.0,
-                        "Variable": "Molar Flow (mol/s)"
-                    },
-                    "1": {
-                        "Inlet": 0.01802,
-                        "Outlet": 0.01802,
-                        "Variable": "Mass Flow (kg/s)"
-                    },
-                    "2": {
-                        "Inlet": 286.34379,
-                        "Outlet": 286.34379,
-                        "Variable": "T (K)"
-                    },
-                    "3": {
-                        "Inlet": 100000.0,
-                        "Outlet": 100000.0,
-                        "Variable": "P (Pa)"
-                    },
-                    "4": {
-                        "Inlet": 0.0,
-                        "Outlet": 0.0,
-                        "Variable": "Vapor Fraction"
-                    },
-                    "5": {
-                        "Inlet": 2168.59605,
-                        "Outlet": 2168.59605,
-                        "Variable": "Molar Enthalpy (J/mol) Vap"
-                    },
-                    "6": {
-                        "Inlet": 1000.0,
-                        "Outlet": 1000.0,
-                        "Variable": "Molar Enthalpy (J/mol) Liq"
-                    }
-                },
-                "type": "heater"
+                }
             },
             "mix1": {
+                "type": "mixer",
                 "image": "/images/icons/mixer.svg",
                 "performance_contents": {},
                 "stream_contents": {
                     "0": {
-                        "Outlet": 1.0,
-                        "PrSH_out": 1.0,
+                        "Variable": "flow_mol_comp N2",
                         "Reheat_out": 1.0,
-                        "Variable": "flow_mol_comp N2"
+                        "PrSH_out": 1.0,
+                        "Outlet": 1.0
                     },
                     "1": {
-                        "Outlet": 1.0,
-                        "PrSH_out": 1.0,
+                        "Variable": "flow_mol_comp O2",
                         "Reheat_out": 1.0,
-                        "Variable": "flow_mol_comp O2"
+                        "PrSH_out": 1.0,
+                        "Outlet": 1.0
                     },
                     "2": {
-                        "Outlet": 1.0,
-                        "PrSH_out": 1.0,
+                        "Variable": "flow_mol_comp NO",
                         "Reheat_out": 1.0,
-                        "Variable": "flow_mol_comp NO"
+                        "PrSH_out": 1.0,
+                        "Outlet": 1.0
                     },
                     "3": {
-                        "Outlet": 1.0,
-                        "PrSH_out": 1.0,
+                        "Variable": "flow_mol_comp CO2",
                         "Reheat_out": 1.0,
-                        "Variable": "flow_mol_comp CO2"
+                        "PrSH_out": 1.0,
+                        "Outlet": 1.0
                     },
                     "4": {
-                        "Outlet": 1.0,
-                        "PrSH_out": 1.0,
+                        "Variable": "flow_mol_comp H2O",
                         "Reheat_out": 1.0,
-                        "Variable": "flow_mol_comp H2O"
+                        "PrSH_out": 1.0,
+                        "Outlet": 1.0
                     },
                     "5": {
-                        "Outlet": 1.0,
-                        "PrSH_out": 1.0,
+                        "Variable": "flow_mol_comp SO2",
                         "Reheat_out": 1.0,
-                        "Variable": "flow_mol_comp SO2"
+                        "PrSH_out": 1.0,
+                        "Outlet": 1.0
                     },
                     "6": {
-                        "Outlet": 500.0,
-                        "PrSH_out": 500.0,
+                        "Variable": "temperature",
                         "Reheat_out": 500.0,
-                        "Variable": "temperature"
+                        "PrSH_out": 500.0,
+                        "Outlet": 500.0
                     },
                     "7": {
-                        "Outlet": 101325.0,
-                        "PrSH_out": 101325.0,
+                        "Variable": "pressure",
                         "Reheat_out": 101325.0,
-                        "Variable": "pressure"
+                        "PrSH_out": 101325.0,
+                        "Outlet": 101325.0
                     }
-                },
-                "type": "mixer"
+                }
+            },
+            "ATMP1": {
+                "type": "mixer",
+                "image": "/images/icons/mixer.svg",
+                "performance_contents": {},
+                "stream_contents": {
+                    "0": {
+                        "Variable": "Molar Flow (mol/s)",
+                        "Steam": 1.0,
+                        "SprayWater": 1.0,
+                        "Outlet": 1.0
+                    },
+                    "1": {
+                        "Variable": "Mass Flow (kg/s)",
+                        "Steam": 0.01802,
+                        "SprayWater": 0.01802,
+                        "Outlet": 0.01802
+                    },
+                    "2": {
+                        "Variable": "T (K)",
+                        "Steam": 286.34379,
+                        "SprayWater": 286.34379,
+                        "Outlet": 286.34379
+                    },
+                    "3": {
+                        "Variable": "P (Pa)",
+                        "Steam": 100000.0,
+                        "SprayWater": 100000.0,
+                        "Outlet": 100000.0
+                    },
+                    "4": {
+                        "Variable": "Vapor Fraction",
+                        "Steam": 0.0,
+                        "SprayWater": 0.0,
+                        "Outlet": 0.0
+                    },
+                    "5": {
+                        "Variable": "Molar Enthalpy (J/mol) Vap",
+                        "Steam": 2168.59605,
+                        "SprayWater": 2168.59605,
+                        "Outlet": 2168.59605
+                    },
+                    "6": {
+                        "Variable": "Molar Enthalpy (J/mol) Liq",
+                        "Steam": 1000.0,
+                        "SprayWater": 1000.0,
+                        "Outlet": 1000.0
+                    }
+                }
             },
             "outlet_1": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
+                "type": "product",
+                "image": "/images/icons/product.svg"
             },
             "side_1_inlet_1": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "side_1_inlet_2": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
-            },
-            "side_1_outlet_1": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
-            },
-            "side_2_inlet_1": {
-                "image": "/images/icons/feed.svg",
-                "type": "feed"
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
             },
             "side_2_outlet_1": {
-                "image": "/images/icons/product.svg",
-                "type": "product"
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            },
+            "side_2_inlet_1": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "side_1_inlet_2": {
+                "type": "feed",
+                "image": "/images/icons/feed.svg"
+            },
+            "side_1_outlet_1": {
+                "type": "product",
+                "image": "/images/icons/product.svg"
+            }
+        },
+        "arcs": {
+            "econ2ww": {
+                "source": "ECON",
+                "dest": "Water_wall",
+                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000."
+            },
+            "ww2prsh": {
+                "source": "Water_wall",
+                "dest": "PrSH",
+                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000."
+            },
+            "prsh2plsh": {
+                "source": "PrSH",
+                "dest": "PlSH",
+                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000."
+            },
+            "plsh2fsh": {
+                "source": "PlSH",
+                "dest": "FSH",
+                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000."
+            },
+            "FSHtoATMP1": {
+                "source": "FSH",
+                "dest": "ATMP1",
+                "label": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000."
+            },
+            "fg_fsh2_separator": {
+                "source": "FSH",
+                "dest": "Spl1",
+                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325."
+            },
+            "fg_fsh2rh": {
+                "source": "Spl1",
+                "dest": "RH",
+                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325."
+            },
+            "fg_fsh2PrSH": {
+                "source": "Spl1",
+                "dest": "PrSH",
+                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325."
+            },
+            "fg_rhtomix": {
+                "source": "RH",
+                "dest": "mix1",
+                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325."
+            },
+            "fg_prsh2mix": {
+                "source": "PrSH",
+                "dest": "mix1",
+                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325."
+            },
+            "fg_mix2econ": {
+                "source": "mix1",
+                "dest": "ECON",
+                "label": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325."
+            },
+            "s_outlet_1": {
+                "source": "ATMP1",
+                "dest": "outlet_1",
+                "label": "product info"
+            },
+            "s_side_1_inlet_1": {
+                "source": "side_1_inlet_1",
+                "dest": "ECON",
+                "label": "feed info"
+            },
+            "s_side_2_outlet_1": {
+                "source": "ECON",
+                "dest": "side_2_outlet_1",
+                "label": "product info"
+            },
+            "s_side_2_inlet_1": {
+                "source": "side_2_inlet_1",
+                "dest": "FSH",
+                "label": "feed info"
+            },
+            "s_side_1_inlet_2": {
+                "source": "side_1_inlet_2",
+                "dest": "RH",
+                "label": "feed info"
+            },
+            "s_side_1_outlet_1": {
+                "source": "RH",
+                "dest": "side_1_outlet_1",
+                "label": "product info"
             }
         }
-    }
+    },
+    "cells": [
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 10,
+                "y": 10
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "ECON",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 0,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 50,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/default.svg"
+                },
+                "label": {
+                    "text": "ECON"
+                },
+                "root": {
+                    "title": "boiler_heat_exchanger"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 110,
+                "y": 110
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "PrSH",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 0,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 50,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/default.svg"
+                },
+                "label": {
+                    "text": "PrSH"
+                },
+                "root": {
+                    "title": "boiler_heat_exchanger"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 210,
+                "y": 210
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "FSH",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 0,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 50,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/default.svg"
+                },
+                "label": {
+                    "text": "FSH"
+                },
+                "root": {
+                    "title": "boiler_heat_exchanger"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 310,
+                "y": 310
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "RH",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 0,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 50,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/default.svg"
+                },
+                "label": {
+                    "text": "RH"
+                },
+                "root": {
+                    "title": "boiler_heat_exchanger"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 410,
+                "y": 410
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "PlSH",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 6,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 43,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/heater_2.svg"
+                },
+                "label": {
+                    "text": "PlSH"
+                },
+                "root": {
+                    "title": "heater"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 510,
+                "y": 510
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "Water_wall",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 6,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 43,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/heater_2.svg"
+                },
+                "label": {
+                    "text": "Water_wall"
+                },
+                "root": {
+                    "title": "heater"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 610,
+                "y": 610
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "Spl1",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "right",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/splitter.svg"
+                },
+                "label": {
+                    "text": "Spl1"
+                },
+                "root": {
+                    "title": "separator"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 710,
+                "y": 710
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "mix1",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/mixer.svg"
+                },
+                "label": {
+                    "text": "mix1"
+                },
+                "root": {
+                    "title": "mixer"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 100,
+                "y": 10
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "ATMP1",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    },
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    },
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/mixer.svg"
+                },
+                "label": {
+                    "text": "ATMP1"
+                },
+                "root": {
+                    "title": "mixer"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 200,
+                "y": 110
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "outlet_1",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/product.svg"
+                },
+                "label": {
+                    "text": "outlet_1"
+                },
+                "root": {
+                    "title": "product"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 300,
+                "y": 210
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "side_1_inlet_1",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/feed.svg"
+                },
+                "label": {
+                    "text": "side_1_inlet_1"
+                },
+                "root": {
+                    "title": "feed"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 400,
+                "y": 310
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "side_2_outlet_1",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/product.svg"
+                },
+                "label": {
+                    "text": "side_2_outlet_1"
+                },
+                "root": {
+                    "title": "product"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 500,
+                "y": 410
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "side_2_inlet_1",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/feed.svg"
+                },
+                "label": {
+                    "text": "side_2_inlet_1"
+                },
+                "root": {
+                    "title": "feed"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 600,
+                "y": 510
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "side_1_inlet_2",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "out": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 48,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "out",
+                        "id": "out"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/feed.svg"
+                },
+                "label": {
+                    "text": "side_1_inlet_2"
+                },
+                "root": {
+                    "title": "feed"
+                }
+            }
+        },
+        {
+            "type": "standard.Image",
+            "position": {
+                "x": 700,
+                "y": 610
+            },
+            "size": {
+                "width": 50,
+                "height": 50
+            },
+            "angle": 0,
+            "id": "side_1_outlet_1",
+            "z": 1,
+            "ports": {
+                "groups": {
+                    "in": {
+                        "position": {
+                            "name": "left",
+                            "args": {
+                                "x": 2,
+                                "y": 25,
+                                "dx": 1,
+                                "dy": 1
+                            }
+                        },
+                        "attrs": {
+                            "rect": {
+                                "stroke": "#000000",
+                                "stroke-width": 0,
+                                "width": 0,
+                                "height": 0
+                            }
+                        },
+                        "markup": "<g><rect/></g>"
+                    }
+                },
+                "items": [
+                    {
+                        "group": "in",
+                        "id": "in"
+                    }
+                ]
+            },
+            "attrs": {
+                "image": {
+                    "xlinkHref": "/images/icons/product.svg"
+                },
+                "label": {
+                    "text": "side_1_outlet_1"
+                },
+                "root": {
+                    "title": "product"
+                }
+            }
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "ECON",
+                "port": "out"
+            },
+            "target": {
+                "id": "Water_wall",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "econ2ww",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "econ2ww"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "Water_wall",
+                "port": "out"
+            },
+            "target": {
+                "id": "PrSH",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "ww2prsh",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "ww2prsh"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "PrSH",
+                "port": "out"
+            },
+            "target": {
+                "id": "PlSH",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "prsh2plsh",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "prsh2plsh"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "PlSH",
+                "port": "out"
+            },
+            "target": {
+                "id": "FSH",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "plsh2fsh",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "plsh2fsh"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "FSH",
+                "port": "out"
+            },
+            "target": {
+                "id": "ATMP1",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "FSHtoATMP1",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Molar flow (mol/s) 1\nMass flow (kg/s) 0.01802\nT (k) 286.34379\nP (pa) 100000.0\nVapor fraction 0.0\nMolar enthalpy (j/mol) Vap 2168.59605\nMolar enthalpy (j/mol) Liq 1000.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "FSHtoATMP1"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "FSH",
+                "port": "out"
+            },
+            "target": {
+                "id": "Spl1",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "fg_fsh2_separator",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "fg_fsh2_separator"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "Spl1",
+                "port": "out"
+            },
+            "target": {
+                "id": "RH",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "fg_fsh2rh",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "fg_fsh2rh"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "Spl1",
+                "port": "out"
+            },
+            "target": {
+                "id": "PrSH",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "fg_fsh2PrSH",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "fg_fsh2PrSH"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "RH",
+                "port": "out"
+            },
+            "target": {
+                "id": "mix1",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "fg_rhtomix",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "fg_rhtomix"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "PrSH",
+                "port": "out"
+            },
+            "target": {
+                "id": "mix1",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "fg_prsh2mix",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "fg_prsh2mix"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "mix1",
+                "port": "out"
+            },
+            "target": {
+                "id": "ECON",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "fg_mix2econ",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "Flow_mol_comp N2 1.0\nFlow_mol_comp O2 1.0\nFlow_mol_comp NO 1.0\nFlow_mol_comp CO2 1.0\nFlow_mol_comp H2O 1.0\nFlow_mol_comp SO2 1.0\nTemperature 500\nPressure 101325.",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "fg_mix2econ"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "ATMP1",
+                "port": "out"
+            },
+            "target": {
+                "id": "outlet_1",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "s_outlet_1",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "product info",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "s_outlet_1"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "side_1_inlet_1",
+                "port": "out"
+            },
+            "target": {
+                "id": "ECON",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "s_side_1_inlet_1",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "feed info",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "s_side_1_inlet_1"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "ECON",
+                "port": "out"
+            },
+            "target": {
+                "id": "side_2_outlet_1",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "s_side_2_outlet_1",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "product info",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "s_side_2_outlet_1"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "side_2_inlet_1",
+                "port": "out"
+            },
+            "target": {
+                "id": "FSH",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "s_side_2_inlet_1",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "feed info",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "s_side_2_inlet_1"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "side_1_inlet_2",
+                "port": "out"
+            },
+            "target": {
+                "id": "RH",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "s_side_1_inlet_2",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "feed info",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "s_side_1_inlet_2"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        },
+        {
+            "type": "standard.Link",
+            "source": {
+                "id": "RH",
+                "port": "out"
+            },
+            "target": {
+                "id": "side_1_outlet_1",
+                "port": "in"
+            },
+            "router": {
+                "name": "orthogonal",
+                "padding": 10
+            },
+            "connector": {
+                "name": "jumpover",
+                "attrs": {
+                    "line": {
+                        "stroke": "#5c9adb"
+                    }
+                }
+            },
+            "id": "s_side_1_outlet_1",
+            "labels": [
+                {
+                    "attrs": {
+                        "rect": {
+                            "fill": "#d7dce0",
+                            "stroke": "white",
+                            "stroke-width": 0,
+                            "fill-opacity": 0
+                        },
+                        "text": {
+                            "text": "product info",
+                            "fill": "black",
+                            "text-anchor": "left",
+                            "display": "none"
+                        }
+                    },
+                    "position": {
+                        "distance": 0.66,
+                        "offset": -40
+                    }
+                },
+                {
+                    "attrs": {
+                        "text": {
+                            "text": "s_side_1_outlet_1"
+                        }
+                    }
+                }
+            ],
+            "z": 2
+        }
+    ]
 }

--- a/idaes/ui/tests/serialized_boiler_flowsheet.json
+++ b/idaes/ui/tests/serialized_boiler_flowsheet.json
@@ -38,7 +38,11 @@
                 [
                     0,
                     "Molar Flow (mol/s)",
-                    "mol/s",
+                    {
+                        "raw": "mol/s",
+                        "html": "mol/s",
+                        "latex": "\\frac{\\mathrm{mol}}{\\mathrm{s}}"
+                    },
                     1,
                     1,
                     1,
@@ -54,7 +58,11 @@
                 [
                     1,
                     "Mass Flow (kg/s)",
-                    "kg/s",
+                    {
+                        "raw": "kg/s",
+                        "html": "kg/s",
+                        "latex": "\\frac{\\mathrm{kg}}{\\mathrm{s}}"
+                    },
                     0.01802,
                     0.01802,
                     0.01802,
@@ -70,7 +78,11 @@
                 [
                     2,
                     "T (K)",
-                    "K",
+                    {
+                        "raw": "K",
+                        "html": "K",
+                        "latex": "\\mathrm{K}"
+                    },
                     286.34379,
                     286.34379,
                     286.34379,
@@ -86,7 +98,11 @@
                 [
                     3,
                     "P (Pa)",
-                    "Pa",
+                    {
+                        "raw": "Pa",
+                        "html": "Pa",
+                        "latex": "\\mathrm{Pa}"
+                    },
                     100000.0,
                     100000.0,
                     100000.0,
@@ -102,7 +118,7 @@
                 [
                     4,
                     "Vapor Fraction",
-                    "None",
+                    null,
                     0.0,
                     0.0,
                     0.0,
@@ -118,7 +134,11 @@
                 [
                     5,
                     "Molar Enthalpy (J/mol) Vap",
-                    "J/mol",
+                    {
+                        "raw": "J/mol",
+                        "html": "J/mol",
+                        "latex": "\\frac{\\mathrm{J}}{\\mathrm{mol}}"
+                    },
                     2168.59605,
                     2168.59605,
                     2168.59605,
@@ -134,7 +154,11 @@
                 [
                     6,
                     "Molar Enthalpy (J/mol) Liq",
-                    "J/mol",
+                    {
+                        "raw": "J/mol",
+                        "html": "J/mol",
+                        "latex": "\\frac{\\mathrm{J}}{\\mathrm{mol}}"
+                    },
                     1000.0,
                     1000.0,
                     1000.0,
@@ -150,7 +174,11 @@
                 [
                     7,
                     "flow_mol_comp N2",
-                    "mol/s",
+                    {
+                        "raw": "mol/s",
+                        "html": "mol/s",
+                        "latex": "\\frac{\\mathrm{mol}}{\\mathrm{s}}"
+                    },
                     "-",
                     "-",
                     "-",
@@ -166,7 +194,11 @@
                 [
                     8,
                     "flow_mol_comp O2",
-                    "mol/s",
+                    {
+                        "raw": "mol/s",
+                        "html": "mol/s",
+                        "latex": "\\frac{\\mathrm{mol}}{\\mathrm{s}}"
+                    },
                     "-",
                     "-",
                     "-",
@@ -182,7 +214,11 @@
                 [
                     9,
                     "flow_mol_comp NO",
-                    "mol/s",
+                    {
+                        "raw": "mol/s",
+                        "html": "mol/s",
+                        "latex": "\\frac{\\mathrm{mol}}{\\mathrm{s}}"
+                    },
                     "-",
                     "-",
                     "-",
@@ -198,7 +234,11 @@
                 [
                     10,
                     "flow_mol_comp CO2",
-                    "mol/s",
+                    {
+                        "raw": "mol/s",
+                        "html": "mol/s",
+                        "latex": "\\frac{\\mathrm{mol}}{\\mathrm{s}}"
+                    },
                     "-",
                     "-",
                     "-",
@@ -214,7 +254,11 @@
                 [
                     11,
                     "flow_mol_comp H2O",
-                    "mol/s",
+                    {
+                        "raw": "mol/s",
+                        "html": "mol/s",
+                        "latex": "\\frac{\\mathrm{mol}}{\\mathrm{s}}"
+                    },
                     "-",
                     "-",
                     "-",
@@ -230,7 +274,11 @@
                 [
                     12,
                     "flow_mol_comp SO2",
-                    "mol/s",
+                    {
+                        "raw": "mol/s",
+                        "html": "mol/s",
+                        "latex": "\\frac{\\mathrm{mol}}{\\mathrm{s}}"
+                    },
                     "-",
                     "-",
                     "-",
@@ -246,7 +294,11 @@
                 [
                     13,
                     "temperature",
-                    "K",
+                    {
+                        "raw": "K",
+                        "html": "K",
+                        "latex": "\\mathrm{K}"
+                    },
                     "-",
                     "-",
                     "-",
@@ -262,7 +314,11 @@
                 [
                     14,
                     "pressure",
-                    "Pa",
+                    {
+                        "raw": "Pa",
+                        "html": "Pa",
+                        "latex": "\\mathrm{Pa}"
+                    },
                     "-",
                     "-",
                     "-",

--- a/idaes/ui/tests/serialized_boiler_flowsheet.json
+++ b/idaes/ui/tests/serialized_boiler_flowsheet.json
@@ -21,6 +21,7 @@
             "columns": [
                 "",
                 "Variable",
+                "Units",
                 "econ2ww",
                 "ww2prsh",
                 "prsh2plsh",
@@ -36,7 +37,8 @@
             "data": [
                 [
                     0,
-                    "Molar Flow (mol/s)<span class=\"units\">mol/s</span>",
+                    "Molar Flow (mol/s)",
+                    "mol/s",
                     1,
                     1,
                     1,
@@ -51,7 +53,8 @@
                 ],
                 [
                     1,
-                    "Mass Flow (kg/s)<span class=\"units\">kg/s</span>",
+                    "Mass Flow (kg/s)",
+                    "kg/s",
                     0.01802,
                     0.01802,
                     0.01802,
@@ -66,7 +69,8 @@
                 ],
                 [
                     2,
-                    "T (K)<span class=\"units\">K</span>",
+                    "T (K)",
+                    "K",
                     286.34379,
                     286.34379,
                     286.34379,
@@ -81,7 +85,8 @@
                 ],
                 [
                     3,
-                    "P (Pa)<span class=\"units\">Pa</span>",
+                    "P (Pa)",
+                    "Pa",
                     100000.0,
                     100000.0,
                     100000.0,
@@ -96,7 +101,8 @@
                 ],
                 [
                     4,
-                    "Vapor Fraction<span class=\"units\">&ndash;</span>",
+                    "Vapor Fraction",
+                    "None",
                     0.0,
                     0.0,
                     0.0,
@@ -111,7 +117,8 @@
                 ],
                 [
                     5,
-                    "Molar Enthalpy (J/mol) Vap<span class=\"units\">J/mol</span>",
+                    "Molar Enthalpy (J/mol) Vap",
+                    "J/mol",
                     2168.59605,
                     2168.59605,
                     2168.59605,
@@ -126,7 +133,8 @@
                 ],
                 [
                     6,
-                    "Molar Enthalpy (J/mol) Liq<span class=\"units\">J/mol</span>",
+                    "Molar Enthalpy (J/mol) Liq",
+                    "J/mol",
                     1000.0,
                     1000.0,
                     1000.0,
@@ -141,7 +149,8 @@
                 ],
                 [
                     7,
-                    "flow_mol_comp N2<span class=\"units\">mol/s</span>",
+                    "flow_mol_comp N2",
+                    "mol/s",
                     "-",
                     "-",
                     "-",
@@ -156,7 +165,8 @@
                 ],
                 [
                     8,
-                    "flow_mol_comp O2<span class=\"units\">mol/s</span>",
+                    "flow_mol_comp O2",
+                    "mol/s",
                     "-",
                     "-",
                     "-",
@@ -171,7 +181,8 @@
                 ],
                 [
                     9,
-                    "flow_mol_comp NO<span class=\"units\">mol/s</span>",
+                    "flow_mol_comp NO",
+                    "mol/s",
                     "-",
                     "-",
                     "-",
@@ -186,7 +197,8 @@
                 ],
                 [
                     10,
-                    "flow_mol_comp CO2<span class=\"units\">mol/s</span>",
+                    "flow_mol_comp CO2",
+                    "mol/s",
                     "-",
                     "-",
                     "-",
@@ -201,7 +213,8 @@
                 ],
                 [
                     11,
-                    "flow_mol_comp H2O<span class=\"units\">mol/s</span>",
+                    "flow_mol_comp H2O",
+                    "mol/s",
                     "-",
                     "-",
                     "-",
@@ -216,7 +229,8 @@
                 ],
                 [
                     12,
-                    "flow_mol_comp SO2<span class=\"units\">mol/s</span>",
+                    "flow_mol_comp SO2",
+                    "mol/s",
                     "-",
                     "-",
                     "-",
@@ -231,7 +245,8 @@
                 ],
                 [
                     13,
-                    "temperature<span class=\"units\">K</span>",
+                    "temperature",
+                    "K",
                     "-",
                     "-",
                     "-",
@@ -246,7 +261,8 @@
                 ],
                 [
                     14,
-                    "pressure<span class=\"units\">Pa</span>",
+                    "pressure",
+                    "Pa",
                     "-",
                     "-",
                     "-",


### PR DESCRIPTION
Fixes #322 

## Summary/Motivation:
Adding units to the stream table view that shows up on the UI page. The units are generated randomly using the pyomo library to read the `derived_units` units from the FlowSheetBlock.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
