### PR TITLE
Fix TypeError introduced by PyYAML 6.0

### DIFF
--- a/idaes/tests/test_headers.py
+++ b/idaes/tests/test_headers.py
@@ -39,7 +39,7 @@ def patterns(package_root):
         print(f"Cannot load configuration file from '{conf_file}'. Perhaps this is not development mode?")
         return None
     with open(conf_file) as f:
-        conf_data = yaml.load(f)  # probable cause
+        conf_data = yaml.safe_load(f)
     print(f"Patterns for finding files with headers: {conf_data['patterns']}")
     return conf_data["patterns"]
 


### PR DESCRIPTION
## Summary/Motivation:

- An error in `test_headers.py` related to `yaml.load()` is causing the tests to fail
- The probable cause is that a major version of PyYAML has recently been released and the error was previously a warning that's now being enforced
- The solution proposed in this PR is to use `yaml.safe_load()` instead of `yaml.load()`


## Changes proposed in this PR:
- Use `yaml.safe_load()` instead of `yaml.load()`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
