### PR TITLE
Correcting units for activity-based rate and equilibrium constants

### DIFF
--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -39,8 +39,9 @@ class ConstantKeq():
                 "Please ensure that this argument is included in your "
                 "configuration dict.".format(rblock.name))
         elif (c_form == ConcentrationForm.moleFraction or
-              c_form == ConcentrationForm.massFraction):
-            e_units = None
+              c_form == ConcentrationForm.massFraction or
+              c_form == ConcentrationForm.activity):
+            e_units = pyunits.dimensionless
         else:
             order = 0
 
@@ -59,8 +60,7 @@ class ConstantKeq():
             for p, j in pc_set:
                 order += rblock.reaction_order[p, j].value
 
-            if (c_form == ConcentrationForm.molarity or
-                    c_form == ConcentrationForm.activity):
+            if c_form == ConcentrationForm.molarity:
                 c_units = units["density_mole"]
             elif c_form == ConcentrationForm.molality:
                 c_units = units["amount"]*units["mass"]**-1
@@ -105,8 +105,9 @@ class van_t_hoff():
                 "Please ensure that this argument is included in your "
                 "configuration dict.".format(rblock.name))
         elif (c_form == ConcentrationForm.moleFraction or
-              c_form == ConcentrationForm.massFraction):
-            e_units = None
+              c_form == ConcentrationForm.massFraction or
+              c_form == ConcentrationForm.activity):
+            e_units = pyunits.dimensionless
         else:
             order = 0
 
@@ -125,8 +126,7 @@ class van_t_hoff():
             for p, j in pc_set:
                 order += rblock.reaction_order[p, j].value
 
-            if (c_form == ConcentrationForm.molarity or
-                    c_form == ConcentrationForm.activity):
+            if c_form == ConcentrationForm.molarity:
                 c_units = units["density_mole"]
             elif c_form == ConcentrationForm.molality:
                 c_units = units["amount"]*units["mass"]**-1

--- a/idaes/generic_models/properties/core/reactions/rate_constant.py
+++ b/idaes/generic_models/properties/core/reactions/rate_constant.py
@@ -50,15 +50,15 @@ class arrhenius():
                 "Please ensure that this argument is included in your "
                 "configuration dict.".format(rblock.name))
         elif (c_form == ConcentrationForm.moleFraction or
-              c_form == ConcentrationForm.massFraction):
+              c_form == ConcentrationForm.massFraction or
+              c_form == ConcentrationForm.activity):
             r_units = r_base*units["volume"]**-1*units["time"]**-1
         else:
             order = 0
             for p, j in parent.config.property_package._phase_component_set:
                 order += -rblock.reaction_order[p, j].value
 
-            if (c_form == ConcentrationForm.molarity or
-                    c_form == ConcentrationForm.activity):
+            if c_form == ConcentrationForm.molarity:
                 c_units = units["density_mole"]
             elif c_form == ConcentrationForm.molality:
                 c_units = units["amount"]*units["mass"]**-1


### PR DESCRIPTION
## Fixes


## Summary/Motivation:
Equilibrium nd rate constants for activity based reactions were erroneously assigned units based on activity having units of [amount]/[volume] when they should be dimensionless.

## Changes proposed in this PR:
- Correct assignment of units to equilibrium constants in activity case
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
