### PR TITLE
Use consistent randomness sources in PySMO sampling methods

### DIFF
--- a/idaes/surrogate/pysmo/sampling.py
+++ b/idaes/surrogate/pysmo/sampling.py
@@ -346,6 +346,7 @@ class LatinHypercubeSampling(SamplingMethods):
 
             number_of_samples (int): The number of samples to be generated. Should be a positive integer less than or equal to the number of entries (rows) in **data_input**.
             sampling_type (str) : Option which determines whether the algorithm selects samples from an existing dataset ("selection") or attempts to generate sample from a supplied range ("creation"). Default is "creation".
+            rng_seed (int): An optional argument which fixes the generation of random numbers in this algorithm to a specific seed for reproducability and testing purposes.
 
         Returns:
             **self** function containing the input information
@@ -356,6 +357,12 @@ class LatinHypercubeSampling(SamplingMethods):
             Exception: When **number_of_samples** is invalid (not an integer, too large, zero, or negative)
 
         """
+
+        if rng_seed is not None:
+            if not isinstance(rng_seed, int):
+                raise Exception('Random number seed (rng_seed) must be an integer.')
+            elif rng_seed < 0 or 2**32-1 < rng_seed:
+                raise Exception('Seed must be between 0 and 2**32 - 1.')
 
         np.random.seed(rng_seed)
 

--- a/idaes/surrogate/pysmo/sampling.py
+++ b/idaes/surrogate/pysmo/sampling.py
@@ -362,7 +362,7 @@ class LatinHypercubeSampling(SamplingMethods):
             if not isinstance(rng_seed, int):
                 raise Exception('Random number seed (rng_seed) must be an integer.')
             elif rng_seed < 0 or 2**32-1 < rng_seed:
-                raise Exception('Seed must be between 0 and 2**32 - 1.')
+                raise Exception('Random number seed (rng_seed) must be between 0 and 2**32 - 1.')
 
         np.random.seed(rng_seed)
 

--- a/idaes/surrogate/pysmo/sampling.py
+++ b/idaes/surrogate/pysmo/sampling.py
@@ -13,7 +13,6 @@
 
 from __future__ import division, print_function
 from six import string_types
-import random
 # from builtins import int, str
 import numpy as np
 import pandas as pd
@@ -334,7 +333,7 @@ class LatinHypercubeSampling(SamplingMethods):
 
     """
 
-    def __init__(self, data_input, number_of_samples=None, sampling_type=None, rng_seed=None):
+    def __init__(self, data_input, number_of_samples=None, sampling_type=None):
         """
         Initialization of **LatinHypercubeSampling** class. Two inputs are required.
 
@@ -346,7 +345,6 @@ class LatinHypercubeSampling(SamplingMethods):
 
             number_of_samples (int): The number of samples to be generated. Should be a positive integer less than or equal to the number of entries (rows) in **data_input**.
             sampling_type (str) : Option which determines whether the algorithm selects samples from an existing dataset ("selection") or attempts to generate sample from a supplied range ("creation"). Default is "creation".
-            rng_seed (int): An optional argument which fixes the generation of random numbers in this algorithm to a specific seed for reproducibility and testing purposes.
 
         Returns:
             **self** function containing the input information
@@ -357,14 +355,6 @@ class LatinHypercubeSampling(SamplingMethods):
             Exception: When **number_of_samples** is invalid (not an integer, too large, zero, or negative)
 
         """
-
-        if rng_seed is not None:
-            if not isinstance(rng_seed, int):
-                raise Exception('Random number seed (rng_seed) must be an integer.')
-            elif rng_seed < 0 or 2**32-1 < rng_seed:
-                raise Exception('Random number seed (rng_seed) must be between 0 and 2**32 - 1.')
-
-        np.random.seed(rng_seed)
 
         if sampling_type is None:
             sampling_type = 'creation'

--- a/idaes/surrogate/pysmo/sampling.py
+++ b/idaes/surrogate/pysmo/sampling.py
@@ -334,7 +334,7 @@ class LatinHypercubeSampling(SamplingMethods):
 
     """
 
-    def __init__(self, data_input, number_of_samples=None, sampling_type=None):
+    def __init__(self, data_input, number_of_samples=None, sampling_type=None, rng_seed=None):
         """
         Initialization of **LatinHypercubeSampling** class. Two inputs are required.
 
@@ -356,6 +356,9 @@ class LatinHypercubeSampling(SamplingMethods):
             Exception: When **number_of_samples** is invalid (not an integer, too large, zero, or negative)
 
         """
+
+        np.random.seed(rng_seed)
+
         if sampling_type is None:
             sampling_type = 'creation'
             self.sampling_type = sampling_type
@@ -444,7 +447,7 @@ class LatinHypercubeSampling(SamplingMethods):
         var_samples = np.zeros((self.number_of_samples, 1))
         for i in range(self.number_of_samples):
             strata_lb = i * strata_size
-            sample_point = strata_lb + (random.random() * strata_size)
+            sample_point = strata_lb + (np.random.rand() * strata_size)
             var_samples[i, 0] = (sample_point * (variable_max - variable_min)) + variable_min
         return var_samples
 

--- a/idaes/surrogate/pysmo/sampling.py
+++ b/idaes/surrogate/pysmo/sampling.py
@@ -346,7 +346,7 @@ class LatinHypercubeSampling(SamplingMethods):
 
             number_of_samples (int): The number of samples to be generated. Should be a positive integer less than or equal to the number of entries (rows) in **data_input**.
             sampling_type (str) : Option which determines whether the algorithm selects samples from an existing dataset ("selection") or attempts to generate sample from a supplied range ("creation"). Default is "creation".
-            rng_seed (int): An optional argument which fixes the generation of random numbers in this algorithm to a specific seed for reproducability and testing purposes.
+            rng_seed (int): An optional argument which fixes the generation of random numbers in this algorithm to a specific seed for reproducibility and testing purposes.
 
         Returns:
             **self** function containing the input information


### PR DESCRIPTION
## Fixes
This is a small change to use `np.random.rand()` in place of `random.rand()` in the Latin Hypercube method.  This change makes the random source used across all the sampling methods consistent.

## Summary/Motivation:
Being consistent with the random source allows a user to set the RNG seed in a systematic way outside the sampling methods and produce repeatable outputs for testing purposes.

## Changes proposed in this PR:
- Use `np.random.rand()` for consistency
- Remove `random` import

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
