### PR TITLE
Fix problem with mixing ideal and cubic eos

### DIFF
--- a/idaes/generic_models/properties/core/eos/ceos.py
+++ b/idaes/generic_models/properties/core/eos/ceos.py
@@ -150,7 +150,7 @@ class Cubic(EoSBase):
             try:
                 rule = m.params.get_phase(p).config.equation_of_state_options[
                     "mixing_rule_a"]
-            except KeyError:
+            except (KeyError, TypeError):
                 rule = MixingRuleA.default
 
             a = getattr(m, cname+"_a")
@@ -168,7 +168,7 @@ class Cubic(EoSBase):
             try:
                 rule = m.params.get_phase(p).config.equation_of_state_options[
                     "mixing_rule_b"]
-            except KeyError:
+            except (KeyError, TypeError):
                 rule = MixingRuleB.default
 
             b = getattr(m, cname+"_b")
@@ -253,7 +253,7 @@ class Cubic(EoSBase):
                 try:
                     rule = m.params.get_phase(p3).config.equation_of_state_options[
                         "mixing_rule_a"]
-                except KeyError:
+                except (KeyError, TypeError):
                     rule = MixingRuleA.default
 
                 a = getattr(m, "_"+cname+"_a_eq")


### PR DESCRIPTION
## Fixes

Fixes an error mixing cubic EOS in one phase with ideal in the other.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
