### PR TITLE
Fixing deprecation warning about using cardinal indices on Pyomo Sets

### DIFF
--- a/idaes/generic_models/properties/core/state_definitions/FPhx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FPhx.py
@@ -190,9 +190,9 @@ def define_state(b):
             return sum(b.mole_frac_phase_comp[b.phase_list.first(), i]
                        for i in b.component_list
                        if (b.phase_list.first(), i) in b.phase_component_set) -\
-                sum(b.mole_frac_phase_comp[b.phase_list[2], i]
+                sum(b.mole_frac_phase_comp[b.phase_list.last(), i]
                     for i in b.component_list
-                    if (b.phase_list[2], i) in b.phase_component_set) == 0
+                    if (b.phase_list.last(), i) in b.phase_component_set) == 0
         b.sum_mole_frac = Constraint(rule=rule_mole_frac)
 
         def rule_phase_frac(b, p):

--- a/idaes/generic_models/properties/core/state_definitions/FTPx.py
+++ b/idaes/generic_models/properties/core/state_definitions/FTPx.py
@@ -173,9 +173,9 @@ def define_state(b):
             return sum(b.mole_frac_phase_comp[b.phase_list.first(), i]
                        for i in b.component_list
                        if (b.phase_list.first(), i) in b.phase_component_set) -\
-                sum(b.mole_frac_phase_comp[b.phase_list[2], i]
+                sum(b.mole_frac_phase_comp[b.phase_list.last(), i]
                     for i in b.component_list
-                    if (b.phase_list[2], i) in b.phase_component_set) == 0
+                    if (b.phase_list.last(), i) in b.phase_component_set) == 0
         b.sum_mole_frac = Constraint(rule=rule_mole_frac)
 
         def rule_phase_frac(b, p):

--- a/idaes/generic_models/properties/core/state_definitions/FcPh.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcPh.py
@@ -197,9 +197,9 @@ def define_state(b):
             return sum(b.mole_frac_phase_comp[b.phase_list.first(), i]
                        for i in b.component_list
                        if (b.phase_list.first(), i) in b.phase_component_set) -\
-                sum(b.mole_frac_phase_comp[b.phase_list[2], i]
+                sum(b.mole_frac_phase_comp[b.phase_list.last(), i]
                     for i in b.component_list
-                    if (b.phase_list[2], i) in b.phase_component_set) == 0
+                    if (b.phase_list.last(), i) in b.phase_component_set) == 0
         b.sum_mole_frac = Constraint(rule=rule_mole_frac)
 
         def rule_phase_frac(b, p):

--- a/idaes/generic_models/properties/core/state_definitions/FcTP.py
+++ b/idaes/generic_models/properties/core/state_definitions/FcTP.py
@@ -175,9 +175,9 @@ def define_state(b):
             return sum(b.mole_frac_phase_comp[b.phase_list.first(), i]
                        for i in b.component_list
                        if (b.phase_list.first(), i) in b.phase_component_set) -\
-                sum(b.mole_frac_phase_comp[b.phase_list[2], i]
+                sum(b.mole_frac_phase_comp[b.phase_list.last(), i]
                     for i in b.component_list
-                    if (b.phase_list[2], i) in b.phase_component_set) == 0
+                    if (b.phase_list.last(), i) in b.phase_component_set) == 0
         b.sum_mole_frac = Constraint(rule=rule_mole_frac)
 
         def rule_phase_frac(b, p):


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Looking over the output of an example notebook in https://github.com/IDAES/examples-pse/pull/65 revealed a deprecation warning that should be fixed.

## Changes proposed in this PR:
- Change cases where a cardinal index was used to get a value from Pyomo Sets
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
