### PR TITLE
Remove `OrderedSet.__getitem__` from Caprese modules

### DIFF
--- a/idaes/apps/caprese/dynamic_block.py
+++ b/idaes/apps/caprese/dynamic_block.py
@@ -287,7 +287,9 @@ class _DynamicBlockData(_BlockData):
 
         finite_elements = time.get_finite_elements()
         fe_set = set(finite_elements)
-        finite_element_indices = [i for i in range(1,n_t+1) if time[i] in fe_set]
+        finite_element_indices = [
+            i for i in range(1, n_t + 1) if time.card(i) in fe_set
+        ]
         sample_points = [time.first()]
         sample_indices = [1] # Indices of sample points with in time set
         sample_no = 1
@@ -335,7 +337,7 @@ class _DynamicBlockData(_BlockData):
             for i in range(i_0+1, i_s+1):
                 # Want to exclude first time point of sample,
                 # but include last time point of sample.
-                t = time[i]
+                t = time.card(i)
                 var[t].set_value(var.setpoint)
 
     def initialize_sample_to_initial(self,
@@ -349,12 +351,12 @@ class _DynamicBlockData(_BlockData):
         sample_point_indices = self.sample_point_indices
         i_0 = sample_point_indices[sample_idx-1]
         i_s = sample_point_indices[sample_idx]
-        t0 = time[i_0]
+        t0 = time.card(i_0)
         for var in self.component_objects(ctype):
             # Would be nice if I could use a slice with
             # start/stop indices to make this more concise.
             for i in range(i_0+1, i_s+1):
-                t = time[i]
+                t = time.card(i)
                 var[t].set_value(var[t0].value)
 
     def initialize_to_setpoint(self, 
@@ -517,7 +519,7 @@ class _DynamicBlockData(_BlockData):
             if idx is None:
                 # t + sample_time is outside the model's "horizon"
                 continue
-            ts = time[idx]
+            ts = time.card(idx)
             for var in self.component_objects(ctype):
                 var[t].set_value(var[ts].value)
 
@@ -548,14 +550,14 @@ class _DynamicBlockData(_BlockData):
         # passing around time points or the integer index of samples.
         time = self.time
         idx_s = time.find_nearest_index(ts, tolerance=tolerance)
-        ts = time[idx_s]
+        ts = time.card(idx_s)
         if t0 is None:
             t0 = ts - self.sample_time
         idx_0 = time.find_nearest_index(t0, tolerance=tolerance)
         idx_start = idx_0 if include_t0 else idx_0 + 1
         for i in range(idx_start, idx_s+1):
             # Don't want to include first point in sample
-            yield time[i]
+            yield time.card(i)
 
     def get_data_from_sample(self,
             ts,
@@ -587,7 +589,7 @@ class _DynamicBlockData(_BlockData):
             cuid = ComponentUID(_slice.referent)
             if include_t0:
                 i0 = time.find_nearest_index(ts-sample_time, tolerance=tolerance)
-                t0 = time[i0]
+                t0 = time.card(i0)
                 data[cuid] = [_slice[t0].value]
             else:
                 data[cuid] = []
@@ -637,7 +639,7 @@ class _DynamicBlockData(_BlockData):
             if idx is None:
                 # t + sample_time is outside the model's "horizon"
                 continue
-            ts = time[idx]
+            ts = time.card(idx)
             for var in self.component_objects(ctype):
                 if var[t] in zL and var[ts] in zL:
                     zL[var[t]] = zL[var[ts]]
@@ -795,7 +797,7 @@ class SquareSolveContext(object):
 
         for var, val in zip(input_vars, input_vals):
             for i in time_indices:
-                t = time[i]
+                t = time.card(i)
                 if val is None:
                     var[t].fix()
                 else:
@@ -811,7 +813,7 @@ class SquareSolveContext(object):
         input_vars = self.block.input_vars
         for var in input_vars:
             for i in time_indices:
-                t = time[i]
+                t = time.card(i)
                 var[t].unfix()
 
         if self.strip_var_bounds:

--- a/idaes/apps/caprese/dynamic_block.py
+++ b/idaes/apps/caprese/dynamic_block.py
@@ -288,7 +288,7 @@ class _DynamicBlockData(_BlockData):
         finite_elements = time.get_finite_elements()
         fe_set = set(finite_elements)
         finite_element_indices = [
-            i for i in range(1, n_t + 1) if time.card(i) in fe_set
+            i for i in range(1, n_t + 1) if time.at(i) in fe_set
         ]
         sample_points = [time.first()]
         sample_indices = [1] # Indices of sample points with in time set
@@ -337,7 +337,7 @@ class _DynamicBlockData(_BlockData):
             for i in range(i_0+1, i_s+1):
                 # Want to exclude first time point of sample,
                 # but include last time point of sample.
-                t = time.card(i)
+                t = time.at(i)
                 var[t].set_value(var.setpoint)
 
     def initialize_sample_to_initial(self,
@@ -351,12 +351,12 @@ class _DynamicBlockData(_BlockData):
         sample_point_indices = self.sample_point_indices
         i_0 = sample_point_indices[sample_idx-1]
         i_s = sample_point_indices[sample_idx]
-        t0 = time.card(i_0)
+        t0 = time.at(i_0)
         for var in self.component_objects(ctype):
             # Would be nice if I could use a slice with
             # start/stop indices to make this more concise.
             for i in range(i_0+1, i_s+1):
-                t = time.card(i)
+                t = time.at(i)
                 var[t].set_value(var[t0].value)
 
     def initialize_to_setpoint(self, 
@@ -519,7 +519,7 @@ class _DynamicBlockData(_BlockData):
             if idx is None:
                 # t + sample_time is outside the model's "horizon"
                 continue
-            ts = time.card(idx)
+            ts = time.at(idx)
             for var in self.component_objects(ctype):
                 var[t].set_value(var[ts].value)
 
@@ -550,14 +550,14 @@ class _DynamicBlockData(_BlockData):
         # passing around time points or the integer index of samples.
         time = self.time
         idx_s = time.find_nearest_index(ts, tolerance=tolerance)
-        ts = time.card(idx_s)
+        ts = time.at(idx_s)
         if t0 is None:
             t0 = ts - self.sample_time
         idx_0 = time.find_nearest_index(t0, tolerance=tolerance)
         idx_start = idx_0 if include_t0 else idx_0 + 1
         for i in range(idx_start, idx_s+1):
             # Don't want to include first point in sample
-            yield time.card(i)
+            yield time.at(i)
 
     def get_data_from_sample(self,
             ts,
@@ -589,7 +589,7 @@ class _DynamicBlockData(_BlockData):
             cuid = ComponentUID(_slice.referent)
             if include_t0:
                 i0 = time.find_nearest_index(ts-sample_time, tolerance=tolerance)
-                t0 = time.card(i0)
+                t0 = time.at(i0)
                 data[cuid] = [_slice[t0].value]
             else:
                 data[cuid] = []
@@ -639,7 +639,7 @@ class _DynamicBlockData(_BlockData):
             if idx is None:
                 # t + sample_time is outside the model's "horizon"
                 continue
-            ts = time.card(idx)
+            ts = time.at(idx)
             for var in self.component_objects(ctype):
                 if var[t] in zL and var[ts] in zL:
                     zL[var[t]] = zL[var[ts]]
@@ -797,7 +797,7 @@ class SquareSolveContext(object):
 
         for var, val in zip(input_vars, input_vals):
             for i in time_indices:
-                t = time.card(i)
+                t = time.at(i)
                 if val is None:
                     var[t].fix()
                 else:
@@ -813,7 +813,7 @@ class SquareSolveContext(object):
         input_vars = self.block.input_vars
         for var in input_vars:
             for i in time_indices:
-                t = time.card(i)
+                t = time.at(i)
                 var[t].unfix()
 
         if self.strip_var_bounds:

--- a/idaes/apps/caprese/util.py
+++ b/idaes/apps/caprese/util.py
@@ -169,9 +169,9 @@ def initialize_by_element_in_range(model, time, t_start, t_end,
 
     # "Integration" loop
     for i in fe_in_range:
-        t_prev = time[(i-1)*ncp+1]
+        t_prev = time.card((i-1)*ncp+1)
 
-        fe = [time[k] for k in range((i-1)*ncp+2, i*ncp+2)]
+        fe = [time.card(k) for k in range((i-1)*ncp+2, i*ncp+2)]
 
         con_list = []
         for t in fe:

--- a/idaes/apps/caprese/util.py
+++ b/idaes/apps/caprese/util.py
@@ -169,9 +169,9 @@ def initialize_by_element_in_range(model, time, t_start, t_end,
 
     # "Integration" loop
     for i in fe_in_range:
-        t_prev = time.card((i-1)*ncp+1)
+        t_prev = time.at((i-1)*ncp+1)
 
-        fe = [time.card(k) for k in range((i-1)*ncp+2, i*ncp+2)]
+        fe = [time.at(k) for k in range((i-1)*ncp+2, i*ncp+2)]
 
         con_list = []
         for t in fe:


### PR DESCRIPTION
## Summary/Motivation:
`OrderedSet.__getitem__` is deprecated in the latest release of Pyomo. This PR updates Caprese modules to not rely on it.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
