### PR TITLE
Unit models for Mea flowsheet v1

### DIFF
--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/kettlereboiler.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/kettlereboiler.py
@@ -1,0 +1,354 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+"""
+IDAES Kettle Reboiler
+
+Author : Paul Akula
+"""
+
+# Import Pyomo libraries
+from pyomo.environ import Expression, Constraint, value, Var, units
+from pyomo.common.config import ConfigBlock, ConfigValue
+
+# Import IDAES cores
+from idaes.core import (ControlVolume0DBlock,
+                        declare_process_block_class,
+                        MaterialBalanceType,
+                        MomentumBalanceType,
+                        UnitModelBlockData,
+                        useDefault)
+from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util import get_solver
+import idaes.logger as idaeslog
+
+# Set up logger
+_log = idaeslog.getLogger(__name__)
+
+
+@declare_process_block_class("KettleReboiler")
+class KettleReboilerData(UnitModelBlockData):
+    """Kettle Reboiler Unit Model."""
+
+    CONFIG = UnitModelBlockData.CONFIG()
+
+    # Configuration template for Phase specific  arguments
+    _PhaseCONFIG = ConfigBlock()
+
+    CONFIG.declare("heat_duty", ConfigValue(
+        default=430.61,
+        domain=float,
+        description="Reboiler heat duty in kW",
+        doc="Reboiler heat duty in kW"))
+
+    _PhaseCONFIG.declare("property_package", ConfigValue(
+        default=useDefault,
+        domain=is_physical_parameter_block,
+        description="Property package to use ",
+        doc="""Property parameter object used to define property calculations
+        **default** - useDefault.
+        **Valid values:** {
+        **useDefault** - use default package from parent model or flowsheet,
+        **PhysicalParameterObject** - a PhysicalParameterBlock object.}"""))
+
+    _PhaseCONFIG.declare("property_package_args", ConfigBlock(
+        implicit=True,
+        description="Arguments to use for constructing property package",
+        doc="""A ConfigBlock with arguments to be passed to
+        property block(s) and used when constructing these,
+        **default** - None.
+        **Valid values:** {
+        see property package for documentation.}"""))
+
+    # Create individual config blocks for vapor and liquid phases
+    CONFIG.declare("vapor_side",
+                   _PhaseCONFIG(doc="Vapor phase config arguments"))
+    CONFIG.declare("liquid_side",
+                   _PhaseCONFIG(doc="liquid phase config arguments"))
+
+    def build(self):
+        # Call UnitModel.build to setup model
+        super(KettleReboilerData, self).build()
+
+        # Build Control Volume for liquid Phase
+        self.liquid_phase = ControlVolume0DBlock(default={
+            "dynamic": self.config.dynamic,
+            "property_package": self.config.liquid_side.property_package,
+            "property_package_args": self.config.liquid_side.property_package_args})
+
+        self.liquid_phase.add_state_blocks(has_phase_equilibrium=False)
+
+        # Add only momentum balance
+        # Combined  Mass and Energy balances for  Liquid and Vapor phases
+        # are added as performance equations
+
+        self.liquid_phase.add_momentum_balances(
+            balance_type=MomentumBalanceType.pressureTotal,
+            has_pressure_change=False)
+
+        # ======================================================================
+        # Build Control Volume for vapor Phase
+        self.vapor_phase = ControlVolume0DBlock(default={
+            "dynamic": self.config.dynamic,
+            "property_package": self.config.vapor_side.property_package,
+            "property_package_args": self.config.vapor_side.property_package_args})
+
+        self.vapor_phase.add_state_blocks(has_phase_equilibrium=False)
+
+        # Energy balance not added: Exit temperature is the equilibruim Temp.
+
+        self.vapor_phase.add_material_balances(
+            balance_type=MaterialBalanceType.componentTotal,
+            has_mass_transfer=False,
+            has_phase_equilibrium=False,
+            has_rate_reactions=False)
+
+        self.vapor_phase.add_momentum_balances(
+            balance_type=MomentumBalanceType.pressureTotal,
+            has_pressure_change=False)
+
+        # ======================================================================
+        # Add Ports to control volumes
+        # Liquid Phase
+        self.add_inlet_port(name="liquid_inlet",
+                            block=self.liquid_phase, doc='inlet Port')
+        self.add_outlet_port(name="liquid_outlet",
+                             block=self.liquid_phase, doc='outlet Port')
+
+        # Vapor Phase : No inlet port
+        self.add_outlet_port(name="vapor_outlet",
+                             block=self.vapor_phase, doc='outlet Port')
+        # ======================================================================
+        # Add performace equation method
+        self._make_params()
+        self._make_performance_method()
+
+    def _make_params(self):
+
+        # Internal variables for custom mass and energy balance
+
+        self.y = Var(self.flowsheet().time,
+                     self.config.vapor_side.property_package.component_list,
+                     initialize=0.5,
+                     units=None,
+                     doc="Vapor component composition")
+
+        self.vf = Var(self.flowsheet().time,
+                      initialize=0.5,
+                      units=None,
+                      doc="Vapor phase fraction")
+
+        self.FV = Var(self.flowsheet().time,
+                      initialize=1,
+                      units=units.kmol,
+                      doc="Vapor exit flow")
+
+        self.heat_duty = Var(self.flowsheet().time,
+                             initialize=1,
+                             units=units.kW,
+                             doc="Reboiler heat duty")
+
+    def _make_performance_method(self):
+
+        # =====================================================================
+        # Custom Material Balance
+        @self.Constraint(self.flowsheet().time,
+                         self.config.liquid_side.property_package.component_list,
+                         doc="Reboiler Material Balance")
+        def reb_material_balance(blk, t, i):
+            if i == 'MEA':
+                return blk.liquid_phase.properties_in[t].mole_frac_comp[i] ==\
+                    (1 - blk.vf[t]) * blk.liquid_phase.properties_out[t].mole_frac_comp[i]
+            else:
+                return blk.liquid_phase.properties_in[t].mole_frac_comp[i] ==\
+                    (1 - blk.vf[t]) * blk.liquid_phase.properties_out[t].mole_frac_comp[i] + blk.vf[t] * blk.y[t, i]
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Vapor exit flow")
+        def vap_exit_flow(blk, t):
+            return blk.FV[t] == blk.vf[t] *\
+                blk.liquid_phase.properties_in[t].flow_mol*1e-3
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Liquid exit flow")
+        def liq_exit_flow(blk, t):
+            return blk.liquid_phase.properties_out[t].flow_mol ==\
+                   blk.liquid_phase.properties_in[t].flow_mol - blk.FV[t]*1e3
+
+        # =====================================================================
+        # Custom Energy Balance
+
+        def rule_heat_vaporization(blk, t):
+            return 40650
+        self.heat_vaporization = Expression(self.flowsheet().time,
+                                            rule=rule_heat_vaporization,
+                                            doc='heat of water vaporization in kJ/mol')
+
+        def rule_heat_desorption(blk, t):
+            return 95000
+        self.heat_desorption = Expression(self.flowsheet().time,
+                                          rule=rule_heat_desorption,
+                                          doc='heat of CO2 desorption in kJ/mol')
+
+        def rule_heat_latent(blk, t):
+            return blk.vf[t] * (blk.y[t, 'H2O'] * blk.heat_vaporization[t] +
+                                blk.y[t, 'CO2'] * blk.heat_desorption[t])
+        self.heat_latent = Expression(self.flowsheet().time,
+                                      rule=rule_heat_latent,
+                                      doc='latent heat ')
+
+        def rule_heat_sens(blk, t):
+            return (1 - blk.vf[t]) * blk.liquid_phase.properties_out[t].cp_mol *\
+                   (blk.liquid_phase.properties_out[t].temperature -
+                    blk.liquid_phase.properties_in[t].temperature)
+        self.heat_sens = Expression(self.flowsheet().time,
+                                    rule=rule_heat_sens,
+                                    doc='sensible heat ')
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Energy balance")
+        def reb_energy_balance(blk, t):
+            return blk.heat_duty[t] == \
+                (blk.heat_latent[t] + blk.heat_sens[t]) *\
+                blk.liquid_phase.properties_in[t].flow_mol*1e-3
+
+        # =====================================================================
+        # Vapor -Liquid Equilibruim
+        @self.Constraint(self.flowsheet().time,
+                         self.config.vapor_side.property_package.component_list,
+                         doc="Vapor-Liquid Equilibruim ")
+        def VLE(blk, t, j):
+            if j == 'H2O':
+                return blk.y[t, j] * blk.liquid_phase.properties_out[t].pressure ==\
+                    (blk.liquid_phase.properties_out[t].vol_mol *
+                     blk.liquid_phase.properties_out[t].conc_mol_comp_true[j] *
+                     blk.liquid_phase.properties_out[t].pressure_sat[j])
+            elif j == 'CO2':
+                return blk.y[t, j] * blk.liquid_phase.properties_out[t].pressure ==\
+                    (blk.liquid_phase.properties_out[t].conc_mol_comp_true[j] *
+                     blk.liquid_phase.properties_out[t].henry_N2O_analogy)
+
+        # ----------------------------------------------------------------------
+        # Vapor Phase Inlet Connections and Exit Temperature Relation
+
+        @self.Constraint(self.flowsheet().time,
+                         self.config.vapor_side.property_package.component_list,
+                         doc="Vapor phase inlet composition relation")
+        def vapor_inlet_comp(blk, t, i):
+            return blk.vapor_phase.properties_in[t].mole_frac_comp[i] == blk.y[t, i]
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Vapor phase inlet flow relation")
+        def vapor_inlet_flow(blk, t):
+            return blk.vapor_phase.properties_in[t].flow_mol == blk.FV[t]*1e3
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Vapor phase inlet temperature relation")
+        def vapor_inlet_temp(blk, t):
+            return blk.vapor_phase.properties_in[t].temperature ==\
+                blk.liquid_phase.properties_out[t].temperature
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Vapor phase exit temperature relation")
+        def vapor_exit_temp(blk, t):
+            return blk.vapor_phase.properties_in[t].temperature ==\
+                blk.vapor_phase.properties_out[t].temperature
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Vapor phase inlet pressure relation")
+        def vapor_inlet_pressure(blk, t):
+            return blk.vapor_phase.properties_in[t].pressure ==\
+                  blk.liquid_phase.properties_in[t].pressure
+
+        # fix heat duty
+        for t in self.flowsheet().time:
+            self.heat_duty[t].fix(self.config.heat_duty)
+
+    def initialize(blk, liquid_state_args=None,
+                   outlvl=idaeslog.NOTSET, solver=None, optarg=None):
+        '''
+        Initialisation routine for reboiler unit (default solver ipopt)
+
+        Keyword Arguments:
+            state_args : a dict of arguments to be passed to the property
+                           package(s) to provide an initial state for
+                           initialization (see documentation of the specific
+                           property package) (default = {}).
+            outlvl : sets output level of initialization routine
+            optarg : solver options dictionary object (default=None, use
+                     default solver options)
+            solver : str indicating which solver to use during
+                     initialization (default = None)
+        Returns:
+            None
+        '''
+        # Set solver options
+        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag='unit')
+        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+
+        # Create solver
+        opt = get_solver(solver, optarg)
+
+        liquid_state_args = {
+            'flow_mol': value(blk.liquid_inlet.flow_mol[0]),
+            'temperature': value(blk.liquid_inlet.temperature[0]),
+            'pressure': value(blk.liquid_inlet.pressure[0]),
+            'mole_frac_comp':
+            {'H2O': value(blk.liquid_inlet.mole_frac_comp[0, 'H2O']),
+             'CO2': value(blk.liquid_inlet.mole_frac_comp[0, 'CO2']),
+             'MEA': value(blk.liquid_inlet.mole_frac_comp[0, 'MEA'])}}
+
+        # ---------------------------------------------------------------------
+        # Initialize the liquid INLET properties
+        init_log.info('STEP 1: PROPERTY INITIALIZATION')
+        init_log.info_high("INLET Properties initialization")
+        blk.liquid_phase.properties_in.initialize(
+            state_args=liquid_state_args,
+            outlvl=outlvl,
+            optarg=optarg,
+            solver=solver,
+            hold_state=True)
+
+        blk.vf[0].value = 0.5
+        flow_out = value((1 - blk.vf[0])
+                         *blk.liquid_phase.properties_in[0].flow_mol)
+
+        liquid_state_args_out = {
+            'flow_mol': flow_out,
+            'temperature': value(blk.liquid_inlet.temperature[0]),
+            'pressure': value(blk.liquid_inlet.pressure[0]),
+            'mole_frac_comp':
+            {'H2O': value(blk.liquid_inlet.mole_frac_comp[0, 'H2O']),
+             'CO2': value(blk.liquid_inlet.mole_frac_comp[0, 'CO2']),
+             'MEA': value(blk.liquid_inlet.mole_frac_comp[0, 'MEA'])}}
+
+        # Initialize the Liquid OUTLET properties
+        init_log.info_high("Liquid OUTLET Properties initialization")
+        blk.liquid_phase.properties_out.initialize(
+            state_args=liquid_state_args_out,
+            outlvl=outlvl,
+            optarg=optarg,
+            solver=solver,
+            hold_state=False)
+
+        blk.heat_duty[0].fix(blk.config.heat_duty)
+
+        blk.FV[0].value = value(blk.vf[0] *
+                                blk.liquid_phase.properties_in[0].flow_mol*1e-3)
+
+        # ----------------------------------------------------------------------
+        init_log.info('STEP 2: Reboiler INITIALIZATION')
+        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+            res = opt.solve(blk, tee=slc.tee)
+        init_log.info_high(
+            "STEP 2 Complete: {}.".format(idaeslog.condition(res)))
+        init_log.info('INITIALIZATION COMPLETED')

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/kettlereboiler.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/kettlereboiler.py
@@ -91,7 +91,7 @@ class KettleReboilerData(UnitModelBlockData):
 
         # Build Control Volume for liquid Phase
         self.liquid_phase = ControlVolume0DBlock(default={
-            "dynamic": self.config.dynamic,
+            "dynamic": False,
             "property_package": self.config.liquid_side.property_package,
             "property_package_args": self.config.liquid_side.property_package_args})
 
@@ -108,7 +108,7 @@ class KettleReboilerData(UnitModelBlockData):
         # ======================================================================
         # Build Control Volume for vapor Phase
         self.vapor_phase = ControlVolume0DBlock(default={
-            "dynamic": self.config.dynamic,
+            "dynamic": False,
             "property_package": self.config.vapor_side.property_package,
             "property_package_args": self.config.vapor_side.property_package_args})
 

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/partialcondenser.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/partialcondenser.py
@@ -1,0 +1,364 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+"""
+IDAES Partial Condenser
+
+Author : Paul Akula
+"""
+
+# Import Pyomo libraries
+from pyomo.environ import Expression, Constraint, value, Var, units
+from pyomo.common.config import ConfigBlock, ConfigValue, Bool
+
+# Import IDAES cores
+from idaes.core import (ControlVolume0DBlock,
+                        declare_process_block_class,
+                        MaterialBalanceType,
+                        MomentumBalanceType,
+                        UnitModelBlockData,
+                        useDefault)
+from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util import get_solver
+import idaes.logger as idaeslog
+
+# Set up logger
+_log = idaeslog.getLogger(__name__)
+
+
+@declare_process_block_class("PartialCondenser")
+class PartialCondenserData(UnitModelBlockData):
+    """Partial Condenser Unit Model."""
+
+    CONFIG = UnitModelBlockData.CONFIG()
+
+    # Configuration template for Phase specific  arguments
+    _PhaseCONFIG = ConfigBlock()
+
+    CONFIG.declare("specify_condenser_temperature", ConfigValue(
+        default=True,
+        domain=Bool,
+        description="Indicates if the outlet temperature of the condenser is specified",
+        doc="""Indicates if the user specifies the condenser temperature or not
+       **default** - True.
+        **Valid values:** {
+        **True** - Condenser outlet temperature is specified,
+        **False** - Condenser outlet temperature is not specified}"""))
+
+    CONFIG.declare("condenser_temperature_spec", ConfigValue(
+        default=303.15,
+        domain=float,
+        description="Condenser outlet temperature in Kelvin",
+        doc="Condenser temperature in Kelvin"))
+
+    _PhaseCONFIG.declare("property_package", ConfigValue(
+        default=useDefault,
+        domain=is_physical_parameter_block,
+        description="Property package to use ",
+        doc="""Property parameter object used to define property calculations
+        **default** - useDefault.
+        **Valid values:** {
+        **useDefault** - use default package from parent model or flowsheet,
+        **PhysicalParameterObject** - a PhysicalParameterBlock object.}"""))
+
+    _PhaseCONFIG.declare("property_package_args", ConfigBlock(
+        implicit=True,
+        description="Arguments to use for constructing property package",
+        doc="""A ConfigBlock with arguments to be passed to
+        property block(s) and used when constructing these,
+        **default** - None.
+        **Valid values:** {
+        see property package for documentation.}"""))
+
+    # Create individual config blocks for vapor and liquid phases
+    CONFIG.declare("vapor_side",
+                   _PhaseCONFIG(doc="Vapor phase config arguments"))
+    CONFIG.declare("liquid_side",
+                   _PhaseCONFIG(doc="liquid phase config arguments"))
+
+    def build(self):
+        # Call UnitModel.build to setup model
+        super(PartialCondenserData, self).build()
+
+        # Build Control Volume for Vapor Phase
+        self.vapor_phase = ControlVolume0DBlock(default={
+            "dynamic": False,
+            "property_package": self.config.vapor_side.property_package,
+            "property_package_args": self.config.vapor_side.property_package_args})
+
+        self.vapor_phase.add_state_blocks(has_phase_equilibrium=False)
+
+        # Add only momentum balance
+        # Combined  Mass and Energy balances for  Liquid and Vapor phases
+        # are added as performance equations
+
+        self.vapor_phase.add_momentum_balances(
+            balance_type=MomentumBalanceType.pressureTotal,
+            has_pressure_change=False)
+
+        # ======================================================================
+        # Build Control Volume for liquid Phase
+        self.liquid_phase = ControlVolume0DBlock(default={
+            "dynamic": False,
+            "property_package": self.config.liquid_side.property_package,
+            "property_package_args": self.config.liquid_side.property_package_args})
+
+        self.liquid_phase.add_state_blocks(has_phase_equilibrium=False)
+
+        # Energy balance not added: Exit temperature is the equilibruim Temp.
+
+        self.liquid_phase.add_material_balances(
+            balance_type=MaterialBalanceType.componentTotal,
+            has_mass_transfer=False,
+            has_phase_equilibrium=False,
+            has_rate_reactions=False)
+
+        self.liquid_phase.add_momentum_balances(
+            balance_type=MomentumBalanceType.pressureTotal,
+            has_pressure_change=False)
+
+        # ======================================================================
+        # Add Ports to control volumes
+        # Vapor Phase
+        self.add_inlet_port(name="vapor_inlet",
+                            block=self.vapor_phase, doc='inlet Port')
+        self.add_outlet_port(name="vapor_outlet",
+                             block=self.vapor_phase, doc='outlet Port')
+
+        # Liquid Phase : No inlet port
+        self.add_outlet_port(name="liquid_outlet",
+                             block=self.liquid_phase, doc='outlet Port')
+        # ======================================================================
+        # Add performace equation method
+        self._make_params()
+        self._make_performance_method()
+
+    def _make_params(self):
+
+        # Internal variables for custom mass and energy balance
+        self.vf = Var(self.flowsheet().time,
+                      initialize=0.5,
+                      units=None,
+                      doc="Vapor phase fraction")
+
+        self.FL = Var(self.flowsheet().time,
+                      initialize=1,
+                      units=units.kmol,
+                      doc="Liquid exit flow")
+
+        self.condenser_duty = Var(self.flowsheet().time,
+                             initialize=1,
+                             units=units.kW,
+                             doc="Condenser heat duty")
+
+    def _make_performance_method(self):
+
+        # =====================================================================
+        # Custom Material Balance
+        @self.Constraint(self.flowsheet().time,
+                         doc="Condenser Material Balance")
+        def cond_material_balance(blk, t):
+            return blk.vapor_phase.properties_in[t].mole_frac_comp['CO2'] ==\
+                   blk.vf[t] * blk.vapor_phase.properties_out[t].mole_frac_comp['CO2']
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Vapor exit flow")
+        def vap_exit_flow(blk, t):
+            return blk.vapor_phase.properties_out[t].flow_mol == blk.vf[t] *\
+                   blk.vapor_phase.properties_in[t].flow_mol
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Liquid exit flow")
+        def liq_exit_flow(blk, t):
+            return blk.FL[t]*1e3 ==blk.vapor_phase.properties_in[t].flow_mol-\
+                   blk.vapor_phase.properties_out[t].flow_mol
+        # =====================================================================
+        # Custom Energy Balance
+
+        def rule_cp_mol_comp_avg(blk, t, i):
+            return 0.5*(blk.vapor_phase.properties_in[t].cp_mol_comp[i] +
+                        blk.vapor_phase.properties_out[t].cp_mol_comp[i])
+        self.cp_mol_comp_avg = Expression(
+                           self.flowsheet().time,
+                           self.config.vapor_side.property_package.component_list,
+                           rule=rule_cp_mol_comp_avg,
+                           doc='''Average molar heat capacity of vapor components
+                                  btw Inlet and Outlet temperature''')
+
+        def rule_cp_mol_avg(blk, t):
+            return sum(blk.vapor_phase.properties_out[t].mole_frac_comp[i]*
+                       blk.cp_mol_comp_avg[t,i] for i in
+                       blk.config.vapor_side.property_package.component_list)
+        self.cp_mol_avg = Expression(
+                           self.flowsheet().time,
+                           rule=rule_cp_mol_avg,
+                           doc='''Average molar heat capacity of vapor phase
+                                  btw Inlet and Outlet temperature''')
+
+        def rule_heat_latent(blk, t):
+            return (1-blk.vf[t]) *blk.liquid_phase.properties_out[t].hvap
+        self.heat_latent = Expression(self.flowsheet().time,
+                                      rule=rule_heat_latent,
+                                      doc='latent heat ')
+
+        def rule_heat_sens(blk, t):
+            return ((1 - blk.vf[t])*blk.cp_mol_comp_avg[t,'H2O'] +
+                    blk.vf[t]*blk.cp_mol_avg[t])*\
+                   (blk.vapor_phase.properties_out[t].temperature -
+                    blk.vapor_phase.properties_in[t].temperature)
+        self.heat_sens = Expression(self.flowsheet().time,
+                                    rule=rule_heat_sens,
+                                    doc='sensible heat ')
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Energy balance")
+        def cond_energy_balance(blk, t):
+            return blk.condenser_duty[t] == (blk.heat_sens[t] -
+                                             blk.heat_latent[t]) *\
+                   blk.vapor_phase.properties_in[t].flow_mol*1e-3
+
+        # =====================================================================
+        # Vapor -Liquid Equilibruim- Only water condensation
+        @self.Constraint(self.flowsheet().time,
+                         doc="Vapor-Liquid Equilibruim ")
+        def VLE(blk, t):
+            return blk.liquid_phase.properties_out[t].pressure_sat['H2O']==\
+                   blk.vapor_phase.properties_out[t].pressure *\
+                   blk.vapor_phase.properties_out[t].mole_frac_comp['H2O']
+
+        # ----------------------------------------------------------------------
+        # Liquid Phase Inlet Connections and Exit Temperature Relation
+        @self.Constraint(self.flowsheet().time,
+                         self.config.liquid_side.property_package.component_list,
+                         doc="Liquid inlet composition relation")
+        def liquid_inlet_comp_mol_frac(blk, t, i):
+            if i == 'H2O':
+                return blk.liquid_phase.properties_in[t].mole_frac_comp[i] == 1
+            else:
+                return blk.liquid_phase.properties_in[t].mole_frac_comp[i] == 0
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Liquid phase inlet flow relation")
+        def liquid_inlet_flow_mol(blk, t):
+            return blk.liquid_phase.properties_in[t].flow_mol == blk.FL[t]*1e3
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Liquid phase inlet temperature relation")
+        def liquid_inlet_temp(blk, t):
+            return blk.liquid_phase.properties_in[t].temperature ==\
+                blk.vapor_phase.properties_out[t].temperature
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Liquid phase exit temperature relation")
+        def liquid_exit_temp(blk, t):
+            return blk.liquid_phase.properties_in[t].temperature ==\
+                   blk.liquid_phase.properties_out[t].temperature
+
+        @self.Constraint(self.flowsheet().time,
+                         doc="Liquid phase inlet pressure relation")
+        def liquid_inlet_pressure(blk, t):
+            return blk.vapor_phase.properties_in[t].pressure ==\
+                   blk.liquid_phase.properties_in[t].pressure
+
+        # fix condenser temperature if provided
+        if self.config.specify_condenser_temperature:
+            for t in self.flowsheet().time:
+                self.vapor_phase.properties_out[t].temperature.fix(
+                    self.config.condenser_temperature_spec)
+
+        # This is a rare case where the speciation model is not required
+        for t in self.flowsheet().time:
+            self.liquid_phase.properties_out[t].speciation_model.deactivate()
+            self.liquid_phase.properties_out[t].conc_mol_comp_true.fix()
+            self.liquid_phase.properties_in[t].speciation_model.deactivate()
+            self.liquid_phase.properties_in[t].conc_mol_comp_true.fix()
+
+    def initialize(blk, vapor_state_args=None,
+                   outlvl=idaeslog.NOTSET, solver=None, optarg=None):
+        '''
+        Initialisation routine for reboiler unit (default solver ipopt)
+
+        Keyword Arguments:
+            state_args : a dict of arguments to be passed to the property
+                           package(s) to provide an initial state for
+                           initialization (see documentation of the specific
+                           property package) (default = {}).
+            outlvl : sets output level of initialization routine
+            optarg : solver options dictionary object (default=None, use
+                     default solver options)
+            solver : str indicating which solver to use during
+                     initialization (default = None)
+        Returns:
+            None
+        '''
+        # Set solver options
+        init_log = idaeslog.getInitLogger(blk.name, outlvl, tag='unit')
+        solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
+
+        # Create solver
+        opt = get_solver(solver, optarg)
+
+        vapor_state_args = {
+            'flow_mol': value(blk.vapor_inlet.flow_mol[0]),
+            'temperature': value(blk.vapor_inlet.temperature[0]),
+            'pressure': value(blk.vapor_inlet.pressure[0]),
+            'mole_frac_comp':
+            {'H2O': value(blk.vapor_inlet.mole_frac_comp[0, 'H2O']),
+             'CO2': value(blk.vapor_inlet.mole_frac_comp[0, 'CO2'])}}
+
+        # ---------------------------------------------------------------------
+        # Initialize the vapor INLET properties
+        init_log.info('STEP 1: PROPERTY INITIALIZATION')
+        init_log.info_high("INLET Properties initialization")
+        blk.vapor_phase.properties_in.initialize(
+            state_args=vapor_state_args,
+            outlvl=outlvl,
+            optarg=optarg,
+            solver=solver,
+            hold_state=True)
+
+        blk.vf[0].value = 0.5
+        flow_out = value(blk.vf[0]*blk.vapor_phase.properties_in[0].flow_mol)
+
+        vapor_state_args_out = {
+            'flow_mol': flow_out,
+            'temperature': value(blk.vapor_inlet.temperature[0]),
+            'pressure': value(blk.vapor_inlet.pressure[0]),
+            'mole_frac_comp':
+            {'H2O': value(blk.vapor_inlet.mole_frac_comp[0, 'H2O']),
+             'CO2': value(blk.vapor_inlet.mole_frac_comp[0, 'CO2'])}}
+
+        # Initialize the Vapor OUTLET properties
+        init_log.info_high("Vapor OUTLET Properties initialization")
+        blk.vapor_phase.properties_out.initialize(
+            state_args=vapor_state_args_out,
+            outlvl=outlvl,
+            optarg=optarg,
+            solver=solver,
+            hold_state=False)
+
+        blk.vapor_phase.properties_out[0].temperature.fix(
+                                         blk.config.condenser_temperature_spec)
+
+        blk.FL[0].value = value((1- blk.vf[0]) *
+                                blk.vapor_phase.properties_in[0].flow_mol*1e-3)
+
+        # ----------------------------------------------------------------------
+        init_log.info('STEP 2: Condenser INITIALIZATION')
+        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+            res = opt.solve(blk, tee=slc.tee)
+        init_log.info_high(
+            "STEP 2 Complete: {}.".format(idaeslog.condition(res)))
+        if not blk.config.specify_condenser_temperature:
+            for t in blk.flowsheet().time:
+                blk.vapor_phase.properties_out[t].temperature.unfix()
+        init_log.info('INITIALIZATION COMPLETED')

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_kettlereboiler.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_kettlereboiler.py
@@ -1,0 +1,192 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+"""
+Test for Kettle reboiler model
+
+Author: Paul Akula
+"""
+# Import Python libraries
+import sys
+import os
+import pytest
+
+# Import Pyomo libraries
+from pyomo.environ import (ConcreteModel,
+                           TerminationCondition,
+                           SolverStatus,
+                           units,
+                           value,
+                           Var)
+
+# TODO
+# Remove this after the ModuleNotFoundError is resolved
+# Access mea_solvent_system dir from the current dir (tests dir)
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+from unit_models.kettlereboiler import KettleReboiler
+
+
+# Import IDAES Libraries
+from idaes.core import FlowsheetBlock
+# from idaes.power_generation.carbon_capture.mea_solvent_system.unit_models.kettlereboiler\
+#     import KettleReboiler
+from idaes.power_generation.carbon_capture.mea_solvent_system.unit_models.column\
+    import ProcessType
+from idaes.power_generation.carbon_capture.mea_solvent_system.properties.vapor_prop \
+    import VaporParameterBlock
+from idaes.power_generation.carbon_capture.mea_solvent_system.properties.liquid_prop \
+    import LiquidParameterBlock
+
+from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_solver
+from pyomo.util.check_units import assert_units_equivalent
+
+# -----------------------------------------------------------------------------
+# Get default solver for testing
+solver = get_solver()
+
+# -----------------------------------------------------------------------------
+class TestKettleReboiler(object):
+    @pytest.fixture(scope="class")
+    def reb(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        # Set up property package
+        m.fs.vapor_properties = VaporParameterBlock(
+            default={'process_type': ProcessType.stripper})
+        m.fs.liquid_properties = LiquidParameterBlock(
+            default={'process_type': ProcessType.stripper})
+
+        # create instance of kettle reboiler  on flowsheet
+        m.fs.unit = KettleReboiler(default={
+                                 "vapor_side": {
+                                     "property_package": m.fs.vapor_properties
+                                 },
+                                 "liquid_side": {
+                                     "property_package": m.fs.liquid_properties
+                                 }})
+
+        # Fix  input variables
+        for t in m.fs.time:
+            m.fs.unit.liquid_inlet.flow_mol[t].fix(83.89)
+            m.fs.unit.liquid_inlet.temperature[t].fix(392.5)
+            m.fs.unit.liquid_inlet.pressure[t].fix(183700)
+            m.fs.unit.liquid_inlet.mole_frac_comp[t, "CO2"].fix(0.0326)
+            m.fs.unit.liquid_inlet.mole_frac_comp[t, "H2O"].fix(0.8589)
+            m.fs.unit.liquid_inlet.mole_frac_comp[t, "MEA"].fix(0.1085)
+            m.fs.unit.heat_duty[t].fix(430.61)
+
+        return m
+
+    @pytest.mark.build
+    @pytest.mark.unit
+    def test_build(self, reb):
+
+        assert hasattr(reb.fs.unit, "liquid_inlet")
+        assert len(reb.fs.unit.liquid_inlet.vars) == 4
+        assert hasattr(reb.fs.unit.liquid_inlet, "flow_mol")
+        assert hasattr(reb.fs.unit.liquid_inlet, "mole_frac_comp")
+        assert hasattr(reb.fs.unit.liquid_inlet, "temperature")
+        assert hasattr(reb.fs.unit.liquid_inlet, "pressure")
+
+        assert hasattr(reb.fs.unit, "liquid_outlet")
+        assert len(reb.fs.unit.liquid_outlet.vars) == 4
+        assert hasattr(reb.fs.unit.liquid_outlet, "flow_mol")
+        assert hasattr(reb.fs.unit.liquid_outlet, "mole_frac_comp")
+        assert hasattr(reb.fs.unit.liquid_outlet, "temperature")
+        assert hasattr(reb.fs.unit.liquid_outlet, "pressure")
+
+        assert not hasattr(reb.fs.unit, "vapor_inlet")
+
+        assert hasattr(reb.fs.unit, "vapor_outlet")
+        assert len(reb.fs.unit.vapor_outlet.vars) == 4
+        assert hasattr(reb.fs.unit.vapor_outlet, "flow_mol")
+        assert hasattr(reb.fs.unit.vapor_outlet, "mole_frac_comp")
+        assert hasattr(reb.fs.unit.vapor_outlet, "temperature")
+        assert hasattr(reb.fs.unit.vapor_outlet, "pressure")
+
+        assert hasattr(reb.fs.unit, "heat_duty")
+
+
+    @pytest.mark.component
+    def test_units(self, reb):
+        assert_units_equivalent(reb.fs.unit.liquid_inlet.flow_mol[0], units.mol/units.s)
+        assert_units_equivalent(reb.fs.unit.liquid_outlet.flow_mol[0], units.mol/units.s)
+        assert_units_equivalent(reb.fs.unit.vapor_outlet.flow_mol[0], units.mol/units.s)
+        assert_units_equivalent(reb.fs.unit.heat_duty[0], units.kW)
+
+
+    @pytest.mark.unit
+    def test_dof(self, reb):
+        assert degrees_of_freedom(reb) == 0
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_initialize(self, reb):
+        initialization_tester(reb)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, reb):
+        results = solver.solve(reb)
+
+        # Check for optimal solution
+        assert results.solver.termination_condition == \
+            TerminationCondition.optimal
+        assert results.solver.status == SolverStatus.ok
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, reb):
+        assert (pytest.approx(183700, abs=1e-2) ==
+                value(reb.fs.unit.liquid_outlet.pressure[0]))
+        assert (pytest.approx(183700, abs=1e-2) ==
+                value(reb.fs.unit.vapor_outlet.pressure[0]))
+        assert (pytest.approx(393.8499, abs=1e-1) ==
+                value(reb.fs.unit.liquid_outlet.temperature[0]))
+        assert (pytest.approx(393.8499, abs=1e-1) ==
+                value(reb.fs.unit.vapor_outlet.temperature[0]))
+        assert (pytest.approx(9.5571, abs=1e-2) ==
+                value(reb.fs.unit.vapor_outlet.flow_mol[0]))
+        assert (pytest.approx(74.33, abs=1e-2) ==
+                value(reb.fs.unit.liquid_outlet.flow_mol[0]))
+        assert (pytest.approx(0.1139, abs=1e-2) ==
+                value(reb.fs.unit.vf[0]))
+        assert (pytest.approx(0.0285, abs=1e-3) ==
+                value(reb.fs.unit.liquid_outlet.mole_frac_comp[0,'CO2']))
+        assert (pytest.approx(0.1224, abs=1e-3) ==
+                value(reb.fs.unit.liquid_outlet.mole_frac_comp[0,'MEA']))
+        assert (pytest.approx(0.8491, abs=1e-3) ==
+                value(reb.fs.unit.liquid_outlet.mole_frac_comp[0,'H2O']))
+        assert (pytest.approx(0.0645, abs=1e-3) ==
+                value(reb.fs.unit.vapor_outlet.mole_frac_comp[0,'CO2']))
+        assert (pytest.approx(0.9355, abs=1e-3) ==
+                value(reb.fs.unit.vapor_outlet.mole_frac_comp[0,'H2O']))
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_conservation(self, reb):
+        assert abs(value(reb.fs.unit.liquid_inlet.flow_mol[0] -
+                         reb.fs.unit.liquid_outlet.flow_mol[0] -
+                         reb.fs.unit.vapor_outlet.flow_mol[0])) <= 1e-5
+
+        assert abs(value(reb.fs.unit.heat_duty[0]  -
+                (reb.fs.unit.heat_latent[0] + reb.fs.unit.heat_sens[0])*
+                 reb.fs.unit.liquid_inlet.flow_mol[0]) <= 1e-5)
+
+

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_kettlereboiler.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_kettlereboiler.py
@@ -126,10 +126,10 @@ class TestKettleReboiler(object):
         assert_units_equivalent(reb.fs.unit.vapor_outlet.flow_mol[0], units.mol/units.s)
         assert_units_equivalent(reb.fs.unit.heat_duty[0], units.kW)
 
-
     @pytest.mark.unit
     def test_dof(self, reb):
         assert degrees_of_freedom(reb) == 0
+
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_kettlereboiler.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_kettlereboiler.py
@@ -187,6 +187,6 @@ class TestKettleReboiler(object):
 
         assert abs(value(reb.fs.unit.heat_duty[0]  -
                 (reb.fs.unit.heat_latent[0] + reb.fs.unit.heat_sens[0])*
-                 reb.fs.unit.liquid_inlet.flow_mol[0]) <= 1e-5)
+                 reb.fs.unit.liquid_inlet.flow_mol[0]*1e-3) <= 1e-5)
 
 

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_partialcondenser.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_partialcondenser.py
@@ -1,0 +1,195 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+"""
+Test for Kettle reboiler model
+
+Author: Paul Akula
+"""
+# Import Python libraries
+import sys
+import os
+import pytest
+
+# Import Pyomo libraries
+from pyomo.environ import (ConcreteModel,
+                           TerminationCondition,
+                           SolverStatus,
+                           units,
+                           value,
+                           Var)
+
+# TODO
+# Remove this after the ModuleNotFoundError is resolved
+# Access mea_solvent_system dir from the current dir (tests dir)
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+from unit_models.partialcondenser import PartialCondenser
+
+
+# Import IDAES Libraries
+from idaes.core import FlowsheetBlock
+# from idaes.power_generation.carbon_capture.mea_solvent_system.unit_models.partialcondenser\
+#     import PartialCondenser
+from idaes.power_generation.carbon_capture.mea_solvent_system.unit_models.column\
+    import ProcessType
+from idaes.power_generation.carbon_capture.mea_solvent_system.properties.vapor_prop \
+    import VaporParameterBlock
+from idaes.power_generation.carbon_capture.mea_solvent_system.properties.liquid_prop \
+    import LiquidParameterBlock
+
+from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.testing import initialization_tester
+from idaes.core.util import get_solver
+from pyomo.util.check_units import assert_units_equivalent
+
+# -----------------------------------------------------------------------------
+# Get default solver for testing
+solver = get_solver()
+
+# -----------------------------------------------------------------------------
+class TestPartialCondenser(object):
+    @pytest.fixture(scope="class")
+    def cond(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        # Set up property package
+        m.fs.vapor_properties = VaporParameterBlock(
+            default={'process_type': ProcessType.stripper})
+        m.fs.liquid_properties = LiquidParameterBlock(
+            default={'process_type': ProcessType.stripper})
+
+        # create instance of kettle reboiler  on flowsheet
+        m.fs.unit = PartialCondenser(default={
+                                 "vapor_side": {
+                                     "property_package": m.fs.vapor_properties
+                                 },
+                                 "liquid_side": {
+                                     "property_package": m.fs.liquid_properties
+                                 }})
+
+        # Fix  input variables
+        for t in m.fs.time:
+            m.fs.unit.vapor_inlet.flow_mol[t].fix(1.1117)
+            m.fs.unit.vapor_inlet.temperature[t].fix(339.33)
+            m.fs.unit.vapor_inlet.pressure[t].fix(184360)
+            m.fs.unit.vapor_inlet.mole_frac_comp[t, "CO2"].fix(0.8817)
+            m.fs.unit.vapor_inlet.mole_frac_comp[t, "H2O"].fix(0.1183)
+
+
+        return m
+
+    @pytest.mark.build
+    @pytest.mark.unit
+    def test_build(self, cond):
+
+        assert hasattr(cond.fs.unit, "vapor_inlet")
+        assert len(cond.fs.unit.vapor_inlet.vars) == 4
+        assert hasattr(cond.fs.unit.vapor_inlet, "flow_mol")
+        assert hasattr(cond.fs.unit.vapor_inlet, "mole_frac_comp")
+        assert hasattr(cond.fs.unit.vapor_inlet, "temperature")
+        assert hasattr(cond.fs.unit.vapor_inlet, "pressure")
+
+        assert hasattr(cond.fs.unit, "vapor_outlet")
+        assert len(cond.fs.unit.vapor_outlet.vars) == 4
+        assert hasattr(cond.fs.unit.vapor_outlet, "flow_mol")
+        assert hasattr(cond.fs.unit.vapor_outlet, "mole_frac_comp")
+        assert hasattr(cond.fs.unit.vapor_outlet, "temperature")
+        assert hasattr(cond.fs.unit.vapor_outlet, "pressure")
+
+        assert not hasattr(cond.fs.unit, "liquid_inlet")
+
+        assert hasattr(cond.fs.unit, "liquid_outlet")
+        assert len(cond.fs.unit.liquid_outlet.vars) == 4
+        assert hasattr(cond.fs.unit.liquid_outlet, "flow_mol")
+        assert hasattr(cond.fs.unit.liquid_outlet, "mole_frac_comp")
+        assert hasattr(cond.fs.unit.liquid_outlet, "temperature")
+        assert hasattr(cond.fs.unit.liquid_outlet, "pressure")
+
+        assert hasattr(cond.fs.unit, "condenser_duty")
+
+
+    @pytest.mark.component
+    def test_units(self, cond):
+        assert_units_equivalent(cond.fs.unit.vapor_inlet.flow_mol[0],
+                                units.mol/units.s)
+        assert_units_equivalent(cond.fs.unit.vapor_outlet.flow_mol[0],
+                                units.mol/units.s)
+        assert_units_equivalent(cond.fs.unit.liquid_outlet.flow_mol[0],
+                                units.mol/units.s)
+        assert_units_equivalent(cond.fs.unit.condenser_duty[0], units.kW)
+
+    @pytest.mark.unit
+    def test_dof(self, cond):
+        assert degrees_of_freedom(cond) == 0
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_initialize(self, cond):
+        initialization_tester(cond)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, cond):
+        results = solver.solve(cond)
+
+        # Check for optimal solution
+        assert results.solver.termination_condition == \
+            TerminationCondition.optimal
+        assert results.solver.status == SolverStatus.ok
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, cond):
+        assert (pytest.approx(184360, abs=1e-2) ==
+                value(cond.fs.unit.liquid_outlet.pressure[0]))
+        assert (pytest.approx(184360, abs=1e-2) ==
+                value(cond.fs.unit.vapor_outlet.pressure[0]))
+        assert (pytest.approx(303.15, abs=1e-2) ==
+                value(cond.fs.unit.liquid_outlet.temperature[0]))
+        assert (pytest.approx(-6.28, abs=1e-2) ==
+                value(cond.fs.unit.condenser_duty[0]))
+        assert (pytest.approx(303.15, abs=1e-2) ==
+                value(cond.fs.unit.vapor_outlet.temperature[0]))
+        assert (pytest.approx(1.0034, abs=1e-4) ==
+                value(cond.fs.unit.vapor_outlet.flow_mol[0]))
+        assert (pytest.approx(0.1083, abs=1e-4) ==
+                value(cond.fs.unit.liquid_outlet.flow_mol[0]))
+        assert (pytest.approx(0.9026, abs=1e-4) ==
+                value(cond.fs.unit.vf[0]))
+        assert (pytest.approx(0.0, abs=1e-4) ==
+                value(cond.fs.unit.liquid_outlet.mole_frac_comp[0,'CO2']))
+        assert (pytest.approx(0.0, abs=1e-4) ==
+                value(cond.fs.unit.liquid_outlet.mole_frac_comp[0,'MEA']))
+        assert (pytest.approx(1.0, abs=1e-4) ==
+                value(cond.fs.unit.liquid_outlet.mole_frac_comp[0,'H2O']))
+        assert (pytest.approx(0.9769, abs=1e-4) ==
+                value(cond.fs.unit.vapor_outlet.mole_frac_comp[0,'CO2']))
+        assert (pytest.approx(0.0231, abs=1e-4) ==
+                value(cond.fs.unit.vapor_outlet.mole_frac_comp[0,'H2O']))
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_conservation(self, cond):
+        assert abs(value(cond.fs.unit.vapor_inlet.flow_mol[0] -
+                         cond.fs.unit.vapor_outlet.flow_mol[0] -
+                         cond.fs.unit.liquid_outlet.flow_mol[0])) <= 1e-5
+
+        assert abs(value(cond.fs.unit.condenser_duty[0]  -
+                (cond.fs.unit.heat_sens[0]-cond.fs.unit.heat_latent[0])*
+                 cond.fs.unit.vapor_inlet.flow_mol[0]*1e-3) <= 1e-5)
+
+


### PR DESCRIPTION
## Summary/Motivation:
This PR adds the reboiler and condenser unit models to support the development of the steady-state MEA solvent flowsheet for carbon capture application. 

## Changes proposed in this PR:
- Adds a Reboiler model - Kettle Reboiler
-Adds a Condenser model- Partial Condenser
- Adds test files for the unit models

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
