### PR TITLE
Updating Pyomo version to the 6.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ for Python 3. The following sub-versions are supported:
 * Python 3.6
 * Python 3.7
 * Python 3.8
-* Python 3.9+ (should work, not explicitly tested)
+* Python 3.9
 
 Note that Python 3.5 is *not* supported.
 

--- a/idaes/core/util/tables.py
+++ b/idaes/core/util/tables.py
@@ -254,7 +254,7 @@ def create_stream_table_dataframe(
                 stream_attributes[key][stream_key] = value(disp_dict[k][i])
                 if add_units:
                     pyomo_unit = units.get_units(disp_dict[k][i])
-                    if pyomo_unit:
+                    if pyomo_unit is not None:
                         pint_unit = pyomo_unit._get_pint_unit()
                         stream_attributes['Units'][stream_key] = {
                             'raw': str(pyomo_unit),

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
@@ -44,6 +44,11 @@ from idaes.generic_models.properties.core.examples.ASU_PR \
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
 
 # Test for configuration dictionaries with parameters from Properties of Gases
 # and liquids 4th edition
@@ -82,8 +87,7 @@ class TestParamBlock(object):
             { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
               "temperature": (10, 300, 350, pyunits.K),
               "pressure": (5e4, 1e5, 1e7, pyunits.Pa) },
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.params.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
@@ -44,6 +44,11 @@ from idaes.generic_models.properties.core.examples.ASU_PR \
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
 
 # Test for configuration dictionaries with parameters from Properties of Gases
 # and liquids 3rd edition and Dowling 2015
@@ -86,8 +91,7 @@ class TestParamBlock(object):
             { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
               "temperature": (10, 300, 350, pyunits.K),
               "pressure": (5e4, 1e5, 1e7, pyunits.Pa) },
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.params.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -44,6 +44,11 @@ from idaes.generic_models.properties.core.examples.BT_ideal \
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
 
 class TestParamBlock(object):
     @pytest.mark.unit
@@ -78,8 +83,7 @@ class TestParamBlock(object):
             {"flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
              "temperature": (273.15, 300, 450, pyunits.K),
              "pressure": (5e4, 1e5, 1e6, pyunits.Pa)},
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.params.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -50,6 +50,12 @@ import idaes.generic_models.properties.core.pure.RPP4 as RPP4
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
+
 config_dict = {
     "components": {
         'benzene': {
@@ -167,8 +173,7 @@ class TestParamBlock(object):
               "enth_mol": (1e4, 5e4, 2e5, pyunits.J/pyunits.mol),
               "temperature": (273.15, 300, 450, pyunits.K),
               "pressure": (5e4, 1e5, 1e6, pyunits.Pa) },
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.params.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
@@ -51,6 +51,12 @@ import idaes.generic_models.properties.core.pure.RPP4 as RPP4
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
+
 config_dict = {
     "components": {
         'benzene': {
@@ -168,8 +174,7 @@ class TestParamBlock(object):
               "enth_mol": (1e4, 5e4, 2e5, pyunits.J/pyunits.mol),
               "temperature": (273.15, 300, 450, pyunits.K),
               "pressure": (5e4, 1e5, 1e6, pyunits.Pa) },
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.params.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
@@ -52,6 +52,12 @@ import idaes.generic_models.properties.core.pure.NIST as NIST
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
+
 config_dict = {
     "components": {
         'benzene': {
@@ -165,8 +171,7 @@ class TestParamBlock(object):
             {"flow_mol_comp": (0, 100, 1000, pyunits.mol/pyunits.s),
              "temperature": (273.15, 300, 450, pyunits.K),
               "pressure": (5e4, 1e5, 1e6, pyunits.Pa)},
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.params.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
@@ -51,6 +51,11 @@ from idaes.generic_models.properties.core.examples.CO2_H2O_Ideal_VLE import (
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
 
 class TestParamBlock(object):
     @pytest.mark.unit
@@ -86,8 +91,7 @@ class TestParamBlock(object):
               "temperature": (273.15, 323.15, 1000, pyunits.K),
               "pressure": (5e4, 108900, 1e7, pyunits.Pa),
               "mole_frac_comp": {"H2O": (0, 0.5, 1),"CO2": (0, 0.5, 1)} },
-             item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+             item_callback=_as_quantity,
         )
 
         assert model.params.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -45,6 +45,11 @@ from idaes.generic_models.properties.core.examples.CO2_bmimPF6_PR \
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
 
 # Test for configuration dictionaries with parameters from Properties of Gases
 # and liquids 4th edition
@@ -82,8 +87,7 @@ class TestParamBlock(object):
             { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
               "temperature": (10, 300, 500, pyunits.K),
               "pressure": (5e-4, 1e5, 1e10, pyunits.Pa) },
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.param.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
@@ -45,6 +45,11 @@ from idaes.generic_models.properties.core.examples.HC_PR \
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
 
 # Test for configuration dictionaries with parameters from Properties of Gases
 # and liquids 4th edition
@@ -100,8 +105,7 @@ class TestParamBlock(object):
             { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
               "temperature": (273.15, 300, 1500, pyunits.K),
               "pressure": (5e4, 1e5, 1e7, pyunits.Pa) },
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.params.config.phase_equilibrium_state == {

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
@@ -48,6 +48,11 @@ from idaes.generic_models.properties.core.examples.HC_PR_vap \
 # Get default solver for testing
 solver = get_solver()
 
+def _as_quantity(x):
+    unit = pyunits.get_units(x)
+    if unit is None:
+        unit = pyunits.dimensionless
+    return value(x) * unit._get_pint_unit()
 
 # Test for configuration dictionaries with parameters from Properties of Gases
 # and liquids 4th edition
@@ -99,8 +104,7 @@ class TestParamBlock(object):
             { "flow_mol": (0, 100, 1000, pyunits.mol/pyunits.s),
               "temperature": (273.15, 300, 1500, pyunits.K),
               "pressure": (5e4, 1e5, 1e7, pyunits.Pa) },
-            item_callback=lambda x: value(x) * (
-                pyunits.get_units(x) or pyunits.dimensionless)._get_pint_unit()
+            item_callback=_as_quantity,
         )
 
         assert model.params.pressure_ref.value == 101325

--- a/idaes/power_generation/unit_models/boiler_heat_exchanger_2D.py
+++ b/idaes/power_generation/unit_models/boiler_heat_exchanger_2D.py
@@ -1694,18 +1694,18 @@ tube side flows from 1 to 0"""))
                 return term == \
                     (4 * b.therm_diffus_header
                      * (b.head_r.first()
-                        + b.head_r[2]) / (b.head_r[2]
+                        + b.head_r.at(2)) / (b.head_r.at(2)
                                           - b.head_r.first())**2
-                        / (3 * b.head_r.first() + b.head_r[2])
+                        / (3 * b.head_r.first() + b.head_r.at(2))
                         / b.head_ri_scaling**2
-                        * (b.header_wall_temperature[t, b.head_r[2]]
+                        * (b.header_wall_temperature[t, b.head_r.at(2)]
                            - b.header_wall_temperature[t, b.head_r.first()])
                         + 8 * b.therm_diffus_header / b.therm_cond_header
                         * b.head_hin[t]
-                        * b.head_r.first() / (b.head_r[2]
+                        * b.head_r.first() / (b.head_r.at(2)
                                               - b.head_r.first())
                         / (3 * b.head_r.first()
-                           + b.head_r[2]) / b.head_ri_scaling
+                           + b.head_r.at(2)) / b.head_ri_scaling
                         * (b.tube.properties[t, b.tube.length_domain.first()].
                            temperature
                            - b.header_wall_temperature[t, b.head_r.first()]))
@@ -1720,16 +1720,17 @@ tube side flows from 1 to 0"""))
                     term = 0
                 return term == \
                     (4 * b.therm_diffus_header * (b.head_r.last()
-                                                  + b.head_r[-2])
-                     / (b.head_r.last() - b.head_r[-2])**2
+                                                  + b.head_r.at(-2))
+                     / (b.head_r.last() - b.head_r.at(-2))**2
                      / (3 * b.head_r.last()
-                        + b.head_r[-2]) / b.head_ri_scaling**2
-                     * (b.header_wall_temperature[t, b.head_r[-2]]
+                        + b.head_r.at(-2)) / b.head_ri_scaling**2
+                     * (b.header_wall_temperature[t, b.head_r.at(-2)]
                         - b.header_wall_temperature[t, b.head_r.last()])
                      + 8 * b.therm_diffus_header / b.therm_cond_header
                      * b.head_hout[t]
-                     * b.head_r.last() / (b.head_r.last() - b.head_r[-2])
-                     / (3 * b.head_r.last() + b.head_r[-2]) / b.head_ri_scaling
+                     * b.head_r.last() / (b.head_r.last() - b.head_r.at(-2))
+                     / (3 * b.head_r.last() + b.head_r.at(-2)) 
+                     / b.head_ri_scaling
                      * (b.temperature_ambient[t]
                      - b.header_wall_temperature[t, b.head_r.last()]))
 
@@ -1830,13 +1831,14 @@ tube side flows from 1 to 0"""))
             @self.Expression(self.flowsheet().time,
                              doc="Mean Temperature for Header")
             def mean_temperature_header(b, t):
-                return 2 * (b.head_r[2] - b.head_r[1]) * b.head_ri_scaling**2 \
-                        / (b.head_ro**2 - b.head_ri**2) \
-                        * (sum(0.5 * (b.head_r[i-1] * b.
-                                      header_wall_temperature[t, b.head_r[i-1]]
-                                      + b.head_r[i] * b.
-                                      header_wall_temperature[t, b.head_r[i]])
-                               for i in range(2, len(b.head_r)+1)))
+                return 2 * (b.head_r.at(2) - b.head_r.at(1)) \
+                    * b.head_ri_scaling**2 \
+                    / (b.head_ro**2 - b.head_ri**2) \
+                    * (sum(0.5 * (b.head_r.at(i-1) * b.
+                                  header_wall_temperature[t, b.head_r.at(i-1)]
+                                  + b.head_r.at(i) * b.
+                                  header_wall_temperature[t, b.head_r.at(i)])
+                           for i in range(2, len(b.head_r)+1)))
 
             for head_index_r, head_value_r in enumerate(self.head_r, 1):
                 self.head_rindex[head_value_r] = head_index_r
@@ -1848,16 +1850,16 @@ tube side flows from 1 to 0"""))
                     return b.header_wall_temperature[t, b.head_r.first()]
                 else:
                     return 2 * (
-                        b.head_r[2] - b.head_r[1]
+                        b.head_r.at(2) - b.head_r.at(1)
                         ) * b.head_ri_scaling**2 / (
-                            (b.head_r[b.head_rindex[r].value]
+                            (b.head_r.at(b.head_rindex[r].value)
                              * b.head_ri_scaling)**2 - b.head_ri**2
                             ) * (sum(
                                 0.5 * (
-                                    b.head_r[j-1] * b.
-                                    header_wall_temperature[t, b.head_r[j-1]]
-                                    + b.head_r[j] * b.
-                                    header_wall_temperature[t, b.head_r[j]]
+                                    b.head_r.at(j-1) * b.
+                                    header_wall_temperature[t, b.head_r.at(j-1)]
+                                    + b.head_r.at(j) * b.
+                                    header_wall_temperature[t, b.head_r.at(j)]
                                     ) for j in range(
                                         2, b.head_rindex[r].value + 1)))
 

--- a/idaes/power_generation/unit_models/boiler_heat_exchanger_2D.py
+++ b/idaes/power_generation/unit_models/boiler_heat_exchanger_2D.py
@@ -802,14 +802,14 @@ tube side flows from 1 to 0"""))
                 term = b.dTdt[t, x, b.r.first()]
             else:
                 term = 0
-            return term == 4 * b.diff_therm_wall * (b.r.first()+b.r[2]) / \
-                (b.r[2]-b.r.first())**2/(3*b.r.first()+b.r[2]) \
+            return term == 4 * b.diff_therm_wall * (b.r.first()+b.r.at(2)) / \
+                (b.r.at(2)-b.r.first())**2/(3*b.r.first()+b.r.at(2)) \
                 / b.ri_scaling**2 \
-                * (b.tube_wall_temperature[t, x, b.r[2]]
+                * (b.tube_wall_temperature[t, x, b.r.at(2)]
                    - b.tube_wall_temperature[t, x, b.r.first()]) \
                 + 8*b.diff_therm_wall/b.therm_cond_wall \
                 * b.hconv_tube_foul[t, x] * b.r.first() / \
-                (b.r[2]-b.r.first())/(3*b.r.first()+b.r[2]) \
+                (b.r.at(2)-b.r.first())/(3*b.r.first()+b.r.at(2)) \
                 / b.ri_scaling*(b.tube.properties[t, x].temperature
                                 - b.tube_wall_temperature[t, x, b.r.first()])
 
@@ -821,14 +821,14 @@ tube side flows from 1 to 0"""))
                 term = b.dTdt[t, x, b.r.last()]
             else:
                 term = 0
-            return term == 4 * b.diff_therm_wall * (b.r.last() + b.r[-2]) / \
-                (b.r.last() - b.r[-2])**2 / (3*b.r.last() + b.r[-2])\
+            return term == 4 * b.diff_therm_wall * (b.r.last() + b.r.at(-2)) / \
+                (b.r.last() - b.r.at(-2))**2 / (3*b.r.last() + b.r.at(-2))\
                 / b.ri_scaling**2\
-                * (b.tube_wall_temperature[t, x, b.r[-2]]
+                * (b.tube_wall_temperature[t, x, b.r.at(-2)]
                    - b.tube_wall_temperature[t, x, b.r.last()]) \
                 + 8*b.diff_therm_wall/b.therm_cond_wall \
                 * b.hconv_shell_foul[t, x] * b.r.last() / \
-                (b.r.last()-b.r[-2])/(3*b.r.last()+b.r[-2])/b.ri_scaling\
+                (b.r.last()-b.r.at(-2))/(3*b.r.last()+b.r.at(-2))/b.ri_scaling\
                 * (b.shell.properties[t, x].temperature
                    - b.tube_wall_temperature[t, x, b.r.last()])
 
@@ -1313,10 +1313,11 @@ tube side flows from 1 to 0"""))
                          self.tube.length_domain,
                          doc="Mean Temperature across the Wall")
         def mean_temperature(b, t, x):
-            return 2 * (b.r[2]-b.r[1]) * b.ri_scaling**2 / (b.tube_ro**2
-                                                            - b.tube_ri**2) * \
-                (sum(0.5 * (b.r[i-1] * b.tube_wall_temperature[t, x, b.r[i-1]]
-                            + b.r[i] * b.tube_wall_temperature[t, x, b.r[i]])
+            return 2 * (b.r.at(2)-b.r.at(1)) * b.ri_scaling**2 / (
+                b.tube_ro**2 - b.tube_ri**2) * \
+                (sum(0.5 * (
+                    b.r.at(i-1) * b.tube_wall_temperature[t, x, b.r.at(i-1)]
+                    + b.r.at(i) * b.tube_wall_temperature[t, x, b.r.at(i)])
                      for i in range(2, len(b.r)+1)))
 
         for index_r, value_r in enumerate(self.r, 1):
@@ -1330,13 +1331,13 @@ tube side flows from 1 to 0"""))
             if b.rindex[r].value == 1:
                 return b.tube_wall_temperature[t, x, b.r.first()]
             else:
-                return 2 * (b.r[2] - b.r[1]) * b.ri_scaling**2 \
-                    / ((b.r[b.rindex[r].value] * b.ri_scaling)**2
+                return 2 * (b.r.at(2) - b.r.at(1)) * b.ri_scaling**2 \
+                    / ((b.r.at(b.rindex[r].value) * b.ri_scaling)**2
                        - b.tube_ri**2) *\
-                    (sum(0.5 * (b.r[j-1] *
-                                b.tube_wall_temperature[t, x, b.r[j-1]]
-                                + b.r[j] *
-                                b.tube_wall_temperature[t, x, b.r[j]])
+                    (sum(0.5 * (b.r.at(j-1) *
+                                b.tube_wall_temperature[t, x, b.r.at(j-1)]
+                                + b.r.at(j) *
+                                b.tube_wall_temperature[t, x, b.r.at(j)])
                          for j in range(2, b.rindex[r].value+1)))
 
         @self.Expression(self.flowsheet().time,

--- a/idaes/ui/tests/test_flowsheet.py
+++ b/idaes/ui/tests/test_flowsheet.py
@@ -181,9 +181,13 @@ def flash_flowsheet():
     )
     # Flash unit
     m.fs.flash = Flash(default={"property_package": m.fs.properties})
-    m.fs.flash.inlet.flow_mol.fix(np.NINF)
+    # TODO: move this to fix(np.NINF, skip_validation=True) once
+    # Pyomo#2180 is merged
+    m.fs.flash.inlet.flow_mol[:].set_value(np.NINF, True)
+    m.fs.flash.inlet.flow_mol.fix()
     m.fs.flash.inlet.temperature.fix(np.inf)
-    m.fs.flash.inlet.pressure.fix(np.nan)
+    m.fs.flash.inlet.pressure[:].set_value(np.nan, True)
+    m.fs.flash.inlet.pressure.fix()
     m.fs.flash.inlet.mole_frac_comp[0, "benzene"].fix(0.5)
     m.fs.flash.inlet.mole_frac_comp[0, "toluene"].fix(0.5)
     m.fs.flash.heat_duty.fix(0)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.2.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.2.0.rc1.idaes.2021.11.17.zip",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.2.0.rc1.idaes.2021.11.17.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.2.zip",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.1.2.idaes.2021.10.26.zip",
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.2.zip",
 ]
 
 
@@ -130,6 +130,8 @@ kwargs = dict(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Chemistry",


### PR DESCRIPTION
This updates the Pyomo tag to the 6.2 release. I also updated the supported versions of Python in `setup.py` and the `README` because I noticed they were out of date. Looks like we are running tests for Python 3.9.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
