### PR TITLE
Removing deprecated features

### DIFF
--- a/docs/technical_specs/model_libraries/generic/control/pid.rst
+++ b/docs/technical_specs/model_libraries/generic/control/pid.rst
@@ -40,7 +40,7 @@ variables, expressions, and parameters in the PIDBlock, model see :ref:`PIDVarsS
   import pyomo.environ as pyo
 
   m = pyo.ConcreteModel(name="PID Example")
-  m.fs = FlowsheetBlock(default={"dynamic":True, "time_set":[0,10]})
+  m.fs = FlowsheetBlock(default={"dynamic":True, "time_set":[0,10], "time_units":pyo.units.s})
 
   m.fs.valve_opening = pyo.Var(m.fs.time, doc="Valve opening")
   m.fs.pressure = pyo.Var(m.fs.time, [1,2], doc="Pressure in unit 1 and 2")

--- a/idaes/apps/caprese/examples/cstr_model.py
+++ b/idaes/apps/caprese/examples/cstr_model.py
@@ -16,7 +16,7 @@ Test for Cappresse's module for NMPC.
 
 import pytest
 from pyomo.environ import (Block, ConcreteModel,  Constraint, Expression,
-                           Set, SolverFactory, Var, value, 
+                           Set, SolverFactory, Var, value, units as pyunits,
                            TransformationFactory, TerminationCondition)
 from pyomo.network import Arc
 from pyomo.common.collections import ComponentSet
@@ -56,7 +56,8 @@ def make_model(horizon=6, ntfe=60, ntcp=2,
         m.fs = FlowsheetBlock(default={'dynamic': False})
     else:
         m.fs = FlowsheetBlock(default={'dynamic': True,
-                                       'time_set': time_set})
+                                       'time_set': time_set,
+                                       'time_units': pyunits.minute})
 
     m.fs.properties = AqueousEnzymeParameterBlock()
     m.fs.reactions = EnzymeReactionParameterBlock(

--- a/idaes/core/components.py
+++ b/idaes/core/components.py
@@ -132,14 +132,9 @@ class ComponentData(ProcessBlockData):
                 self._add_to_electrolyte_component_list()
 
         base_units = self.parent_block().get_metadata().default_units
-        if isinstance(base_units["mass"], _PyomoUnit):
-            # Backwards compatability check
-            p_units = (base_units["mass"] /
-                       base_units["length"] /
-                       base_units["time"]**2)
-        else:
-            # Backwards compatability check
-            p_units = None
+        p_units = (base_units["mass"] /
+                   base_units["length"] /
+                   base_units["time"]**2)
 
         # Create Param for molecular weight if provided
         if "mw" in self.config.parameter_data:

--- a/idaes/core/flowsheet_model.py
+++ b/idaes/core/flowsheet_model.py
@@ -265,14 +265,15 @@ within this flowsheet if not otherwise specified,
                         .format(self.name))
 
         # Validate units for time domain
-        if self.config.time_units is None and self.config.dynamic:
-            _log.warning("DEPRECATED: No units were specified for the time "
-                         "domain. Users should provide units via the "
-                         "time_units configuration argument.")
+        if self.config.time is None and fs is not None:
+            # We will get units from parent
+            pass
+        elif self.config.time_units is None and self.config.dynamic:
+            raise ConfigurationError(
+                f"{self.name} - no units were specified for the time domain. "
+                f"Units must be be specified for dynamic models.")
         elif self.config.time_units is None and not self.config.dynamic:
-            _log.info_high("DEPRECATED: No units were specified for the time "
-                            "domain. Users should provide units via the "
-                            "time_units configuration argument.")
+            _log.debug("No units specified for stady-state time domain.")
         elif not isinstance(self.config.time_units, _PyomoUnit):
             raise ConfigurationError(
                 "{} unrecognised value for time_units argument. This must be "

--- a/idaes/core/property_base.py
+++ b/idaes/core/property_base.py
@@ -265,96 +265,42 @@ class PhysicalParameterBlock(ProcessBlockData,
                     .format(self.name, phase))
         return obj
 
-    # TODO : Deprecate this code at some point
     def _validate_parameter_block(self):
         """
-        Backwards compatability checks.
-
-        This is code to check for old-style property packages and create
-        the necessary Phase and Component objects.
-
-        It also tries to catch some possible mistakes and provide the user with
+        Tries to catch some possible mistakes and provide the user with
         useful error messages.
         """
         try:
             # Check names in component list have matching Component objects
             for c in self.component_list:
-                try:
-                    obj = getattr(self, str(c))
-                    if not isinstance(obj, ComponentData):
-                        raise TypeError(
-                                "Property package {} has an object {} whose "
-                                "name appears in component_list but is not an "
-                                "instance of Component".format(self.name, c))
-                except AttributeError:
-                    # No object with name c, must be old-style package
-                    self._make_component_objects()
-                    break
+                obj = getattr(self, str(c))
+                if not isinstance(obj, ComponentData):
+                    raise TypeError(
+                            "Property package {} has an object {} whose "
+                            "name appears in component_list but is not an "
+                            "instance of Component".format(self.name, c))
         except AttributeError:
             # No component list
-            raise PropertyPackageError("Property package {} has not defined a "
-                                       "component list.".format(self.name))
+            raise PropertyPackageError(
+                f"Property package {self.name} has not defined any "
+                f"Components.")
 
         try:
             # Valdiate that names in phase list have matching Phase objects
             for p in self.phase_list:
-                try:
-                    obj = getattr(self, str(p))
-                    if not isinstance(obj, PhaseData):
-                        raise TypeError(
-                                "Property package {} has an object {} whose "
-                                "name appears in phase_list but is not an "
-                                "instance of Phase".format(self.name, p))
-                except AttributeError:
-                    # No object with name p, must be old-style package
-                    self._make_phase_objects()
-                    break
+                obj = getattr(self, str(p))
+                if not isinstance(obj, PhaseData):
+                    raise TypeError(
+                            "Property package {} has an object {} whose "
+                            "name appears in phase_list but is not an "
+                            "instance of Phase".format(self.name, p))
         except AttributeError:
             # No phase list
-            raise PropertyPackageError("Property package {} has not defined a "
-                                       "phase list.".format(self.name))
+            raise PropertyPackageError(
+                f"Property package {self.name} has not defined any Phases.")
 
         # Also check that the phase-component set has been created.
         self.get_phase_component_set()
-
-    def _make_component_objects(self):
-        _log.warning("DEPRECATED: {} appears to be an old-style property "
-                     "package. It will be automatically converted to a "
-                     "new-style package, however users are strongly encouraged"
-                     " to convert their property packages to use phase and "
-                     "component objects."
-                     .format(self.name))
-        for c in self.component_list:
-            if hasattr(self, c):
-                # An object with this name already exists, raise exception
-                raise PropertyPackageError(
-                    "{} could not add Component object {} - an object with "
-                    "that name already exists.".format(self.name, c))
-
-            self.add_component(str(c), Component(
-                default={"_component_list_exists": True}))
-
-    def _make_phase_objects(self):
-        _log.warning("DEPRECATED: {} appears to be an old-style property "
-                     "package. It will be automatically converted to a "
-                     "new-style package, however users are strongly encouraged"
-                     " to convert their property packages to use phase and "
-                     "component objects."
-                     .format(self.name))
-        for p in self.phase_list:
-            if hasattr(self, p):
-                # An object with this name already exists, raise exception
-                raise PropertyPackageError(
-                    "{} could not add Phase object {} - an object with "
-                    "that name already exists.".format(self.name, p))
-
-            try:
-                pc_list = self.phase_comp[p]
-            except AttributeError:
-                pc_list = None
-            self.add_component(str(p), Phase(
-                default={"component_list": pc_list,
-                         "_phase_list_exists": True}))
 
 
 class StateBlock(ProcessBlock):

--- a/idaes/core/property_base.py
+++ b/idaes/core/property_base.py
@@ -168,13 +168,6 @@ class PhysicalParameterBlock(ProcessBlockData,
                 "with this property package. Please contact the developer of "
                 "the property package.".format(self.name))
 
-    @state_block_class.setter
-    def state_block_class(self, val):
-        _log.warning("DEPRECATED: state_block_class should not be set "
-                     "directly. Property package developers should set the "
-                     "_state_block_class attribute instead.")
-        self._state_block_class = val
-
     @property
     def has_inherent_reactions(self):
         return self._has_inherent_reactions

--- a/idaes/core/property_meta.py
+++ b/idaes/core/property_meta.py
@@ -182,30 +182,14 @@ class PropertyClassMetadata(object):
 
         # Validate values. Pyomo units are all-or-nothing, so check to see that
         # this is the case
-        _units = 0
         for q, u in self._default_units.items():
-            if isinstance(u, _PyomoUnit):
-                _units += 1
-            elif u is None and (q == "luminous intensity" or q == "current"):
+            if u is None and (q == "luminous intensity" or q == "current"):
                 # these units are infrequently used in PSE, so allow users
                 # to skip these
                 continue
-            elif _units > 0:
-                # Mix of units and non-unit objects
+            elif not isinstance(u, _PyomoUnit):
                 raise PropertyPackageError(
-                    "default_units ({}: {}): if using Pyomo Units objects, "
-                    "all units must be defined using Units objects (not "
-                    "compount units)."
-                    .format(q, u))
-
-        # Take opportunity to log a deprecation warning if units are not used
-        if _units == 0:
-            _log.warning("DEPRECATED: IDAES is moving to using Pyomo Units "
-                         "when defining default units, which are used "
-                         "to automatically determine units of measurement "
-                         "for quantities and convert where necessary. "
-                         "Users are strongly encouraged to convert their "
-                         "property packages to use Pyomo Units objects.")
+                    f"Unrecognized units of measurment for quantity {q} ({u})")
 
     def add_properties(self, p):
         """Add properties to the metadata.

--- a/idaes/core/reaction_base.py
+++ b/idaes/core/reaction_base.py
@@ -171,13 +171,6 @@ class ReactionParameterBlock(ProcessBlockData,
                 "with this reaction package. Please contact the developer of "
                 "the reaction package.".format(self.name))
 
-    @reaction_block_class.setter
-    def reaction_block_class(self, val):
-        _log.warning("DEPRECATED: reaction_block_class should not be set "
-                     "directly. Property package developers should set the "
-                     "_reaction_block_class attribute instead.")
-        self._reaction_block_class = val
-
     def build_reaction_block(self, *args, **kwargs):
         """
         Methods to construct a ReactionBlock assoicated with this

--- a/idaes/core/tests/test_components.py
+++ b/idaes/core/tests/test_components.py
@@ -34,6 +34,12 @@ class TestComponent():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -208,6 +214,12 @@ class TestSolute():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -316,6 +328,12 @@ class TestSovent():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -441,6 +459,12 @@ class TestIon():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -459,6 +483,12 @@ class TestAnion():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -475,6 +505,12 @@ class TestAnion():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -567,6 +603,12 @@ class TestCation():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -643,6 +685,12 @@ class TestApparent():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -660,6 +708,12 @@ class TestApparent():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object
@@ -680,6 +734,12 @@ class TestApparent():
         m = ConcreteModel()
 
         m.meta_object = PropertyClassMetadata()
+        m.meta_object.add_default_units({
+            'time': pyunits.s,
+            'length': pyunits.m,
+            'mass': pyunits.kg,
+            'amount': pyunits.mol,
+            'temperature': pyunits.K})
 
         def get_metadata(self):
             return m.meta_object

--- a/idaes/core/tests/test_control_volume_0d.py
+++ b/idaes/core/tests/test_control_volume_0d.py
@@ -592,7 +592,7 @@ def test_add_phase_component_balances_dynamic():
 @pytest.mark.unit
 def test_add_phase_component_balances_dynamic_no_geometry():
     m = ConcreteModel()
-    m.fs = Flowsheet(default={"dynamic": True})
+    m.fs = Flowsheet(default={"dynamic": True, "time_units": units.s})
     m.fs.pp = PhysicalParameterTestBlock()
     m.fs.rp = ReactionParameterTestBlock(default={"property_package": m.fs.pp})
 
@@ -1163,7 +1163,7 @@ def test_add_total_component_balances_dynamic():
 @pytest.mark.unit
 def test_add_total_component_balances_dynamic_no_geometry():
     m = ConcreteModel()
-    m.fs = Flowsheet(default={"dynamic": True})
+    m.fs = Flowsheet(default={"dynamic": True, "time_units": units.s})
     m.fs.pp = PhysicalParameterTestBlock()
     m.fs.rp = ReactionParameterTestBlock(default={"property_package": m.fs.pp})
 
@@ -1700,7 +1700,7 @@ def test_add_total_element_balances_dynamic():
 @pytest.mark.unit
 def test_add_total_element_balances_dynamic_no_geometry():
     m = ConcreteModel()
-    m.fs = Flowsheet(default={"dynamic": True})
+    m.fs = Flowsheet(default={"dynamic": True, "time_units": units.s})
     m.fs.pp = PhysicalParameterTestBlock()
     m.fs.rp = ReactionParameterTestBlock(default={"property_package": m.fs.pp})
 
@@ -1970,7 +1970,7 @@ def test_add_total_enthalpy_balances_dynamic():
 @pytest.mark.unit
 def test_add_total_enthalpy_balances_dynamic_no_geometry():
     m = ConcreteModel()
-    m.fs = Flowsheet(default={"dynamic": True})
+    m.fs = Flowsheet(default={"dynamic": True, "time_units": units.s})
     m.fs.pp = PhysicalParameterTestBlock()
     m.fs.rp = ReactionParameterTestBlock(default={"property_package": m.fs.pp})
 

--- a/idaes/core/tests/test_control_volume_base.py
+++ b/idaes/core/tests/test_control_volume_base.py
@@ -17,7 +17,7 @@ Author: Andrew Lee
 """
 import inspect
 import pytest
-from pyomo.environ import ConcreteModel, Block, Set
+from pyomo.environ import ConcreteModel, Block, Set, units
 from pyomo.common.config import ConfigBlock, ConfigValue
 from idaes.core import (ControlVolumeBlockData, CONFIG_Template,
                         MaterialBalanceType, EnergyBalanceType,
@@ -241,7 +241,8 @@ def test_setup_dynamics_dynamic_in_ss():
 @pytest.mark.unit
 def test_setup_dynamics_dynamic_holdup_inconsistent():
     # Test that dynamic = None works correctly
-    fs = Flowsheet(default={"dynamic": True}, concrete=True)
+    fs = Flowsheet(default={"dynamic": True, "time_units": units.s},
+                   concrete=True)
 
     # Create a Block (with no dynamic attribute)
     fs.b = Block()

--- a/idaes/core/tests/test_flowsheet_model.py
+++ b/idaes/core/tests/test_flowsheet_model.py
@@ -197,37 +197,43 @@ class TestBuild(object):
     @pytest.mark.unit
     def test_dynamic_default(self):
         m = ConcreteModel()
-        m.fs = FlowsheetBlock(default={"dynamic": True})
+        m.fs = FlowsheetBlock(default={
+            "dynamic": True, "time_units": units.s})
 
         assert m.fs.config.dynamic is True
         assert isinstance(m.fs.time, ContinuousSet)
         for t in m.fs.time:
             assert t in [0, 1]
         assert m.fs.config.time is m.fs.time
-        assert m.fs.time_units is None
+        assert m.fs.time_units == units.s
 
     @pytest.mark.unit
     def test_dynamic_time_set(self):
         m = ConcreteModel()
         m.fs = FlowsheetBlock(default={
                 "dynamic": True,
-                "time_set": [1, 2]})
+                "time_set": [1, 2],
+                "time_units": units.s})
 
         assert m.fs.config.dynamic is True
         assert isinstance(m.fs.time, ContinuousSet)
         for t in m.fs.time:
             assert t in [1, 2]
         assert m.fs.config.time is m.fs.time
-        assert m.fs.time_units is None
+        assert m.fs.time_units == units.s
 
     @pytest.mark.unit
     def test_dynamic_time_set_invalid(self):
         m = ConcreteModel()
 
-        with pytest.raises(DynamicError):
+        with pytest.raises(DynamicError,
+                           match="Flowsheet provided with invalid "
+                           "time_set attribute - must have at "
+                           "least two values \(start and end\)."):
             m.fs = FlowsheetBlock(default={
                     "dynamic": True,
-                    "time_set": 1})
+                    "time_set": 1,
+                    "time_units": units.s})
 
     @pytest.mark.unit
     def test_ss_external_time(self):
@@ -261,12 +267,13 @@ class TestBuild(object):
         m.s = ContinuousSet(initialize=[4, 5])
         m.fs = FlowsheetBlock(default={
                 "dynamic": True,
-                "time": m.s})
+                "time": m.s,
+                "time_units": units.s})
 
         assert m.fs.config.dynamic is True
         assert m.fs.config.time is m.s
         assert m.fs.time is m.s
-        assert m.fs.time_units is None
+        assert m.fs.time_units == units.s
 
     @pytest.mark.unit
     def test_dynamic_external_time_invalid(self):
@@ -276,7 +283,8 @@ class TestBuild(object):
         with pytest.raises(DynamicError):
             m.fs = FlowsheetBlock(default={
                     "dynamic": True,
-                    "time": m.s})
+                    "time": m.s,
+                    "time_units": units.s})
 
     @pytest.mark.unit
     def test_ss_external_time_and_time_set(self):
@@ -301,15 +309,16 @@ class TestBuild(object):
         m.fs = FlowsheetBlock(default={
                 "dynamic": True,
                 "time": m.s,
-                "time_set": [1, 2]})
+                "time_set": [1, 2],
+                "time_units": units.s})
 
         assert m.fs.config.dynamic is True
         assert m.fs.config.time is m.s
         assert m.fs.time is m.s
-        assert m.fs.time_units is None
+        assert m.fs.time_units == units.s
 
     @pytest.mark.unit
-    def testtime_units_ss(self):
+    def test_time_units_ss(self):
         m = ConcreteModel()
         m.fs = FlowsheetBlock(default={
                 "dynamic": False,
@@ -318,7 +327,7 @@ class TestBuild(object):
         assert m.fs.time_units is units.s
 
     @pytest.mark.unit
-    def testtime_units_dynamic(self):
+    def test_time_units_dynamic(self):
         m = ConcreteModel()
         m.fs = FlowsheetBlock(default={
                 "dynamic": True,
@@ -327,7 +336,7 @@ class TestBuild(object):
         assert m.fs.time_units is units.s
 
     @pytest.mark.unit
-    def testtime_units_external(self):
+    def test_time_units_external(self):
         # Should ignore time set
         m = ConcreteModel()
         m.s = ContinuousSet(initialize=[4, 5])
@@ -363,32 +372,32 @@ class TestSubFlowsheetBuild(object):
     @pytest.mark.unit
     def test_parent_dynamic_inherit(self):
         m = ConcreteModel()
-        m.fs = FlowsheetBlock(default={"dynamic": True})
+        m.fs = FlowsheetBlock(default={"dynamic": True, "time_units": units.s})
         m.fs.sub = FlowsheetBlock()
 
         assert m.fs.sub.config.dynamic is True
         assert m.fs.sub.config.time is m.fs.config.time
-        assert m.fs.sub.time_units is None
+        assert m.fs.sub.time_units == units.s
 
     @pytest.mark.unit
     def test_both_dynamic(self):
         m = ConcreteModel()
-        m.fs = FlowsheetBlock(default={"dynamic": True})
+        m.fs = FlowsheetBlock(default={"dynamic": True, "time_units": units.s})
         m.fs.sub = FlowsheetBlock(default={"dynamic": True})
 
         assert m.fs.sub.config.dynamic is True
         assert m.fs.sub.config.time is m.fs.config.time
-        assert m.fs.sub.time_units is None
+        assert m.fs.sub.time_units == units.s
 
     @pytest.mark.unit
     def test_ss_in_dynamic(self):
         m = ConcreteModel()
-        m.fs = FlowsheetBlock(default={"dynamic": True})
+        m.fs = FlowsheetBlock(default={"dynamic": True, "time_units": units.s})
         m.fs.sub = FlowsheetBlock(default={"dynamic": False})
 
         assert m.fs.sub.config.dynamic is False
         assert m.fs.sub.config.time is m.fs.config.time
-        assert m.fs.sub.time_units is None
+        assert m.fs.sub.time_units == units.s
 
     @pytest.mark.unit
     def test_dynamic_in_ss(self):
@@ -401,7 +410,7 @@ class TestSubFlowsheetBuild(object):
     def test_ss_external_time(self):
         m = ConcreteModel()
         m.s = Set(initialize=[4, 5])
-        m.fs = FlowsheetBlock(default={"dynamic": True})
+        m.fs = FlowsheetBlock(default={"dynamic": True, "time_units": units.s})
         m.fs.sub = FlowsheetBlock(default={"dynamic": False, "time": m.s})
 
         assert m.fs.sub.config.dynamic is False
@@ -409,23 +418,25 @@ class TestSubFlowsheetBuild(object):
         assert m.fs.sub.time_units is None
 
     @pytest.mark.unit
-    def test__dynamic_external_time(self):
+    def test_dynamic_external_time(self):
         m = ConcreteModel()
         m.s = ContinuousSet(initialize=[4, 5])
-        m.fs = FlowsheetBlock(default={"dynamic": True})
-        m.fs.sub = FlowsheetBlock(default={"dynamic": True, "time": m.s})
+        m.fs = FlowsheetBlock(default={"dynamic": True, "time_units": units.s})
+        m.fs.sub = FlowsheetBlock(default={
+            "dynamic": True, "time": m.s, "time_units": units.minute})
 
         assert m.fs.sub.config.dynamic is True
         assert m.fs.sub.config.time is m.s
-        assert m.fs.sub.time_units is None
+        assert m.fs.sub.time_units == units.minute
 
     @pytest.mark.unit
     def test_dynamic_external_time_invalid(self):
         m = ConcreteModel()
         m.s = Set(initialize=[4, 5])
-        m.fs = FlowsheetBlock(default={"dynamic": True})
+        m.fs = FlowsheetBlock(default={"dynamic": True, "time_units": units.s})
         with pytest.raises(DynamicError):
-            m.fs.sub = FlowsheetBlock(default={"dynamic": True, "time": m.s})
+            m.fs.sub = FlowsheetBlock(default={
+                "dynamic": True, "time": m.s, "time_units": units.minute})
 
     @pytest.mark.unit
     def testtime_units_inherit(self):

--- a/idaes/core/tests/test_property_base.py
+++ b/idaes/core/tests/test_property_base.py
@@ -71,11 +71,18 @@ def test_get_phase_component_set():
     m = ConcreteModel()
     m.p = ParameterBlock()
 
-    m.p.phase_list = Set(initialize=["1", "2", "3"])
-    m.p.component_list = Set(initialize=["a", "b", "c"])
+    m.meta_object = PropertyClassMetadata()
 
-    # Need to call this to trigger build of Phase objects for now
-    m.p._make_phase_objects()
+    def get_metadata(self):
+        return m.meta_object
+    m.p.get_metadata = types.MethodType(get_metadata, m.p)
+
+    m.p.p1 = Phase()
+    m.p.p2 = Phase()
+    m.p.p3 = Phase()
+    m.p.a = Component()
+    m.p.b = Component()
+    m.p.c = Component()
 
     pc_set = m.p.get_phase_component_set()
 
@@ -99,21 +106,30 @@ def test_get_phase_component_set_subset():
     m = ConcreteModel()
     m.p = ParameterBlock()
 
-    m.p.phase_list = ["1", "2", "3"]
-    m.p.phase_comp = {"1": ["a", "b", "c"],
-                      "2": ["a", "b"],
-                      "3": ["c"]}
+    m.meta_object = PropertyClassMetadata()
 
-    # Need to call this to trigger build of Phase objects for now
-    m.p._make_phase_objects()
+    def get_metadata(self):
+        return m.meta_object
+    m.p.get_metadata = types.MethodType(get_metadata, m.p)
+
+    m.p.p1 = Phase()
+    m.p.p2 = Phase(default={"component_list": ["a", "b"]})
+    m.p.p3 = Phase(default={"component_list": ["c"]})
+    m.p.a = Component()
+    m.p.b = Component()
+    m.p.c = Component()
+
+    phase_comp = {"p1": ["a", "b", "c"],
+                  "p2": ["a", "b"],
+                  "p3": ["c"]}
 
     pc_set = m.p.get_phase_component_set()
 
     assert isinstance(m.p._phase_component_set, Set)
     assert len(m.p._phase_component_set) == 6
     for v in m.p._phase_component_set:
-        assert v[0] in m.p.phase_comp.keys()
-        assert v[1] in m.p.phase_comp[v[0]]
+        assert v[0] in phase_comp.keys()
+        assert v[1] in phase_comp[v[0]]
 
     assert pc_set is m.p._phase_component_set
 
@@ -167,80 +183,13 @@ def test_get_phase():
 
 
 @pytest.mark.unit
-def test_make_component_objects():
-    m = ConcreteModel()
-    m.p = ParameterBlock()
-
-    m.meta_object = PropertyClassMetadata()
-
-    def get_metadata(self):
-        return m.meta_object
-    m.p.get_metadata = types.MethodType(get_metadata, m.p)
-
-    m.p.component_list = Set(initialize=["comp1", "comp2"])
-
-    m.p._make_component_objects()
-
-    assert isinstance(m.p.comp1, Component)
-    assert isinstance(m.p.comp2, Component)
-
-
-@pytest.mark.unit
-def test_make_component_objects_already_exists():
-    m = ConcreteModel()
-    m.p = ParameterBlock()
-
-    m.p.comp1 = object()
-
-    m.p.component_list = Set(initialize=["comp1", "comp2"])
-
-    with pytest.raises(PropertyPackageError,
-                       match="p could not add Component object comp1 - an "
-                       "object with that name already exists."):
-        m.p._make_component_objects()
-
-
-@pytest.mark.unit
-def test_make_phase_objects():
-    m = ConcreteModel()
-    m.p = ParameterBlock()
-
-    m.p.phase_list = Set(initialize=["phase1", "phase2"])
-    m.p.phase_comp = {"phase1": [1, 2, 3],
-                      "phase2": [4, 5, 6]}
-
-    m.p._make_phase_objects()
-
-    assert isinstance(m.p.phase1, Phase)
-    assert isinstance(m.p.phase2, Phase)
-
-    assert m.p.phase1.config.component_list == [1, 2, 3]
-    assert m.p.phase2.config.component_list == [4, 5, 6]
-
-
-@pytest.mark.unit
-def test_make_phase_objects_already_exists():
-    m = ConcreteModel()
-    m.p = ParameterBlock()
-
-    m.p.phase1 = object()
-
-    m.p.phase_list = Set(initialize=["phase1", "phase2"])
-
-    with pytest.raises(PropertyPackageError,
-                       match="p could not add Phase object phase1 - an "
-                       "object with that name already exists."):
-        m.p._make_phase_objects()
-
-
-@pytest.mark.unit
 def test_validate_parameter_block_no_component_list():
     m = ConcreteModel()
     m.p = ParameterBlock()
 
     with pytest.raises(
             PropertyPackageError,
-            match="Property package p has not defined a component list."):
+            match="Property package p has not defined any Components."):
         m.p._validate_parameter_block()
 
 
@@ -255,11 +204,12 @@ def test_validate_parameter_block_no_phase_list():
         return m.meta_object
     m.p.get_metadata = types.MethodType(get_metadata, m.p)
 
-    m.p.component_list = Set(initialize=["c1", "c2"])
+    m.p.c1 = Component()
+    m.p.c2 = Component()
 
     with pytest.raises(
             PropertyPackageError,
-            match="Property package p has not defined a phase list."):
+            match="Property package p has not defined any Phases."):
         m.p._validate_parameter_block()
 
 
@@ -288,17 +238,21 @@ def test_validate_parameter_block_invalid_phase_object():
         return m.meta_object
     m.p.get_metadata = types.MethodType(get_metadata, m.p)
 
-    m.p.component_list = Set(initialize=["c1", "c2"])
+    m.p.c1 = Component()
+    m.p.c2 = Component()
 
     m.p.phase_list = Set(initialize=["foo"])
     m.p.foo = object()
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError,
+                       match="Property package p has an object foo whose "
+                       "name appears in phase_list but is not an "
+                       "instance of Phase"):
         m.p._validate_parameter_block()
 
 
 @pytest.mark.unit
-def test_has_inherent_Reactions():
+def test_has_inherent_reactions():
     m = ConcreteModel()
     m.p = ParameterBlock()
 
@@ -416,8 +370,8 @@ class _Parameters(PhysicalParameterBlock):
     def build(self):
         super(_Parameters, self).build()
 
-        self.phase_list = ["p1"]
-        self.component_list = ["c1"]
+        self.p1 = Phase()
+        self.c1 = Component()
 
     @classmethod
     def define_metadata(cls, obj):

--- a/idaes/core/tests/test_property_base.py
+++ b/idaes/core/tests/test_property_base.py
@@ -18,7 +18,7 @@ Author: Andrew Lee
 import pytest
 import types
 
-from pyomo.environ import ConcreteModel, Constraint, Set, Var
+from pyomo.environ import ConcreteModel, Constraint, Set, Var, units as pyunits
 from pyomo.common.config import ConfigBlock
 
 from idaes.core import (declare_process_block_class, PhysicalParameterBlock,
@@ -72,6 +72,12 @@ def test_get_phase_component_set():
     m.p = ParameterBlock()
 
     m.meta_object = PropertyClassMetadata()
+    m.meta_object.add_default_units({
+        'time': pyunits.s,
+        'length': pyunits.m,
+        'mass': pyunits.kg,
+        'amount': pyunits.mol,
+        'temperature': pyunits.K})
 
     def get_metadata(self):
         return m.meta_object
@@ -107,6 +113,12 @@ def test_get_phase_component_set_subset():
     m.p = ParameterBlock()
 
     m.meta_object = PropertyClassMetadata()
+    m.meta_object.add_default_units({
+        'time': pyunits.s,
+        'length': pyunits.m,
+        'mass': pyunits.kg,
+        'amount': pyunits.mol,
+        'temperature': pyunits.K})
 
     def get_metadata(self):
         return m.meta_object
@@ -140,6 +152,12 @@ def test_get_component():
     m.p = ParameterBlock()
 
     m.meta_object = PropertyClassMetadata()
+    m.meta_object.add_default_units({
+        'time': pyunits.s,
+        'length': pyunits.m,
+        'mass': pyunits.kg,
+        'amount': pyunits.mol,
+        'temperature': pyunits.K})
 
     def get_metadata(self):
         return m.meta_object
@@ -199,6 +217,12 @@ def test_validate_parameter_block_no_phase_list():
     m.p = ParameterBlock()
 
     m.meta_object = PropertyClassMetadata()
+    m.meta_object.add_default_units({
+        'time': pyunits.s,
+        'length': pyunits.m,
+        'mass': pyunits.kg,
+        'amount': pyunits.mol,
+        'temperature': pyunits.K})
 
     def get_metadata(self):
         return m.meta_object
@@ -233,6 +257,12 @@ def test_validate_parameter_block_invalid_phase_object():
     m.p = ParameterBlock()
 
     m.meta_object = PropertyClassMetadata()
+    m.meta_object.add_default_units({
+        'time': pyunits.s,
+        'length': pyunits.m,
+        'mass': pyunits.kg,
+        'amount': pyunits.mol,
+        'temperature': pyunits.K})
 
     def get_metadata(self):
         return m.meta_object
@@ -383,6 +413,12 @@ class _Parameters(PhysicalParameterBlock):
                             'not_supported': {'method': False},
                             'does_not_create_component': {
                                 'method': '_does_not_create_component'}})
+        obj.add_default_units({
+            "time": pyunits.s,
+            "mass": pyunits.kg,
+            "length": pyunits.m,
+            "amount": pyunits.mol,
+            "temperature": pyunits.K})
 
 
 @declare_process_block_class("StateTest", block_class=StateBlock)

--- a/idaes/core/tests/test_reaction_base.py
+++ b/idaes/core/tests/test_reaction_base.py
@@ -17,7 +17,7 @@ Author: Andrew Lee
 """
 import pytest
 import inspect
-from pyomo.environ import ConcreteModel, Constraint, Set, Var
+from pyomo.environ import ConcreteModel, Constraint, Set, Var, units as pyunits
 from pyomo.common.config import ConfigBlock
 from idaes.core import (declare_process_block_class, ReactionParameterBlock,
                         ReactionBlockBase, ReactionBlockDataBase,
@@ -38,13 +38,11 @@ class _PropertyParameterBlock(PhysicalParameterBlock):
     def define_metadata(cls, obj):
         obj.add_properties({'prop1': {'method': None, 'units': 'm'},
                             'prop3': {'method': False}})
-        obj.add_default_units({'time': 's',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.s,
+                               'length': pyunits.m,
+                               'mass': pyunits.g,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
 
 
 @declare_process_block_class("ReactionParameterTestBlock")
@@ -86,13 +84,11 @@ class _ReactionParameterBlock2(ReactionParameterBlock):
     @classmethod
     def define_metadata(cls, obj):
         obj.add_properties({'rxn1': {'method': None}})
-        obj.add_default_units({'time': 'hr',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.hr,
+                               'length': pyunits.m,
+                               'mass': pyunits.g,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
 
 @pytest.mark.unit
 def test_validate_state_block_invalid_units():
@@ -113,13 +109,11 @@ class _ReactionParameterBlock3(ReactionParameterBlock):
     @classmethod
     def define_metadata(cls, obj):
         obj.add_properties({'rxn1': {'method': None}})
-        obj.add_default_units({'time': 's',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.s,
+                               'length': pyunits.m,
+                               'mass': pyunits.g,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
         obj.add_required_properties({'prop2': 'some'})
 
 
@@ -142,13 +136,11 @@ class _ReactionParameterBlock4(ReactionParameterBlock):
     @classmethod
     def define_metadata(cls, obj):
         obj.add_properties({'rxn1': {'method': None}})
-        obj.add_default_units({'time': 's',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.s,
+                               'length': pyunits.m,
+                               'mass': pyunits.g,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
         obj.add_required_properties({'prop3': 'some'})
 
 
@@ -171,13 +163,11 @@ class _ReactionParameterBlock5(ReactionParameterBlock):
     @classmethod
     def define_metadata(cls, obj):
         obj.add_properties({'rxn1': {'method': None}})
-        obj.add_default_units({'time': 's',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.s,
+                               'length': pyunits.m,
+                               'mass': pyunits.g,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
         obj.add_required_properties({'prop1': 'km'})
 
 
@@ -200,13 +190,11 @@ class _ReactionParameterBlock6(ReactionParameterBlock):
     @classmethod
     def define_metadata(cls, obj):
         obj.add_properties({'rxn1': {'method': None}})
-        obj.add_default_units({'time': 's',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.s,
+                               'length': pyunits.m,
+                               'mass': pyunits.g,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
         obj.add_required_properties({'prop1': 'm'})
 
 

--- a/idaes/core/tests/test_unit_model.py
+++ b/idaes/core/tests/test_unit_model.py
@@ -16,7 +16,7 @@ Tests for unit_model.
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import Block, ConcreteModel, Constraint, Var
+from pyomo.environ import Block, ConcreteModel, Constraint, Var, units
 from pyomo.network import Port
 
 from idaes.core import (FlowsheetBlockData, declare_process_block_class,
@@ -138,7 +138,7 @@ def test_setup_dynamics_has_holdup():
     # Test that has_holdup argument is True when dynamic is True
     m = ConcreteModel()
 
-    m.fs = Flowsheet(default={"dynamic": True})
+    m.fs = Flowsheet(default={"dynamic": True, "time_units": units.s})
 
     m.fs.u = Unit()
     m.fs.u.config.has_holdup=False
@@ -401,7 +401,8 @@ def test_add_outlet_port_CV0D_part_args():
 
 @pytest.mark.unit
 def test_fix_unfix_initial_conditions():
-    fs = Flowsheet(default={"dynamic": True, "time_set": [0, 1, 2]},
+    fs = Flowsheet(default={
+        "dynamic": True, "time_set": [0, 1, 2], "time_units": units.s},
                    concrete=True)
     fs._setup_dynamics()
 

--- a/idaes/core/util/tests/test_initialization.py
+++ b/idaes/core/util/tests/test_initialization.py
@@ -19,7 +19,6 @@ from pyomo.environ import (Block, ConcreteModel, Constraint, Expression, exp,
                            Set, Var, value, Param, Reals,
                            TransformationFactory, TerminationCondition)
 from pyomo.network import Arc, Port
-from pyomo.core.base.units_container import UnitsError
 
 from idaes.core import (FlowsheetBlock,
                         MaterialBalanceType,
@@ -32,7 +31,9 @@ from idaes.core import (FlowsheetBlock,
                         ReactionParameterBlock,
                         ReactionBlockBase,
                         ReactionBlockDataBase,
-                        MaterialFlowBasis)
+                        MaterialFlowBasis,
+                        Component,
+                        Phase)
 from idaes.core.util.testing import PhysicalParameterTestBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.generic_models.unit_models import CSTR
@@ -62,8 +63,12 @@ class ParameterData(PhysicalParameterBlock):
         super(ParameterData, self).build()
 
         # all components are in the aqueous phase
-        self.phase_list = Set(initialize=['aq'])
-        self.component_list = Set(initialize=['S', 'E', 'C', 'P', 'Solvent'])
+        self.aq = Phase()
+        self.S = Component()
+        self.E = Component()
+        self.C = Component()
+        self.P = Component()
+        self.Solvent = Component()
 
         self._state_block_class = AqueousEnzymeStateBlock
 

--- a/idaes/core/util/tests/test_initialization.py
+++ b/idaes/core/util/tests/test_initialization.py
@@ -839,7 +839,8 @@ def test_initialize_by_time_element():
     ntcp = 2
     m = ConcreteModel(name='CSTR model for testing')
     m.fs = FlowsheetBlock(default={'dynamic': True,
-                                   'time_set': time_set})
+                                   'time_set': time_set,
+                                   'time_units': pyunits.s})
 
     m.fs.properties = AqueousEnzymeParameterBlock()
     m.fs.reactions = EnzymeReactionParameterBlock(

--- a/idaes/core/util/tests/test_initialization.py
+++ b/idaes/core/util/tests/test_initialization.py
@@ -840,7 +840,7 @@ def test_initialize_by_time_element():
     m = ConcreteModel(name='CSTR model for testing')
     m.fs = FlowsheetBlock(default={'dynamic': True,
                                    'time_set': time_set,
-                                   'time_units': pyunits.s})
+                                   'time_units': pyunits.minute})
 
     m.fs.properties = AqueousEnzymeParameterBlock()
     m.fs.reactions = EnzymeReactionParameterBlock(

--- a/idaes/core/util/tests/test_initialization.py
+++ b/idaes/core/util/tests/test_initialization.py
@@ -65,7 +65,7 @@ class ParameterData(PhysicalParameterBlock):
         self.phase_list = Set(initialize=['aq'])
         self.component_list = Set(initialize=['S', 'E', 'C', 'P', 'Solvent'])
 
-        self.state_block_class = AqueousEnzymeStateBlock
+        self._state_block_class = AqueousEnzymeStateBlock
 
     @classmethod
     def define_metadata(cls, obj):
@@ -144,7 +144,7 @@ class EnzymeReactionParameterData(ReactionParameterBlock):
     def build(self):
         super(EnzymeReactionParameterData, self).build()
 
-        self.reaction_block_class = EnzymeReactionBlock
+        self._reaction_block_class = EnzymeReactionBlock
 
         self.rate_reaction_idx = Set(initialize=['R1', 'R2', 'R3'])
         self.rate_reaction_stoichiometry = {('R1', 'aq', 'S'): -1,

--- a/idaes/core/util/tests/test_initialization.py
+++ b/idaes/core/util/tests/test_initialization.py
@@ -16,7 +16,7 @@ Tests for math util methods.
 
 import pytest
 from pyomo.environ import (Block, ConcreteModel, Constraint, Expression, exp,
-                           Set, Var, value, Param, Reals,
+                           Set, Var, value, Param, Reals, units as pyunits,
                            TransformationFactory, TerminationCondition)
 from pyomo.network import Arc, Port
 
@@ -74,12 +74,11 @@ class ParameterData(PhysicalParameterBlock):
 
     @classmethod
     def define_metadata(cls, obj):
-        obj.add_default_units({'time': 'min',
-                               'length': 'm',
-                               'amount': 'kmol',
-                               'temperature': 'K',
-                               'energy': 'kcal',
-                               'holdup': 'kmol'})
+        obj.add_default_units({'time': pyunits.minute,
+                               'length': pyunits.m,
+                               'amount': pyunits.kmol,
+                               'temperature': pyunits.K,
+                               'mass': pyunits.kg})
 
 
 class _AqueousEnzymeStateBlock(StateBlock):
@@ -191,12 +190,11 @@ class EnzymeReactionParameterData(ReactionParameterBlock):
 
     @classmethod
     def define_metadata(cls, obj):
-        obj.add_default_units({'time': 'min',
-                               'length': 'm',
-                               'amount': 'kmol',
-                               'temperature': 'K',
-                               'energy': 'kcal',
-                               'holdup': 'kmol'})
+        obj.add_default_units({'time': pyunits.minute,
+                               'length': pyunits.m,
+                               'amount': pyunits.kmol,
+                               'temperature': pyunits.K,
+                               'mass': pyunits.kg})
 
 
 class _EnzymeReactionBlock(ReactionBlockBase):

--- a/idaes/core/util/tests/test_pid_initialization.py
+++ b/idaes/core/util/tests/test_pid_initialization.py
@@ -20,7 +20,7 @@ import pytest
 from pyomo.environ import (Block, ConcreteModel, Constraint, Expression,
                            Set, SolverFactory, Var, value, Param, Reals,
                            TransformationFactory, TerminationCondition,
-                           exp)
+                           exp, units as pyunits)
 from pyomo.network import Arc, Port
 from pyomo.dae import DerivativeVar
 from pyomo.common.collections import ComponentMap
@@ -60,7 +60,8 @@ def make_model(horizon=6, ntfe=60, ntcp=2, inlet_E=11.91, inlet_S=12.92):
 
     m = ConcreteModel(name='CSTR with level control')
     m.fs = FlowsheetBlock(default={'dynamic': True,
-                                   'time_set': time_set})
+                                   'time_set': time_set,
+                                   'time_units': pyunits.s})
 
     m.fs.properties = AqueousEnzymeParameterBlock()
     m.fs.reactions = EnzymeReactionParameterBlock(

--- a/idaes/dmf/tests/for_propindex.py
+++ b/idaes/dmf/tests/for_propindex.py
@@ -11,12 +11,17 @@
 # license information.
 #################################################################################
 from idaes.core.property_base import PhysicalParameterBlock
+from pyomo.environ import units as pyunits
 
 
 class IndexMePlease1(PhysicalParameterBlock):
 
     @classmethod
     def define_metadata(cls, m):
-        m.add_default_units({'temperature': 'K'})
+        m.add_default_units({'temperature': pyunits.K,
+                             'time': pyunits.s,
+                             'length': pyunits.m,
+                             'mass': pyunits.kg,
+                             'amount': pyunits.mol})
         m.add_properties({'pressure': {'units': 'Pa', 'method': 'foo'},
                           'temperature': {'method': 'bar'}})

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -204,32 +204,9 @@ class GenericParameterData(PhysicalParameterBlock):
         # Call super.build() to initialize Block
         super(GenericParameterData, self).build()
 
-        # Validate and set base units of measurement
+        # Set base units of measurement
         self.get_metadata().add_default_units(self.config.base_units)
         units_meta = self.get_metadata().default_units
-
-        for key, unit in self.config.base_units.items():
-            if key in ['time', 'length', 'mass', 'amount', 'temperature',
-                       "current", "luminous intensity"]:
-                if not isinstance(unit, _PyomoUnit):
-                    raise ConfigurationError(
-                        "{} recieved unexpected units for quantity {}: {}. "
-                        "Units must be instances of a Pyomo unit object."
-                        .format(self.name, key, unit))
-            else:
-                raise ConfigurationError(
-                    "{} defined units for an unexpected quantity {}. "
-                    "Generic property packages only support units for the 7 "
-                    "base SI quantities.".format(self.name, key))
-
-        # Check that main 5 base units are assigned
-        for k in ['time', 'length', 'mass', 'amount', 'temperature']:
-            if not isinstance(units_meta[k], _PyomoUnit):
-                raise ConfigurationError(
-                    "{} units for quantity {} were not assigned. "
-                    "Please make sure to provide units for all base units "
-                    "when configuring the property package."
-                    .format(self.name, k))
 
         # Call configure method to set construction arguments
         self.configure()

--- a/idaes/generic_models/properties/core/generic/generic_reaction.py
+++ b/idaes/generic_models/properties/core/generic/generic_reaction.py
@@ -196,32 +196,8 @@ class GenericReactionParameterData(ReactionParameterBlock):
         super(ReactionParameterBlock, self).build()
         self.default_scaling_factor = {}
 
-        # Validate and set base units of measurement
+        # Set base units of measurement
         self.get_metadata().add_default_units(self.config.base_units)
-        units_meta = self.get_metadata().default_units
-
-        for key, unit in self.config.base_units.items():
-            if key in ['time', 'length', 'mass', 'amount', 'temperature',
-                       "current", "luminous intensity"]:
-                if not isinstance(unit, _PyomoUnit):
-                    raise ConfigurationError(
-                        "{} recieved unexpected units for quantity {}: {}. "
-                        "Units must be instances of a Pyomo unit object."
-                        .format(self.name, key, unit))
-            else:
-                raise ConfigurationError(
-                    "{} defined units for an unexpected quantity {}. "
-                    "Generic reaction packages only support units for the 7 "
-                    "base SI quantities.".format(self.name, key))
-
-        # Check that main 5 base units are assigned
-        for k in ['time', 'length', 'mass', 'amount', 'temperature']:
-            if not isinstance(units_meta[k], _PyomoUnit):
-                raise ConfigurationError(
-                    "{} units for quantity {} were not assigned. "
-                    "Please make sure to provide units for all base units "
-                    "when configuring the reaction package."
-                    .format(self.name, k))
 
         # TODO: Need way to tie reaction package to a specfic property package
         self._validate_property_parameter_units()

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -29,7 +29,7 @@ from idaes.generic_models.properties.core.generic.tests.dummy_eos import DummyEo
 from idaes.core import (declare_process_block_class, Component,
                         Phase, LiquidPhase, VaporPhase, MaterialFlowBasis)
 from idaes.core.phases import PhaseType as PT
-from idaes.core.util.exceptions import (ConfigurationError)
+from idaes.core.util.exceptions import ConfigurationError, PropertyPackageError
 import idaes.logger as idaeslog
 
 
@@ -127,9 +127,9 @@ class TestGenericParameterBlock(object):
         m = ConcreteModel()
 
         with pytest.raises(
-                ConfigurationError,
-                match="params recieved unexpected units for quantity time: "
-                "foo. Units must be instances of a Pyomo unit object."):
+                PropertyPackageError,
+                match="Unrecognized units of measurment for quantity time "
+                "\(foo\)"):
             m.params = DummyParameterBlock(default={
                 "components": {"a": {}, "b": {}, "c": {}},
                 "phases": {
@@ -151,10 +151,9 @@ class TestGenericParameterBlock(object):
         m = ConcreteModel()
 
         with pytest.raises(
-                ConfigurationError,
-                match="params units for quantity time were not assigned. "
-                "Please make sure to provide units for all base units "
-                "when configuring the property package."):
+                PropertyPackageError,
+                match="Unrecognized units of measurment for quantity time "
+                "\(None\)"):
             m.params = DummyParameterBlock(default={
                 "components": {"a": {}, "b": {}, "c": {}},
                 "phases": {

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_reaction.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_reaction.py
@@ -42,7 +42,7 @@ from idaes.generic_models.properties.core.reactions.equilibrium_forms import \
 from idaes.core.util.testing import PhysicalParameterTestBlock
 from idaes.core.util.constants import Constants as constants
 
-from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.exceptions import ConfigurationError, PropertyPackageError
 import idaes.logger as idaeslog
 
 
@@ -132,9 +132,9 @@ class TestGenericReactionParameterBlock(object):
     @pytest.mark.unit
     def test_invalid_unit(self, m):
         with pytest.raises(
-                ConfigurationError,
-                match="rxn_params recieved unexpected units for quantity time:"
-                " foo. Units must be instances of a Pyomo unit object."):
+                PropertyPackageError,
+                match="Unrecognized units of measurment for quantity time "
+                "\(foo\)"):
             m.rxn_params = GenericReactionParameterBlock(default={
                 "property_package": m.params,
                 "rate_reactions": {
@@ -151,10 +151,9 @@ class TestGenericReactionParameterBlock(object):
     @pytest.mark.unit
     def test_missing_required_quantity(self, m):
         with pytest.raises(
-                ConfigurationError,
-                match="rxn_params units for quantity time were not assigned. "
-                "Please make sure to provide units for all base units "
-                "when configuring the reaction package."):
+                PropertyPackageError,
+                match="Unrecognized units of measurment for quantity time "
+                "\(None\)"):
             m.rxn_params = GenericReactionParameterBlock(default={
                 "property_package": m.params,
                 "rate_reactions": {

--- a/idaes/generic_models/properties/cubic_eos/tests/test_cubic_prop_pack.py
+++ b/idaes/generic_models/properties/cubic_eos/tests/test_cubic_prop_pack.py
@@ -21,7 +21,7 @@ from pyomo.environ import (ConcreteModel,
                            sqrt,
                            Var)
 
-from idaes.core import FlowsheetBlock
+from idaes.core import FlowsheetBlock, Component
 from idaes.generic_models.properties.cubic_eos.cubic_prop_pack import \
     (cubic_roots_available,
      CubicParameterBlock,
@@ -136,7 +136,10 @@ class TestStateBlock_LV_PR(object):
         m.fs = FlowsheetBlock(default={"dynamic": False})
 
         m.fs.params = CubicParameterBlock()
-        m.fs.params.component_list = Set(initialize=["a", "b"])
+
+        m.fs.params.a = Component()
+        m.fs.params.b = Component()
+
         m.fs.params.cubic_type = CubicEoS.PR
 
         m.fs.params.gas_const = Param(default=8.314462618)
@@ -300,7 +303,10 @@ class TestStateBlock_L_PR(object):
         m.fs = FlowsheetBlock(default={"dynamic": False})
 
         m.fs.params = CubicParameterBlock(default={"valid_phase": "Liq"})
-        m.fs.params.component_list = Set(initialize=["a", "b"])
+
+        m.fs.params.a = Component()
+        m.fs.params.b = Component()
+
         m.fs.params.cubic_type = CubicEoS.PR
 
         m.fs.params.gas_const = Param(default=8.314462618)
@@ -407,7 +413,10 @@ class TestStateBlock_V_PR(object):
         m.fs = FlowsheetBlock(default={"dynamic": False})
 
         m.fs.params = CubicParameterBlock(default={"valid_phase": "Vap"})
-        m.fs.params.component_list = Set(initialize=["a", "b"])
+
+        m.fs.params.a = Component()
+        m.fs.params.b = Component()
+
         m.fs.params.cubic_type = CubicEoS.PR
 
         m.fs.params.gas_const = Param(default=8.314462618)
@@ -514,7 +523,10 @@ class TestStateBlock_LV_SRK(object):
         m.fs = FlowsheetBlock(default={"dynamic": False})
 
         m.fs.params = CubicParameterBlock()
-        m.fs.params.component_list = Set(initialize=["a", "b"])
+
+        m.fs.params.a = Component()
+        m.fs.params.b = Component()
+
         m.fs.params.cubic_type = CubicEoS.SRK
 
         m.fs.params.gas_const = Param(default=8.314462618)
@@ -678,7 +690,10 @@ class TestStateBlock_L_SRK(object):
         m.fs = FlowsheetBlock(default={"dynamic": False})
 
         m.fs.params = CubicParameterBlock(default={"valid_phase": "Liq"})
-        m.fs.params.component_list = Set(initialize=["a", "b"])
+
+        m.fs.params.a = Component()
+        m.fs.params.b = Component()
+
         m.fs.params.cubic_type = CubicEoS.SRK
 
         m.fs.params.gas_const = Param(default=8.314462618)
@@ -785,7 +800,10 @@ class TestStateBlock_V_SRK(object):
         m.fs = FlowsheetBlock(default={"dynamic": False})
 
         m.fs.params = CubicParameterBlock(default={"valid_phase": "Vap"})
-        m.fs.params.component_list = Set(initialize=["a", "b"])
+
+        m.fs.params.a = Component()
+        m.fs.params.b = Component()
+
         m.fs.params.cubic_type = CubicEoS.SRK
 
         m.fs.params.gas_const = Param(default=8.314462618)

--- a/idaes/generic_models/unit_models/tests/test_mixer.py
+++ b/idaes/generic_models/unit_models/tests/test_mixer.py
@@ -25,21 +25,21 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            TerminationCondition,
                            SolverStatus,
-                           value,
-                           units)
-from pyomo.util.check_units import (assert_units_consistent,
-                                    assert_units_equivalent)
+                           value)
+from pyomo.util.check_units import assert_units_consistent
+
 from pyomo.network import Port
 from pyomo.common.config import ConfigBlock
 
 from idaes.core import (FlowsheetBlock,
-                        StateBlock,
                         declare_process_block_class,
                         StateBlockData,
                         StateBlock,
                         PhysicalParameterBlock,
                         MaterialBalanceType,
-                        EnergyBalanceType)
+                        EnergyBalanceType,
+                        Phase,
+                        Component)
 from idaes.generic_models.properties.activity_coeff_models.BTX_activity_coeff_VLE \
     import BTXParameterBlock
 from idaes.generic_models.properties import iapws95
@@ -827,8 +827,11 @@ class _NoPressureParameterBlock(PhysicalParameterBlock):
     def build(self):
         super(_NoPressureParameterBlock, self).build()
 
-        self.phase_list = Set(initialize=["p1", "p2"])
-        self.component_list = Set(initialize=["c1", "c2"])
+        self.p1 = Phase()
+        self.p2 = Phase()
+        self.c1 = Component()
+        self.c2 = Component()
+
         self.phase_equilibrium_idx = Set(initialize=["e1", "e2"])
 
         self.phase_equilibrium_list = \

--- a/idaes/generic_models/unit_models/tests/test_mixer.py
+++ b/idaes/generic_models/unit_models/tests/test_mixer.py
@@ -25,7 +25,8 @@ from pyomo.environ import (ConcreteModel,
                            Var,
                            TerminationCondition,
                            SolverStatus,
-                           value)
+                           value,
+                           units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
 
 from pyomo.network import Port
@@ -842,13 +843,11 @@ class _NoPressureParameterBlock(PhysicalParameterBlock):
 
     @classmethod
     def define_metadata(cls, obj):
-        obj.add_default_units({'time': 's',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.s,
+                               'length': pyunits.m,
+                               'mass': pyunits.g,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
 
 
 @declare_process_block_class("NoPressureStateBlock",

--- a/idaes/generic_models/unit_models/tests/test_mixer.py
+++ b/idaes/generic_models/unit_models/tests/test_mixer.py
@@ -835,7 +835,7 @@ class _NoPressureParameterBlock(PhysicalParameterBlock):
             {"e1": ["c1", ("p1", "p2")],
              "e2": ["c2", ("p1", "p2")]}
 
-        self.state_block_class = NoPressureStateBlock
+        self._state_block_class = NoPressureStateBlock
 
     @classmethod
     def define_metadata(cls, obj):

--- a/idaes/generic_models/unit_models/tests/test_separator.py
+++ b/idaes/generic_models/unit_models/tests/test_separator.py
@@ -1310,7 +1310,7 @@ class _IdealParameterBlock(PhysicalParameterBlock):
         self._phase_component_set = Set(initialize=[
             ("p1", "c1"), ("p1", "c2"), ("p2", "c1"), ("p2", "c2")])
 
-        self.state_block_class = IdealStateBlock
+        self._state_block_class = IdealStateBlock
 
     @classmethod
     def define_metadata(cls, obj):

--- a/idaes/generic_models/unit_models/tests/test_separator.py
+++ b/idaes/generic_models/unit_models/tests/test_separator.py
@@ -23,7 +23,8 @@ from pyomo.environ import (ConcreteModel,
                            Set,
                            SolverStatus,
                            value,
-                           Var)
+                           Var,
+                           units as pyunits)
 
 from pyomo.network import Port
 from pyomo.common.config import ConfigBlock
@@ -1317,13 +1318,11 @@ class _IdealParameterBlock(PhysicalParameterBlock):
 
     @classmethod
     def define_metadata(cls, obj):
-        obj.add_default_units({'time': 's',
-                               'length': 'm',
-                               'mass': 'g',
-                               'amount': 'mol',
-                               'temperature': 'K',
-                               'energy': 'J',
-                               'holdup': 'mol'})
+        obj.add_default_units({'time': pyunits.s,
+                               'length': pyunits.m,
+                               'mass': pyunits.g,
+                               'amount': pyunits.mol,
+                               'temperature': pyunits.K})
 
 
 @declare_process_block_class("IdealStateBlock", block_class=StateBlock)

--- a/idaes/generic_models/unit_models/tests/test_separator.py
+++ b/idaes/generic_models/unit_models/tests/test_separator.py
@@ -31,11 +31,12 @@ from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import (FlowsheetBlock,
                         declare_process_block_class,
-                        StateBlock,
                         MaterialBalanceType,
                         StateBlockData,
                         StateBlock,
-                        PhysicalParameterBlock)
+                        PhysicalParameterBlock,
+                        Phase,
+                        Component)
 from idaes.generic_models.unit_models.separator import (Separator,
                                                         SeparatorData,
                                                         SplittingType,
@@ -1304,9 +1305,11 @@ class _IdealParameterBlock(PhysicalParameterBlock):
     def build(self):
         super(_IdealParameterBlock, self).build()
 
-        self.phase_list = Set(initialize=["p1", "p2"])
-        self.component_list = Set(initialize=["c1", "c2"],
-                                  ordered=True)
+        self.p1 = Phase()
+        self.p2 = Phase()
+        self.c1 = Component()
+        self.c2 = Component()
+
         self._phase_component_set = Set(initialize=[
             ("p1", "c1"), ("p1", "c2"), ("p2", "c1"), ("p2", "c2")])
 

--- a/idaes/power_generation/unit_models/helm/tests/test_condenser_ntu.py
+++ b/idaes/power_generation/unit_models/helm/tests/test_condenser_ntu.py
@@ -65,7 +65,7 @@ def test_condenser_steady():
 def test_condenser_dynamic():
     m = pyo.ConcreteModel()
     m.fs = idaes.core.FlowsheetBlock(
-        default={"dynamic": True, "time_set":[0,3]})
+        default={"dynamic": True, "time_set":[0,3], "time_units": pyo.units.s})
     m.fs.properties = iapws95.Iapws95ParameterBlock()
     m.fs.unit = HelmNtuCondenser(
         default={

--- a/idaes/power_generation/unit_models/helm/tests/test_turbine_inlet.py
+++ b/idaes/power_generation/unit_models/helm/tests/test_turbine_inlet.py
@@ -17,7 +17,7 @@ Author: John Eslick
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel, SolverFactory, TransformationFactory,
+from pyomo.environ import (ConcreteModel, TransformationFactory,
                            units as pyunits, value)
 
 from idaes.core import FlowsheetBlock
@@ -37,16 +37,19 @@ def build_turbine():
     m = ConcreteModel()
     m.fs = FlowsheetBlock(default={"dynamic": False})
     m.fs.properties = iapws95.Iapws95ParameterBlock()
-    m.fs.turb = HelmTurbineInletStage(default={"property_package": m.fs.properties})
+    m.fs.turb = HelmTurbineInletStage(
+        default={"property_package": m.fs.properties})
     return m
 
 
 @pytest.fixture()
 def build_turbine_dyn():
     m = ConcreteModel()
-    m.fs = FlowsheetBlock(default={"dynamic": True, "time_set":[0,4]})
+    m.fs = FlowsheetBlock(
+        default={"dynamic": True, "time_set":[0,4], "time_units": pyunits.s})
     m.fs.properties = iapws95.Iapws95ParameterBlock()
-    m.fs.turb = HelmTurbineInletStage(default={"property_package": m.fs.properties})
+    m.fs.turb = HelmTurbineInletStage(
+        default={"property_package": m.fs.properties})
     return m
 
 

--- a/idaes/power_generation/unit_models/helm/tests/test_turbine_outlet.py
+++ b/idaes/power_generation/unit_models/helm/tests/test_turbine_outlet.py
@@ -17,7 +17,7 @@ Author: John Eslick
 """
 import pytest
 
-from pyomo.environ import ConcreteModel, SolverFactory, TransformationFactory, value
+from pyomo.environ import ConcreteModel, TransformationFactory, units as pyunits
 
 from idaes.core import FlowsheetBlock
 from idaes.power_generation.unit_models.helm import HelmTurbineOutletStage
@@ -43,7 +43,7 @@ def build_turbine():
 @pytest.fixture()
 def build_turbine_dyn():
     m = ConcreteModel()
-    m.fs = FlowsheetBlock(default={"dynamic": True})
+    m.fs = FlowsheetBlock(default={"dynamic": True, "time_units": pyunits.s})
     m.fs.properties = iapws95.Iapws95ParameterBlock()
     m.fs.turb = HelmTurbineOutletStage(default={
         "dynamic": False,


### PR DESCRIPTION
## Fixes #477


## Summary/Motivation:
Removing some backwards compatibility code for features that have been deprecated for over a year.

## Changes proposed in this PR:
- Units are now required for dynamic time domains
- Pyomo units must be used for all property packages (can use `dimensionless` to ignore units, but must be explicit).
- Property packages must use `Phase` and `Component` objects rather than creating phase and component lists
- Developers can no longer directly set `state_block_class` and `reaction_block_class`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
