### PR TITLE
Configure pytest jobs in GitHub Actions to get coverage reports

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -78,7 +78,7 @@ jobs:
           pytest -m "not integration"
       - name: Upload coverage report to Codecov
         if: matrix.cov-report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,8 +27,9 @@ on:
 
 env:
   # default Python version to use for checks that do not require multiple versions
-  DEFAULT_PYTHON_VERSION: '3.7'
+  DEFAULT_PYTHON_VERSION: '3.8'
   IDAES_CONDA_ENV_NAME_DEV: idaes-pse-dev
+  PYTEST_ADDOPTS: "--color=yes"
 
 defaults:
   run:
@@ -51,6 +52,11 @@ jobs:
         os:
           - ubuntu-18.04
           - windows-latest
+        include:
+          - python-version: '3.8'
+            # only generate coverage report for a single python version in the matrix
+            # to avoid overloading Codecov
+            cov-report: true
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/display-debug-info
@@ -63,11 +69,15 @@ jobs:
         uses: ./.github/actions/setup-idaes
         with:
           install-target: -r requirements-dev.txt
-      - name: Run pytest (not integration) with coverage
+      - name: Add pytest CLI options for coverage
+        if: matrix.cov-report
         run: |
-          which python
-          pytest -m "not integration" --cov
+          echo PYTEST_ADDOPTS="$PYTEST_ADDOPTS --cov --cov-report=xml" >> "$GITHUB_ENV"
+      - name: Run pytest (not integration)
+        run: |
+          pytest -m "not integration"
       - name: Upload coverage report to Codecov
+        if: matrix.cov-report
         uses: codecov/codecov-action@v1
   build-docs:
     name: Build Sphinx docs

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   # default Python version to use for checks that do not require multiple versions
-  DEFAULT_PYTHON_VERSION: '3.8'
+  DEFAULT_PYTHON_VERSION: '3.7'
   IDAES_CONDA_ENV_NAME_DEV: idaes-pse-dev
   PYTEST_ADDOPTS: "--color=yes"
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Upload coverage report to Codecov
         if: matrix.cov-report
         uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+
   build-docs:
     name: Build Sphinx docs
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Fixes #495

## Changes proposed in this PR:

- Change GHA workflow definition file so that pytest jobs are properly set up to generate and upload coverage reports to Codecov

## Motivation

It looks like Codecov is back in business again, although I'm not exactly sure why it stopped working in the first place.

### Why wasn't Codecov working before?

- The main difference in this PR was adding the `--cov-report` pytest CLI flag, whereas previously only `--cov` was being used
- My best guess is that some defaults in the `pytest`/`pytest-cov`/`coverage`/Codecov chain changed, and whatever report was being generated with the sole `--cov` flag ceased to be compatible with the Codecov upload
- In any case, I've added the optional `fail_ci_if_errors = True` for the Codecov upload step. I'm not exactly sure what it does but hopefully it should increase the chances that we'll realize if something stops working again

### How does Codecov work now?

- I've added some logic to restrict the coverage report generation and upload to only a single Python version in the matrix
  - This results in (1 x 2) = 2 Codecov uploads at most (one for each OS, i.e. Linux and Windows), as opposed to (4 x 2) = 8 for the full matrix
- This seems like a reasonable solution since AFAIK we have no reason to suspect that there would be enough portions of the codebase specific to particular Python versions to result in significant changes in coverage by adding more versions of Python to the report
  - This assumption might of course be wrong, in which case let me know, and I'll add back the other Python versions
- I've also enabled the full-featured app to generate the PR report
- This ended up being somewhat orthogonal to the reason why the reports were not being generated, but it adds nice functionality:
  - The checks (patch and project diffs) show up in the "Checks" overview table on the PR's main ("Conversation") tab
  - More detailed reports (i.e. a list of lines in the PR patch that are not covered) are available when clicking on "details..." in the check's row

### Why are the checks failing now?

- This is just a one-time glitch because the reference commit for the Codecov comparison is very old (i.e. not the most recent commit on `main`)
- This PR does not touch any of the IDAES codebase outside of the `pytest` job section of the `core.yml` GHA workflow file, so if you're OK with the Codecov behavior, this can be merged without waiting for the rest of the checks to pass

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
