### PR TITLE
Bumping Pyomo tag to 6.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.1.1.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.1.2.zip",
 ]
 
 


### PR DESCRIPTION
## Fixes

## Summary/Motivation:
This picks up the Pyomo 6.1.2 tag (and the rename of `Set.card()` to `Set.at()`)

## Changes proposed in this PR:
- Bump Pyomo tag for development

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
