### PR TITLE
Fixing deprecation warning for get_default_solver

### DIFF
--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -48,8 +48,8 @@ def get_default_solver():
     Move to idaes.core.util.misc - leaving redirection method here for
     deprecation warning
     """
-    _log.warn("Deprecated: get_default_solve has been moved and can now be "
-              "imported from idaes.core.util")
+    _log.warn("Deprecated: get_default_solver has been moved and renamed. It "
+              "can now be imported from idaes.core.util as get_solver")
     return default_solver()
 
 


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Corrects the path to the replacement for `get_default_solver`

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
