### PR TITLE
Adding set_value method to GeneralVarLikeExpression

### DIFF
--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -254,14 +254,39 @@ class _GeneralVarLikeExpressionData(_GeneralExpressionData):
 
     # Define methods for common APIs on Vars in case user mistakes
     # an Expression for a Var
+    def set_value(self, value, force=False):
+        """
+        Overload set_value method to provide meaningful error if user attempts
+        to set the value of the Expression. In order to support changing the
+        expression (and setting it originally), if self._expr is None or
+        force=True, the value of the expression will be updated, otherwise a
+        TypeError will be raised.
+
+        Args:
+            value: value to set for _expr
+            force: force updating of _expr if True (default = False)
+
+        Returns:
+            None
+
+        Raises:
+            TypeError if _expr is not None and force=False
+        """
+        if self._expr is None or force:
+            super().set_value(value)
+        else:
+            raise TypeError(
+                f"{self.name} is an Expression and does not have a value "
+                f"which can be set.")
+
     @property
     def value(self):
-        # Overload value so it behaves like a Var
-        return pyo.value(self.expr)
+        raise TypeError(
+            f"{self.name} is an Expression and does not have a value "
+            f"attribute. Use the 'value()' method instead.")
 
     @value.setter
     def value(self, expr):
-        # Overload value seter to prevent users changing the expression body
         raise TypeError(
             "%s is an Expression and does not have a value which can be set."
             % (self.name))

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -152,7 +152,16 @@ def test_SimpleVarLikeExpression():
 
     assert m.e.type() is Expression
     assert not m.e.is_indexed()
-    assert m.e.value == 42
+
+    with pytest.raises(TypeError,
+                       match="e is an Expression and does not have a value "
+                       "attribute. Use the 'value\(\)' method instead."):
+        assert m.e.value == 42
+
+    with pytest.raises(TypeError,
+                       match="e is an Expression and does not have a value "
+                       "which can be set."):
+        m.e.set_value(10)
 
     with pytest.raises(TypeError,
                        match="e is an Expression and does not have a value "
@@ -174,6 +183,9 @@ def test_SimpleVarLikeExpression():
     with pytest.raises(TypeError,
                        match="e is an Expression and can not be unfixed."):
         m.e.unfix()
+
+    m.e.set_value(10, force=True)
+    assert m.e._expr == 10
 
 
 @pytest.mark.unit
@@ -206,7 +218,16 @@ def test_IndexedVarLikeExpression():
         m.e.unfix()
 
     for i in m.e:
-        assert m.e[i].value == 42
+        with pytest.raises(TypeError,
+                           match=f"e\[{i}\] is an Expression and does not have"
+                           f" a value attribute. Use the 'value\(\)' method "
+                           "instead"):
+            assert m.e[i].value == 42
+
+        with pytest.raises(TypeError,
+                           match=f"e\[{i}\] is an Expression and does not "
+                           f"have a value which can be set."):
+            m.e[i].set_value(10)
 
         with pytest.raises(TypeError,
                            match="e\[{}\] is an Expression and does not have "
@@ -232,6 +253,9 @@ def test_IndexedVarLikeExpression():
                            match="e\[{}\] is an Expression and can not be "
                            "unfixed.".format(i)):
             m.e[i].unfix()
+
+        m.e[i].set_value(i, force=True)
+        assert m.e[i]._expr == i
 
 
 @pytest.mark.unit

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -294,14 +294,14 @@ class TestFlashIntegration(object):
     @pytest.mark.component
     def test_solution(self, model):
         # Check phase equilibrium results
-        assert model.fs.unit.liq_outlet.mole_frac_comp[
-            0, "carbon_dioxide"].value == \
+        assert value(model.fs.unit.liq_outlet.mole_frac_comp[
+            0, "carbon_dioxide"]) == \
             pytest.approx(0.3119, abs=1e-4)
-        assert model.fs.unit.vap_outlet.mole_frac_comp[
-            0, "carbon_dioxide"].value == \
+        assert value(model.fs.unit.vap_outlet.mole_frac_comp[
+            0, "carbon_dioxide"]) == \
             pytest.approx(1.0000, abs=1e-4)
-        assert (model.fs.unit.vap_outlet.flow_mol[0].value /
-                model.fs.unit.liq_outlet.flow_mol[0].value) == \
+        assert value(model.fs.unit.vap_outlet.flow_mol[0] /
+                     model.fs.unit.liq_outlet.flow_mol[0]) == \
             pytest.approx(0.37619, abs=1e-4)
 
     @pytest.mark.ui


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
@dallan-keylogic identified an issue where using `set_value()` on the IDAES `GeneralVarLikeExpression` component would overwrite the expression with the new value, which was undesired behaviour. This PR overloads `set_value` to raise an `Exception` in normal use, but retains a `force` option to allow users to change the expression if desired.


## Changes proposed in this PR:
- Overloads `set_value()`
- Adds new tests for `set_value`
- Fixes a case where `value()` should have been used in a test.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
