### PR TITLE
Power plant costing update

### DIFF
--- a/idaes/power_generation/costing/tests/test_NGCC_costing.py
+++ b/idaes/power_generation/costing/tests/test_NGCC_costing.py
@@ -329,7 +329,7 @@ def test_units3_costing(build_costing):
 def test_flowsheet_costing(build_costing):
     m = build_costing
     # Build cost constraints
-    get_total_TPC(m)
+    get_total_TPC(m.fs)
 
     # Initialize costing
     costing_initialization(m.fs)

--- a/idaes/power_generation/costing/tests/test_power_plant_costing.py
+++ b/idaes/power_generation/costing/tests/test_power_plant_costing.py
@@ -118,7 +118,7 @@ def test_PP_costing():
                    m.fs.ash_handling.ash_mass_flow, 'lb/hr', 2)
 
     # add total cost
-    get_total_TPC(m)
+    get_total_TPC(m.fs)
 
     # add initialize
     costing_initialization(m.fs)
@@ -280,7 +280,7 @@ def test_power_plant_costing():
                    'lb/hr', 7)
 
     # add total cost
-    get_total_TPC(m)
+    get_total_TPC(m.fs)
 
     # add initialize
     costing_initialization(m.fs)
@@ -479,7 +479,7 @@ def test_sCO2_costing():
                        n_equip=4.0)
 
     # add total cost
-    get_total_TPC(m)
+    get_total_TPC(m.fs)
 
     # add initialize
     costing_initialization(m.fs)
@@ -564,7 +564,7 @@ def test_OM_costing():
     tech = 1
     fixed_TPC = 800  # MM$
 
-    get_fixed_OM_costs(m,
+    get_fixed_OM_costs(m.fs,
                        nameplate_capacity,
                        labor_rate=labor_rate,
                        labor_burden=labor_burden,
@@ -572,7 +572,7 @@ def test_OM_costing():
                        tech=tech,
                        fixed_TPC=fixed_TPC)
 
-    initialize_fixed_OM_costs(m)
+    initialize_fixed_OM_costs(m.fs)
 
     # build variable costs
     m.fs.net_power = pyo.Var(m.fs.time, initialize=650, units=pyunits.MW)

--- a/idaes/power_generation/flowsheets/ngcc/ngcc_costing.py
+++ b/idaes/power_generation/flowsheets/ngcc/ngcc_costing.py
@@ -463,7 +463,7 @@ def get_ngcc_costing(m, evaluate_cost=False):
         get_PP_costing(m.fs.b16, gasturbine_accounts, gt_power, "kW", 6)
 
     # Build cost constraints
-    get_total_TPC(m)
+    get_total_TPC(m.fs)
 
     # Initialize costing
     costing_initialization(m.fs)
@@ -572,9 +572,9 @@ def ngcc_costing_validation(m):
 def build_ngcc_OM_costs(m):
     # testing fixed OM costs
     get_fixed_OM_costs(
-        m, 650, operators_per_shift=5, tech=6, fixed_TPC=555.35  # MW
+        m.fs, 650, operators_per_shift=5, tech=6, fixed_TPC=555.35  # MW
     )  # MW
-    initialize_fixed_OM_costs(m)
+    initialize_fixed_OM_costs(m.fs)
 
     # fixed cost is required to estimate variable O&M costs
     # testing variable OM costs
@@ -603,7 +603,7 @@ def build_ngcc_OM_costs(m):
     m.fs.water_use.fix()
     #
     get_variable_OM_costs(
-        m,
+        m.fs,
         m.fs.net_power_cost,
         ["natural gas", "water"],
         [m.fs.natural_gas, m.fs.water_use],
@@ -613,7 +613,7 @@ def build_ngcc_OM_costs(m):
     #                       [m.fs.natural_gas])
     # [m.fs.flow_mass]
 
-    initialize_variable_OM_costs(m)
+    initialize_variable_OM_costs(m.fs)
 
 
 if __name__ == "__main__":

--- a/idaes/power_generation/flowsheets/soec/soec_costing.py
+++ b/idaes/power_generation/flowsheets/soec/soec_costing.py
@@ -190,7 +190,7 @@ def get_soec_capital_costing(m):
     get_PP_costing(m.fs.aux_load_block, auxilliary_load_accounts, aux_load, "kW", 6)
 
     # build constraint summing total plant costs
-    get_total_TPC(m)
+    get_total_TPC(m.fs)
 
     # costing initialization
     calculate_variable_from_constraint(
@@ -236,7 +236,7 @@ def lock_capital_cost(m):
 
 def get_soec_OM_costing(m, design_h2_production=2.5 * pyo.units.kg / pyo.units.s):
     # fixed O&M costs
-    get_fixed_OM_costs(m, design_h2_production, tech=6)
+    get_fixed_OM_costs(m.fs, design_h2_production, tech=6)
 
     @m.fs.Constraint()
     def stack_replacement_cost(fs):
@@ -255,7 +255,7 @@ def get_soec_OM_costing(m, design_h2_production=2.5 * pyo.units.kg / pyo.units.s
     calculate_variable_from_constraint(
         m.fs.costing.other_fixed_costs, m.fs.stack_replacement_cost
     )
-    initialize_fixed_OM_costs(m)
+    initialize_fixed_OM_costs(m.fs)
 
     # variable O&M costs
 
@@ -308,10 +308,10 @@ def get_soec_OM_costing(m, design_h2_production=2.5 * pyo.units.kg / pyo.units.s
 
     print(pyo.units.convert(m.fs.h2_product_rate_mass[0], pyo.units.g / pyo.units.s))
     m.fs.h2_product_rate_mass.display()
-    get_variable_OM_costs(m, m.fs.h2_product_rate_mass, resources, rates, prices=prices)
+    get_variable_OM_costs(m.fs, m.fs.h2_product_rate_mass, resources, rates, prices=prices)
 
     # initialize variable costs
-    initialize_variable_OM_costs(m)
+    initialize_variable_OM_costs(m.fs)
 
 
 def display_soec_costing(m):

--- a/idaes/power_generation/flowsheets/sofc/sofc.py
+++ b/idaes/power_generation/flowsheets/sofc/sofc.py
@@ -1396,7 +1396,7 @@ def add_costing(m):
     # fixed O&M costs
     NGFC_TPC = 693.019  # MM$
 
-    get_fixed_OM_costs(m, 650, tech=6, fixed_TPC=NGFC_TPC)
+    get_fixed_OM_costs(m.fs, 650, tech=6, fixed_TPC=NGFC_TPC)
 
     m.fs.costing.stack_replacement_cost = pyo.Var(
         initialize=13.26,
@@ -1547,7 +1547,7 @@ def add_costing(m):
     prices = {"desulfur adsorbent": 6.0297*pyunits.USD/pyunits.lb,
               "methanation catalyst": 601.765*pyunits.USD/pyunits.m**3}
 
-    get_variable_OM_costs(m, m.fs.net_power, resources, rates, prices)
+    get_variable_OM_costs(m.fs, m.fs.net_power, resources, rates, prices)
 
 
 def initialize_costing(m):
@@ -1583,8 +1583,8 @@ def initialize_costing(m):
         for t in m.fs.time:
             calculate_variable_from_constraint(v[t], c[t])
 
-    initialize_fixed_OM_costs(m)
-    initialize_variable_OM_costs(m)
+    initialize_fixed_OM_costs(m.fs)
+    initialize_variable_OM_costs(m.fs)
 
 
 def make_stream_dict(m):


### PR DESCRIPTION
Updated power_plant_costing module and tests to allow for costing of different flowsheets in a concrete model

## Fixes


## Summary/Motivation:
a. Work on the reversible sofc which comprises of two different flowsheets has shown the need to be able to calculate capital costs of unit models across different flowsheets.
b. Work on the reversible sofc which comprises of two different flowsheets has shown the need to be able to obtain variable O&M costs of unit models across different flowsheets. This change allows the variable O&M cost to be added to the flowsheet from which it is calculated from.

## Changes proposed in this PR:
- Update the get_total_TPC method to address (a)
- Update the get_variable_OM_costs and initialize_variable_OM_costs methods to address (b)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
