### PR TITLE
Update Tagged SVG Output to use ModelTagGroups

### DIFF
--- a/docs/technical_specs/core/util/tags.rst
+++ b/docs/technical_specs/core/util/tags.rst
@@ -2,7 +2,7 @@ Tagging Classes
 ===============
 
 IDAES contains classes for tagging model quantities and grouping them.  The tags
-provide a convenient short cut to important model inputs and outputs and 
+provide a convenient short cut to important model inputs and outputs and
 facilities for numeric formatting and displaying output in desired units.
 
 Examples:
@@ -97,6 +97,24 @@ independently.
   assert abs(group["x"][1].expression.lb - 0.001) < 1e-5 # x is in kg
   assert abs(group["x"][1].expression.ub - 0.003) < 1e-5 # x is in kg
 
+When a tagged a quantity can vary over several orders of magnitude, it can be
+helpful to provide conditional formatting. To do this a callable can be provided
+as the ``format_string`` which takes the quantity value and returns a format
+string. A simple example is given below.
+
+.. testcode::
+
+  m = model()
+
+  tagw = ModelTag(
+    expr=m.w,
+    format_string=lambda x: "{:,.0f}" if x >= 100 else "{:.2f}",
+  )
+
+  tagw.set(1*pyo.units.g)
+  assert str(tagw[1, "a"]) == "1.00 g"
+  tagw.set(1*pyo.units.kg)
+  assert str(tagw[1,"a"]) == "1,000 g"
 
 Available Classes
 -----------------
@@ -106,3 +124,5 @@ Available Classes
 
 .. autoclass:: idaes.core.util.tags.ModelTagGroup
   :members:
+
+.. autofunction:: idaes.core.util.tags.svg_tag

--- a/docs/technical_specs/core/util/tags.rst
+++ b/docs/technical_specs/core/util/tags.rst
@@ -109,6 +109,7 @@ string. A simple example is given below.
   tagw = ModelTag(
     expr=m.w,
     format_string=lambda x: "{:,.0f}" if x >= 100 else "{:.2f}",
+    display_units=pyo.units.g,
   )
 
   tagw.set(1*pyo.units.g)

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -25,7 +25,7 @@ from pyomo.common.config import ConfigBlock
 
 import idaes.logger as idaeslog
 import idaes.core.solvers
-from idaes.core.util.tags import svg_tag
+from idaes.core.util.tags import svg_tag as svg_tag_new
 
 _log = idaeslog.getLogger(__name__)
 
@@ -117,7 +117,6 @@ def TagReference(s, description=""):
     return r
 
 
-# Author: John Eslick
 def copy_port_values(destination=None, source=None, arc=None,
         direction="forward"):
     """
@@ -130,6 +129,16 @@ def copy_port_values(destination=None, source=None, arc=None,
     from idaes.core.util.initialization import propagate_state
     propagate_state(destination=destination, source=source, arc=arc,
             direction=direction)
+
+
+def svg_tag(*args, **kwargs):
+    """
+    Moved to idaes.core.util.tags.svg_tag
+    Leaving redirection function here for deprecation warning.
+    """
+    _log.warning("DEPRECATED: idaes.core.util.misc.svg_tag has been deprecated. "
+        "It can now be imported from idaes.core.util.tags.svg_tag")
+    return svg_tag_new(*args, **kwargs)
 
 
 def set_param_from_config(b, param, config=None, index=None):

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -14,7 +14,6 @@
 """
 This module contains miscellaneous utility functions for use in IDAES models.
 """
-import xml.dom.minidom
 
 import pyomo.environ as pyo
 from pyomo.core.base.expression import _GeneralExpressionData
@@ -26,6 +25,7 @@ from pyomo.common.config import ConfigBlock
 
 import idaes.logger as idaeslog
 import idaes.core.solvers
+from idaes.core.util.tags import svg_tag
 
 _log = idaeslog.getLogger(__name__)
 
@@ -115,114 +115,6 @@ def TagReference(s, description=""):
     r = pyo.Reference(s)
     r.description = description
     return r
-
-
-# Author John Eslick
-def svg_tag(
-    tags,
-    svg,
-    outfile=None,
-    idx=None,
-    tag_map=None,
-    show_tags=False,
-    byte_encoding="utf-8",
-    tag_format=None,
-    tag_format_default="{:.4e}"
-):
-    """
-    Replace text in a SVG with tag values for the model. This works by looking
-    for text elements in the SVG with IDs that match the tags or are in tag_map.
-
-    Args:
-        tags: A dictionary where the key is the tag and the value is a Pyomo
-            Reference.  The reference could be indexed. In typical IDAES
-            applications the references would be indexed by time.
-        svg: a file pointer or a string continaing svg contents
-        outfile: a file name to save the results, if None don't save
-        idx: if None not indexed, otherwise an index in the indexing set of the
-            reference
-        tag_map: dictionary with svg id keys and tag values, to map svg ids to
-            tags
-        show_tags: Put tag labels of the diagram instead of numbers
-        byte_encoding: If svg is given as a byte-array, use this encoding to
-            convert it to a string.
-        tag_format: A dictionary of formatting strings.  If the formatting
-            string is a callable, it should be a function that takes the value
-            to display and returns a formatting string.
-        tag_format_default: The default formatting if not explicitly by
-            tag_format. If the formatting string is a callable, it should be a
-            function that takes the value to display and returns a formatting
-            string.
-
-    Returns:
-        SVG String
-    """
-    if tag_format is None:
-        tag_format = {}
-
-    if isinstance(svg, str):  # assume this is svg content string
-        pass
-    elif isinstance(svg, bytes):
-        svg = svg.decode(byte_encoding)
-    elif hasattr(svg, "read"):  # file-like object to svg
-        svg = svg.read()
-    else:
-        raise TypeError("SVG must either be a string or a file-like object")
-    # Make tag map here because the tags may not make valid XML IDs if no
-    # tag_map provided we'll go ahead and handle XML @ (maybe more in future)
-    if tag_map is None:
-        tag_map = dict()
-        for tag in tags:
-            new_tag = tag.replace("@", "_")
-            tag_map[new_tag] = tag
-    # Search for text in the svg that has an id in tags
-    doc = xml.dom.minidom.parseString(svg)
-    texts = doc.getElementsByTagName("text")
-    for t in texts:
-        id = t.attributes["id"].value
-        if id in tag_map:
-            # if it's multiline change last line
-            try:
-                tspan = t.getElementsByTagName("tspan")[-1]
-            except IndexError:
-                _log.warning(f"Text object but no tspan for tag {tag_map[id]}.")
-                _log.warning(f"Skipping output for {tag_map[id]}.")
-                continue
-            try:
-                tspan = tspan.childNodes[0]
-            except IndexError:
-                # No child node means there is a line with no text, so add some.
-                tspan.appendChild(doc.createTextNode(""))
-                tspan = tspan.childNodes[0]
-            try:
-                if show_tags:
-                    val = tag_map[id]
-                elif idx is None:
-                    val = pyo.value(tags[tag_map[id]], exception=False)
-                else:
-                    val = pyo.value(tags[tag_map[id]][idx], exception=False)
-            except ZeroDivisionError:
-                val = "Divide_by_0"
-            tf = tag_format.get(tag_map[id], tag_format_default)
-            try:
-                if callable(tf): # conditional formatting
-                    tspan.nodeValue = tf(val).format(val)
-                else:
-                    tspan.nodeValue = tf.format(val)
-            except ValueError:
-                # whatever it is, it doesn't match the format.  Usually this
-                # happens when a string is given, but it is using a default
-                # number format
-                tspan.nodeValue = val
-
-    new_svg = doc.toxml()
-    # If outfile is provided save to a file
-    if outfile is not None:
-        with open(outfile, "w") as f:
-            f.write(new_svg)
-    # Return the SVG as a string.  This lets you take several passes at adding
-    # output without saving and loading files.
-    return new_svg
 
 
 # Author: John Eslick

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -14,6 +14,7 @@
 """
 This module contains miscellaneous utility functions for use in IDAES models.
 """
+from pyomo.common.deprecation import deprecated
 
 import pyomo.environ as pyo
 from pyomo.core.base.expression import _GeneralExpressionData
@@ -130,14 +131,15 @@ def copy_port_values(destination=None, source=None, arc=None,
     propagate_state(destination=destination, source=source, arc=arc,
             direction=direction)
 
-
+@deprecated(
+    "idaes.core.util.misc.svg_tag has moved to idaes.core.util.tags.svg_tag",
+    version=1.12
+)
 def svg_tag(*args, **kwargs):
     """
     Moved to idaes.core.util.tags.svg_tag
     Leaving redirection function here for deprecation warning.
     """
-    _log.warning("DEPRECATED: idaes.core.util.misc.svg_tag has been deprecated. "
-        "It can now be imported from idaes.core.util.tags.svg_tag")
     return svg_tag_new(*args, **kwargs)
 
 

--- a/idaes/core/util/tags.py
+++ b/idaes/core/util/tags.py
@@ -16,6 +16,7 @@ and group them, for easy display, formatting, and input.
 import xml.dom.minidom
 
 import pyomo.environ as pyo
+from pyomo.common.deprecation import deprecation_warning
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 
 import idaes.logger as idaeslog
@@ -53,8 +54,8 @@ class ModelTag:
                 expression to tag. This can be a scalar or indexed.
             format_string: A formating string used to print an elememnt of the
                 tagged expression (e.g. '{:.3f}').
-            doc: A description of the tagged qunatity.
-            display_units: Pyomo units to display the qunatity in. If a string
+            doc: A description of the tagged quantity.
+            display_units: Pyomo units to display the quantity in. If a string
                 is provided it will be used to display as the unit, but will not
                 be used to convert units. If None, use native units of the
                 quantity.
@@ -261,7 +262,7 @@ class ModelTag:
 
     @property
     def is_indexed(self):
-        """Returns whether the tagged expression is a indexed."""
+        """Returns whether the tagged expression is an indexed."""
         try:
             return self.expression.is_indexed()
         except AttributeError:
@@ -276,7 +277,7 @@ class ModelTag:
 
     @property
     def indices(self):
-        """The index set of the tagged qunatity"""
+        """The index set of the tagged quantity"""
         if self.is_indexed:
             return list(self.expression.keys())
         return None
@@ -361,7 +362,7 @@ class ModelTag:
         try:
             try:
                 self.expression.set_value(val)
-            except ValueError:  # it's a indexed expression or slice
+            except ValueError:  # it's an indexed expression or slice
                 for index in self.expression:
                     self.expression[index].set_value(val)
         except AttributeError as attr_err:
@@ -391,7 +392,7 @@ class ModelTag:
         try:
             try:
                 self.expression.setlb(val)
-            except ValueError:  # it's a indexed expression or slice
+            except ValueError:  # it's an indexed expression or slice
                 for index in self.expression:
                     self.expression[index].lb(val)
         except AttributeError as attr_err:
@@ -421,7 +422,7 @@ class ModelTag:
         try:
             try:
                 self.expression.setub(val)
-            except ValueError:  # it's a indexed expression or slice
+            except ValueError:  # it's an indexed expression or slice
                 for index in self.expression:
                     self.expression[index].setub(val)
         except AttributeError as attr_err:
@@ -598,9 +599,10 @@ def svg_tag(
 
     # Deal with soon to be depricated input by converting it to new style
     if tags is not None:
-        _log.warning(
+        deprecation_warning(
             "DEPRECATED: svg_tag, the tags, tag_format and "
-            "tag_format_default arguments are deprecated use tag_group instead."
+            "tag_format_default arguments are deprecated use tag_group instead.",
+            version=1.12,
         )
         # As a temporary measure, allow a tag and tag format dict.  To simplfy
         # and make it easier to remove this option in the future, use the old

--- a/idaes/core/util/tags.py
+++ b/idaes/core/util/tags.py
@@ -138,7 +138,7 @@ class ModelTag:
             # Probably trying to put None through the numeric format.  This
             # can happen for example when variables don't have values.  I'll
             # allow 'None' to be printed.  It's not uncommon to happen, and I
-            # don't want to raise an exception. 
+            # don't want to raise an exception.
             return str(val)
 
     def _join_units(self, index=None, format_string=None):
@@ -271,14 +271,7 @@ class ModelTag:
 
     @property
     def is_indexed(self):
-        """Returns whether the tagged expression is a indexed.
-
-        Args:
-            None
-
-        Returns:
-            True if tagged expression is a variable
-        """
+        """Returns whether the tagged expression is a indexed."""
         try:
             return self.expression.is_indexed()
         except AttributeError:

--- a/idaes/core/util/tags.py
+++ b/idaes/core/util/tags.py
@@ -18,6 +18,10 @@ import xml.dom.minidom
 import pyomo.environ as pyo
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 
+import idaes.logger as idaeslog
+
+_log = idaeslog.getLogger(__name__)
+
 __Author__ = "John Eslick"
 
 
@@ -201,8 +205,7 @@ class ModelTag:
         except KeyError as key_err:
             if self._name is None:
                 raise KeyError(f"{index} not a valid key for tag") from key_err
-            raise KeyError(
-                f"{index} not a valid key for tag {self._name}") from key_err
+            raise KeyError(f"{index} not a valid key for tag {self._name}") from key_err
         except TypeError:
             expr = self.expression
 
@@ -250,8 +253,7 @@ class ModelTag:
 
     @property
     def is_slice(self):
-        """Whether the tagged expression is a Pyomo slice.
-        """
+        """Whether the tagged expression is a Pyomo slice."""
         try:
             return isinstance(self._expression, IndexedComponent_slice)
         except AttributeError:
@@ -259,8 +261,7 @@ class ModelTag:
 
     @property
     def is_indexed(self):
-        """Returns whether the tagged expression is a indexed.
-        """
+        """Returns whether the tagged expression is a indexed."""
         try:
             return self.expression.is_indexed()
         except AttributeError:
@@ -268,32 +269,28 @@ class ModelTag:
 
     @property
     def indexes(self):
-        """The index set of the tagged quantity
-        """
+        """The index set of the tagged quantity"""
         if self.is_indexed:
             return list(self.expression.keys())
         return None
 
     @property
     def indices(self):
-        """The index set of the tagged qunatity
-        """
+        """The index set of the tagged qunatity"""
         if self.is_indexed:
             return list(self.expression.keys())
         return None
 
     @property
     def group(self):
-        """The ModelTagGroup object that this belongs to, if any.
-        """
+        """The ModelTagGroup object that this belongs to, if any."""
         if self._root is not None:
             return self._root.group
         return self._group
 
     @group.setter
     def group(self, val):
-        """The ModelTagGroup object that this belongs to, if any.
-        """
+        """The ModelTagGroup object that this belongs to, if any."""
         if self._root is not None:
             raise RuntimeError("group is superseded by the root property.")
         self._group = val
@@ -361,11 +358,10 @@ class ModelTag:
             if self._display_units is not None:
                 val *= self._display_units
 
-
         try:
             try:
                 self.expression.set_value(val)
-            except ValueError: # it's a indexed expression or slice
+            except ValueError:  # it's a indexed expression or slice
                 for index in self.expression:
                     self.expression[index].set_value(val)
         except AttributeError as attr_err:
@@ -373,9 +369,7 @@ class ModelTag:
                 raise AttributeError(
                     f"Tagged expression {self._name}, has no set_value()."
                 ) from attr_err
-            raise AttributeError(
-                "Tagged expression has no set_value()."
-            ) from attr_err
+            raise AttributeError("Tagged expression has no set_value().") from attr_err
 
     def setlb(self, val, in_display_units=None):
         """Set the lower bound of a tagged variable.
@@ -394,11 +388,10 @@ class ModelTag:
             if self._display_units is not None:
                 val *= self._display_units
 
-
         try:
             try:
                 self.expression.setlb(val)
-            except ValueError: # it's a indexed expression or slice
+            except ValueError:  # it's a indexed expression or slice
                 for index in self.expression:
                     self.expression[index].lb(val)
         except AttributeError as attr_err:
@@ -406,9 +399,7 @@ class ModelTag:
                 raise AttributeError(
                     f"Tagged expression {self._name}, has no setlb()."
                 ) from attr_err
-            raise AttributeError(
-                "Tagged expression has no setlb()."
-            ) from attr_err
+            raise AttributeError("Tagged expression has no setlb().") from attr_err
 
     def setub(self, val, in_display_units=None):
         """Set the value of a tagged variable.
@@ -430,7 +421,7 @@ class ModelTag:
         try:
             try:
                 self.expression.setub(val)
-            except ValueError: # it's a indexed expression or slice
+            except ValueError:  # it's a indexed expression or slice
                 for index in self.expression:
                     self.expression[index].setub(val)
         except AttributeError as attr_err:
@@ -438,9 +429,7 @@ class ModelTag:
                 raise AttributeError(
                     f"Tagged expression {self._name}, has no setub()."
                 ) from attr_err
-            raise AttributeError(
-                "Tagged expression has no setub()."
-            ) from attr_err
+            raise AttributeError("Tagged expression has no setub().") from attr_err
 
     def fix(self, val=None, in_display_units=None):
         """Fix the value of a tagged variable.
@@ -570,6 +559,7 @@ class ModelTagGroup(dict):
         """
         self._set_in_display_units = value
 
+
 # Author John Eslick
 def svg_tag(
     tags=None,
@@ -581,7 +571,7 @@ def svg_tag(
     show_tags=False,
     byte_encoding="utf-8",
     tag_format=None,
-    tag_format_default="{:.4e}"
+    tag_format_default="{:.4e}",
 ):
     """
     Replace text in a SVG with tag values for the model. This works by looking
@@ -608,8 +598,10 @@ def svg_tag(
 
     # Deal with soon to be depricated input by converting it to new style
     if tags is not None:
-        _log.warning("DEPRECATED: svg_tag, the tags, tag_format and "
-            "tag_format_default arguments are deprecated use tag_group instead.")
+        _log.warning(
+            "DEPRECATED: svg_tag, the tags, tag_format and "
+            "tag_format_default arguments are deprecated use tag_group instead."
+        )
         # As a temporary measure, allow a tag and tag format dict.  To simplfy
         # and make it easier to remove this option in the future, use the old
         # style input to make a ModelTagGroup object.
@@ -622,13 +614,13 @@ def svg_tag(
             tag_group.str_include_units = False
 
     # get SVG content string
-    if isinstance(svg, str): # already a string
+    if isinstance(svg, str):  # already a string
         pass
-    elif isinstance(svg, bytes): # bytes to string
-        svg = svg.decode(byte_encoding) # file-like to string
+    elif isinstance(svg, bytes):  # bytes to string
+        svg = svg.decode(byte_encoding)  # file-like to string
     elif hasattr(svg, "read"):
         svg = svg.read()
-    else: # Can't handle whatever this is.
+    else:  # Can't handle whatever this is.
         raise TypeError("SVG must either be a string or a file-like object")
 
     # Make tag map here because the tags may not make valid XML IDs if no

--- a/idaes/core/util/tags.py
+++ b/idaes/core/util/tags.py
@@ -608,6 +608,8 @@ def svg_tag(
 
     # Deal with soon to be depricated input by converting it to new style
     if tags is not None:
+        _log.warning("DEPRECATED: svg_tag, the tags, tag_format and "
+            "tag_format_default arguments are deprecated use tag_group instead.")
         # As a temporary measure, allow a tag and tag format dict.  To simplfy
         # and make it easier to remove this option in the future, use the old
         # style input to make a ModelTagGroup object.

--- a/idaes/core/util/tags.py
+++ b/idaes/core/util/tags.py
@@ -242,12 +242,6 @@ class ModelTag:
     def is_var(self):
         """Whether the tagged expression is a Pyomo Var. Tagged variables
         can be fixed or set, while expressions cannot.
-
-        Args:
-            None
-
-        Returns:
-            True if tagged expression is a variable
         """
         try:
             return issubclass(self._expression.ctype, pyo.Var)
@@ -257,12 +251,6 @@ class ModelTag:
     @property
     def is_slice(self):
         """Whether the tagged expression is a Pyomo slice.
-
-        Args:
-            None
-
-        Returns:
-            True if tagged expression is a Pyomo component slice
         """
         try:
             return isinstance(self._expression, IndexedComponent_slice)
@@ -271,7 +259,8 @@ class ModelTag:
 
     @property
     def is_indexed(self):
-        """Returns whether the tagged expression is a indexed."""
+        """Returns whether the tagged expression is a indexed.
+        """
         try:
             return self.expression.is_indexed()
         except AttributeError:
@@ -279,28 +268,32 @@ class ModelTag:
 
     @property
     def indexes(self):
-        """The index set of the tagged quantity"""
+        """The index set of the tagged quantity
+        """
         if self.is_indexed:
             return list(self.expression.keys())
         return None
 
     @property
     def indices(self):
-        """The index set of the tagged qunatity"""
+        """The index set of the tagged qunatity
+        """
         if self.is_indexed:
             return list(self.expression.keys())
         return None
 
     @property
     def group(self):
-        """The ModelTagGroup object that this belongs to, if any."""
+        """The ModelTagGroup object that this belongs to, if any.
+        """
         if self._root is not None:
             return self._root.group
         return self._group
 
     @group.setter
     def group(self, val):
-        """The ModelTagGroup object that this belongs to, if any."""
+        """The ModelTagGroup object that this belongs to, if any.
+        """
         if self._root is not None:
             raise RuntimeError("group is superseded by the root property.")
         self._group = val

--- a/idaes/core/util/tests/test_tag_svg.py
+++ b/idaes/core/util/tests/test_tag_svg.py
@@ -277,3 +277,7 @@ def test_tag_reference_tag_format_conditional():
     assert("10,000 kPa" in xml_str)
     assert("1.10 kPa" in xml_str)
     assert("4.50 kPa" in xml_str)
+
+if __name__ == "__main__":
+    # Check deprication warnings
+    test_tag_reference_tag_format_conditional()

--- a/idaes/core/util/tests/test_tag_svg.py
+++ b/idaes/core/util/tests/test_tag_svg.py
@@ -268,7 +268,6 @@ def test_tag_reference_tag_format_conditional():
     test_tag["TAGME@4.f"] = TagReference(m.f[:], description="z tag")
     m.tag = test_tag
 
-
     xml_str = svg_tag(
         m.tag,
         svg_test_str,

--- a/idaes/core/util/tests/test_tags.py
+++ b/idaes/core/util/tests/test_tags.py
@@ -61,6 +61,41 @@ def test_tag_display(model):
     assert str(tz) == "7.0"
 
 @pytest.mark.unit
+def test_tag_conditional_formatting(model):
+    m = model
+
+    tx = ModelTag(
+        expr=m.x,
+        format_string=lambda x: "{:,.0f}" if x >= 100 else "{:.2f}",
+        doc="Tag for x",
+        display_units=pyo.units.g
+    )
+
+    tx.set(1*pyo.units.g)
+    assert str(tx[1]) == "1.00 g"
+    tx.set(1*pyo.units.kg)
+    assert str(tx[1]) == "1,000 g"
+
+@pytest.mark.unit
+def test_tag_errors(model):
+    m = model
+
+    tx = ModelTag(
+        expr=m.x,
+        format_string=lambda x: "{:,.0f}" if x >= 100 else "{:.2f}",
+        display_units=pyo.units.g
+    )
+    tg = ModelTag(
+        expr=m.g,
+        format_string="{:,.0f}",
+        display_units=None
+    )
+    m.x.fix(0)
+    assert str(tg[1, "a"]) == "ZeroDivisionError"
+    m.x.fix(None)
+    assert str(tg[1, "a"]) == "None"
+
+@pytest.mark.unit
 def test_tag_display_convert(model):
     m = model
     tw = ModelTag(expr=m.w, format_string="{:.3f}", doc="Tag for w", display_units=pyo.units.g)


### PR DESCRIPTION
This mainly updates updates the svg_tag function to use the new model tag classes.  It also move some feature (conditional formatting, division by zero trapping, and no value trapping) to model tags, as it was previously part of the svg output function.

I moved the svg_tag function and updated the API.  The new function support the old API and old import location.  At some future point we can add deprecation warnings.  I don't want to bother anyone with it yet though. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
