### PR TITLE
Reimplement _get_state_from_port

### DIFF
--- a/idaes/core/unit_model.py
+++ b/idaes/core/unit_model.py
@@ -139,10 +139,8 @@ Must be True if dynamic = True,
                                      "StateBlocks.".format(blk.name))
 
         # Create empty Port
-        p = Port(noruleinit=True, doc=doc)
+        p = Port(doc=doc)
         setattr(blk, name, p)
-
-        p._state_block = (block, )
 
         # Get dict of Port members and names
         member_list = block[
@@ -215,7 +213,7 @@ Must be True if dynamic = True,
             doc = "Inlet Port"
 
         # Create empty Port
-        p = Port(noruleinit=True, doc=doc)
+        p = Port(doc=doc)
         setattr(blk, name, p)
 
         # Get dict of Port members and names
@@ -223,19 +221,12 @@ Must be True if dynamic = True,
             try:
                 member_list = (block.properties_in[
                                     block.flowsheet().time.first()]
-                               .define_port_members())
-                p._state_block = (block.properties_in, )
+                                .define_port_members())
             except AttributeError:
                 try:
                     member_list = (block.properties[
                                     block.flowsheet().time.first(), 0]
-                                   .define_port_members())
-                    if block._flow_direction == FlowDirection.forward:
-                        p._state_block = (block.properties,
-                                          block.length_domain.first())
-                    elif block._flow_direction == FlowDirection.backward:
-                        p._state_block = (block.properties,
-                                          block.length_domain.last())
+                                    .define_port_members())
                 except AttributeError:
                     raise PropertyPackageError(
                             "{} property package does not appear to have "
@@ -245,7 +236,6 @@ Must be True if dynamic = True,
         elif isinstance(block, StateBlock):
             member_list = block[
                     blk.flowsheet().time.first()].define_port_members()
-            p._state_block = (block, )
         else:
             raise ConfigurationError(
                     "{} block provided to add_inlet_port "
@@ -370,7 +360,7 @@ Must be True if dynamic = True,
             doc = "Outlet Port"
 
         # Create empty Port
-        p = Port(noruleinit=True, doc=doc)
+        p = Port(doc=doc)
         setattr(blk, name, p)
 
         # Get dict of Port members and names
@@ -379,18 +369,11 @@ Must be True if dynamic = True,
                 member_list = (block.properties_out[
                                     block.flowsheet().time.first()]
                                .define_port_members())
-                p._state_block = (block.properties_out, )
             except AttributeError:
                 try:
                     member_list = (block.properties[
                                     block.flowsheet().time.first(), 0]
                                    .define_port_members())
-                    if block._flow_direction == FlowDirection.forward:
-                        p._state_block = (block.properties,
-                                          block.length_domain.last())
-                    elif block._flow_direction == FlowDirection.backward:
-                        p._state_block = (block.properties,
-                                          block.length_domain.first())
                 except AttributeError:
                     raise PropertyPackageError(
                             "{} property package does not appear to have "
@@ -400,7 +383,6 @@ Must be True if dynamic = True,
         elif isinstance(block, StateBlock):
             member_list = block[
                     blk.flowsheet().time.first()].define_port_members()
-            p._state_block = (block, )
         else:
             raise ConfigurationError(
                     "{} block provided to add_inlet_port "

--- a/idaes/core/util/tables.py
+++ b/idaes/core/util/tables.py
@@ -292,7 +292,7 @@ def _get_state_from_port(port,time_point):
     except AttributeError as err:
         raise AttributeError(
                 f"No block could be retrieved from Port {port.name} "
-                f"because block {vlist[0].parent_block()} is not indexed."
+                f"because block {vlist[0].parent_block()} has no index."
                 ) from err
     # Assuming the time index is always first and the spatial indices are all
     # the same

--- a/idaes/core/util/tables.py
+++ b/idaes/core/util/tables.py
@@ -303,7 +303,7 @@ def _get_state_from_port(port,time_point):
     except AttributeError as err:
         raise AttributeError(
                 f"No block could be retrieved from Port {port.name} "
-                f"because block {vlist[0].parent_block()} has no index."
+                f"because block {vlist[0].parent_block().name} has no index."
                 ) from err
     # Assuming the time index is always first and the spatial indices are all
     # the same

--- a/idaes/core/util/tests/test_tables.py
+++ b/idaes/core/util/tests/test_tables.py
@@ -546,7 +546,7 @@ def test_state_block_retrieval_fail(flash_model):
     # outlet ports. There is a mixture of references, expressions, and multiple
     # state blocks. Therefore we don't want any state block getting through.
     m = flash_model
-    with pytest.raises(AttributeError,
+    with pytest.raises(RuntimeError,
            match="No block could be retrieved from Port fs.flash.liq_outlet "
            "because components are derived from multiple blocks."
            ):
@@ -556,7 +556,7 @@ def test_state_block_retrieval_fail(flash_model):
 def test_state_block_retrieval_empty_port():
     m = ConcreteModel()
     m.p = Port()
-    with pytest.raises(AttributeError,
+    with pytest.raises(ValueError,
            match="No block could be retrieved from Port p because it contains "
            "no components."
            ):

--- a/idaes/core/util/tests/test_tables.py
+++ b/idaes/core/util/tests/test_tables.py
@@ -22,7 +22,7 @@ from pyomo.environ import (
     value,
     units as pyunits
 )
-from pyomo.network import Arc
+from pyomo.network import Arc, Port
 from idaes.core import (
     FlowsheetBlock,
     StateBlock,
@@ -553,7 +553,16 @@ def test_state_block_retrieval_fail(flash_model):
            "belong to a state block."
            ):
         df = create_stream_table_dataframe({"state": m.fs.flash.liq_outlet})
-        
+
+@pytest.mark.unit
+def test_state_block_retrieval_empty_port():
+    m = ConcreteModel()
+    m.p = Port()
+    with pytest.raises(AttributeError,
+           match="No state block could be retrieved from Port p because it "
+           "contains no variables."
+           ):
+        df = create_stream_table_dataframe({"state": m.p})
 @pytest.fixture()
 def distillation_model():
     m = ConcreteModel()

--- a/idaes/core/util/tests/test_tables.py
+++ b/idaes/core/util/tests/test_tables.py
@@ -548,9 +548,8 @@ def test_state_block_retrieval_fail(flash_model):
     m = flash_model
     with pytest.raises(TypeError,
            match="No state block could be retrieved from Port "
-           "fs.flash.liq_outlet because variable "
-           "fs.flash.split._Liq_flow_mol_phase_comp_ref\[0.0,p1,c1\] does not "
-           "belong to a state block."
+           "fs.flash.liq_outlet because Component fs.flash.split "
+           "is not indexed."
            ):
         df = create_stream_table_dataframe({"state": m.fs.flash.liq_outlet})
 
@@ -560,7 +559,7 @@ def test_state_block_retrieval_empty_port():
     m.p = Port()
     with pytest.raises(AttributeError,
            match="No state block could be retrieved from Port p because it "
-           "contains no variables."
+           "contains no components."
            ):
         df = create_stream_table_dataframe({"state": m.p})
 @pytest.fixture()

--- a/idaes/core/util/tests/test_tables.py
+++ b/idaes/core/util/tests/test_tables.py
@@ -546,10 +546,9 @@ def test_state_block_retrieval_fail(flash_model):
     # outlet ports. There is a mixture of references, expressions, and multiple
     # state blocks. Therefore we don't want any state block getting through.
     m = flash_model
-    with pytest.raises(TypeError,
-           match="No state block could be retrieved from Port "
-           "fs.flash.liq_outlet because Component fs.flash.split "
-           "is not indexed."
+    with pytest.raises(AttributeError,
+           match="No block could be retrieved from Port fs.flash.liq_outlet "
+           "because components are derived from multiple blocks."
            ):
         df = create_stream_table_dataframe({"state": m.fs.flash.liq_outlet})
 
@@ -558,8 +557,8 @@ def test_state_block_retrieval_empty_port():
     m = ConcreteModel()
     m.p = Port()
     with pytest.raises(AttributeError,
-           match="No state block could be retrieved from Port p because it "
-           "contains no components."
+           match="No block could be retrieved from Port p because it contains "
+           "no components."
            ):
         df = create_stream_table_dataframe({"state": m.p})
 @pytest.fixture()

--- a/idaes/core/util/tests/test_tables.py
+++ b/idaes/core/util/tests/test_tables.py
@@ -19,7 +19,8 @@ from pyomo.environ import (
     Expression,
     TransformationFactory,
     Var,
-    value
+    value,
+    units as pyunits
 )
 from pyomo.network import Arc
 from idaes.core import (
@@ -38,8 +39,12 @@ from idaes.core.util.tables import (
 )
 import idaes.generic_models.properties.examples.saponification_thermo as thermo_props
 import idaes.generic_models.properties.examples.saponification_reactions as rxn_props
-from idaes.generic_models.unit_models import CSTR
-
+from idaes.generic_models.unit_models import CSTR, Flash
+from idaes.generic_models.unit_models.heat_exchanger_1D import HeatExchanger1D as HX1D
+from idaes.core.util.testing import PhysicalParameterTestBlock
+from idaes.generic_models.unit_models.distillation import TrayColumn
+from idaes.generic_models.unit_models.distillation.condenser import CondenserType, TemperatureSpec
+from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VLE import BTXParameterBlock
 
 @pytest.fixture()
 def m():
@@ -448,3 +453,132 @@ def test_tag_states(gtmodel):
     tags["a_enth_mol_differ"].value = 1200
     assert value(m.state_a[0].enth_mol) == 1200
     assert value(m.state_a[0].temperature) == 1200*2
+
+@pytest.fixture()
+def HX1D_array_model():
+    # An example of maximum perversity. Dynamics, 1D control volumes, and 
+    # an indexed unit
+    unit_set = range(3)
+    time_set = [0,5]
+    time_units=pyunits.s
+    fs_cfg = {
+        "dynamic": True, "time_set": time_set, "time_units": time_units}
+    
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default=fs_cfg)
+
+    m.fs.properties = thermo_props.SaponificationParameterBlock()
+
+    m.fs.unit_array = HX1D(unit_set,default={
+            "shell_side": {"property_package": m.fs.properties},
+            "tube_side": {"property_package": m.fs.properties}})
+
+    def tube_stream_array_rule(b, i):
+        return {'source':b.unit_array[i].tube_outlet, 
+                'destination':b.unit_array[i+1].tube_inlet}
+    m.fs.tube_stream_array = Arc(range(2), rule=tube_stream_array_rule)
+    
+    def shell_stream_array_rule(b, i):
+        return {'source':b.unit_array[i+1].shell_outlet, 
+                'destination':b.unit_array[i].shell_inlet}
+    m.fs.shell_stream_array = Arc(range(1,-1,-1), rule=shell_stream_array_rule)
+
+    TransformationFactory("network.expand_arcs").apply_to(m)
+    return m
+
+@pytest.mark.unit
+def test_create_stream_table_dataframe_from_Port_HX1D(HX1D_array_model):
+    m = HX1D_array_model
+    df = create_stream_table_dataframe({
+            "state": m.fs.unit_array[0].tube_inlet})
+    
+    assert df.loc["Pressure"]["state"] == pytest.approx(101325)
+    assert df.loc["Temperature"]["state"] == pytest.approx(298.15)
+    assert df.loc["Volumetric Flowrate"]["state"] == pytest.approx(1.0)
+    assert df.loc["Molar Concentration H2O"]["state"] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration NaOH"]["state"] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration EthylAcetate"]["state"] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration SodiumAcetate"]["state"] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration Ethanol"]["state"] == pytest.approx(100.0)
+
+    df = create_stream_table_dataframe({
+            "state": m.fs.unit_array[0].tube_outlet})
+    
+    assert df.loc["Pressure"]["state"] == pytest.approx(101325)
+    assert df.loc["Temperature"]["state"] == pytest.approx(298.15)
+    assert df.loc["Volumetric Flowrate"]["state"] == pytest.approx(1.0)
+    assert df.loc["Molar Concentration H2O"]["state"] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration NaOH"]["state"] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration EthylAcetate"]["state"] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration SodiumAcetate"]["state"] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration Ethanol"]["state"] == pytest.approx(100.0)
+
+@pytest.mark.unit
+def test_create_stream_table_dataframe_from_Arc_HX1D(HX1D_array_model):
+    m = HX1D_array_model
+    df = create_stream_table_dataframe({
+            "state": m.fs.tube_stream_array},time_point=5)
+
+    for i in range(2):
+        stg = f"state[{i}]"
+    assert df.loc["Pressure"][stg] == pytest.approx(101325)
+    assert df.loc["Temperature"][stg] == pytest.approx(298.15)
+    assert df.loc["Volumetric Flowrate"][stg] == pytest.approx(1.0)
+    assert df.loc["Molar Concentration H2O"][stg] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration NaOH"][stg] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration EthylAcetate"][stg] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration SodiumAcetate"][stg] == pytest.approx(100.0)
+    assert df.loc["Molar Concentration Ethanol"][stg] == pytest.approx(100.0)
+        
+@pytest.fixture()
+def flash_model():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.properties = PhysicalParameterTestBlock()#default={"valid_phase": 
+                                                 # ('Liq', 'Vap')})
+    m.fs.flash = Flash(default={"property_package": m.fs.properties})
+    
+    return m
+
+@pytest.mark.unit
+def test_state_block_retrieval_fail(flash_model):
+    # The flash unit does not have real state blocks associated with the
+    # outlet ports. There is a mixture of references, expressions, and multiple
+    # state blocks. Therefore we don't want any state block getting through.
+    m = flash_model
+    with pytest.raises(TypeError,
+           match="No state block could be retrieved from Port "
+           "fs.flash.liq_outlet because variable "
+           "fs.flash.split._Liq_flow_mol_phase_comp_ref\[0.0,p1,c1\] does not "
+           "belong to a state block."
+           ):
+        df = create_stream_table_dataframe({"state": m.fs.flash.liq_outlet})
+        
+@pytest.fixture()
+def distillation_model():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.properties = BTXParameterBlock(default={"valid_phase": ('Liq', 'Vap'),
+                                            "activity_coeff_model": "Ideal",
+                                            "state_vars": "FTPz"})
+    m.fs.unit = TrayColumn(default={
+                        "number_of_trays": 3,
+                        "feed_tray_location": 2,
+                        "condenser_type":
+                            CondenserType.totalCondenser,
+                        "condenser_temperature_spec":
+                            TemperatureSpec.atBubblePoint,
+                        "property_package": m.fs.properties})
+    return m
+
+@pytest.mark.unit
+def test_extended_port_retrieval(distillation_model):
+    m = distillation_model
+    df = create_stream_table_dataframe({"state": m.fs.unit.feed})
+    stg = "state"
+    assert df.loc["pressure"][stg] == pytest.approx(101325)
+    assert df.loc["temperature"][stg] == pytest.approx(298.15)
+    assert df.loc["mole_frac_comp benzene"][stg] == pytest.approx(0.5)
+    assert df.loc["mole_frac_comp toluene"][stg] == pytest.approx(0.5)
+    assert df.loc["flow_mol"][stg] == pytest.approx(1)
+    

--- a/idaes/core/util/tests/test_tables.py
+++ b/idaes/core/util/tests/test_tables.py
@@ -588,4 +588,3 @@ def test_extended_port_retrieval(distillation_model):
     assert df.loc["mole_frac_comp benzene"][stg] == pytest.approx(0.5)
     assert df.loc["mole_frac_comp toluene"][stg] == pytest.approx(0.5)
     assert df.loc["flow_mol"][stg] == pytest.approx(1)
-    

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ kwargs = dict(
         "pandas",
         "pint",
         "psutil",
-        "pyomo>=6.0",
+        "pyomo>=6.1.2",
         "pytest",
         "pyyaml",
         "requests",  # for ui/fsvis


### PR DESCRIPTION
## Fixes
-Fixes issue with stream tables for the distillation column described in #96

## Summary/Motivation:
As suggested by #480, I took a look at `_get_state_from_port` to see whether we could make it public. Because it fails in instances where a naïve user might expect it to succeed (such as on the outlet ports of the Flash unit), I elected to not make it public at this time.  In the course of the investigation, however, I found that the previous implementation did not work when a port was extended through Pyomo (such as in the `TrayColumn` feed). Therefore I reimplemented it along the lines @jsiirola suggested in #480 . We can then close #480 as inadvisable at the moment.

## Changes proposed in this PR:
- Reimplement `_get_state_from_port`
- Remove the `_state_block` attribute from ports generated through `add_port` functions
- Add additional tests to ensure that the function works reliably for systems with dynamics, `1DControlVolume`s, and other edge cases.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
