### PR TITLE
Minor fix in Generic Property Model

### DIFF
--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -2361,7 +2361,7 @@ class GenericStateBlockData(StateBlockData):
             def rule_flow_mass_comp(b, i):
                 if b.get_material_flow_basis() == MaterialFlowBasis.mass:
                     return self.mass_frac_comp[i]*self.flow_mass
-                elif b.get_material_flow_basis() == MaterialFlowBasis.mass:
+                elif b.get_material_flow_basis() == MaterialFlowBasis.molar:
                     return b.flow_mol_comp[i]*b.mw_comp[i]
                 else:
                     raise PropertyPackageError(

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -123,7 +123,7 @@ class GenericParameterData(PhysicalParameterBlock):
         default=StateIndex.true,
         domain=In(StateIndex),
         doc="Index state variables by true or apparent components",
-        description="Argument idicating whether the true or apparent species "
+        description="Argument indicating whether the true or apparent species "
         "set should be used for indexing state variables. Must be "
         "StateIndex.true or StateIndex.apparent."))
 


### PR DESCRIPTION
## Fixes
## Summary/Motivation:
Revises a conditional statement that should've checked for molar flow basis rather than mass flow basis in `generic_property.py`

## Changes proposed in this PR:
- change `MaterialFlowbasis.mass` to `MaterialFlowbasis.molar` 


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
