### PR TITLE
Improved generic error

### DIFF
--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -769,10 +769,16 @@ class GenericParameterData(PhysicalParameterBlock):
         for v in self.component_objects(Var, descend_into=True):
             for i in v:
                 if v[i].value is None:
-                    raise ConfigurationError(
-                        "{} parameter {} was not assigned"
-                        " a value. Please check your configuration "
-                        "arguments.".format(self.name, v.local_name))
+                    if i is None: # Scalar Var
+                        raise ConfigurationError(
+                            "{} parameter {} was not assigned"
+                            " a value. Please check your configuration "
+                            "arguments.".format(self.name, v.local_name))
+                    else: # Indexed Var
+                        raise ConfigurationError(
+                            "{} parameter {}[{}] was not assigned"
+                            " a value. Please check your configuration "
+                            "arguments.".format(self.name, v.local_name, i))
                 v[i].fix()
 
         self.config.state_definition.set_metadata(self)


### PR DESCRIPTION
## Fixes

Improved an error message in the generic property package.

## Summary/Motivation:

I spent a fair amount of time debugging an implementation of a generic property package. The error message lead me to believe that I was defining the `PR_kappa` dictionary in the wrong place, because it seemingly couldn't find values for it:

![image](https://user-images.githubusercontent.com/88728506/136406967-4033e1dd-ab5d-468a-88ed-9b00c3e81318.png)

Eventually, I figured out that I was in fact defining it in the right place, but I had put the wrong key for one set of parameters:

![image](https://user-images.githubusercontent.com/88728506/136407187-af56707d-d8f6-41f2-863d-4483d2561886.png)

## Changes proposed in this PR:

I've added a check where that error message is generated about whether or not the variable is indexed. If it is indexed, it prints the index for which the variable is not defined:

![image](https://user-images.githubusercontent.com/88728506/136407533-92b85cd4-f5af-47dd-bf32-43ac52f88db9.png)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
