### PR TITLE
Deprecating old list_of config validators

### DIFF
--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -16,7 +16,7 @@ IDAES Component objects
 @author: alee
 """
 from pyomo.environ import Set, Param, Var, units as pyunits
-from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf, Bool
 from pyomo.core.base.units_container import _PyomoUnit
 
 from .process_base import (declare_process_block_class,
@@ -91,7 +91,7 @@ class ComponentData(ProcessBlockData):
 
     CONFIG.declare("has_vapor_pressure", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Flag indicating whether component has a vapor pressure"))
     CONFIG.declare("pressure_sat_comp", ConfigValue(
         description="Method to use to calculate saturation pressure"))

--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -21,7 +21,7 @@ from pyomo.core.base.units_container import _PyomoUnit
 
 from .process_base import (declare_process_block_class,
                            ProcessBlockData)
-from .phases import PhaseType as PT
+from .phases import PhaseType
 from .util.exceptions import ConfigurationError, PropertyPackageError
 from idaes.core.util.misc import set_param_from_config
 import idaes.logger as idaeslog
@@ -36,7 +36,7 @@ class ComponentData(ProcessBlockData):
     CONFIG = ConfigBlock()
 
     CONFIG.declare("valid_phase_types", ConfigValue(
-            domain=ListOf(PT),
+            domain=ListOf(PhaseType),
             doc="List of valid PhaseTypes (Enums) for this Component."))
 
     CONFIG.declare("elemental_composition", ConfigValue(
@@ -219,19 +219,20 @@ class ComponentData(ProcessBlockData):
             # Check if this is an aqueous phase
             if phase.is_aqueous_phase():
                 if (self._is_aqueous_phase_valid() and
-                        PT.aqueousPhase in self.config.valid_phase_types):
+                        PhaseType.aqueousPhase in
+                        self.config.valid_phase_types):
                     return True
                 else:
                     return False
-            elif PT.liquidPhase in self.config.valid_phase_types:
+            elif PhaseType.liquidPhase in self.config.valid_phase_types:
                 return True
             else:
                 return False
         elif (phase.is_vapor_phase() and
-                PT.vaporPhase in self.config.valid_phase_types):
+                PhaseType.vaporPhase in self.config.valid_phase_types):
             return True
         elif (phase.is_solid_phase() and
-                PT.solidPhase in self.config.valid_phase_types):
+                PhaseType.solidPhase in self.config.valid_phase_types):
             return True
         else:
             return False

--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -16,13 +16,12 @@ IDAES Component objects
 @author: alee
 """
 from pyomo.environ import Set, Param, Var, units as pyunits
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 from pyomo.core.base.units_container import _PyomoUnit
 
 from .process_base import (declare_process_block_class,
                            ProcessBlockData)
 from .phases import PhaseType as PT
-from .util.config import list_of_phase_types
 from .util.exceptions import ConfigurationError, PropertyPackageError
 from idaes.core.util.misc import set_param_from_config
 import idaes.logger as idaeslog
@@ -37,7 +36,7 @@ class ComponentData(ProcessBlockData):
     CONFIG = ConfigBlock()
 
     CONFIG.declare("valid_phase_types", ConfigValue(
-            domain=list_of_phase_types,
+            domain=ListOf(PT),
             doc="List of valid PhaseTypes (Enums) for this Component."))
 
     CONFIG.declare("elemental_composition", ConfigValue(

--- a/idaes/core/control_volume_base.py
+++ b/idaes/core/control_volume_base.py
@@ -18,7 +18,7 @@ Base class for control volumes
 from enum import Enum
 
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ProcessBlockData,
@@ -86,7 +86,7 @@ CONFIG_Template.declare("dynamic", ConfigValue(
 **False** - set as a steady-state model}"""))
 CONFIG_Template.declare("has_holdup", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Holdup construction flag",
     doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,
@@ -132,7 +132,7 @@ CONFIG_Template.declare("momentum_balance_type", ConfigValue(
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
 CONFIG_Template.declare("has_rate_reactions", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Rate reaction construction flag",
     doc="""Indicates whether terms for rate controlled reactions should be
 constructed,
@@ -142,7 +142,7 @@ constructed,
 **False** - exclude kinetic reaction terms.}"""))
 CONFIG_Template.declare("has_equilibrium_reactions", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Equilibrium reaction construction flag",
     doc="""Indicates whether terms for equilibrium controlled reactions
 should be constructed,
@@ -152,7 +152,7 @@ should be constructed,
 **False** - exclude equilibrium reaction terms.}"""))
 CONFIG_Template.declare("has_phase_equilibrium", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Phase equilibrium construction flag",
     doc="""Indicates whether terms for phase equilibrium should be
 constructed,
@@ -162,7 +162,7 @@ constructed,
 **False** - exclude phase equilibrium terms.}"""))
 CONFIG_Template.declare("has_mass_transfer", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Mass transfer term construction flag",
     doc="""Indicates whether terms for mass transfer should be constructed,
 **default** - False.
@@ -171,7 +171,7 @@ CONFIG_Template.declare("has_mass_transfer", ConfigValue(
 **False** - exclude mass transfer terms.}"""))
 CONFIG_Template.declare("has_heat_of_reaction", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Heat of reaction term construction flag",
     doc="""Indicates whether terms for heat of reaction should be constructed,
 **default** - False.
@@ -180,7 +180,7 @@ CONFIG_Template.declare("has_heat_of_reaction", ConfigValue(
 **False** - exclude heat of reaction terms.}"""))
 CONFIG_Template.declare("has_heat_transfer", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Heat transfer term construction flag",
     doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -189,7 +189,7 @@ CONFIG_Template.declare("has_heat_transfer", ConfigValue(
 **False** - exclude heat transfer terms.}"""))
 CONFIG_Template.declare("has_work_transfer", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Work transfer term construction flag",
     doc="""Indicates whether terms for work transfer should be constructed,
 **default** - False.
@@ -198,7 +198,7 @@ CONFIG_Template.declare("has_work_transfer", ConfigValue(
 **False** - exclude work transfer terms.}"""))
 CONFIG_Template.declare("has_enthalpy_transfer", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Enthalpy transfer term construction flag",
     doc="""Indicates whether terms for enthalpy transfer due to mass trasnfer
 should be constructed, **default** - False.
@@ -207,7 +207,7 @@ should be constructed, **default** - False.
 **False** - exclude enthalpy transfer terms.}"""))
 CONFIG_Template.declare("has_pressure_change", ConfigValue(
     default=False,
-    domain=In([True, False]),
+    domain=Bool,
     description="Pressure change term construction flag",
     doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -323,7 +323,7 @@ and used when constructing these,
 see reaction package for documentation.}"""))
     CONFIG.declare("auto_construct", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Argument indicating whether ControlVolume should "
                     "automatically construct balance equations",
         doc="""If set to True, this argument will trigger the auto_construct

--- a/idaes/core/control_volume_base.py
+++ b/idaes/core/control_volume_base.py
@@ -26,7 +26,8 @@ from idaes.core import (ProcessBlockData,
                         useDefault,
                         declare_process_block_class)
 from idaes.core.util.config import (is_physical_parameter_block,
-                                    is_reaction_parameter_block)
+                                    is_reaction_parameter_block,
+                                    DefaultBool)
 from idaes.core.util.exceptions import (BurntToast,
                                         ConfigurationError,
                                         PropertyNotSupportedError)
@@ -76,7 +77,7 @@ class FlowDirection(Enum):
 CONFIG_Template = ProcessBlockData.CONFIG()
 CONFIG_Template.declare("dynamic", ConfigValue(
     default=useDefault,
-    domain=In([useDefault, True, False]),
+    domain=DefaultBool,
     description="Dynamic model flag",
     doc="""Indicates whether this model will be dynamic,
 **default** - useDefault.
@@ -270,7 +271,7 @@ class ControlVolumeBlockData(ProcessBlockData):
 
     CONFIG = ProcessBlockData.CONFIG()
     CONFIG.declare("dynamic", ConfigValue(
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         default=useDefault,
         description="Dynamic model flag",
         doc="""Indicates whether this model will be dynamic,
@@ -281,7 +282,7 @@ class ControlVolumeBlockData(ProcessBlockData):
 **False** - set as a steady-state model}"""))
     CONFIG.declare("has_holdup", ConfigValue(
         default=useDefault,
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         description="Holdup construction flag",
         doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,

--- a/idaes/core/flowsheet_model.py
+++ b/idaes/core/flowsheet_model.py
@@ -18,14 +18,13 @@ IDAES modeling framework.
 import pyomo.environ as pe
 from pyomo.dae import ContinuousSet
 from pyomo.network import Arc
-from pyomo.common.config import ConfigValue, In
+from pyomo.common.config import ConfigValue, In, ListOf
 from pyomo.core.base.units_container import _PyomoUnit
 
 from idaes.core import (ProcessBlockData, declare_process_block_class,
                         UnitModelBlockData, useDefault)
 from idaes.core.util.config import (is_physical_parameter_block,
-                                    is_time_domain,
-                                    list_of_floats)
+                                    is_time_domain)
 from idaes.core.util.misc import add_object_reference
 from idaes.core.util.exceptions import DynamicError, ConfigurationError
 from idaes.core.util.tables import create_stream_table_dataframe
@@ -80,7 +79,7 @@ search for a parent with a time domain or create a new time domain and
 reference it here."""))
     CONFIG.declare("time_set", ConfigValue(
         default=[0],
-        domain=list_of_floats,
+        domain=ListOf(float),
         description="Set of points for initializing time domain",
         doc="""Set of points for initializing time domain. This should be a
 list of floating point numbers,

--- a/idaes/core/flowsheet_model.py
+++ b/idaes/core/flowsheet_model.py
@@ -18,13 +18,14 @@ IDAES modeling framework.
 import pyomo.environ as pe
 from pyomo.dae import ContinuousSet
 from pyomo.network import Arc
-from pyomo.common.config import ConfigValue, In, ListOf
+from pyomo.common.config import ConfigValue, ListOf
 from pyomo.core.base.units_container import _PyomoUnit
 
 from idaes.core import (ProcessBlockData, declare_process_block_class,
                         UnitModelBlockData, useDefault)
 from idaes.core.util.config import (is_physical_parameter_block,
-                                    is_time_domain)
+                                    is_time_domain,
+                                    DefaultBool)
 from idaes.core.util.misc import add_object_reference
 from idaes.core.util.exceptions import DynamicError, ConfigurationError
 from idaes.core.util.tables import create_stream_table_dataframe
@@ -61,7 +62,7 @@ class FlowsheetBlockData(ProcessBlockData):
     CONFIG = ProcessBlockData.CONFIG()
     CONFIG.declare("dynamic", ConfigValue(
         default=useDefault,
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         description="Dynamic model flag",
         doc="""Indicates whether this model will be dynamic,
 **default** - useDefault.

--- a/idaes/core/property_base.py
+++ b/idaes/core/property_base.py
@@ -20,7 +20,7 @@ import sys
 from pyomo.environ import Set, value, Var, Expression, Constraint
 from pyomo.core.base.var import _VarData
 from pyomo.core.base.expression import _ExpressionData
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.common.formatting import tabular_writer
 
 # Import IDAES cores
@@ -562,7 +562,7 @@ class StateBlockData(ProcessBlockData):
 Block associated with this property package."""))
     CONFIG.declare("defined_state", ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Flag indicating if incoming state is fully defined",
             doc="""Flag indicating whether the state should be considered fully
 defined, and thus whether constraints such as sum of mass/mole fractions should
@@ -573,7 +573,7 @@ be included,
 **False** - state variables will not be fully defined.}"""))
     CONFIG.declare("has_phase_equilibrium", ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Phase equilibrium constraint flag",
             doc="""Flag indicating whether phase equilibrium constraints
 should be constructed in this state block,

--- a/idaes/core/reaction_base.py
+++ b/idaes/core/reaction_base.py
@@ -15,7 +15,7 @@ This module contains classes for reaction blocks and reaction parameter blocks.
 """
 
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, Bool
 from pyomo.environ import Var, Constraint, Expression
 
 # Import IDAES cores
@@ -24,7 +24,6 @@ from idaes.core import ProcessBlockData
 from idaes.core import property_meta
 from idaes.core import MaterialFlowBasis
 from idaes.core.util.exceptions import (BurntToast,
-                                        ConfigurationError,
                                         PropertyNotSupportedError,
                                         PropertyPackageError)
 from idaes.core.util.config import (is_physical_parameter_block,
@@ -317,7 +316,7 @@ Block associated with this property package."""))
 which this reaction block should be associated."""))
     CONFIG.declare("has_equilibrium", ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Equilibrium constraint flag",
             doc="""Flag indicating whether equilibrium constraints
 should be constructed in this reaction block,

--- a/idaes/core/unit_model.py
+++ b/idaes/core/unit_model.py
@@ -16,7 +16,7 @@ Base class for unit models
 
 from pyomo.environ import Reference
 from pyomo.network import Port
-from pyomo.common.config import ConfigValue, In
+from pyomo.common.config import ConfigValue
 
 from .process_base import (declare_process_block_class,
                            ProcessBlockData,
@@ -33,6 +33,8 @@ from idaes.core.util.tables import create_stream_table_dataframe
 import idaes.core.util.unit_costing
 import idaes.logger as idaeslog
 from idaes.core.util import get_solver
+from idaes.core.util.config import DefaultBool
+
 
 __author__ = "John Eslick, Qi Chen, Andrew Lee"
 
@@ -53,7 +55,7 @@ class UnitModelBlockData(ProcessBlockData):
     CONFIG = ProcessBlockData.CONFIG()
     CONFIG.declare("dynamic", ConfigValue(
         default=useDefault,
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         description="Dynamic model flag",
         doc="""Indicates whether this model will be dynamic or not,
 **default** = useDefault.
@@ -63,7 +65,7 @@ class UnitModelBlockData(ProcessBlockData):
 **False** - set as a steady-state model.}"""))
     CONFIG.declare("has_holdup", ConfigValue(
         default=useDefault,
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         description="Holdup construction flag",
         doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,

--- a/idaes/core/util/config.py
+++ b/idaes/core/util/config.py
@@ -20,7 +20,7 @@ the `domain` argument in ConfigBlocks.
 __author__ = "Andrew Lee"
 
 from pyomo.common.deprecation import deprecation_warning
-from pyomo.common.config import ListOf
+from pyomo.common.config import ListOf, Bool
 
 from pyomo.environ import Set
 from pyomo.dae import ContinuousSet
@@ -209,3 +209,23 @@ def is_transformation_scheme(arg):
                 'Invalid value provided for transformation_scheme. '
                 'Please check the value and spelling of the argument provided.'
                 )
+
+
+def DefaultBool(arg):
+    """
+    Domain validator for bool-like arguments with a 'use default' option.
+    Relies on Pyomo's Bool() validator for identifying bool-like arguments.
+
+    Args:
+        arg : argument to be validated.
+
+    Returns:
+        A bool or useDefault
+
+    Raises:
+        ValueError if arg is not bool-like or useDefault
+    """
+    if arg == useDefault:
+        return arg
+    else:
+        return Bool(arg)

--- a/idaes/core/util/config.py
+++ b/idaes/core/util/config.py
@@ -19,6 +19,9 @@ the `domain` argument in ConfigBlocks.
 
 __author__ = "Andrew Lee"
 
+from pyomo.common.deprecation import deprecation_warning
+from pyomo.common.config import ListOf
+
 from pyomo.environ import Set
 from pyomo.dae import ContinuousSet
 from pyomo.network import Port
@@ -98,13 +101,12 @@ def list_of_floats(arg):
     Returns:
         List of strings
     '''
-    try:
-        # Assume arg is iterable
-        lst = [float(i) for i in arg]
-    except TypeError:
-        # arg is not iterable
-        lst = [float(arg)]
-    return lst
+    deprecation_warning(
+        "The list_of_floats function is deprecated.  Use the ListOf(float) "
+        "validator from pyomo.common.config instead.", version='1.11',
+        remove_in='1.13')
+
+    return ListOf(float)(arg)
 
 
 def list_of_strings(arg):
@@ -116,21 +118,12 @@ def list_of_strings(arg):
     Returns:
         List of strings
     '''
-    if isinstance(arg, dict):
-        raise ConfigurationError("Invalid argument type (dict). "
-                                 "Expected a list of strings, or something "
-                                 "that can be cast to a list of strings")
+    deprecation_warning(
+        "The list_of_strings function is deprecated.  Use the ListOf(str) "
+        "validator from pyomo.common.config instead.", version='1.11',
+        remove_in='1.13')
 
-    try:
-        # Assume arg is iterable
-        if isinstance(arg, str):
-            lst = [arg]
-        else:
-            lst = [str(i) for i in arg]
-    except TypeError:
-        # arg is not iterable
-        lst = [str(arg)]
-    return lst
+    return ListOf(str)(arg)
 
 
 def list_of_phase_types(arg):
@@ -142,17 +135,12 @@ def list_of_phase_types(arg):
     Returns:
         List of PhaseTypes
     '''
-    if isinstance(arg, PhaseType):
-        # Cast to list and return
-        return [arg]
-    else:
-        # Assume arg is iterable
-        for i in arg:
-            if not isinstance(i, PhaseType):
-                raise ConfigurationError(
-                    "valid_phase_types configuration argument must be a list "
-                    "of PhaseTypes.")
-    return arg
+    deprecation_warning(
+        "The list_of_phase_types function is deprecated.  Use the "
+        "ListOf(PhaseType) validator from pyomo.common.config instead.",
+        version='1.11', remove_in='1.13')
+
+    return ListOf(PhaseType)(arg)
 
 
 def is_port(arg):

--- a/idaes/core/util/tests/test_config.py
+++ b/idaes/core/util/tests/test_config.py
@@ -150,13 +150,6 @@ def test_list_of_strings():
 
 
 @pytest.mark.unit
-def test_list_of_strings_errors():
-    # Test that list_of_strings fails correctly
-    with pytest.raises(ConfigurationError):
-        list_of_strings({"foo": "bar"})  # dict
-
-
-@pytest.mark.unit
 def test_list_of_floats():
     # Test list_of_floats returns correctly
     assert list_of_floats(1) == [1.0]  # int
@@ -258,7 +251,5 @@ def test_list_of_phase_types():
     assert list_of_phase_types([PT.liquidPhase]) == [PT.liquidPhase]
     assert list_of_phase_types([PT.liquidPhase, PT.vaporPhase]) == \
         [PT.liquidPhase, PT.vaporPhase]
-    with pytest.raises(ConfigurationError,
-                       match="valid_phase_types configuration argument must "
-                       "be a list of PhaseTypes."):
+    with pytest.raises(ValueError):
         list_of_phase_types("foo")

--- a/idaes/core/util/tests/test_config.py
+++ b/idaes/core/util/tests/test_config.py
@@ -35,7 +35,8 @@ from idaes.core.util.config import (is_physical_parameter_block,
                                     is_port,
                                     is_time_domain,
                                     is_transformation_method,
-                                    is_transformation_scheme)
+                                    is_transformation_scheme,
+                                    DefaultBool)
 from idaes.core.util.exceptions import ConfigurationError
 
 
@@ -253,3 +254,12 @@ def test_list_of_phase_types():
         [PT.liquidPhase, PT.vaporPhase]
     with pytest.raises(ValueError):
         list_of_phase_types("foo")
+
+
+@pytest.mark.unit
+def test_DefaultBool():
+    assert DefaultBool(useDefault) is useDefault
+    assert DefaultBool(True)
+    assert not DefaultBool(False)
+    with pytest.raises(ValueError):
+        DefaultBool("foo")

--- a/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/hetero_reactions.py
+++ b/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/hetero_reactions.py
@@ -33,7 +33,7 @@ from pyomo.environ import (Constraint,
                            Var,
                            units as pyunits)
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, Bool
 
 
 # Import IDAES cores
@@ -325,7 +325,7 @@ class ReactionBlockData(ReactionBlockDataBase):
             """))
     CONFIG.declare("has_equilibrium", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Equilibrium reaction construction flag",
         doc="""
         Indicates whether terms for equilibrium controlled reactions

--- a/idaes/gas_solid_contactors/properties/oxygen_iron_OC_oxidation/hetero_reactions.py
+++ b/idaes/gas_solid_contactors/properties/oxygen_iron_OC_oxidation/hetero_reactions.py
@@ -33,7 +33,7 @@ from pyomo.environ import (Constraint,
                            Var,
                            units as pyunits)
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, Bool
 
 
 # Import IDAES cores
@@ -332,7 +332,7 @@ class ReactionBlockData(ReactionBlockDataBase):
             """))
     CONFIG.declare("has_equilibrium", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Equilibrium reaction construction flag",
         doc="""
         Indicates whether terms for equilibrium controlled reactions

--- a/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
@@ -32,10 +32,10 @@ Solid superficial velocity is constant throughout the bed
 import matplotlib.pyplot as plt
 
 # Import Pyomo libraries
-from pyomo.environ import (Var, Param, Reals, SolverFactory,
+from pyomo.environ import (Var, Param, Reals,
                            TerminationCondition, Constraint,
                            TransformationFactory, sqrt, value)
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.dae import ContinuousSet, DerivativeVar
 
@@ -161,7 +161,7 @@ discretizing length domain (default=3)"""))
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -174,7 +174,7 @@ constructed,
     _PhaseTemplate = UnitModelBlockData.CONFIG()
     _PhaseTemplate.declare("has_equilibrium_reactions", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Equilibrium reaction construction flag",
         doc="""Indicates whether terms for equilibrium controlled reactions
 should be constructed,

--- a/idaes/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/moving_bed.py
@@ -36,10 +36,10 @@ from __future__ import division
 import matplotlib.pyplot as plt
 
 # Import Pyomo libraries
-from pyomo.environ import (Var, Param, Reals, value, SolverFactory,
+from pyomo.environ import (Var, Param, Reals, value,
                            TransformationFactory, Constraint,
                            TerminationCondition)
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.dae import ContinuousSet
 
@@ -162,7 +162,7 @@ solid side flows from 1 to 0"""))
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -184,7 +184,7 @@ constructed,
     _PhaseTemplate = UnitModelBlockData.CONFIG()
     _PhaseTemplate.declare("has_equilibrium_reactions", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Equilibrium reaction construction flag",
         doc="""Indicates whether terms for equilibrium controlled reactions
 should be constructed,

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -26,7 +26,7 @@ from pyomo.environ import (Block,
                            value,
                            Var,
                            units as pyunits)
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.core.base.units_container import _PyomoUnit
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 
@@ -174,7 +174,7 @@ class GenericParameterData(PhysicalParameterBlock):
     # Property package options
     CONFIG.declare("include_enthalpy_of_formation", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Include enthalpy of formation in property calculations",
         doc="Flag indiciating whether enthalpy of formation should be included"
         " when calculating specific enthalpies."))

--- a/idaes/generic_models/unit_models/cstr.py
+++ b/idaes/generic_models/unit_models/cstr.py
@@ -15,7 +15,7 @@ Standard IDAES CSTR model.
 """
 
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.environ import Reference, Block, Var, Constraint
 
 # Import IDAES cores
@@ -82,7 +82,7 @@ balance type
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -91,7 +91,7 @@ balance type
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -101,7 +101,7 @@ constructed,
 **False** - exclude pressure change terms.}"""))
     CONFIG.declare("has_equilibrium_reactions", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Equilibrium reaction construction flag",
         doc="""Indicates whether terms for equilibrium controlled reactions
 should be constructed,
@@ -111,7 +111,7 @@ should be constructed,
 **False** - exclude equilibrium reaction terms.}"""))
     CONFIG.declare("has_phase_equilibrium", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Phase equilibrium construction flag",
         doc="""Indicates whether terms for phase equilibrium should be
 constructed,
@@ -121,7 +121,7 @@ constructed,
 **False** - exclude phase equilibrium terms.}"""))
     CONFIG.declare("has_heat_of_reaction", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat of reaction term construction flag",
         doc="""Indicates whether terms for heat of reaction terms should be
 constructed,

--- a/idaes/generic_models/unit_models/distillation/reboiler.py
+++ b/idaes/generic_models/unit_models/distillation/reboiler.py
@@ -23,10 +23,9 @@ __author__ = "Jaffer Ghouse"
 from pandas import DataFrame
 
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.network import Port
-from pyomo.environ import Reference, Expression, Var, Constraint, \
-    value, Set, SolverFactory
+from pyomo.environ import Reference, Expression, Var, Constraint, value, Set
 
 # Import IDAES cores
 import idaes.logger as idaeslog
@@ -57,7 +56,7 @@ class ReboilerData(UnitModelBlockData):
     CONFIG = UnitModelBlockData.CONFIG()
     CONFIG.declare("has_boilup_ratio", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Boilup ratio term construction flag",
         doc="""Indicates whether terms for boilup ratio should be
 constructed,
@@ -103,7 +102,7 @@ constructed,
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/generic_models/unit_models/distillation/tray.py
+++ b/idaes/generic_models/unit_models/distillation/tray.py
@@ -27,9 +27,9 @@ __author__ = "Jaffer Ghouse"
 import idaes.logger as idaeslog
 
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.network import Port
-from pyomo.environ import Reference, Expression, Var, Set, value, SolverFactory
+from pyomo.environ import Reference, Expression, Var, Set, value
 
 # Import IDAES cores
 from idaes.core import (declare_process_block_class,
@@ -65,7 +65,7 @@ class TrayData(UnitModelBlockData):
 this must be False."""))
     CONFIG.declare("is_feed_tray", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="flag to indicate feed tray.",
         doc="""indicates if this is a feed tray and constructs
 corresponding ports,
@@ -75,7 +75,7 @@ corresponding ports,
 **False** - conventional tray with no feed inlet}"""))
     CONFIG.declare("has_liquid_side_draw", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="liquid side draw construction flag.",
         doc="""indicates if there is a liquid side draw from the tray,
 **default** - False.
@@ -84,7 +84,7 @@ corresponding ports,
 **False** - exclude a liquid side draw from the tray.}"""))
     CONFIG.declare("has_vapor_side_draw", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="vapor side draw construction flag.",
         doc="""indicates if there is a vapor side draw from the tray,
 **default** - False.
@@ -93,7 +93,7 @@ corresponding ports,
 **False** - exclude a vapor side draw from the tray.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="heat duty to/from tray construction flag.",
         doc="""indicates if there is heat duty to/from the tray,
 **default** - False.
@@ -102,7 +102,7 @@ corresponding ports,
 **False** - exclude a heat duty term.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="pressure change term construction flag",
         doc="""indicates whether terms for pressure change should be
     constructed,

--- a/idaes/generic_models/unit_models/distillation/tray_column.py
+++ b/idaes/generic_models/unit_models/distillation/tray_column.py
@@ -19,11 +19,10 @@ __author__ = "Jaffer Ghouse"
 import idaes.logger as idaeslog
 
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.network import Arc, Port
 from pyomo.environ import value, Integers, RangeSet, TransformationFactory, \
-    Block, Reference, SolverFactory
-from pyomo.util.infeasible import log_infeasible_constraints
+    Block, Reference
 
 # Import IDAES cores
 from idaes.generic_models.unit_models.distillation import Tray, Condenser, \
@@ -100,7 +99,7 @@ bubble point i.e. total condenser,
 user specified temperature.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="heat duty to/from tray construction flag.",
         doc="""indicates if there is heat duty to/from the tray,
 **default** - False.
@@ -109,7 +108,7 @@ user specified temperature.}"""))
 **False** - exclude a heat duty term.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="pressure change term construction flag",
         doc="""indicates whether terms for pressure change should be
 constructed,
@@ -119,7 +118,7 @@ constructed,
 **False** - exclude pressure change terms.}"""))
     CONFIG.declare("has_liquid_side_draw", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="liquid side draw construction flag.",
         doc="""indicates if there is a liquid side draw from all trays,
 **default** - False.
@@ -128,7 +127,7 @@ constructed,
 **False** - exclude a liquid side draw for all trays.}"""))
     CONFIG.declare("has_vapor_side_draw", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="vapor side draw construction flag.",
         doc="""indicates if there is a vapor side draw from all trays,
 **default** - False.

--- a/idaes/generic_models/unit_models/equilibrium_reactor.py
+++ b/idaes/generic_models/unit_models/equilibrium_reactor.py
@@ -15,7 +15,7 @@ Standard IDAES Equilibrium Reactor model.
 """
 
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.environ import Reference
 
 # Import IDAES cores
@@ -93,7 +93,7 @@ balance type
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_rate_reactions", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Rate reaction construction flag",
         doc="""Indicates whether terms for rate controlled reactions
 should be constructed, along with constraints equating these to zero,
@@ -103,7 +103,7 @@ should be constructed, along with constraints equating these to zero,
 **False** - exclude rate reaction terms.}"""))
     CONFIG.declare("has_equilibrium_reactions", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Equilibrium reaction construction flag",
         doc="""Indicates whether terms for equilibrium controlled reactions
 should be constructed,
@@ -113,7 +113,7 @@ should be constructed,
 **False** - exclude equilibrium reaction terms.}"""))
     CONFIG.declare("has_phase_equilibrium", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Phase equilibrium term construction flag",
         doc="""Indicates whether terms for phase equilibrium should be
 constructed, **default** - True.
@@ -122,7 +122,7 @@ constructed, **default** - True.
 **False** - exclude phase equlibirum terms.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -131,7 +131,7 @@ constructed, **default** - True.
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_heat_of_reaction", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat of reaction term construction flag",
         doc="""Indicates whether terms for heat of reaction terms should be
 constructed,
@@ -141,7 +141,7 @@ constructed,
 **False** - exclude heat of reaction terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/generic_models/unit_models/flash.py
+++ b/idaes/generic_models/unit_models/flash.py
@@ -19,7 +19,7 @@ from pandas import DataFrame
 
 # Import Pyomo libraries
 from pyomo.environ import Constraint, value, Reference, Var, Block
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.network import Port
 
 # Import IDAES cores
@@ -119,7 +119,7 @@ inlet,
 flows.}"""))
     CONFIG.declare("ideal_separation", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Ideal splitting flag",
         doc="""Argument indicating whether ideal splitting should be used.
 Ideal splitting assumes perfect separation of material, and attempts to
@@ -132,7 +132,7 @@ has_phase_equilibrium = True,
 **False** - use explicit splitting equations with split fractions.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -141,7 +141,7 @@ has_phase_equilibrium = True,
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/generic_models/unit_models/gibbs_reactor.py
+++ b/idaes/generic_models/unit_models/gibbs_reactor.py
@@ -15,7 +15,7 @@ Standard IDAES Gibbs reactor model.
 """
 # Import Pyomo libraries
 from pyomo.environ import Constraint, Param, Reals, Reference, Var
-from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -85,7 +85,7 @@ balance type
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -94,7 +94,7 @@ balance type
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/generic_models/unit_models/gibbs_reactor.py
+++ b/idaes/generic_models/unit_models/gibbs_reactor.py
@@ -15,7 +15,7 @@ Standard IDAES Gibbs reactor model.
 """
 # Import Pyomo libraries
 from pyomo.environ import Constraint, Param, Reals, Reference, Var
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -24,7 +24,7 @@ from idaes.core import (ControlVolume0DBlock,
                         MomentumBalanceType,
                         UnitModelBlockData,
                         useDefault)
-from idaes.core.util.config import is_physical_parameter_block, list_of_strings
+from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError
 
 __author__ = "Jinliang Ma, Andrew Lee"
@@ -121,7 +121,7 @@ and used when constructing these,
 see property package for documentation.}"""))
     CONFIG.declare("inert_species", ConfigValue(
         default=[],
-        domain=list_of_strings,
+        domain=ListOf(str),
         description="List of inert species",
         doc="List of species which do not take part in reactions."))
 

--- a/idaes/generic_models/unit_models/heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/heat_exchanger_1D.py
@@ -20,13 +20,12 @@ from enum import Enum
 
 # Import Pyomo libraries
 from pyomo.environ import (
-    SolverFactory,
     Var,
     Constraint,
     value,
     units as pyunits
 )
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (
@@ -156,7 +155,7 @@ be constructed,
         "has_pressure_change",
         ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Pressure change term construction flag",
             doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -170,7 +169,7 @@ constructed,
         "has_phase_equilibrium",
         ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Phase equilibrium term construction flag",
             doc="""Argument to enable phase equilibrium on the shell side.
 - True - include phase equilibrium term

--- a/idaes/generic_models/unit_models/heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/heat_exchanger_1D.py
@@ -40,7 +40,7 @@ from idaes.core import (
 )
 from idaes.generic_models.unit_models.heat_exchanger \
     import HeatExchangerFlowPattern
-from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.config import is_physical_parameter_block, DefaultBool
 from idaes.core.util.misc import add_object_reference
 from idaes.core.util.exceptions import ConfigurationError
 from idaes.core.util.tables import create_stream_table_dataframe
@@ -73,7 +73,7 @@ class HeatExchanger1DData(UnitModelBlockData):
         "dynamic",
         ConfigValue(
             default=useDefault,
-            domain=In([useDefault, True, False]),
+            domain=DefaultBool,
             description="Dynamic model flag",
             doc="""Indicates whether this model will be dynamic or not,
 **default** = useDefault.
@@ -87,7 +87,7 @@ class HeatExchanger1DData(UnitModelBlockData):
         "has_holdup",
         ConfigValue(
             default=useDefault,
-            domain=In([useDefault, True, False]),
+            domain=DefaultBool,
             description="Holdup construction flag",
             doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,

--- a/idaes/generic_models/unit_models/heater.py
+++ b/idaes/generic_models/unit_models/heater.py
@@ -18,7 +18,7 @@ __author__ = "John Eslick"
 
 # Import Pyomo libraries
 from pyomo.environ import Reference
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -118,7 +118,7 @@ balance type
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     config.declare("has_phase_equilibrium", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Phase equilibrium construction flag",
         doc="""Indicates whether terms for phase equilibrium should be
 constructed, **default** = False.
@@ -127,7 +127,7 @@ constructed, **default** = False.
 **False** - exclude phase equilibrium terms.}"""))
     config.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/generic_models/unit_models/mixer.py
+++ b/idaes/generic_models/unit_models/mixer.py
@@ -21,10 +21,9 @@ from pyomo.environ import (
     PositiveReals,
     Reals,
     RangeSet,
-    SolverFactory,
     Var,
 )
-from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf, Bool
 
 from idaes.core import (
     declare_process_block_class,
@@ -184,7 +183,7 @@ balance type
         "has_phase_equilibrium",
         ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Calculate phase equilibrium in mixed stream",
             doc="""Argument indicating whether phase equilibrium should be
 calculated for the resulting mixed stream,
@@ -249,7 +248,7 @@ Mixer block,
         "construct_ports",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Construct inlet and outlet Port objects",
             doc="""Argument indicating whether model should construct Port
 objects linked to all inlet states and the mixed state,

--- a/idaes/generic_models/unit_models/mixer.py
+++ b/idaes/generic_models/unit_models/mixer.py
@@ -24,7 +24,7 @@ from pyomo.environ import (
     SolverFactory,
     Var,
 )
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 
 from idaes.core import (
     declare_process_block_class,
@@ -36,7 +36,6 @@ from idaes.core import (
 from idaes.core.util.config import (
     is_physical_parameter_block,
     is_state_block,
-    list_of_strings,
 )
 from idaes.core.util.exceptions import (
     BurntToast,
@@ -139,7 +138,7 @@ see property package for documentation.}""",
     CONFIG.declare(
         "inlet_list",
         ConfigValue(
-            domain=list_of_strings,
+            domain=ListOf(str),
             description="List of inlet names",
             doc="""A list containing names of inlets,
 **default** - None.

--- a/idaes/generic_models/unit_models/plug_flow_reactor.py
+++ b/idaes/generic_models/unit_models/plug_flow_reactor.py
@@ -15,7 +15,7 @@ Standard IDAES PFR model.
 """
 # Import Pyomo libraries
 from pyomo.environ import Constraint, Var, Reference, Block
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 
 # Import IDAES cores
 from idaes.core import (ControlVolume1DBlock,
@@ -26,8 +26,7 @@ from idaes.core import (ControlVolume1DBlock,
                         UnitModelBlockData,
                         useDefault)
 from idaes.core.util.config import (is_physical_parameter_block,
-                                    is_reaction_parameter_block,
-                                    list_of_floats)
+                                    is_reaction_parameter_block)
 from idaes.core.util.misc import add_object_reference
 import idaes.core.util.unit_costing as costing
 from idaes.core.util.constants import Constants as const
@@ -166,7 +165,7 @@ and used when constructing these,
 see reaction package for documentation.}"""))
     CONFIG.declare("length_domain_set", ConfigValue(
         default=[0.0, 1.0],
-        domain=list_of_floats,
+        domain=ListOf(float),
         description="List of points to use to initialize length domain",
         doc="""A list of values to be used when constructing the length domain
 of the reactor. Point must lie between 0.0 and 1.0,

--- a/idaes/generic_models/unit_models/plug_flow_reactor.py
+++ b/idaes/generic_models/unit_models/plug_flow_reactor.py
@@ -15,7 +15,7 @@ Standard IDAES PFR model.
 """
 # Import Pyomo libraries
 from pyomo.environ import Constraint, Var, Reference, Block
-from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume1DBlock,
@@ -82,7 +82,7 @@ balance type
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_equilibrium_reactions", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Equilibrium reaction construction flag",
         doc="""Indicates whether terms for equilibrium controlled reactions
 should be constructed,
@@ -92,7 +92,7 @@ should be constructed,
 **False** - exclude equilibrium reaction terms.}"""))
     CONFIG.declare("has_phase_equilibrium", ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Phase equilibrium construction flag",
             doc="""Indicates whether terms for phase equilibrium should be
 constructed,
@@ -102,7 +102,7 @@ constructed,
 **False** - exclude phase equilibrium terms.}"""))
     CONFIG.declare("has_heat_of_reaction", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat of reaction term construction flag",
         doc="""Indicates whether terms for heat of reaction terms should be
 constructed,
@@ -112,7 +112,7 @@ constructed,
 **False** - exclude heat of reaction terms.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -121,7 +121,7 @@ constructed,
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/generic_models/unit_models/pressure_changer.py
+++ b/idaes/generic_models/unit_models/pressure_changer.py
@@ -19,9 +19,8 @@ Standard IDAES pressure changer model.
 from enum import Enum
 
 # Import Pyomo libraries
-from pyomo.environ import SolverFactory, value, Var, Block, Expression,\
-    Constraint, Reference
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.environ import value, Var, Block, Expression, Constraint, Reference
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (
@@ -179,7 +178,7 @@ constructed, **default** - MomentumBalanceType.pressureTotal.
         "has_phase_equilibrium",
         ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Phase equilibrium construction flag",
             doc="""Indicates whether terms for phase equilibrium should be
 constructed, **default** = False.
@@ -192,7 +191,7 @@ constructed, **default** = False.
         "compressor",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Compressor flag",
             doc="""Indicates whether this unit should be considered a
             compressor (True (default), pressure increase) or an expander
@@ -241,7 +240,7 @@ see property package for documentation.}""",
         "support_isentropic_performance_curves",
         ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             doc="Include a block for performance curves, configure via"
                 " isentropic_performance_curves.",
         ),

--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -24,12 +24,11 @@ from pyomo.environ import (
     Reals,
     Reference,
     Set,
-    SolverFactory,
     Var,
     value,
 )
 from pyomo.network import Port
-from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf, Bool
 
 from idaes.core import (
     declare_process_block_class,
@@ -211,7 +210,7 @@ balance type
         "has_phase_equilibrium",
         ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Calculate phase equilibrium in mixed stream",
             doc="""Argument indicating whether phase equilibrium should be
 calculated for the resulting mixed stream,
@@ -242,7 +241,7 @@ flows. Does not work with component or phase-component splitting.}""",
         "ideal_separation",
         ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Ideal splitting flag",
             doc="""Argument indicating whether ideal splitting should be used.
 Ideal splitting assumes perfect spearation of material, and attempts to
@@ -286,7 +285,7 @@ Separator block,
         "construct_ports",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Construct inlet and outlet Port objects",
             doc="""Argument indicating whether model should construct Port
 objects linked the mixed state and all outlet states,

--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -29,7 +29,7 @@ from pyomo.environ import (
     value,
 )
 from pyomo.network import Port
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 
 from idaes.core import (
     declare_process_block_class,
@@ -41,7 +41,6 @@ from idaes.core import (
 from idaes.core.util.config import (
     is_physical_parameter_block,
     is_state_block,
-    list_of_strings,
 )
 from idaes.core.util.exceptions import (
     BurntToast,
@@ -147,7 +146,7 @@ see property package for documentation.}""",
     CONFIG.declare(
         "outlet_list",
         ConfigValue(
-            domain=list_of_strings,
+            domain=ListOf(str),
             description="List of outlet names",
             doc="""A list containing names of outlets,
 **default** - None.

--- a/idaes/generic_models/unit_models/stoichiometric_reactor.py
+++ b/idaes/generic_models/unit_models/stoichiometric_reactor.py
@@ -16,7 +16,7 @@ Standard IDAES STOICHIOMETRIC reactor model
 
 # Import Pyomo libraries
 from pyomo.environ import Reference, Var, Block
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -84,7 +84,7 @@ balance type
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_of_reaction", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat of reaction term construction flag",
         doc="""Indicates whether terms for heat of reaction terms should be
 constructed,
@@ -94,7 +94,7 @@ constructed,
 **False** - exclude heat of reaction terms.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -103,7 +103,7 @@ constructed,
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/generic_models/unit_models/translator.py
+++ b/idaes/generic_models/unit_models/translator.py
@@ -14,9 +14,7 @@
 Generic template for a translator block.
 """
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
-from pyomo.environ import SolverFactory
-
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 # Import IDAES cores
 from idaes.core import declare_process_block_class, UnitModelBlockData
 from idaes.core.util.config import is_physical_parameter_block
@@ -61,7 +59,7 @@ class TranslatorData(UnitModelBlockData):
         "outlet_state_defined",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Indicated whether outlet state will be fully defined",
             doc="""Indicates whether unit model will fully define outlet state.
 If False, the outlet property package will enforce constraints such as sum
@@ -77,7 +75,7 @@ constraints.}""",
         "has_phase_equilibrium",
         ConfigValue(
             default=False,
-            domain=In([True, False]),
+            domain=Bool,
             description="Indicates whether outlet is in phase equilibrium",
             doc="""Indicates whether outlet property package should enforce
 phase equilibrium constraints.

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/column.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/column.py
@@ -31,9 +31,9 @@ from enum import Enum
 
 # Import Pyomo libraries
 from pyomo.environ import (Constraint, Expression, Param, Reals, NonNegativeReals,
-                           value, Var, exp, SolverFactory, SolverStatus,
+                           value, Var, exp, SolverStatus,
                            units as pyunits)
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES Libraries
 from idaes.core.util.constants import Constants as CONST
@@ -148,7 +148,7 @@ discretizing length domain (default=3)"""))
         doc="Packing porosity or void fraction (default= 0.97 )"))
     CONFIG.declare("fix_column_pressure", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Indicates whether the column pressure should be fixed",
         doc="""Indicates whether the column pressure should be fixed or not.
 The momentum balances are not added when this is True.
@@ -164,7 +164,7 @@ The momentum balances are not added when this is True.
     # Populate the phase side template to default values
     _PhaseCONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be constructed,
 **default** - False.

--- a/idaes/power_generation/unit_models/balance.py
+++ b/idaes/power_generation/unit_models/balance.py
@@ -19,7 +19,7 @@ __author__ = "John Eslick"
 
 # Import Pyomo libraries
 from pyomo.environ import Reference
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -127,7 +127,7 @@ balance type
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     config.declare("has_phase_equilibrium", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Phase equilibrium construction flag",
         doc="""Indicates whether terms for phase equilibrium should be
 constructed, **default** = False.
@@ -136,7 +136,7 @@ constructed, **default** = False.
 **False** - exclude phase equilibrium terms.}"""))
     config.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -163,13 +163,13 @@ and used when constructing these,
 see property package for documentation.}"""))
     config.declare("has_work_transfer", ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="True if model a has work transfer term.",
         )
     )
     config.declare("has_heat_transfer", ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="True if model has a heat transfer term.",
         )
     )

--- a/idaes/power_generation/unit_models/boiler_fireside.py
+++ b/idaes/power_generation/unit_models/boiler_fireside.py
@@ -68,7 +68,7 @@ The surrogate models are typically a function of:
 
 """
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (declare_process_block_class,
@@ -83,12 +83,10 @@ import idaes.logger as idaeslog
 
 
 # Additional import for the unit operation
-from pyomo.environ import \
-    SolverFactory, Var, Param, exp, log, RangeSet, Constraint
+from pyomo.environ import Var, Param, exp, RangeSet, Constraint, log
 import idaes.core.util.scaling as iscale
 from idaes.core.util.constants import Constants as const
 from idaes.core.util import get_solver
-from idaes.core.util.exceptions import ConfigurationError
 
 __author__ = "Boiler Team (J. Ma, M. Zamarripa)"
 __version__ = "1.0.0"
@@ -114,7 +112,7 @@ Boiler fire-side surrogate model with enforced mass and energy balance
 **False** - set as a steady-state model.}"""))
     CONFIG.declare("has_holdup", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Holdup construction flag",
         doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,
@@ -141,7 +139,7 @@ and used when constructing these,
 see property package for documentation.}"""))
     CONFIG.declare("calculate_PA_SA_flows", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether the primary air and secondary air calculations
 have to be constructed or not,
@@ -156,7 +154,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
         doc='number of boiler zones'))
     CONFIG.declare("has_platen_superheater", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="True if boiler includes a platen superheater",
         doc="""Indicates if boiler includes a platen superheater,
 **default** - True.
@@ -165,7 +163,7 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
 **False** - exclude heat duty to platen superheater.}"""))
     CONFIG.declare("has_roof_superheater", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="True if roof is treated as a superheater",
         doc="""Indicates if roof is a section of superheater,
 **default** - True.

--- a/idaes/power_generation/unit_models/boiler_fireside.py
+++ b/idaes/power_generation/unit_models/boiler_fireside.py
@@ -68,7 +68,7 @@ The surrogate models are typically a function of:
 
 """
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
+from pyomo.common.config import ConfigBlock, ConfigValue, Bool
 
 # Import IDAES cores
 from idaes.core import (declare_process_block_class,
@@ -77,7 +77,7 @@ from idaes.core import (declare_process_block_class,
 
 from idaes.core.util.model_statistics import degrees_of_freedom
 
-from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.config import is_physical_parameter_block, DefaultBool
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
 
@@ -101,7 +101,7 @@ Boiler fire-side surrogate model with enforced mass and energy balance
 
     CONFIG = ConfigBlock()
     CONFIG.declare("dynamic", ConfigValue(
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         default=useDefault,
         description="Dynamic model flag",
         doc="""Indicates whether this model will be dynamic or not,

--- a/idaes/power_generation/unit_models/boiler_heat_exchanger.py
+++ b/idaes/power_generation/unit_models/boiler_heat_exchanger.py
@@ -38,11 +38,10 @@ import logging
 from enum import Enum
 
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 # Additional import for the unit operation
-from pyomo.environ import SolverFactory, value, Var, Param, exp, sqrt,\
+from pyomo.environ import value, Var, Param, exp, sqrt,\
     log, PositiveReals, NonNegativeReals, units as pyunits
-from pyomo.opt import TerminationCondition
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -176,7 +175,7 @@ see property package for documentation.}"""))
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/power_generation/unit_models/boiler_heat_exchanger.py
+++ b/idaes/power_generation/unit_models/boiler_heat_exchanger.py
@@ -52,7 +52,7 @@ from idaes.core import (ControlVolume0DBlock,
                         UnitModelBlockData,
                         useDefault)
 
-from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.config import is_physical_parameter_block, DefaultBool
 from idaes.core.util.misc import add_object_reference
 from idaes.core.util.constants import Constants as c
 from idaes.core.util import get_solver
@@ -84,7 +84,7 @@ class BoilerHeatExchangerData(UnitModelBlockData):
     """
     CONFIG = ConfigBlock()
     CONFIG.declare("dynamic", ConfigValue(
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         default=useDefault,
         description="Dynamic model flag",
         doc="""Indicates whether this model will be dynamic or not,
@@ -95,7 +95,7 @@ class BoilerHeatExchangerData(UnitModelBlockData):
 **False** - set as a steady-state model.}"""))
     CONFIG.declare("has_holdup", ConfigValue(
         default=useDefault,
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         description="Holdup construction flag",
         doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,

--- a/idaes/power_generation/unit_models/boiler_heat_exchanger_2D.py
+++ b/idaes/power_generation/unit_models/boiler_heat_exchanger_2D.py
@@ -23,10 +23,10 @@ model)
 
 """
 # Import Pyomo libraries
-from pyomo.environ import (SolverFactory, Var, Param, Constraint,
+from pyomo.environ import (Var, Param, Constraint,
                            TransformationFactory, Reference,
                            value, exp, sqrt, log, log10, sin, cos)
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume1DBlock,
@@ -96,7 +96,7 @@ class HeatExchangerCrossFlow2D_HeaderData(UnitModelBlockData):
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     _SideTemplate.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -203,7 +203,7 @@ tube side flows from 1 to 0"""))
         domain (default=5)."""))
     CONFIG.declare("has_header", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Flag to include tube header",
         doc="""If has_header is True, user must provide header thickness and
         inner diameter."""))
@@ -318,22 +318,22 @@ tube side flows from 1 to 0"""))
                                      'tube_thickness')
         # header inputs:
         if self.config.has_header is False and \
-            self.config.header_inner_diameter is True:
+                self.config.header_inner_diameter is True:
             _log.info_high("User set has_header to False "
                            "and provided header_inner_diameter")
 
         if self.config.has_header and \
-            self.config.header_inner_diameter is None:
+                self.config.header_inner_diameter is None:
             raise ConfigurationError('If has_heder is True, user must '
                                      'provide header_inner_diameter')
 
         if self.config.has_header is False and \
-            self.config.header_wall_thickness is True:
+                self.config.header_wall_thickness is True:
             _log.info_high("User set has_header to False "
                            "and provided header_wall_thickness")
 
         if self.config.has_header and \
-            self.config.header_wall_thickness is None:
+                self.config.header_wall_thickness is None:
             raise ConfigurationError(
                 'If has_heder is True, user must '
                 'provide header_wall_thickness')

--- a/idaes/power_generation/unit_models/downcomer.py
+++ b/idaes/power_generation/unit_models/downcomer.py
@@ -32,7 +32,7 @@ from idaes.core import (ControlVolume0DBlock,
                         UnitModelBlockData,
                         useDefault)
 
-from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.config import is_physical_parameter_block, DefaultBool
 
 # Additional import for the unit operation
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -53,7 +53,7 @@ class DowncomerData(UnitModelBlockData):
     """
     CONFIG = ConfigBlock()
     CONFIG.declare("dynamic", ConfigValue(
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         default=useDefault,
         description="Dynamic model flag",
         doc="""Indicates whether this model will be dynamic or not,

--- a/idaes/power_generation/unit_models/downcomer.py
+++ b/idaes/power_generation/unit_models/downcomer.py
@@ -20,9 +20,8 @@ Main assumptions:
 Created August 27, 2020
 """
 # Import Pyomo libraries
-from pyomo.environ import (
-    SolverFactory, value, Var, Reference, units as pyunits)
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.environ import value, Var, Reference, units as pyunits
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -65,7 +64,7 @@ class DowncomerData(UnitModelBlockData):
 **False** - set as a steady-state model.}"""))
     CONFIG.declare("has_holdup", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Holdup construction flag",
         doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,
@@ -111,7 +110,7 @@ Must be True if dynamic = True,
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.

--- a/idaes/power_generation/unit_models/drum.py
+++ b/idaes/power_generation/unit_models/drum.py
@@ -48,7 +48,7 @@ are mixed before entering drum
 Created: August 19 2020
 """
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 import pyomo.environ as pyo
 # Import IDAES cores
 from idaes.core import (
@@ -64,7 +64,7 @@ import idaes.logger as idaeslog
 
 from idaes.core.util.config import is_physical_parameter_block
 # Additional import for the unit operation
-from pyomo.environ import SolverFactory, Var, asin, cos
+from pyomo.environ import Var, asin, cos
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.initialization import fix_state_vars, revert_state_vars
 from pyomo.network import Port
@@ -99,7 +99,7 @@ class DrumData(UnitModelBlockData):
 **False** - set as a steady-state model.}"""))
     CONFIG.declare("has_holdup", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Holdup construction flag",
         doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,
@@ -145,7 +145,7 @@ Must be True if dynamic = True,
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -154,7 +154,7 @@ Must be True if dynamic = True,
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/power_generation/unit_models/drum.py
+++ b/idaes/power_generation/unit_models/drum.py
@@ -62,7 +62,7 @@ from idaes.core import (
 )
 import idaes.logger as idaeslog
 
-from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.config import is_physical_parameter_block, DefaultBool
 # Additional import for the unit operation
 from pyomo.environ import Var, asin, cos
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -88,7 +88,7 @@ class DrumData(UnitModelBlockData):
     """
     CONFIG = ConfigBlock()
     CONFIG.declare("dynamic", ConfigValue(
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         default=useDefault,
         description="Dynamic model flag",
         doc="""Indicates whether this model will be dynamic or not,

--- a/idaes/power_generation/unit_models/drum1D.py
+++ b/idaes/power_generation/unit_models/drum1D.py
@@ -64,11 +64,10 @@ from idaes.core import (
 import idaes.logger as idaeslog
 # Import Pyomo libraries
 from pyomo.dae import ContinuousSet, DerivativeVar
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from idaes.core.util.config import is_physical_parameter_block
 # Additional import for the unit operation
-from pyomo.environ import (SolverFactory,
-                           value,
+from pyomo.environ import (value,
                            Var,
                            Param,
                            Reference,
@@ -142,7 +141,7 @@ class Drum1DData(UnitModelBlockData):
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -151,7 +150,7 @@ class Drum1DData(UnitModelBlockData):
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/power_generation/unit_models/feedwater_heater_0D.py
+++ b/idaes/power_generation/unit_models/feedwater_heater_0D.py
@@ -27,8 +27,8 @@ are two models included here.
 
 __author__ = "John Eslick"
 
-from pyomo.common.config import ConfigValue, In, ConfigBlock
-from pyomo.environ import SolverFactory, TransformationFactory, Var, value
+from pyomo.common.config import ConfigValue, In, ConfigBlock, Bool
+from pyomo.environ import TransformationFactory, Var, value
 from pyomo.network import Arc
 
 from idaes.core import (
@@ -53,7 +53,7 @@ def _define_feedwater_heater_0D_config(config):
         "has_drain_mixer",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Add a mixer to the inlet of the condensing section",
             doc="""Add a mixer to the inlet of the condensing section to add
 water from the drain of another feedwaterheater to the steam, if True""",
@@ -63,7 +63,7 @@ water from the drain of another feedwaterheater to the steam, if True""",
         "has_desuperheat",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Add a mixer desuperheat section to the heat exchanger",
             doc="Add a mixer desuperheat section to the heat exchanger",
         ),
@@ -72,7 +72,7 @@ water from the drain of another feedwaterheater to the steam, if True""",
         "has_drain_cooling",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Add a section after condensing section cool condensate.",
             doc="Add a section after condensing section to cool condensate.",
         ),

--- a/idaes/power_generation/unit_models/feedwater_heater_0D_dynamic.py
+++ b/idaes/power_generation/unit_models/feedwater_heater_0D_dynamic.py
@@ -26,9 +26,8 @@ are two models included here.
 """
 
 __author__ = "John Eslick, Jinliang Ma"
-from pyomo.common.config import ConfigValue, In, ConfigBlock
+from pyomo.common.config import ConfigValue, In, ConfigBlock, Bool
 from pyomo.environ import (
-    SolverFactory,
     TransformationFactory,
     Var,
     value,
@@ -63,7 +62,7 @@ def _define_feedwater_heater_0D_config(config):
         "has_drain_mixer",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Add a mixer to the inlet of the condensing section",
             doc="""Add a mixer to the inlet of the condensing section to add
 water from the drain of another feedwaterheater to the steam, if True""",
@@ -73,7 +72,7 @@ water from the drain of another feedwaterheater to the steam, if True""",
         "has_desuperheat",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Add a desuperheat section to the heat exchanger",
             doc="Add a mixer desuperheat section to the heat exchanger",
         ),
@@ -82,7 +81,7 @@ water from the drain of another feedwaterheater to the steam, if True""",
         "has_drain_cooling",
         ConfigValue(
             default=True,
-            domain=In([True, False]),
+            domain=Bool,
             description="Add a drain cooler section to the heat exchanger.",
             doc="Add a section after condensing section to cool condensate.",
         ),

--- a/idaes/power_generation/unit_models/heat_exchanger_3streams.py
+++ b/idaes/power_generation/unit_models/heat_exchanger_3streams.py
@@ -15,7 +15,7 @@
 side 1 is hot stream, side 2 and 3 are cold streams
 """
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -34,7 +34,7 @@ import idaes.logger as idaeslog
 
 
 # Additional import for the unit operation
-from pyomo.environ import SolverFactory, Var, Reference
+from pyomo.environ import Var, Reference
 
 __author__ = "Boiler Subsystem Team (J. Ma, M. Zamarripa)"
 __version__ = "1.0.0"
@@ -135,7 +135,7 @@ see property package for documentation.}"""))
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -144,7 +144,7 @@ see property package for documentation.}"""))
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/power_generation/unit_models/helm/mixer.py
+++ b/idaes/power_generation/unit_models/helm/mixer.py
@@ -19,7 +19,7 @@ from pyomo.environ import (
     SolverFactory,
     value
 )
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 
 from idaes.core import (
     declare_process_block_class,
@@ -27,8 +27,7 @@ from idaes.core import (
     useDefault,
 )
 from idaes.core.util.config import (
-    is_physical_parameter_block,
-    list_of_strings,
+    is_physical_parameter_block
 )
 from idaes.core.util.exceptions import ConfigurationError
 
@@ -104,7 +103,7 @@ see property package for documentation.}""",
     CONFIG.declare(
         "inlet_list",
         ConfigValue(
-            domain=list_of_strings,
+            domain=ListOf(str),
             description="List of inlet names",
             doc="""A list containing names of inlets,
 **default** - None.

--- a/idaes/power_generation/unit_models/helm/splitter.py
+++ b/idaes/power_generation/unit_models/helm/splitter.py
@@ -21,14 +21,14 @@ This model is psuedo-steady-state when used in dynamic mode.
 """
 
 from pyomo.environ import SolverFactory, Var, value
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 
 from idaes.core import (
     declare_process_block_class,
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.util.config import is_physical_parameter_block, list_of_strings
+from idaes.core.util.config import is_physical_parameter_block
 
 from idaes.core.util.exceptions import ConfigurationError
 from idaes.core.util import from_json, to_json, StoreSpec, get_solver
@@ -99,7 +99,7 @@ see property package for documentation.}""",
     CONFIG.declare(
         "outlet_list",
         ConfigValue(
-            domain=list_of_strings,
+            domain=ListOf(str),
             description="List of outlet names",
             doc="""A list containing names of outlets,
 **default** - None.

--- a/idaes/power_generation/unit_models/steamheater.py
+++ b/idaes/power_generation/unit_models/steamheater.py
@@ -21,9 +21,8 @@ and roof superheater, model main equations:
 
 """
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
-from pyomo.environ import SolverFactory, value, Var, \
-    Param, asin, cos, Reference
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
+from pyomo.environ import value, Var, Param, asin, cos, Reference
 from pyomo.core.expr.current import Expr_if
 from pyomo.dae import DerivativeVar
 
@@ -91,7 +90,7 @@ class SteamHeaterData(UnitModelBlockData):
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -100,7 +99,7 @@ class SteamHeaterData(UnitModelBlockData):
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -127,7 +126,7 @@ and used when constructing these,
 see property package for documentation.}"""))
     CONFIG.declare("single_side_only", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Flag indicating the heat is from one side of tubes only",
         doc="""Indicates whether tubes are heated from one side only,
 **default** - True.

--- a/idaes/power_generation/unit_models/waterpipe.py
+++ b/idaes/power_generation/unit_models/waterpipe.py
@@ -23,7 +23,7 @@ main equations:
 Created: April 2019 by Jinliang Ma
 """
 # Import Pyomo libraries
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -91,7 +91,7 @@ class WaterPipeData(UnitModelBlockData):
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -100,7 +100,7 @@ class WaterPipeData(UnitModelBlockData):
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/power_generation/unit_models/watertank.py
+++ b/idaes/power_generation/unit_models/watertank.py
@@ -30,8 +30,8 @@ are mixed before entering the tank
 Created: November 04 2020
 """
 # Import Pyomo libraries
-from pyomo.environ import SolverFactory, value, Var, Reference, acos
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.environ import value, Var, Reference, acos
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -115,7 +115,7 @@ provide the length and diameter.}"""))
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -124,7 +124,7 @@ provide the length and diameter.}"""))
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=True,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,

--- a/idaes/power_generation/unit_models/waterwall_section.py
+++ b/idaes/power_generation/unit_models/waterwall_section.py
@@ -23,10 +23,10 @@ main equations:
 
 """
 # Import Pyomo libraries
-from pyomo.environ import SolverFactory, value, Var, Param, \
+from pyomo.environ import value, Var, Param, \
     asin, cos, sqrt, log10, PositiveReals, Reference, units as pyunits
 from pyomo.dae import DerivativeVar
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.core.expr.current import Expr_if
 
 # Import IDAES cores
@@ -70,7 +70,7 @@ class WaterwallSectionData(UnitModelBlockData):
 **False** - set as a steady-state model.}"""))
     CONFIG.declare("has_holdup", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Holdup construction flag",
         doc="""Indicates whether holdup terms should be constructed or not.
 Must be True if dynamic = True,
@@ -116,7 +116,7 @@ Must be True if dynamic = True,
 **MomentumBalanceType.momentumPhase** - momentum balances for each phase.}"""))
     CONFIG.declare("has_heat_transfer", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat transfer term construction flag",
         doc="""Indicates whether terms for heat transfer should be constructed,
 **default** - False.
@@ -125,7 +125,7 @@ Must be True if dynamic = True,
 **False** - exclude heat transfer terms.}"""))
     CONFIG.declare("has_pressure_change", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Pressure change term construction flag",
         doc="""Indicates whether terms for pressure change should be
 constructed,
@@ -152,7 +152,7 @@ and used when constructing these,
 see property package for documentation.}"""))
     CONFIG.declare("rigorous_boiling", ConfigValue(
         default=False,
-        domain=In([True, False]),
+        domain=Bool,
         description="Heat of reaction term construction flag",
         doc="""Indicates whether terms for heat of reaction terms should be
 constructed,

--- a/idaes/power_generation/unit_models/waterwall_section.py
+++ b/idaes/power_generation/unit_models/waterwall_section.py
@@ -38,7 +38,7 @@ from idaes.core import (ControlVolume0DBlock,
                         UnitModelBlockData,
                         useDefault)
 
-from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.config import is_physical_parameter_block, DefaultBool
 import idaes.core.util.scaling as iscale
 from idaes.core.util import get_solver
 import idaes.logger as idaeslog
@@ -59,7 +59,7 @@ class WaterwallSectionData(UnitModelBlockData):
     """
     CONFIG = ConfigBlock()
     CONFIG.declare("dynamic", ConfigValue(
-        domain=In([useDefault, True, False]),
+        domain=DefaultBool,
         default=useDefault,
         description="Dynamic model flag",
         doc="""Indicates whether this model will be dynamic or not,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.1.2.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.1.2.idaes.2021.09.01.zip",
 ]
 
 


### PR DESCRIPTION
## Fixes #485


## Summary/Motivation:
Pyomo has introduced a new `ListOf` method for validating configuration domains, so this PR deprecates all the old methods we had for similar tasks in IDAES.

## Changes proposed in this PR:
- Bumps Pyomo tag to get changes to validators snice the 6.1.2 release.
- Add deprecation warning to all "list_of" methods in `idaes.core.util.config` and redirect them to the new `ListOf` method.
- Update all core models to use the `ListOf` method to clean up the resulting deprecation warnings (which were causing doc tests to fail).
- Change to us the new `Bool` validator in place of `In([True, False])`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
