### PR TITLE
Fix ProcessBlock doc string for ctype

### DIFF
--- a/idaes/core/process_block.py
+++ b/idaes/core/process_block.py
@@ -44,7 +44,7 @@ _process_block_docstring = """
     Args:
         rule (function): A rule function or None. Default rule calls build().
         concrete (bool): If True, make this a toplevel model. **Default** - False.
-        ctype (str): Pyomo ctype of the block.  **Default** - "Block"
+        ctype (class): Pyomo ctype of the block.  **Default** - pyomo.environ.Block
         default (dict): Default ProcessBlockData config{}
         initialize (dict): ProcessBlockData config for individual elements. Keys
             are BlockData indexes and values are dictionaries described under the
@@ -181,4 +181,3 @@ def declare_process_block_class(name, block_class=ProcessBlock, doc=""):
 
         return cls
     return proc_dec  # return decorator function
-


### PR DESCRIPTION
Docs related to ctype for process blocks was out of date. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
