### PR TITLE
Fix mixer and spe scale when components not in a phase

### DIFF
--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1646,13 +1646,16 @@ class GenericStateBlockData(StateBlockData):
                 pe_form_config[pp].calculate_scaling_factors(self, pp)
 
             for k in self.equilibrium_constraint:
-                sf_fug = self.params.get_component(
-                    k[2]).config.phase_equilibrium_form[
-                        (k[0], k[1])].calculate_scaling_factors(
-                            self, k[0], k[1], k[2])
+                try:
+                    sf_fug = self.params.get_component(
+                        k[2]).config.phase_equilibrium_form[
+                            (k[0], k[1])].calculate_scaling_factors(
+                                self, k[0], k[1], k[2])
 
-                iscale.constraint_scaling_transform(
-                    self.equilibrium_constraint[k], sf_fug, overwrite=False)
+                    iscale.constraint_scaling_transform(
+                        self.equilibrium_constraint[k], sf_fug, overwrite=False)
+                except KeyError: # compoent not in phase
+                    pass
 
         # Inherent reactions
         if hasattr(self, "k_eq"):

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1654,7 +1654,7 @@ class GenericStateBlockData(StateBlockData):
 
                     iscale.constraint_scaling_transform(
                         self.equilibrium_constraint[k], sf_fug, overwrite=False)
-                except KeyError: # compoent not in phase
+                except KeyError: # component not in phase
                     pass
 
         # Inherent reactions

--- a/idaes/generic_models/unit_models/mixer.py
+++ b/idaes/generic_models/unit_models/mixer.py
@@ -998,13 +998,19 @@ objects linked to all inlet states and the mixed state,
         if hasattr(self, "material_mixing_equations"):
             if mb_type == MaterialBalanceType.componentPhase:
                 for (t, p, j), c in self.material_mixing_equations.items():
-                    flow_term = self.mixed_state[t].get_material_flow_terms(p, j)
+                    try: # not all phases contain all components
+                        flow_term = self.mixed_state[t].get_material_flow_terms(p, j)
+                    except KeyError:
+                        continue
                     s = iscale.get_scaling_factor(flow_term, default=1)
                     iscale.constraint_scaling_transform(c, s, overwrite=False)
             elif mb_type == MaterialBalanceType.componentTotal:
                 for (t, j), c in self.material_mixing_equations.items():
                     for i, p in enumerate(self.mixed_state.phase_list):
-                        ft = self.mixed_state[t].get_material_flow_terms(p, j)
+                        try: # not all phases contain all components
+                            ft = self.mixed_state[t].get_material_flow_terms(p, j)
+                        except KeyError:
+                            continue
                         if i == 0:
                             s = iscale.get_scaling_factor(ft, default=1)
                         else:
@@ -1015,7 +1021,10 @@ objects linked to all inlet states and the mixed state,
                 pc_set = self.mixed_state.phase_component_set
                 for t, c in self.material_mixing_equations.items():
                     for i, (p, j) in enumerate(pc_set):
-                        ft = self.mixed_state[t].get_material_flow_terms(p, j)
+                        try: # not all phases contain all components
+                            ft = self.mixed_state[t].get_material_flow_terms(p, j)
+                        except KeyError:
+                            continue
                         if i == 0:
                             s = iscale.get_scaling_factor(ft, default=1)
                         else:

--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -1631,13 +1631,19 @@ objects linked the mixed state and all outlet states,
         if hasattr(self, "material_splitting_eqn"):
             if mb_type == MaterialBalanceType.componentPhase:
                 for (t, o, p, j), c in self.material_splitting_eqn.items():
-                    flow_term = mixed_state[t].get_material_flow_terms(p, j)
+                    try: # not all phases contain all components
+                        flow_term = mixed_state[t].get_material_flow_terms(p, j)
+                    except KeyError:
+                        continue
                     s = iscale.get_scaling_factor(flow_term, default=1)
                     iscale.constraint_scaling_transform(c, s)
             elif mb_type == MaterialBalanceType.componentTotal:
                 for (t, o, j), c in self.material_splitting_eqn.items():
                     for i, p in enumerate(mixed_state.phase_list):
-                        ft = mixed_state[t].get_material_flow_terms(p, j)
+                        try:
+                            ft = mixed_state[t].get_material_flow_terms(p, j)
+                        except KeyError:
+                            continue
                         if i == 0:
                             s = iscale.get_scaling_factor(ft, default=1)
                         else:
@@ -1648,7 +1654,10 @@ objects linked the mixed state and all outlet states,
                 pc_set = mixed_state.phase_component_set
                 for (t, o), c in self.material_splitting_eqn.items():
                     for i, (p, j) in enumerate(pc_set):
-                        ft = mixed_state[t].get_material_flow_terms(p, j)
+                        try: # not all phases contain all components
+                            ft = mixed_state[t].get_material_flow_terms(p, j)
+                        except KeyError:
+                            continue
                         if i == 0:
                             s = iscale.get_scaling_factor(ft, default=1)
                         else:

--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -1631,19 +1631,13 @@ objects linked the mixed state and all outlet states,
         if hasattr(self, "material_splitting_eqn"):
             if mb_type == MaterialBalanceType.componentPhase:
                 for (t, o, p, j), c in self.material_splitting_eqn.items():
-                    try: # not all phases contain all components
-                        flow_term = mixed_state[t].get_material_flow_terms(p, j)
-                    except KeyError:
-                        continue
+                    flow_term = mixed_state[t].get_material_flow_terms(p, j)
                     s = iscale.get_scaling_factor(flow_term, default=1)
                     iscale.constraint_scaling_transform(c, s)
             elif mb_type == MaterialBalanceType.componentTotal:
                 for (t, o, j), c in self.material_splitting_eqn.items():
                     for i, p in enumerate(mixed_state.phase_list):
-                        try:
-                            ft = mixed_state[t].get_material_flow_terms(p, j)
-                        except KeyError:
-                            continue
+                        ft = mixed_state[t].get_material_flow_terms(p, j)
                         if i == 0:
                             s = iscale.get_scaling_factor(ft, default=1)
                         else:
@@ -1654,10 +1648,7 @@ objects linked the mixed state and all outlet states,
                 pc_set = mixed_state.phase_component_set
                 for (t, o), c in self.material_splitting_eqn.items():
                     for i, (p, j) in enumerate(pc_set):
-                        try: # not all phases contain all components
-                            ft = mixed_state[t].get_material_flow_terms(p, j)
-                        except KeyError:
-                            continue
+                        ft = mixed_state[t].get_material_flow_terms(p, j)
                         if i == 0:
                             s = iscale.get_scaling_factor(ft, default=1)
                         else:

--- a/idaes/generic_models/unit_models/tests/test_mixer.py
+++ b/idaes/generic_models/unit_models/tests/test_mixer.py
@@ -60,6 +60,10 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
 from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      TestStateBlock,
                                      initialization_tester)
+from idaes.generic_models.properties.core.generic.generic_property import (
+    GenericParameterBlock)
+from idaes.power_generation.properties.natural_gas_PR import get_prop
+import idaes.core.util.scaling as iscale
 from idaes.core.util import get_solver
 
 
@@ -1186,3 +1190,15 @@ class TestSaponification(object):
     @pytest.mark.unit
     def test_report(self, sapon):
         sapon.fs.unit.report()
+
+@pytest.mark.component
+def test_construction_component_not_in_phase():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock()
+    m.fs.prop_params = GenericParameterBlock(
+        default=get_prop(["H2O", "H2"], ["Liq", "Vap"]))
+    m.fs.inject1 = Mixer(default={
+        "property_package": m.fs.prop_params,
+        "inlet_list":["in1", "in2"],
+        "momentum_mixing_type":MomentumMixingType.none})
+    iscale.calculate_scaling_factors(m)


### PR DESCRIPTION
## Fixes
An issue with mixer and separator scaling when components are not in a phase.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
