### PR TITLE
Adding log concentration variables in generic properties

### DIFF
--- a/idaes/generic_models/properties/core/eos/enrtl.py
+++ b/idaes/generic_models/properties/core/eos/enrtl.py
@@ -555,17 +555,17 @@ class ENRTL(Ideal):
             ln_gamma = getattr(b, p+"_log_gamma")
         else:
             ln_gamma = getattr(b, p+"_log_gamma_appr")
-        return log(b.mole_frac_phase_comp[p, j]) + ln_gamma[p, j]
+        return log(b.mole_frac_phase_comp[p, j]) + ln_gamma[j]
 
     @staticmethod
     def log_act_phase_comp_true(b, p, j):
         ln_gamma = getattr(b, p+"_log_gamma")
-        return log(b.mole_frac_phase_comp_true[p, j]) + ln_gamma[p, j]
+        return log(b.mole_frac_phase_comp_true[p, j]) + ln_gamma[j]
 
     @staticmethod
     def log_act_phase_comp_appr(b, p, j):
         ln_gamma = getattr(b, p+"_log_gamma_appr")
-        return log(b.mole_frac_phase_comp_apparent[p, j]) + ln_gamma[p, j]
+        return log(b.mole_frac_phase_comp_apparent[p, j]) + ln_gamma[j]
 
     @staticmethod
     def act_coeff_phase_comp(b, p, j):

--- a/idaes/generic_models/properties/core/examples/reactions/reaction_example.py
+++ b/idaes/generic_models/properties/core/examples/reactions/reaction_example.py
@@ -11,7 +11,7 @@
 # license information.
 #################################################################################
 """
-Example of defining a reaction package for the follwoing reaction system:
+Example of defining a reaction package for the following reaction system:
 
 R1)  A + B --> 2C  Power law rate reaction
 R2)  B + C <-> D  Power law equilibrium reaction
@@ -25,7 +25,7 @@ from idaes.core import LiquidPhase, Component
 from idaes.generic_models.properties.core.state_definitions import FcTP
 from idaes.generic_models.properties.core.eos.ideal import Ideal
 
-from idaes.generic_models.properties.core.generic.generic_reaction import (
+from idaes.generic_models.properties.core.generic.utility import (
         ConcentrationForm)
 from idaes.generic_models.properties.core.reactions.dh_rxn import \
     constant_dh_rxn

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -908,9 +908,9 @@ class GenericParameterData(PhysicalParameterBlock):
              'henry': {'method': '_henry'},
              'mass_frac_phase_comp': {'method': '_mass_frac_phase_comp'},
              'mass_frac_phase_comp_apparent': {
-                 'method': '_mass}_frac_phase_comp_apparent'},
+                 'method': '_mass_frac_phase_comp_apparent'},
              'mass_frac_phase_comp_true': {
-                 'method': '_mass}_frac_phase_comp_true'},
+                 'method': '_mass_frac_phase_comp_true'},
              'molality_phase_comp': {'method': '_molality_phase_comp'},
              'molality_phase_comp_apparent': {
                  'method': '_molality_phase_comp_apparent'},
@@ -941,8 +941,30 @@ class GenericParameterData(PhysicalParameterBlock):
                  'method': '_log_conc_mol_phase_comp'},
              'log_conc_mol_phase_comp_true': {
                  'method': '_log_conc_mol_phase_comp_true'},
+             'log_mass_frac_phase_comp': {
+                 'method': '_log_mass_frac_phase_comp'},
+             'log_mass_frac_phase_comp_apparent': {
+                 'method': '_log_mass_frac_phase_comp_apparent'},
+             'log_mass_frac_phase_comp_true': {
+                 'method': '_log_mass_frac_phase_comp_true'},
+             'log_molality_phase_comp': {
+                 'method': '_log_molality_phase_comp'},
+             'log_molality_phase_comp_apparent': {
+                 'method': '_log_molality_phase_comp_apparent'},
+             'log_molality_phase_comp_true': {
+                 'method': '_log_molality_phase_comp_true'},
              'log_mole_frac_phase_comp': {
-                 'method': '_log_mole_frac_phase_comp'}})
+                 'method': '_log_mole_frac_phase_comp'},
+             'log_mole_frac_phase_comp_apparent': {
+                 'method': '_log_mole_frac_phase_comp_apparent'},
+             'log_mole_frac_phase_comp_true': {
+                 'method': '_log_mole_frac_phase_comp_true'},
+             'log_pressure_phase_comp': {
+                 'method': '_log_pressure_phase_comp'},
+             'log_pressure_phase_comp_apparent': {
+                 'method': '_log_pressure_phase_comp_apparent'},
+             'log_pressure_phase_comp_true': {
+                 'method': '_log_pressure_phase_comp_true'}})
 
 
 class _GenericStateBlock(StateBlock):
@@ -3016,6 +3038,126 @@ class GenericStateBlockData(StateBlockData):
             self.del_component(self.log_conc_mol_phase_comp_true_eq)
             raise
 
+    def _log_mass_frac_phase_comp(self):
+        try:
+            self.log_mass_frac_phase_comp = Var(
+                self.phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of mass fractions of component by phase")
+
+            def rule_log_mass_frac_phase_comp(b, p, j):
+                return exp(b.log_mass_frac_phase_comp[p, j]) == (
+                    b.mass_frac_phase_comp[p, j])
+            self.log_mass_frac_phase_comp_eq = Constraint(
+                self.phase_component_set,
+                rule=rule_log_mass_frac_phase_comp,
+                doc="Constraint for log of mass fractions")
+        except AttributeError:
+            self.del_component(self.log_mass_frac_phase_comp)
+            self.del_component(self.log_mass_frac_phase_comp_eq)
+            raise
+
+    def _log_mass_frac_phase_comp_apparent(self):
+        try:
+            self.log_mass_frac_phase_comp_apparent = Var(
+                self.params.apparent_phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of mass fractions of component by phase")
+
+            def rule_log_mass_frac_phase_comp_appr(b, p, j):
+                return exp(b.log_mass_frac_phase_comp_apparent[p, j]) == (
+                    b.mass_frac_phase_comp_apparent[p, j])
+            self.log_mass_frac_phase_comp_apparent_eq = Constraint(
+                self.params.apparent_phase_component_set,
+                rule=rule_log_mass_frac_phase_comp_appr,
+                doc="Constraint for log of mass fractions")
+        except AttributeError:
+            self.del_component(self.log_mass_frac_phase_comp_apparent)
+            self.del_component(self.log_mass_frac_phase_comp_apparent_eq)
+            raise
+
+    def _log_mass_frac_phase_comp_true(self):
+        try:
+            self.log_mass_frac_phase_comp_true = Var(
+                self.params.true_phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of mass fractions of component by phase")
+
+            def rule_log_mass_frac_phase_comp_true(b, p, j):
+                return exp(b.log_mass_frac_phase_comp_true[p, j]) == (
+                    b.mass_frac_phase_comp_true[p, j])
+            self.log_mass_frac_phase_comp_true_eq = Constraint(
+                self.params.true_phase_component_set,
+                rule=rule_log_mass_frac_phase_comp_true,
+                doc="Constraint for log of mass fractions")
+        except AttributeError:
+            self.del_component(self.log_mass_frac_phase_comp_true)
+            self.del_component(self.log_mass_frac_phase_comp_true_eq)
+            raise
+
+    def _log_molality_phase_comp(self):
+        try:
+            self.log_molality_phase_comp = Var(
+                self.phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of molality of component by phase")
+
+            def rule_log_molality_phase_comp(b, p, j):
+                return exp(b.log_molality_phase_comp[p, j]) == (
+                    b.molality_phase_comp[p, j])
+            self.log_molality_phase_comp_eq = Constraint(
+                self.phase_component_set,
+                rule=rule_log_molality_phase_comp,
+                doc="Constraint for log of molality")
+        except AttributeError:
+            self.del_component(self.log_molality_phase_comp)
+            self.del_component(self.log_molality_phase_comp_eq)
+            raise
+
+    def _log_molality_phase_comp_apparent(self):
+        try:
+            self.log_molality_phase_comp_apparent = Var(
+                self.params.apparent_phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of molality of component by phase")
+
+            def rule_log_molality_phase_comp_appr(b, p, j):
+                return exp(b.log_molality_phase_comp_apparent[p, j]) == (
+                    b.molality_phase_comp_apparent[p, j])
+            self.log_molality_phase_comp_apparent_eq = Constraint(
+                self.params.apparent_phase_component_set,
+                rule=rule_log_molality_phase_comp_appr,
+                doc="Constraint for log of molality")
+        except AttributeError:
+            self.del_component(self.log_molality_phase_comp_apparent)
+            self.del_component(self.log_molality_phase_comp_apparent_eq)
+            raise
+
+    def _log_molality_phase_comp_true(self):
+        try:
+            self.log_molality_phase_comp_true = Var(
+                self.params.true_phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of molality of component by phase")
+
+            def rule_log_molality_phase_comp_true(b, p, j):
+                return exp(b.log_molality_phase_comp_true[p, j]) == (
+                    b.molality_phase_comp_true[p, j])
+            self.log_molality_phase_comp_true_eq = Constraint(
+                self.params.true_phase_component_set,
+                rule=rule_log_molality_phase_comp_true,
+                doc="Constraint for log of molality")
+        except AttributeError:
+            self.del_component(self.log_molality_phase_comp_true)
+            self.del_component(self.log_molality_phase_comp_true_eq)
+            raise
+
     def _log_mole_frac_phase_comp(self):
         try:
             self.log_mole_frac_phase_comp = Var(
@@ -3034,6 +3176,106 @@ class GenericStateBlockData(StateBlockData):
         except AttributeError:
             self.del_component(self.log_mole_frac_phase_comp)
             self.del_component(self.log_mole_frac_phase_comp_eq)
+            raise
+
+    def _log_mole_frac_phase_comp_apparent(self):
+        try:
+            self.log_mole_frac_phase_comp_apparent = Var(
+                self.params.apparent_phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of mole fractions of component by phase")
+
+            def rule_log_mole_frac_phase_comp_appr(b, p, j):
+                return exp(b.log_mole_frac_phase_comp_apparent[p, j]) == (
+                    b.mole_frac_phase_comp_apparent[p, j])
+            self.log_mole_frac_phase_comp_apparent_eq = Constraint(
+                self.params.apparent_phase_component_set,
+                rule=rule_log_mole_frac_phase_comp_appr,
+                doc="Constraint for log of mole fractions")
+        except AttributeError:
+            self.del_component(self.log_mole_frac_phase_comp_apparent)
+            self.del_component(self.log_mole_frac_phase_comp_apparent_eq)
+            raise
+
+    def _log_mole_frac_phase_comp_true(self):
+        try:
+            self.log_mole_frac_phase_comp_true = Var(
+                self.params.true_phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of mole fractions of component by phase")
+
+            def rule_log_mole_frac_phase_comp_true(b, p, j):
+                return exp(b.log_mole_frac_phase_comp_true[p, j]) == (
+                    b.mole_frac_phase_comp_true[p, j])
+            self.log_mole_frac_phase_comp_true_eq = Constraint(
+                self.params.true_phase_component_set,
+                rule=rule_log_mole_frac_phase_comp_true,
+                doc="Constraint for log of mole fractions")
+        except AttributeError:
+            self.del_component(self.log_mole_frac_phase_comp_true)
+            self.del_component(self.log_mole_frac_phase_comp_true_eq)
+            raise
+
+    def _log_pressure_phase_comp(self):
+        try:
+            self.log_pressure_phase_comp = Var(
+                self.phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of partial pressures of component by phase")
+
+            def rule_log_pressure_phase_comp(b, p, j):
+                return exp(b.log_pressure_phase_comp[p, j]) == (
+                    b.pressure_phase_comp[p, j])
+            self.log_pressure_phase_comp_eq = Constraint(
+                self.phase_component_set,
+                rule=rule_log_pressure_phase_comp,
+                doc="Constraint for log of partial pressures")
+        except AttributeError:
+            self.del_component(self.log_pressure_phase_comp)
+            self.del_component(self.log_pressure_phase_comp_eq)
+            raise
+
+    def _log_pressure_phase_comp_apparent(self):
+        try:
+            self.log_pressure_phase_comp_apparent = Var(
+                self.params.apparent_phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of partial pressures of component by phase")
+
+            def rule_log_pressure_phase_comp_appr(b, p, j):
+                return exp(b.log_pressure_phase_comp_apparent[p, j]) == (
+                    b.pressure_phase_comp_apparent[p, j])
+            self.log_pressure_phase_comp_apparent_eq = Constraint(
+                self.params.apparent_phase_component_set,
+                rule=rule_log_pressure_phase_comp_appr,
+                doc="Constraint for log of partial pressures")
+        except AttributeError:
+            self.del_component(self.log_pressure_phase_comp_apparent)
+            self.del_component(self.log_pressure_phase_comp_apparent_eq)
+            raise
+
+    def _log_pressure_phase_comp_true(self):
+        try:
+            self.log_pressure_phase_comp_true = Var(
+                self.params.true_phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of partial pressures of component by phase")
+
+            def rule_log_pressure_phase_comp_true(b, p, j):
+                return exp(b.log_pressure_phase_comp_true[p, j]) == (
+                    b.pressure_phase_comp_true[p, j])
+            self.log_pressure_phase_comp_true_eq = Constraint(
+                self.params.true_phase_component_set,
+                rule=rule_log_pressure_phase_comp_true,
+                doc="Constraint for log of partial pressures")
+        except AttributeError:
+            self.del_component(self.log_pressure_phase_comp_true)
+            self.del_component(self.log_pressure_phase_comp_true_eq)
             raise
 
 

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -20,6 +20,7 @@ from enum import Enum
 # Import Pyomo libraries
 from pyomo.environ import (Block,
                            Constraint,
+                           exp,
                            Expression,
                            Set,
                            Param,
@@ -917,7 +918,11 @@ class GenericParameterData(PhysicalParameterBlock):
              'temperature_dew': {'method': '_temperature_dew'},
              'visc_d_phase': {'method': '_visc_d_phase'},
              'vol_mol_phase': {'method': '_vol_mol_phase'},
-             'dh_rxn': {'method': '_dh_rxn'}})
+             'dh_rxn': {'method': '_dh_rxn'},
+             'log_conc_mol_phase_comp': {
+                 'method': '_log_conc_mol_phase_comp'},
+             'log_mole_frac_phase_comp': {
+                 'method': '_log_mole_frac_phase_comp'}})
 
 
 class _GenericStateBlock(StateBlock):
@@ -1738,6 +1743,31 @@ class GenericStateBlockData(StateBlockData):
                     iscale.set_scaling_factor(v, sf_mf[i])
             self.params.config.bubble_dew_method.scale_pressure_dew(
                 self, overwrite=False)
+
+        if self.is_property_constructed("log_conc_mol_phase_comp"):
+            for (p, j), v in self.log_conc_mole_phase_comp_eq.items():
+                sf_dens_mol = iscale.get_scaling_factor(
+                    self.dens_mol_phase[p],
+                    default=55e3,
+                    warning=True,
+                    hint="for log_conc_mol_phase_comp")
+                sf_x = iscale.get_scaling_factor(
+                    self.mole_frac_phase_comp[p, j],
+                    default=1,
+                    warning=True,
+                    hint="for log_conc_mol_phase_comp")
+                iscale.constraint_scaling_transform(
+                    v, sf_dens_mol*sf_x, overwrite=False)
+
+        if self.is_property_constructed("log_mole_frac_phase_comp"):
+            for (p, j), v in self.log_mole_frac_phase_comp_eq.items():
+                sf_x = iscale.get_scaling_factor(
+                    self.mole_frac_phase_comp[p, j],
+                    default=1,
+                    warning=True,
+                    hint="for log_mole_frac_phase_comp")
+                iscale.constraint_scaling_transform(
+                    v, sf_x, overwrite=False)
 
     def components_in_phase(self, phase):
         """
@@ -2719,6 +2749,47 @@ class GenericStateBlockData(StateBlockData):
             self.params.inherent_reaction_idx,
             doc="Specific heat of reaction for inherent reactions",
             rule=dh_rule)
+
+    def _log_conc_mol_phase_comp(self):
+        try:
+            self.log_conc_mol_phase_comp = Var(
+                self.phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of molar concentration of component by phase")
+
+            def rule_log_conc_mol_phase_comp(b, p, j):
+                return exp(b.log_conc_mol_phase_comp[p, j]) == (
+                    b.conc_mol_phase_comp[p, j] /
+                    pyunits.get_units(b.conc_mol_phase_comp[p, j]))
+            self.log_conc_mol_phase_comp_eq = Constraint(
+                self.phase_component_set,
+                rule=rule_log_conc_mol_phase_comp,
+                doc="Constraint for log of molar concentration")
+        except AttributeError:
+            self.del_component(self.log_conc_mol_phase_comp)
+            self.del_component(self.log_conc_mol_phase_comp_eq)
+            raise
+
+    def _log_mole_frac_phase_comp(self):
+        try:
+            self.log_mole_frac_phase_comp = Var(
+                self.phase_component_set,
+                initialize=1,
+                units=pyunits.dimensionless,
+                doc="Log of mole fractions of component by phase")
+
+            def rule_log_mole_frac_phase_comp(b, p, j):
+                return exp(b.log_mole_frac_phase_comp[p, j]) == (
+                    b.mole_frac_phase_comp[p, j])
+            self.log_mole_frac_phase_comp_eq = Constraint(
+                self.phase_component_set,
+                rule=rule_log_mole_frac_phase_comp,
+                doc="Constraint for log of mole fractions")
+        except AttributeError:
+            self.del_component(self.log_mole_frac_phase_comp)
+            self.del_component(self.log_mole_frac_phase_comp_eq)
+            raise
 
 
 def _valid_VL_component_list(blk, pp):

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1248,8 +1248,8 @@ class _GenericStateBlock(StateBlock):
                 if blk[k].is_property_constructed("log_"+prop):
                     comp = getattr(blk[k], prop)
                     lcomp = getattr(blk[k], "log_"+prop)
-                    for k, v in lcomp.items():
-                        c = value(comp[k])
+                    for k2, v in lcomp.items():
+                        c = value(comp[k2])
                         if c == 0:
                             c = 1e-8
                         lc = log(c)

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -3096,6 +3096,11 @@ class GenericStateBlockData(StateBlockData):
                 doc="Log of molality of component by phase")
 
             def rule_log_molality_phase_comp(b, p, j):
+                pobj = b.params.get_phase(p)
+                if not isinstance(pobj, LiquidPhase):
+                    # Molality is defined per mass of solvent so only makes
+                    # sense in liquid phases
+                    return Expression.Skip
                 return exp(b.log_molality_phase_comp[p, j]) == (
                     b.molality_phase_comp[p, j])
             self.log_molality_phase_comp_eq = Constraint(
@@ -3116,6 +3121,11 @@ class GenericStateBlockData(StateBlockData):
                 doc="Log of molality of component by phase")
 
             def rule_log_molality_phase_comp_appr(b, p, j):
+                pobj = b.params.get_phase(p)
+                if not isinstance(pobj, LiquidPhase):
+                    # Molality is defined per mass of solvent so only makes
+                    # sense in liquid phases
+                    return Expression.Skip
                 return exp(b.log_molality_phase_comp_apparent[p, j]) == (
                     b.molality_phase_comp_apparent[p, j])
             self.log_molality_phase_comp_apparent_eq = Constraint(
@@ -3136,6 +3146,11 @@ class GenericStateBlockData(StateBlockData):
                 doc="Log of molality of component by phase")
 
             def rule_log_molality_phase_comp_true(b, p, j):
+                pobj = b.params.get_phase(p)
+                if not isinstance(pobj, LiquidPhase):
+                    # Molality is defined per mass of solvent so only makes
+                    # sense in liquid phases
+                    return Expression.Skip
                 return exp(b.log_molality_phase_comp_true[p, j]) == (
                     b.molality_phase_comp_true[p, j])
             self.log_molality_phase_comp_true_eq = Constraint(

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -964,7 +964,8 @@ class GenericParameterData(PhysicalParameterBlock):
              'log_pressure_phase_comp_apparent': {
                  'method': '_log_pressure_phase_comp_apparent'},
              'log_pressure_phase_comp_true': {
-                 'method': '_log_pressure_phase_comp_true'}})
+                 'method': '_log_pressure_phase_comp_true'},
+             'log_k_eq': {'method': '_log_k_eq'}})
 
 
 class _GenericStateBlock(StateBlock):
@@ -1270,8 +1271,8 @@ class _GenericStateBlock(StateBlock):
                 if blk[k].is_property_constructed("log_"+prop):
                     comp = getattr(blk[k], prop)
                     lcomp = getattr(blk[k], "log_"+prop)
-                    for (p, j), v in lcomp.items():
-                        c = value(comp[p, j])
+                    for k, v in lcomp.items():
+                        c = value(comp[k])
                         if c == 0:
                             c = 1e-8
                         lc = log(c)
@@ -3284,6 +3285,29 @@ class GenericStateBlockData(StateBlockData):
         except AttributeError:
             self.del_component(self.log_pressure_phase_comp_true)
             self.del_component(self.log_pressure_phase_comp_true_eq)
+            raise
+
+    def _log_k_eq(self):
+        try:
+            self.log_k_eq = Var(
+                self.params.inherent_reaction_idx,
+                initialize=1,
+                doc="Log of equilibrium constant for inherent reactions")
+
+            def rule_log_k_eq(b, r):
+                rblock = getattr(b.params, "reaction_"+r)
+
+                carg = b.params.config.inherent_reactions[r]
+                return carg["equilibrium_constant"].return_log_expression(
+                    b, rblock, r, b.temperature)
+
+            self.log_k_eq_constraint = Constraint(
+                self.params.inherent_reaction_idx,
+                rule=rule_log_k_eq,
+                doc="Constraint for log of equilibrium constant")
+        except AttributeError:
+            self.del_component(self.log_k_eq)
+            self.del_component(self.log_k_eq_constraint)
             raise
 
 

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1246,28 +1246,36 @@ class _GenericStateBlock(StateBlock):
                         blk[k].params.config
                         .state_definition.do_not_initialize):
                     c.activate()
-            if blk[k].is_property_constructed("log_conc_mol_phase_comp"):
-                print("1")
-                for (p, j), v in blk[k].log_conc_mol_phase_comp.items():
-                    c = value(blk[k].conc_mol_phase_comp[p, j])
-                    if c == 0:
-                        c = 1e-8
-                    lc = log(c)
-                    v.set_value(value(lc))
 
-            if blk[k].is_property_constructed("log_conc_mol_phase_comp_true"):
-                print("2")
-                for (p, j), v in blk[k].log_conc_mol_phase_comp_true.items():
-                    c = value(blk[k].conc_mol_phase_comp_true[p, j])
-                    if c == 0:
-                        c = 1e-8
-                    lc = log(c)
-                    v.set_value(value(lc))
+            # Initialize log-form variables
+            # Activity is handled separately
+            log_form_vars = [
+                "conc_mol_phase_comp",
+                "conc_mol_phase_comp_apparent",
+                "conc_mol_phase_comp_true",
+                "mass_frac_phase_comp",
+                "mass_frac_phase_comp_apparent",
+                "mass_frac_phase_comp_true",
+                "molality_phase_comp",
+                "molality_phase_comp_apparent",
+                "molality_phase_comp_true",
+                "mole_frac_phase_comp",
+                "mole_frac_phase_comp_apparent",
+                "mole_frac_phase_comp_true",
+                "pressure_phase_comp",
+                "pressure_phase_comp_apparent",
+                "pressure_phase_comp_true"]
 
-            if blk[k].is_property_constructed("log_mole_frac_phase_comp"):
-                print("3")
-                for (p, j), v in blk[k].log_conc_mol_phase_comp.items():
-                    v.set_value(value(log(blk[k].mole_frac_phase_comp[p, j])))
+            for prop in log_form_vars:
+                if blk[k].is_property_constructed("log_"+prop):
+                    comp = getattr(blk[k], prop)
+                    lcomp = getattr(blk[k], "log_"+prop)
+                    for (p, j), v in lcomp.items():
+                        c = value(comp[p, j])
+                        if c == 0:
+                            c = 1e-8
+                        lc = log(c)
+                        v.set_value(value(lc))
 
         n_cons = 0
         skip = False

--- a/idaes/generic_models/properties/core/generic/generic_reaction.py
+++ b/idaes/generic_models/properties/core/generic/generic_reaction.py
@@ -13,9 +13,6 @@
 """
 Framework for generic reaction packages
 """
-from enum import Enum
-
-
 # Import Pyomo libraries
 from pyomo.environ import (Block,
                            Constraint,
@@ -31,6 +28,8 @@ from idaes.core import (declare_process_block_class,
                         ReactionBlockDataBase,
                         ReactionBlockBase,
                         MaterialFlowBasis)
+from idaes.generic_models.properties.core.generic.utility import \
+    ConcentrationForm
 from idaes.core.util.exceptions import (
     BurntToast, ConfigurationError, PropertyPackageError)
 import idaes.core.util.scaling as iscale
@@ -53,64 +52,6 @@ class GenericReactionPackageError(PropertyPackageError):
                f"{self.prop}, but was not provided with a method " \
                f"for this property. Please add a method for this property " \
                f"in the reaction parameter configuration."
-
-
-# Enumerate concentration form options
-class ConcentrationForm(Enum):
-    molarity = 1
-    activity = 2
-    molality = 3
-    moleFraction = 4
-    massFraction = 5
-    partialPressure = 6
-
-
-def get_concentration_term(blk, r_idx, log=False):
-    cfg = blk.params.config
-    if "rate_reactions" in cfg:
-        try:
-            conc_form = cfg.rate_reactions[r_idx].concentration_form
-        except KeyError:
-            conc_form = cfg.equilibrium_reactions[r_idx].concentration_form
-        state = blk.state_ref
-    else:
-        conc_form = cfg.inherent_reactions[r_idx].concentration_form
-        state = blk
-
-    if hasattr(state.params, "_electrolyte") and state.params._electrolyte:
-        sub = "_true"
-    else:
-        sub = ""
-
-    if log:
-        pre = "log_"
-    else:
-        pre = ""
-
-    if conc_form is None:
-        raise ConfigurationError(
-            "{} concentration_form configuration argument was not set. "
-            "Please ensure that this argument is included in your "
-            "configuration dict.".format(blk.name))
-    elif conc_form == ConcentrationForm.molarity:
-        conc_term = getattr(state, pre+"conc_mol_phase_comp"+sub)
-    elif conc_form == ConcentrationForm.activity:
-        conc_term = getattr(state, pre+"act_phase_comp"+sub)
-    elif conc_form == ConcentrationForm.molality:
-        conc_term = getattr(state, pre+"molality_phase_comp"+sub)
-    elif conc_form == ConcentrationForm.moleFraction:
-        conc_term = getattr(state, pre+"mole_frac_phase_comp"+sub)
-    elif conc_form == ConcentrationForm.massFraction:
-        conc_term = getattr(state, pre+"mass_frac_phase_comp"+sub)
-    elif conc_form == ConcentrationForm.partialPressure:
-        conc_term = (getattr(state, pre+"pressure_phase_comp"+sub))
-    else:
-        raise BurntToast(
-            "{} get_concentration_term received unrecognised "
-            "ConcentrationForm ({}). This should not happen - please contact "
-            "the IDAES developers with this bug.".format(blk.name, conc_form))
-
-    return conc_term
 
 
 rxn_config = ConfigBlock()

--- a/idaes/generic_models/properties/core/generic/tests/dummy_eos.py
+++ b/idaes/generic_models/properties/core/generic/tests/dummy_eos.py
@@ -13,7 +13,7 @@
 """
 Mock-up EoS module for testing generic property packages
 """
-from pyomo.environ import Var
+from pyomo.environ import Var, units as pyunits
 
 from idaes.generic_models.properties.core.eos.eos_base import EoSBase
 
@@ -47,12 +47,40 @@ class DummyEoS(EoSBase):
             b.dummy_param = Var(initialize=42)
 
     @staticmethod
+    def act_phase_comp(b, p, j):
+        return 42
+
+    @staticmethod
+    def act_coeff_phase_comp(b, p, j):
+        return 1
+
+    @staticmethod
+    def compress_fact_phase(b, p):
+        return 42
+
+    @staticmethod
+    def cp_mol_phase(b, p):
+        return 42
+
+    @staticmethod
+    def cp_mol_phase_comp(b, p, j):
+        return 42
+
+    @staticmethod
+    def cv_mol_phase(b, p):
+        return 42
+
+    @staticmethod
+    def cv_mol_phase_comp(b, p, j):
+        return 42
+
+    @staticmethod
     def dens_mass_phase(b, p):
         return 42
 
     @staticmethod
     def dens_mol_phase(b, p):
-        return 55e3
+        return 55e3*pyunits.mol/pyunits.m**3
 
     @staticmethod
     def energy_internal_mol_phase(b, p):
@@ -93,3 +121,11 @@ class DummyEoS(EoSBase):
     @staticmethod
     def gibbs_mol_phase_comp(b, p, j):
         return 42
+
+    @staticmethod
+    def vol_mol_phase(b, p):
+        return 42
+
+    @staticmethod
+    def log_act_phase_comp(b, p, j):
+        return 1

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -1061,15 +1061,28 @@ class TestGenericStateBlock(object):
             if p.endswith(("apparent", "true")):
                 # True and apparent properties require electrolytes, which are
                 # not tested here
+                # Check that method exists and continue
+                assert hasattr(
+                    frame.props[1],
+                    frame.params.get_metadata().properties[p]["method"])
                 continue
             elif p.endswith(("bubble", "dew")):
                 # Bubble and dew properties require phase equilibria, which are
                 # not tested here
+                # Check that method exists and continue
+                assert hasattr(
+                    frame.props[1],
+                    frame.params.get_metadata().properties[p]["method"])
                 continue
             elif p == "dh_rxn":
                 # Not testing inherent reactions here either
+                # Check that method exists and continue
+                assert hasattr(
+                    frame.props[1],
+                    frame.params.get_metadata().properties[p]["method"])
                 continue
-            assert hasattr(frame.props[1], p)
+            else:
+                assert hasattr(frame.props[1], p)
 
     @pytest.mark.unit
     def test_flows(self, frame):

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -1074,7 +1074,7 @@ class TestGenericStateBlock(object):
                     frame.props[1],
                     frame.params.get_metadata().properties[p]["method"])
                 continue
-            elif p == "dh_rxn":
+            elif p in ["dh_rxn", "log_k_eq"]:
                 # Not testing inherent reactions here either
                 # Check that method exists and continue
                 assert hasattr(

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property.py
@@ -17,6 +17,7 @@ Author: Andrew Lee
 """
 import pytest
 from sys import modules
+from types import MethodType
 
 from pyomo.environ import (value, Block, ConcreteModel, Param,
                            Set, Var, units as pyunits)
@@ -965,15 +966,30 @@ def define_state(b):
     b.state_defined = True
 
 
+def get_material_flow_basis(self, *args, **kwargs):
+    return MaterialFlowBasis.molar
+
+
+def dummy_method(*args, **kwargs):
+    return 42
+
+
 class TestGenericStateBlock(object):
     @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
         m.params = DummyParameterBlock(default={
-                "components": {"a": {}, "b": {}, "c": {}},
+                "components": {
+                    "a": {"pressure_sat_comp": dummy_method},
+                    "b": {"pressure_sat_comp": dummy_method},
+                    "c": {"pressure_sat_comp": dummy_method}},
                 "phases": {
-                    "p1": {"equation_of_state": DummyEoS},
-                    "p2": {"equation_of_state": DummyEoS}},
+                    "p1": {"equation_of_state": DummyEoS,
+                           "diffus_phase_comp": dummy_method,
+                           "visc_d_phase": dummy_method},
+                    "p2": {"equation_of_state": DummyEoS,
+                           "diffus_phase_comp": dummy_method,
+                           "visc_d_phase": dummy_method}},
                 "state_definition": modules[__name__],
                 "pressure_ref": 1e5,
                 "temperature_ref": 300,
@@ -981,13 +997,16 @@ class TestGenericStateBlock(object):
 
         m.props = m.params.build_state_block([1],
                                              default={"defined_state": False})
+        m.props[1].get_material_flow_basis = MethodType(
+            get_material_flow_basis, m.props[1].get_material_flow_basis)
 
         # Add necessary variables to state block
         m.props[1].flow_mol = Var(bounds=(0, 3000))
         m.props[1].pressure = Var(bounds=(1000, 3000))
         m.props[1].temperature = Var(bounds=(100, 200))
         m.props[1].mole_frac_phase_comp = Var(m.params.phase_list,
-                                              m.params.component_list)
+                                              m.params.component_list,
+                                              initialize=0.3)
         m.props[1].phase_frac = Var(m.params.phase_list)
 
         return m
@@ -1025,6 +1044,32 @@ class TestGenericStateBlock(object):
             frame.props[1].mole_frac_phase_comp["p2", "b"]] == 1000
         assert frame.props[1].scaling_factor[
             frame.props[1].mole_frac_phase_comp["p2", "c"]] == 1000
+
+    @pytest.mark.unit
+    def test_build_all(self, frame):
+        # Add necessary parameters
+        frame.params.a.mw = 1
+        frame.params.b.mw = 2
+        frame.params.c.mw = 3
+
+        # Add variables that would be built by state definition
+        frame.props[1].flow_mol_phase_comp = Var(
+            frame.props[1].phase_component_set)
+
+        # Call all properties in metadata and assert they exist.
+        for p in frame.params.get_metadata().properties:
+            if p.endswith(("apparent", "true")):
+                # True and apparent properties require electrolytes, which are
+                # not tested here
+                continue
+            elif p.endswith(("bubble", "dew")):
+                # Bubble and dew properties require phase equilibria, which are
+                # not tested here
+                continue
+            elif p == "dh_rxn":
+                # Not testing inherent reactions here either
+                continue
+            assert hasattr(frame.props[1], p)
 
     @pytest.mark.unit
     def test_flows(self, frame):

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property_integration.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property_integration.py
@@ -38,8 +38,8 @@ from idaes.generic_models.properties.core.reactions.equilibrium_constant import 
     van_t_hoff
 from idaes.generic_models.properties.core.reactions.equilibrium_forms import \
     power_law_equil
-from idaes.generic_models.properties.core.generic.generic_reaction import (
-        ConcentrationForm)
+from idaes.generic_models.properties.core.generic.utility import (
+    ConcentrationForm)
 
 from idaes.generic_models.unit_models import Heater
 from idaes.core.util.model_statistics import degrees_of_freedom

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property_integration.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property_integration.py
@@ -290,14 +290,14 @@ class TestInherentReactions(object):
 
         solver = get_solver()
 
-        results = solver.solve(frame, tee=True)
+        results = solver.solve(frame)
 
         assert results.solver.termination_condition == \
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-        assert value(
-            frame.fs.cv.properties[0, 1].k_eq["e1"]) == 2
+        assert pytest.approx(2, rel=1e-8) == value(
+            frame.fs.cv.properties[0, 1].k_eq["e1"])
 
         assert (
             value(frame.fs.cv.properties[0, 1].k_eq["e1"]) ==
@@ -361,8 +361,8 @@ class TestInherentReactions(object):
             TerminationCondition.optimal
         assert results.solver.status == SolverStatus.ok
 
-        assert value(
-            frame.fs.cv.properties[0, 1].k_eq["e1"]) == 2
+        assert pytest.approx(2, rel=1e-8) == value(
+            frame.fs.cv.properties[0, 1].k_eq["e1"])
 
         assert (
             value(frame.fs.cv.properties[0, 1].k_eq["e1"]) ==

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_reaction.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_reaction.py
@@ -510,9 +510,7 @@ class TestGenericReactionBlock(object):
 
         assert isinstance(model.rblock[1].k_eq, Expression)
         assert len(model.rblock[1].k_eq) == 1
-        assert value(model.rblock[1].k_eq["e1"]) == value(
-            100*exp(-(-20000/constants.gas_constant) *
-                    (1/model.sblock[1].temperature - 1/350)))
+        assert value(model.rblock[1].k_eq["e1"]) == value(exp(1))
 
     @pytest.mark.unit
     def test_equilibrium_form(self, model):

--- a/idaes/generic_models/properties/core/generic/utility.py
+++ b/idaes/generic_models/properties/core/generic/utility.py
@@ -15,10 +15,12 @@ Common methods used by generic framework
 
 Author: A Lee
 """
+from enum import Enum
 
 from pyomo.environ import units as pyunits
 
-from idaes.core.util.exceptions import ConfigurationError, PropertyPackageError
+from idaes.core.util.exceptions import \
+    BurntToast, ConfigurationError, PropertyPackageError
 import idaes.logger as idaeslog
 
 # Set up logger
@@ -202,3 +204,61 @@ def get_bounds_from_config(b, state, base_units):
         default_val = var_config[1]
 
     return bounds, default_val
+
+
+# Enumerate concentration form options
+class ConcentrationForm(Enum):
+    molarity = 1
+    activity = 2
+    molality = 3
+    moleFraction = 4
+    massFraction = 5
+    partialPressure = 6
+
+
+def get_concentration_term(blk, r_idx, log=False):
+    cfg = blk.params.config
+    if "rate_reactions" in cfg:
+        try:
+            conc_form = cfg.rate_reactions[r_idx].concentration_form
+        except KeyError:
+            conc_form = cfg.equilibrium_reactions[r_idx].concentration_form
+        state = blk.state_ref
+    else:
+        conc_form = cfg.inherent_reactions[r_idx].concentration_form
+        state = blk
+
+    if hasattr(state.params, "_electrolyte") and state.params._electrolyte:
+        sub = "_true"
+    else:
+        sub = ""
+
+    if log:
+        pre = "log_"
+    else:
+        pre = ""
+
+    if conc_form is None:
+        raise ConfigurationError(
+            "{} concentration_form configuration argument was not set. "
+            "Please ensure that this argument is included in your "
+            "configuration dict.".format(blk.name))
+    elif conc_form == ConcentrationForm.molarity:
+        conc_term = getattr(state, pre+"conc_mol_phase_comp"+sub)
+    elif conc_form == ConcentrationForm.activity:
+        conc_term = getattr(state, pre+"act_phase_comp"+sub)
+    elif conc_form == ConcentrationForm.molality:
+        conc_term = getattr(state, pre+"molality_phase_comp"+sub)
+    elif conc_form == ConcentrationForm.moleFraction:
+        conc_term = getattr(state, pre+"mole_frac_phase_comp"+sub)
+    elif conc_form == ConcentrationForm.massFraction:
+        conc_term = getattr(state, pre+"mass_frac_phase_comp"+sub)
+    elif conc_form == ConcentrationForm.partialPressure:
+        conc_term = (getattr(state, pre+"pressure_phase_comp"+sub))
+    else:
+        raise BurntToast(
+            "{} get_concentration_term received unrecognised "
+            "ConcentrationForm ({}). This should not happen - please contact "
+            "the IDAES developers with this bug.".format(blk.name, conc_form))
+
+    return conc_term

--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -13,7 +13,7 @@
 """
 Methods for calculating equilibrium constants
 """
-from pyomo.environ import exp, Var, units as pyunits, value
+from pyomo.environ import exp, log, Var, units as pyunits, value
 
 from idaes.generic_models.properties.core.generic.utility import \
     ConcentrationForm
@@ -85,6 +85,15 @@ class ConstantKeq():
         return rblock.k_eq_ref
 
     @staticmethod
+    def return_log_expression(b, rblock, r_idx, T):
+        units = pyunits.get_units(rblock.k_eq_ref)
+        if units is None or units == pyunits.dimensionless:
+            expr = rblock.k_eq_ref
+        else:
+            expr = rblock.k_eq_ref/units
+        return b.log_k_eq[r_idx] == log(expr)
+
+    @staticmethod
     def calculate_scaling_factors(b, rblock):
         return 1/value(rblock.k_eq_ref)
 
@@ -153,13 +162,29 @@ class van_t_hoff():
 
     @staticmethod
     def return_expression(b, rblock, r_idx, T):
+        units = pyunits.get_units(rblock.k_eq_ref)
+        if units is None or units is pyunits.dimensionless:
+            return exp(b.log_k_eq[r_idx])
+        else:
+            return exp(b.log_k_eq[r_idx]) * units
+
+    @staticmethod
+    def return_log_expression(b, rblock, r_idx, T):
         units = rblock.parent_block().get_metadata().derived_units
 
-        return rblock.k_eq_ref * exp(
-            -(b.dh_rxn[r_idx] /
-              pyunits.convert(c.gas_constant,
-                              to_units=units["gas_constant"])) *
-            (1/T - 1/rblock.T_eq_ref))
+        k_units = pyunits.get_units(rblock.k_eq_ref)
+
+        if (k_units is None or
+                k_units is pyunits.dimensionless):
+            l_keq_ref = log(rblock.k_eq_ref)
+        else:
+            l_keq_ref = log(rblock.k_eq_ref/k_units)
+
+        return (b.log_k_eq[r_idx] - l_keq_ref) == (
+                -b.dh_rxn[r_idx] /
+                pyunits.convert(c.gas_constant,
+                                to_units=units["gas_constant"]) *
+                (1/T - 1/rblock.T_eq_ref))
 
     @staticmethod
     def calculate_scaling_factors(b, rblock):
@@ -181,31 +206,11 @@ class gibbs_energy():
                 "{} concentration_form configuration argument was not set. "
                 "Please ensure that this argument is included in your "
                 "configuration dict.".format(rblock.name))
-        elif (c_form == ConcentrationForm.molarity or
-              c_form == ConcentrationForm.activity):
-
-            order = 0
-            try:
-                # This will work for Reaction Packages
-                pc_set = parent.config.property_package._phase_component_set
-            except AttributeError:
-                # Need to allow for inherent reactions in Property Packages
-                if not parent._electrolyte:
-                    # In most cases ,should have _phase_component_set
-                    pc_set = parent._phase_component_set
-                else:
-                    # However, for electrolytes need true species set
-                    pc_set = parent.true_phase_component_set
-
-            for p, j in pc_set:
-                order += rblock.reaction_order[p, j].value
-
-            rblock._keq_units = (pyunits.convert(1*pyunits.mol/pyunits.L,
-                                                 units["density_mole"]))**order
-        else:
+        elif not (c_form == ConcentrationForm.moleFraction or
+                  c_form == ConcentrationForm.activity):
             raise ConfigurationError(
                 "{} calculation of equilibrium constant based on Gibbs energy "
-                "is only supported for molarity or activity forms. "
+                "is only supported for mole fraction or activity forms. "
                 "Currently selected form: {}".format(rblock.name, c_form))
 
         # Check that heat of reaction is constant
@@ -228,13 +233,16 @@ class gibbs_energy():
 
     @staticmethod
     def return_expression(b, rblock, r_idx, T):
-        units = rblock.parent_block().get_metadata().derived_units
+        return exp(b.log_k_eq[r_idx])
 
+    @staticmethod
+    def return_log_expression(b, rblock, r_idx, T):
+        units = rblock.parent_block().get_metadata().derived_units
         R = pyunits.convert(c.gas_constant, to_units=units["gas_constant"])
 
-        return (exp(
+        return b.log_k_eq[r_idx] == (
             (-rblock.dh_rxn_ref / (R*T)) +
-            (rblock.ds_rxn_ref / R)) * rblock._keq_units)
+            (rblock.ds_rxn_ref / R))
 
     @staticmethod
     def calculate_scaling_factors(b, rblock):

--- a/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_constant.py
@@ -15,7 +15,7 @@ Methods for calculating equilibrium constants
 """
 from pyomo.environ import exp, Var, units as pyunits, value
 
-from idaes.generic_models.properties.core.generic.generic_reaction import \
+from idaes.generic_models.properties.core.generic.utility import \
     ConcentrationForm
 from .dh_rxn import constant_dh_rxn
 from idaes.core.util.misc import set_param_from_config
@@ -68,9 +68,9 @@ class ConstantKeq():
                 c_units = units["pressure"]
             else:
                 raise BurntToast(
-                    "{} get_concentration_term received unrecognised "
-                    "ConcentrationForm ({}). This should not happen - please "
-                    "contact the IDAES developers with this bug."
+                    "{} received unrecognised ConcentrationForm ({}). "
+                    "This should not happen - please contact the IDAES "
+                    "developers with this bug."
                     .format(rblock.name, c_form))
 
             e_units = c_units**order
@@ -134,9 +134,9 @@ class van_t_hoff():
                 c_units = units["pressure"]
             else:
                 raise BurntToast(
-                    "{} get_concentration_term received unrecognised "
-                    "ConcentrationForm ({}). This should not happen - please "
-                    "contact the IDAES developers with this bug."
+                    "{} received unrecognised ConcentrationForm ({}). "
+                    "This should not happen - please contact the IDAES "
+                    "developers with this bug."
                     .format(rblock.name, c_form))
 
             e_units = c_units**order

--- a/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
@@ -19,7 +19,7 @@ from idaes.core.util.math import safe_log, smooth_max
 from idaes.core.util.exceptions import ConfigurationError
 
 from idaes.generic_models.properties.core.generic.generic_reaction import \
-    get_concentration_term
+    get_concentration_term, get_log_concentration_term
 
 
 # Smooth parameter to use in safe_log approximations
@@ -83,26 +83,12 @@ class log_power_law_equil():
 
             if e is None and o.value != 0:
                 # Need to strip units from concentration term (if applicable)
-                c = get_concentration_term(b, r_idx)[p, j]
-                u = pyunits.get_units(c)
-                if u is not None:
-                    # Has units, so divide conc by units
-                    expr = c/u
-                else:
-                    # Units is None, so just use conc
-                    expr = c
-                e = o*safe_log(expr, eps=rblock.eps)
+                c = get_log_concentration_term(b, r_idx)[p, j]
+                e = o*c
             elif e is not None and o.value != 0:
                 # Need to strip units from concentration term (if applicable)
-                c = get_concentration_term(b, r_idx)[p, j]
-                u = pyunits.get_units(c)
-                if u is not None:
-                    # Has units, so divide conc by units
-                    expr = c/u
-                else:
-                    # Units is None, so just use conc
-                    expr = c
-                e = e + o*safe_log(expr, eps=rblock.eps)
+                c = get_log_concentration_term(b, r_idx)[p, j]
+                e = e + o*c
 
         # Need to check units on k_eq as well
         u = pyunits.get_units(b.k_eq[r_idx])

--- a/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
@@ -18,7 +18,7 @@ from pyomo.environ import Param, units as pyunits
 from idaes.core.util.math import safe_log, smooth_max
 from idaes.core.util.exceptions import ConfigurationError
 
-from idaes.generic_models.properties.core.generic.generic_reaction import \
+from idaes.generic_models.properties.core.generic.utility import \
     get_concentration_term
 
 

--- a/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
+++ b/idaes/generic_models/properties/core/reactions/equilibrium_forms.py
@@ -19,7 +19,7 @@ from idaes.core.util.math import safe_log, smooth_max
 from idaes.core.util.exceptions import ConfigurationError
 
 from idaes.generic_models.properties.core.generic.generic_reaction import \
-    get_concentration_term, get_log_concentration_term
+    get_concentration_term
 
 
 # Smooth parameter to use in safe_log approximations
@@ -83,11 +83,11 @@ class log_power_law_equil():
 
             if e is None and o.value != 0:
                 # Need to strip units from concentration term (if applicable)
-                c = get_log_concentration_term(b, r_idx)[p, j]
+                c = get_concentration_term(b, r_idx, log=True)[p, j]
                 e = o*c
             elif e is not None and o.value != 0:
                 # Need to strip units from concentration term (if applicable)
-                c = get_log_concentration_term(b, r_idx)[p, j]
+                c = get_concentration_term(b, r_idx, log=True)[p, j]
                 e = e + o*c
 
         # Need to check units on k_eq as well

--- a/idaes/generic_models/properties/core/reactions/rate_constant.py
+++ b/idaes/generic_models/properties/core/reactions/rate_constant.py
@@ -16,7 +16,7 @@ Methods for calculating rate constants
 from pyomo.environ import exp, Var, units as pyunits
 
 from idaes.core import MaterialFlowBasis
-from idaes.generic_models.properties.core.generic.generic_reaction import \
+from idaes.generic_models.properties.core.generic.utility import \
     ConcentrationForm
 from idaes.core.util.misc import set_param_from_config
 from idaes.core.util.constants import Constants as c
@@ -66,9 +66,9 @@ class arrhenius():
                 c_units = units["pressure"]
             else:
                 raise BurntToast(
-                    "{} get_concentration_term received unrecognised "
-                    "ConcentrationForm ({}). This should not happen - please "
-                    "contact the IDAES developers with this bug."
+                    "{} received unrecognised ConcentrationForm ({}). "
+                    "This should not happen - please contact the IDAES "
+                    "developers with this bug."
                     .format(rblock.name, c_form))
 
             r_units = (r_base *

--- a/idaes/generic_models/properties/core/reactions/rate_forms.py
+++ b/idaes/generic_models/properties/core/reactions/rate_forms.py
@@ -13,7 +13,7 @@
 """
 Methods for defining reaction rates
 """
-from idaes.generic_models.properties.core.generic.generic_reaction import \
+from idaes.generic_models.properties.core.generic.utility import \
     get_concentration_term
 
 

--- a/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
@@ -16,7 +16,7 @@ Tests for rate forms
 
 import pytest
 
-from pyomo.environ import ConcreteModel, Var, units as pyunits, value
+from pyomo.environ import ConcreteModel, log, Var, units as pyunits, value
 from pyomo.util.check_units import assert_units_equivalent
 
 from idaes.generic_models.properties.core.generic.generic_reaction import \
@@ -26,6 +26,7 @@ from idaes.generic_models.properties.core.reactions.dh_rxn import constant_dh_rx
 from idaes.core import MaterialFlowBasis
 from idaes.core.util.testing import PhysicalParameterTestBlock
 from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.constants import Constants as c
 
 
 @pytest.fixture
@@ -247,11 +248,25 @@ class TestVanTHoff(object):
         assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
         # Check expression
-        rform = van_t_hoff.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        units = model.rparams.get_metadata().derived_units
 
-        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-        assert_units_equivalent(rform, None)
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+        rform1 = van_t_hoff.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform1) == str(
+            (model.rxn[1].log_k_eq["r1"] -
+             log(model.rparams.reaction_r1.k_eq_ref)) == (
+                 -model.rxn[1].dh_rxn["r1"] /
+                 pyunits.convert(c.gas_constant,
+                                 to_units=units["gas_constant"]) *
+                 (1/(300*pyunits.K) -
+                  1/model.rparams.reaction_r1.T_eq_ref)))
+
+        rform2 = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert value(rform2) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, None)
+        assert_units_equivalent(rform2, None)
 
     @pytest.mark.unit
     def test_van_t_hoff_mole_frac_convert(self, model):
@@ -271,11 +286,25 @@ class TestVanTHoff(object):
         assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
         # Check expression
-        rform = van_t_hoff.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        units = model.rparams.get_metadata().derived_units
 
-        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-        assert_units_equivalent(rform, None)
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+        rform1 = van_t_hoff.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform1) == str(
+            (model.rxn[1].log_k_eq["r1"] -
+             log(model.rparams.reaction_r1.k_eq_ref)) == (
+                 -model.rxn[1].dh_rxn["r1"] /
+                 pyunits.convert(c.gas_constant,
+                                 to_units=units["gas_constant"]) *
+                 (1/(300*pyunits.K) -
+                  1/model.rparams.reaction_r1.T_eq_ref)))
+
+        rform2 = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert value(rform2) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, None)
+        assert_units_equivalent(rform2, None)
 
     @pytest.mark.unit
     def test_van_t_hoff_molarity(self, model):
@@ -297,11 +326,26 @@ class TestVanTHoff(object):
         assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
         # Check expression
-        rform = van_t_hoff.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        units = model.rparams.get_metadata().derived_units
 
-        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.mol/pyunits.m**3)
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+        rform1 = van_t_hoff.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform1) == str(
+            (model.rxn[1].log_k_eq["r1"] -
+             log(1/(pyunits.mol/pyunits.m**3) *
+                 model.rparams.reaction_r1.k_eq_ref)) == (
+                 -model.rxn[1].dh_rxn["r1"] /
+                 pyunits.convert(c.gas_constant,
+                                 to_units=units["gas_constant"]) *
+                 (1/(300*pyunits.K) -
+                  1/model.rparams.reaction_r1.T_eq_ref)))
+
+        rform2 = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert value(rform2) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, None)
+        assert_units_equivalent(rform2, pyunits.mol/pyunits.m**3)
 
     @pytest.mark.unit
     def test_van_t_hoff_molarity_convert(self, model):
@@ -323,11 +367,26 @@ class TestVanTHoff(object):
         assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
         # Check expression
-        rform = van_t_hoff.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        units = model.rparams.get_metadata().derived_units
 
-        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.mol/pyunits.m**3)
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+        rform1 = van_t_hoff.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform1) == str(
+            (model.rxn[1].log_k_eq["r1"] -
+             log(1/(pyunits.mol/pyunits.m**3) *
+                 model.rparams.reaction_r1.k_eq_ref)) == (
+                 -model.rxn[1].dh_rxn["r1"] /
+                 pyunits.convert(c.gas_constant,
+                                 to_units=units["gas_constant"]) *
+                 (1/(300*pyunits.K) -
+                  1/model.rparams.reaction_r1.T_eq_ref)))
+
+        rform2 = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert value(rform2) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, None)
+        assert_units_equivalent(rform2, pyunits.mol/pyunits.m**3)
 
     @pytest.mark.unit
     def test_van_t_hoff_molality(self, model):
@@ -349,11 +408,26 @@ class TestVanTHoff(object):
         assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
         # Check expression
-        rform = van_t_hoff.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        units = model.rparams.get_metadata().derived_units
 
-        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.mol/pyunits.kg)
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+        rform1 = van_t_hoff.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform1) == str(
+            (model.rxn[1].log_k_eq["r1"] -
+             log(1/(pyunits.mol/pyunits.kg) *
+                 model.rparams.reaction_r1.k_eq_ref)) == (
+                 -model.rxn[1].dh_rxn["r1"] /
+                 pyunits.convert(c.gas_constant,
+                                 to_units=units["gas_constant"]) *
+                 (1/(300*pyunits.K) -
+                  1/model.rparams.reaction_r1.T_eq_ref)))
+
+        rform2 = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert value(rform2) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, None)
+        assert_units_equivalent(rform2, pyunits.mol/pyunits.kg)
 
     @pytest.mark.unit
     def test_van_t_hoff_molality_convert(self, model):
@@ -375,11 +449,26 @@ class TestVanTHoff(object):
         assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
         # Check expression
-        rform = van_t_hoff.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        units = model.rparams.get_metadata().derived_units
 
-        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.mol/pyunits.kg)
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+        rform1 = van_t_hoff.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform1) == str(
+            (model.rxn[1].log_k_eq["r1"] -
+             log(1/(pyunits.mol/pyunits.kg) *
+                 model.rparams.reaction_r1.k_eq_ref)) == (
+                 -model.rxn[1].dh_rxn["r1"] /
+                 pyunits.convert(c.gas_constant,
+                                 to_units=units["gas_constant"]) *
+                 (1/(300*pyunits.K) -
+                  1/model.rparams.reaction_r1.T_eq_ref)))
+
+        rform2 = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert value(rform2) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, None)
+        assert_units_equivalent(rform2, pyunits.mol/pyunits.kg)
 
     @pytest.mark.unit
     def test_van_t_hoff_partial_pressure(self, model):
@@ -401,11 +490,26 @@ class TestVanTHoff(object):
         assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
         # Check expression
-        rform = van_t_hoff.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        units = model.rparams.get_metadata().derived_units
 
-        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.Pa)
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+        rform1 = van_t_hoff.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform1) == str(
+            (model.rxn[1].log_k_eq["r1"] -
+             log(1/(pyunits.kg/pyunits.m/pyunits.s**2) *
+                 model.rparams.reaction_r1.k_eq_ref)) == (
+                 -model.rxn[1].dh_rxn["r1"] /
+                 pyunits.convert(c.gas_constant,
+                                 to_units=units["gas_constant"]) *
+                 (1/(300*pyunits.K) -
+                  1/model.rparams.reaction_r1.T_eq_ref)))
+
+        rform2 = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert value(rform2) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, None)
+        assert_units_equivalent(rform2, pyunits.Pa)
 
     @pytest.mark.unit
     def test_van_t_hoff_partial_pressure_convert(self, model):
@@ -427,11 +531,26 @@ class TestVanTHoff(object):
         assert model.rparams.reaction_r1.T_eq_ref.value == 500
 
         # Check expression
-        rform = van_t_hoff.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        units = model.rparams.get_metadata().derived_units
 
-        assert value(rform) == pytest.approx(0.99984, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.Pa)
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+        rform1 = van_t_hoff.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert str(rform1) == str(
+            (model.rxn[1].log_k_eq["r1"] -
+             log(1/(pyunits.kg/pyunits.m/pyunits.s**2) *
+                 model.rparams.reaction_r1.k_eq_ref)) == (
+                 -model.rxn[1].dh_rxn["r1"] /
+                 pyunits.convert(c.gas_constant,
+                                 to_units=units["gas_constant"]) *
+                 (1/(300*pyunits.K) -
+                  1/model.rparams.reaction_r1.T_eq_ref)))
+
+        rform2 = van_t_hoff.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        assert value(rform2) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, None)
+        assert_units_equivalent(rform2, pyunits.Pa)
 
 
 class TestGibbsEnergy(object):
@@ -445,20 +564,39 @@ class TestGibbsEnergy(object):
         model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
                                                    units=pyunits.J/pyunits.mol)
 
-        with pytest.raises(
-                ConfigurationError,
-                match="rparams.reaction_r1 calculation of equilibrium constant"
-                " based on Gibbs energy is only supported for molarity or"
-                " activity forms. Currently selected form: "
-                "ConcentrationForm.moleFraction"):
-            gibbs_energy.build_parameters(
-                model.rparams.reaction_r1,
-                model.rparams.config.equilibrium_reactions["r1"])
+        gibbs_energy.build_parameters(
+            model.rparams.reaction_r1,
+            model.rparams.config.equilibrium_reactions["r1"])
+
+        # Check parameter construction
+        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
+        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
+
+        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
+        assert model.rparams.reaction_r1.T_eq_ref.value == 500
+
+        # Check expression
+        model.rxn[1].log_k_eq = Var(["r1"], initialize=0)
+
+        rform1 = gibbs_energy.return_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+        rform2 = gibbs_energy.return_log_expression(
+            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
+
+        assert str(rform1) == ('exp(rxn[1].log_k_eq[r1])')
+        assert str(rform2) == (
+            'rxn[1].log_k_eq[r1]  ==  '
+            '- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
+            '(8.314462618*(J)/mol/K)*(300*K)) + '
+            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))'
+            '*rparams.reaction_r1.ds_rxn_ref')
+
+        assert value(rform1) == pytest.approx(1, rel=1e-3)
+        assert_units_equivalent(rform1, pyunits.dimensionless)
+        assert_units_equivalent(rform2, pyunits.dimensionless)
 
     @pytest.mark.unit
     def test_gibbs_energy_invalid_dh_rxn(self, model):
-        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-            ConcentrationForm.molarity
         model.rparams.config.equilibrium_reactions.r1.parameter_data = {
             "ds_rxn_ref": 1,
             "T_eq_ref": 500}
@@ -486,71 +624,15 @@ class TestGibbsEnergy(object):
         model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
                                                    units=pyunits.J/pyunits.mol)
 
-        gibbs_energy.build_parameters(
-            model.rparams.reaction_r1,
-            model.rparams.config.equilibrium_reactions["r1"])
-
-        # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
-        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
-
-        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-        assert model.rparams.reaction_r1.T_eq_ref.value == 500
-
-        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
-                                pyunits.mol*pyunits.m**-3)
-
-        # Check expression
-        rform = gibbs_energy.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
-
-        assert str(rform) == (
-            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*'
-            '(999.9999999999999*l/m**3*(mol/l))')
-        assert value(rform) == pytest.approx(1.1269e3, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.mol*pyunits.m**-3)
-
-    @pytest.mark.unit
-    def test_gibbs_energy_molarity_convert(self, model):
-        model.rparams.config.equilibrium_reactions.r1.concentration_form = \
-            ConcentrationForm.molarity
-        model.rparams.config.equilibrium_reactions.r1.heat_of_reaction = \
-            constant_dh_rxn
-        model.rparams.config.equilibrium_reactions.r1.parameter_data = {
-            "ds_rxn_ref": (1000, pyunits.J/pyunits.kmol/pyunits.K),
-            "T_eq_ref": (900, pyunits.degR)}
-        model.rparams.reaction_r1.dh_rxn_ref = Var(initialize=2,
-                                                   units=pyunits.J/pyunits.mol)
-
-        gibbs_energy.build_parameters(
-            model.rparams.reaction_r1,
-            model.rparams.config.equilibrium_reactions["r1"])
-
-        # Check parameter construction
-        assert isinstance(model.rparams.reaction_r1.ds_rxn_ref, Var)
-        assert model.rparams.reaction_r1.ds_rxn_ref.value == 1
-
-        assert isinstance(model.rparams.reaction_r1.T_eq_ref, Var)
-        assert model.rparams.reaction_r1.T_eq_ref.value == 500
-
-        assert_units_equivalent(model.rparams.reaction_r1._keq_units,
-                                pyunits.mol/pyunits.m**3)
-
-        # Check expression
-        rform = gibbs_energy.return_expression(
-            model.rxn[1], model.rparams.reaction_r1, "r1", 300*pyunits.K)
-
-        assert str(rform) == (
-            'exp(- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))*'
-            'rparams.reaction_r1.ds_rxn_ref)*'
-            '(999.9999999999999*l/m**3*(mol/l))')
-        assert value(rform) == pytest.approx(1.1269e3, rel=1e-3)
-        assert_units_equivalent(rform, pyunits.mol*pyunits.m**-3)
+        with pytest.raises(
+                ConfigurationError,
+                match="rparams.reaction_r1 calculation of equilibrium constant"
+                " based on Gibbs energy is only supported for mole fraction or"
+                " activity forms. Currently selected form: "
+                "ConcentrationForm.molarity"):
+            gibbs_energy.build_parameters(
+                model.rparams.reaction_r1,
+                model.rparams.config.equilibrium_reactions["r1"])
 
     @pytest.mark.unit
     def test_gibbs_energy_molality(self, model):
@@ -567,7 +649,7 @@ class TestGibbsEnergy(object):
         with pytest.raises(
                 ConfigurationError,
                 match="rparams.reaction_r1 calculation of equilibrium constant"
-                " based on Gibbs energy is only supported for molarity or"
+                " based on Gibbs energy is only supported for mole fraction or"
                 " activity forms. Currently selected form: "
                 "ConcentrationForm.molality"):
             gibbs_energy.build_parameters(
@@ -589,7 +671,7 @@ class TestGibbsEnergy(object):
         with pytest.raises(
                 ConfigurationError,
                 match="rparams.reaction_r1 calculation of equilibrium constant"
-                " based on Gibbs energy is only supported for molarity or"
+                " based on Gibbs energy is only supported for mole fraction or"
                 " activity forms. Currently selected form: "
                 "ConcentrationForm.partialPressure"):
             gibbs_energy.build_parameters(

--- a/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_forms.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_forms.py
@@ -184,6 +184,7 @@ def test_log_power_law_equil_no_order():
     m.pparams.sol = SolidPhase()
 
     m.thermo = m.pparams.build_state_block([1])
+    m.thermo[1].log_mole_frac_phase_comp = Var(m.pparams._phase_component_set)
 
     # Create a dummy reaction parameter block
     m.rparams = GenericReactionParameterBlock(default={
@@ -235,11 +236,9 @@ def test_log_power_law_equil_no_order():
     assert str(rform) == str(
         safe_log(m.rxn[1].k_eq["r1"], eps=m.rparams.reaction_r1.eps) ==
         m.rparams.reaction_r1.reaction_order["p1", "c1"] *
-        safe_log(m.thermo[1].mole_frac_phase_comp["p1", "c1"],
-                 eps=m.rparams.reaction_r1.eps) +
+        m.thermo[1].log_mole_frac_phase_comp["p1", "c1"] +
         m.rparams.reaction_r1.reaction_order["p1", "c2"] *
-        safe_log(m.thermo[1].mole_frac_phase_comp["p1", "c2"],
-                 eps=m.rparams.reaction_r1.eps))
+        m.thermo[1].log_mole_frac_phase_comp["p1", "c2"])
 
 
 @pytest.mark.unit
@@ -253,6 +252,7 @@ def test_log_power_law_equil_with_order():
     m.pparams.sol = SolidPhase()
 
     m.thermo = m.pparams.build_state_block([1])
+    m.thermo[1].log_mole_frac_phase_comp = Var(m.pparams._phase_component_set)
 
     # Create a dummy reaction parameter block
     m.rparams = GenericReactionParameterBlock(default={
@@ -309,23 +309,17 @@ def test_log_power_law_equil_with_order():
     assert str(rform) == str(
         safe_log(m.rxn[1].k_eq["r1"], eps=m.rparams.reaction_r1.eps) ==
         m.rparams.reaction_r1.reaction_order["p1", "c1"] *
-        safe_log(m.thermo[1].mole_frac_phase_comp["p1", "c1"],
-                 eps=m.rparams.reaction_r1.eps) +
+        m.thermo[1].log_mole_frac_phase_comp["p1", "c1"] +
         m.rparams.reaction_r1.reaction_order["p1", "c2"] *
-        safe_log(m.thermo[1].mole_frac_phase_comp["p1", "c2"],
-                 eps=m.rparams.reaction_r1.eps) +
+        m.thermo[1].log_mole_frac_phase_comp["p1", "c2"] +
         m.rparams.reaction_r1.reaction_order["p2", "c1"] *
-        safe_log(m.thermo[1].mole_frac_phase_comp["p2", "c1"],
-                 eps=m.rparams.reaction_r1.eps) +
+        m.thermo[1].log_mole_frac_phase_comp["p2", "c1"] +
         m.rparams.reaction_r1.reaction_order["p2", "c2"] *
-        safe_log(m.thermo[1].mole_frac_phase_comp["p2", "c2"],
-                 eps=m.rparams.reaction_r1.eps) +
+        m.thermo[1].log_mole_frac_phase_comp["p2", "c2"] +
         m.rparams.reaction_r1.reaction_order["sol", "c1"] *
-        safe_log(m.thermo[1].mole_frac_phase_comp["sol", "c1"],
-                 eps=m.rparams.reaction_r1.eps) +
+        m.thermo[1].log_mole_frac_phase_comp["sol", "c1"] +
         m.rparams.reaction_r1.reaction_order["sol", "c2"] *
-        safe_log(m.thermo[1].mole_frac_phase_comp["sol", "c2"],
-                 eps=m.rparams.reaction_r1.eps))
+        m.thermo[1].log_mole_frac_phase_comp["sol", "c2"])
 
 
 @pytest.mark.unit

--- a/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_forms.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_forms.py
@@ -209,11 +209,7 @@ def test_log_power_law_equil_no_order():
     add_object_reference(m.rxn[1], "params", m.rparams)
     add_object_reference(m.rxn[1], "state_ref", m.thermo[1])
 
-    m.rxn[1].k_eq = Var(["r1"], initialize=1)
-
-    log_power_law_equil.build_parameters(
-        m.rparams.reaction_r1,
-        m.rparams.config.equilibrium_reactions["r1"])
+    m.rxn[1].log_k_eq = Var(["r1"], initialize=1)
 
     # Check parameter construction
     assert isinstance(m.rparams.reaction_r1.reaction_order, Var)
@@ -226,15 +222,13 @@ def test_log_power_law_equil_no_order():
     # Solids should have zero order, as they are excluded
     assert m.rparams.reaction_r1.reaction_order["sol", "c1"].value == 0
     assert m.rparams.reaction_r1.reaction_order["sol", "c2"].value == 0
-    assert isinstance(m.rparams.reaction_r1.eps, Param)
-    assert m.rparams.reaction_r1.eps.value == 1e-15
 
     # Check reaction form
     rform = log_power_law_equil.return_expression(
         m.rxn[1], m.rparams.reaction_r1, "r1", 300)
 
     assert str(rform) == str(
-        safe_log(m.rxn[1].k_eq["r1"], eps=m.rparams.reaction_r1.eps) ==
+        m.rxn[1].log_k_eq["r1"] ==
         m.rparams.reaction_r1.reaction_order["p1", "c1"] *
         m.thermo[1].log_mole_frac_phase_comp["p1", "c1"] +
         m.rparams.reaction_r1.reaction_order["p1", "c2"] *
@@ -284,11 +278,7 @@ def test_log_power_law_equil_with_order():
     add_object_reference(m.rxn[1], "params", m.rparams)
     add_object_reference(m.rxn[1], "state_ref", m.thermo[1])
 
-    m.rxn[1].k_eq = Var(["r1"], initialize=1)
-
-    log_power_law_equil.build_parameters(
-        m.rparams.reaction_r1,
-        m.rparams.config.equilibrium_reactions["r1"])
+    m.rxn[1].log_k_eq = Var(["r1"], initialize=1)
 
     # Check parameter construction
     assert isinstance(m.rparams.reaction_r1.reaction_order, Var)
@@ -299,15 +289,13 @@ def test_log_power_law_equil_with_order():
     assert m.rparams.reaction_r1.reaction_order["p2", "c2"].value == 4
     assert m.rparams.reaction_r1.reaction_order["sol", "c1"].value == 5
     assert m.rparams.reaction_r1.reaction_order["sol", "c2"].value == 6
-    assert isinstance(m.rparams.reaction_r1.eps, Param)
-    assert m.rparams.reaction_r1.eps.value == 1e-15
 
     # Check reaction form
     rform = log_power_law_equil.return_expression(
         m.rxn[1], m.rparams.reaction_r1, "r1", 300)
 
     assert str(rform) == str(
-        safe_log(m.rxn[1].k_eq["r1"], eps=m.rparams.reaction_r1.eps) ==
+        m.rxn[1].log_k_eq["r1"] ==
         m.rparams.reaction_r1.reaction_order["p1", "c1"] *
         m.thermo[1].log_mole_frac_phase_comp["p1", "c1"] +
         m.rparams.reaction_r1.reaction_order["p1", "c2"] *

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx_electrolyte.py
@@ -39,7 +39,7 @@ from idaes.generic_models.properties.core.reactions.equilibrium_constant import 
     van_t_hoff
 from idaes.generic_models.properties.core.reactions.equilibrium_forms import \
     power_law_equil
-from idaes.generic_models.properties.core.generic.generic_reaction import (
+from idaes.generic_models.properties.core.generic.utility import (
     ConcentrationForm)
 
 from idaes.core import FlowsheetBlock

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx_electrolyte.py
@@ -39,7 +39,7 @@ from idaes.generic_models.properties.core.reactions.equilibrium_constant import 
     van_t_hoff
 from idaes.generic_models.properties.core.reactions.equilibrium_forms import \
     power_law_equil
-from idaes.generic_models.properties.core.generic.generic_reaction import (
+from idaes.generic_models.properties.core.generic.utility import (
     ConcentrationForm)
 
 from idaes.core import FlowsheetBlock

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh_electrolyte.py
@@ -39,7 +39,7 @@ from idaes.generic_models.properties.core.reactions.equilibrium_constant import 
     van_t_hoff
 from idaes.generic_models.properties.core.reactions.equilibrium_forms import \
     power_law_equil
-from idaes.generic_models.properties.core.generic.generic_reaction import (
+from idaes.generic_models.properties.core.generic.utility import (
     ConcentrationForm)
 
 from idaes.core import FlowsheetBlock

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP_electrolyte.py
@@ -40,7 +40,7 @@ from idaes.generic_models.properties.core.reactions.equilibrium_constant import 
     van_t_hoff
 from idaes.generic_models.properties.core.reactions.equilibrium_forms import \
     power_law_equil
-from idaes.generic_models.properties.core.generic.generic_reaction import (
+from idaes.generic_models.properties.core.generic.utility import (
     ConcentrationForm)
 
 from idaes.core import FlowsheetBlock

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP_electrolyte.py
@@ -40,7 +40,7 @@ from idaes.generic_models.properties.core.reactions.equilibrium_constant import 
     van_t_hoff
 from idaes.generic_models.properties.core.reactions.equilibrium_forms import \
     power_law_equil
-from idaes.generic_models.properties.core.generic.generic_reaction import (
+from idaes.generic_models.properties.core.generic.utility import (
     ConcentrationForm)
 
 from idaes.core import FlowsheetBlock


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Experience in NAWI has shown that we can get significantly better convergence and robustness by replacing `log(expr)` with `exp(log_expr) == expr` (which should surprise no-one). This PR adds log variables for concentrations in the generic property framework, and will be the first of a series of PRs.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
