### PR TITLE
Adding option to use external length variable in 1D control volumes

### DIFF
--- a/docs/technical_specs/core/control_volume_1d.rst
+++ b/docs/technical_specs/core/control_volume_1d.rst
@@ -44,7 +44,7 @@ This method also adds variables and constraints to describe the geometry of the 
    "length_domain", ":math:`x`", "None", "None"
    "volume", ":math:`V`", "None", "None"
    "area", ":math:`A`", "None", "None"
-   "length", ":math:`L`", "None", "None"
+   "length", ":math:`L`", "None", "If `length_var` argument is provided, a reference to the provided component is made in place of creating a new variable"
 
 **Constraints**
 

--- a/idaes/core/control_volume1d.py
+++ b/idaes/core/control_volume1d.py
@@ -20,6 +20,8 @@ from enum import Enum
 
 # Import Pyomo libraries
 from pyomo.environ import (Constraint,
+                           Expression,
+                           Param,
                            Reals,
                            TransformationFactory,
                            units as pyunits,
@@ -153,6 +155,7 @@ argument)."""))
     def add_geometry(self,
                      length_domain=None,
                      length_domain_set=None,
+                     length_var=None,
                      flow_direction=FlowDirection.forward):
         """
         Method to create spatial domain and volume Var in ControlVolume.
@@ -166,6 +169,10 @@ argument)."""))
             length_domain_set - (optional) list of point to use to initialize
                             a new ContinuousSet if length_domain is not
                             provided (default = [0.0, 1.0]).
+            length_var - (optional) external variable to use for the length of
+                         the spatial domain,. If a variable is provided, a
+                         reference will be made to this in place of the length
+                         Var.
             flow_direction - argument indicating direction of material flow
                             relative to length domain. Valid values:
                                 - FlowDirection.forward (default), flow goes
@@ -218,9 +225,22 @@ argument)."""))
             self.area = Var(initialize=1.0,
                             doc='Cross-sectional area of Control Volume',
                             units=units("area"))
-        self.length = Var(initialize=1.0,
-                          doc='Length of Control Volume',
-                          units=units("length"))
+
+        if length_var is not None:
+            # Validate length_Var and add a reference
+            if not isinstance(length_var, (Var, Param, Expression)):
+                raise ConfigurationError(
+                    f"{self.name} length_var must be a Pyomo Var, Param or "
+                    "Expression.")
+            elif len(length_var) != 1:
+                raise ConfigurationError(
+                    f"{self.name} length_var must be a scalar (unidexed) "
+                    "component.")
+            add_object_reference(self, "length", length_var)
+        else:
+            self.length = Var(initialize=1.0,
+                              doc='Length of Control Volume',
+                              units=units("length"))
 
     def add_state_blocks(self,
                          information_flow=FlowDirection.forward,

--- a/idaes/core/control_volume1d.py
+++ b/idaes/core/control_volume1d.py
@@ -232,9 +232,9 @@ argument)."""))
                 raise ConfigurationError(
                     f"{self.name} length_var must be a Pyomo Var, Param or "
                     "Expression.")
-            elif len(length_var) != 1:
+            elif length_var.is_indexed():
                 raise ConfigurationError(
-                    f"{self.name} length_var must be a scalar (unidexed) "
+                    f"{self.name} length_var must be a scalar (unindexed) "
                     "component.")
             add_object_reference(self, "length", length_var)
         else:

--- a/idaes/core/tests/test_control_volume_1d.py
+++ b/idaes/core/tests/test_control_volume_1d.py
@@ -17,7 +17,7 @@ Author: Andrew Lee
 """
 import pytest
 from pyomo.environ import (ConcreteModel, Constraint, Expression, Param,
-                           Set, units, Var)
+                           Set, units, value, Var)
 from pyomo.util.check_units import assert_units_consistent
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.common.config import ConfigBlock
@@ -350,7 +350,7 @@ def test_add_geometry_length_var_Expression():
     assert m.fs.cv.length is m.fs.length
     assert isinstance(m.fs.cv.length, Expression)
     assert len(m.fs.cv.length) == 1.0
-    assert m.fs.cv.length.value == 4
+    assert value(m.fs.cv.length) == 4
     assert m.fs.cv._flow_direction == FlowDirection.forward
 
 

--- a/idaes/core/tests/test_control_volume_1d.py
+++ b/idaes/core/tests/test_control_volume_1d.py
@@ -387,7 +387,7 @@ def test_add_geometry_length_var_indexed():
     m.fs.length = Var([1, 2, 3, 4])
 
     with pytest.raises(ConfigurationError,
-                       match="fs.cv length_var must be a scalar \(unidexed\) "
+                       match="fs.cv length_var must be a scalar \(unindexed\) "
                        "component."):
         m.fs.cv.add_geometry(length_var=m.fs.length)
 

--- a/idaes/core/tests/test_control_volume_1d.py
+++ b/idaes/core/tests/test_control_volume_1d.py
@@ -16,7 +16,7 @@ Tests for ControlVolumeBlockData.
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import (ConcreteModel, Constraint, Expression,
+from pyomo.environ import (ConcreteModel, Constraint, Expression, Param,
                            Set, units, Var)
 from pyomo.util.check_units import assert_units_consistent
 from pyomo.dae import ContinuousSet, DerivativeVar
@@ -268,6 +268,128 @@ def test_add_geometry_discretized_area():
     m.fs.cv.add_geometry()
 
     assert len(m.fs.cv.area) == 2
+
+
+@pytest.mark.unit
+def test_add_geometry_length_var_Var():
+    m = ConcreteModel()
+    m.fs = Flowsheet(default={"dynamic": False})
+    m.fs.pp = PhysicalParameterTestBlock()
+
+    m.fs.cv = ControlVolume1DBlock(default={
+                "property_package": m.fs.pp,
+                "transformation_method": "dae.finite_difference",
+                "transformation_scheme": "BACKWARD",
+                "finite_elements": 10})
+
+    m.fs.length = Var(initialize=4)
+
+    m.fs.cv.add_geometry(length_var=m.fs.length)
+
+    assert isinstance(m.fs.cv.length_domain, ContinuousSet)
+    assert len(m.fs.cv.length_domain) == 2
+    assert isinstance(m.fs.cv.area, Var)
+    assert len(m.fs.cv.area) == 1.0
+    assert m.fs.cv.area.value == 1.0
+    assert m.fs.cv.length is m.fs.length
+    assert isinstance(m.fs.cv.length, Var)
+    assert len(m.fs.cv.length) == 1.0
+    assert m.fs.cv.length.value == 4
+    assert m.fs.cv._flow_direction == FlowDirection.forward
+
+
+@pytest.mark.unit
+def test_add_geometry_length_var_Param():
+    m = ConcreteModel()
+    m.fs = Flowsheet(default={"dynamic": False})
+    m.fs.pp = PhysicalParameterTestBlock()
+
+    m.fs.cv = ControlVolume1DBlock(default={
+                "property_package": m.fs.pp,
+                "transformation_method": "dae.finite_difference",
+                "transformation_scheme": "BACKWARD",
+                "finite_elements": 10})
+
+    m.fs.length = Param(initialize=4)
+
+    m.fs.cv.add_geometry(length_var=m.fs.length)
+
+    assert isinstance(m.fs.cv.length_domain, ContinuousSet)
+    assert len(m.fs.cv.length_domain) == 2
+    assert isinstance(m.fs.cv.area, Var)
+    assert len(m.fs.cv.area) == 1.0
+    assert m.fs.cv.area.value == 1.0
+    assert m.fs.cv.length is m.fs.length
+    assert isinstance(m.fs.cv.length, Param)
+    assert len(m.fs.cv.length) == 1.0
+    assert m.fs.cv.length.value == 4
+    assert m.fs.cv._flow_direction == FlowDirection.forward
+
+
+@pytest.mark.unit
+def test_add_geometry_length_var_Expression():
+    m = ConcreteModel()
+    m.fs = Flowsheet(default={"dynamic": False})
+    m.fs.pp = PhysicalParameterTestBlock()
+
+    m.fs.cv = ControlVolume1DBlock(default={
+                "property_package": m.fs.pp,
+                "transformation_method": "dae.finite_difference",
+                "transformation_scheme": "BACKWARD",
+                "finite_elements": 10})
+
+    m.fs.length = Expression(expr=4)
+
+    m.fs.cv.add_geometry(length_var=m.fs.length)
+
+    assert isinstance(m.fs.cv.length_domain, ContinuousSet)
+    assert len(m.fs.cv.length_domain) == 2
+    assert isinstance(m.fs.cv.area, Var)
+    assert len(m.fs.cv.area) == 1.0
+    assert m.fs.cv.area.value == 1.0
+    assert m.fs.cv.length is m.fs.length
+    assert isinstance(m.fs.cv.length, Expression)
+    assert len(m.fs.cv.length) == 1.0
+    assert m.fs.cv.length.value == 4
+    assert m.fs.cv._flow_direction == FlowDirection.forward
+
+
+@pytest.mark.unit
+def test_add_geometry_length_var_invalid_type():
+    m = ConcreteModel()
+    m.fs = Flowsheet(default={"dynamic": False})
+    m.fs.pp = PhysicalParameterTestBlock()
+
+    m.fs.cv = ControlVolume1DBlock(default={
+                "property_package": m.fs.pp,
+                "transformation_method": "dae.finite_difference",
+                "transformation_scheme": "BACKWARD",
+                "finite_elements": 10})
+
+    with pytest.raises(ConfigurationError,
+                       match="fs.cv length_var must be a Pyomo Var, Param or "
+                       "Expression."):
+        m.fs.cv.add_geometry(length_var="foo")
+
+
+@pytest.mark.unit
+def test_add_geometry_length_var_indexed():
+    m = ConcreteModel()
+    m.fs = Flowsheet(default={"dynamic": False})
+    m.fs.pp = PhysicalParameterTestBlock()
+
+    m.fs.cv = ControlVolume1DBlock(default={
+                "property_package": m.fs.pp,
+                "transformation_method": "dae.finite_difference",
+                "transformation_scheme": "BACKWARD",
+                "finite_elements": 10})
+
+    m.fs.length = Var([1, 2, 3, 4])
+
+    with pytest.raises(ConfigurationError,
+                       match="fs.cv length_var must be a scalar \(unidexed\) "
+                       "component."):
+        m.fs.cv.add_geometry(length_var=m.fs.length)
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
@@ -312,6 +312,10 @@ see reaction package for documentation.}"""))
                                 initialize=self.config.length_domain_set,
                                 doc="Normalized length domain")
 
+        self.bed_height = Var(domain=Reals,
+                              initialize=1,
+                              doc='Bed Height [m]')
+
     # =========================================================================
         """ Build Control volume 1D for the bubble region and
             populate its control volume"""
@@ -332,6 +336,7 @@ see reaction package for documentation.}"""))
         self.bubble.add_geometry(
                 length_domain=self.length_domain,
                 length_domain_set=self.config.length_domain_set,
+                length_var=self.bed_height,
                 flow_direction=set_direction_gas)
 
         self.bubble.add_state_blocks(
@@ -379,8 +384,8 @@ see reaction package for documentation.}"""))
 
         self.gas_emulsion.add_geometry(
                 length_domain=self.length_domain,
-                length_domain_set=self.config.
-                length_domain_set,
+                length_domain_set=self.config.length_domain_set,
+                length_var=self.bed_height,
                 flow_direction=set_direction_gas)
 
         self.gas_emulsion.add_state_blocks(
@@ -429,8 +434,8 @@ see reaction package for documentation.}"""))
 
         self.solid_emulsion.add_geometry(
             length_domain=self.length_domain,
-            length_domain_set=self.config.
-            length_domain_set,
+            length_domain_set=self.config.length_domain_set,
+            length_var=self.bed_height,
             flow_direction=set_direction_solid)
 
         self.solid_emulsion.add_state_blocks(
@@ -546,9 +551,6 @@ see reaction package for documentation.}"""))
         self.bed_area = Var(domain=Reals,
                             initialize=1,
                             doc='Reactor Cross-sectional Area [m2]')
-        self.bed_height = Var(domain=Reals,
-                              initialize=1,
-                              doc='Bed Height [m]')
 
         # Distributor Design
         self.area_orifice = Var(
@@ -810,19 +812,6 @@ see reaction package for documentation.}"""))
         def solid_emulsion_area(b, t, x):
             return (b.solid_emulsion.area[t, x] ==
                     b.bed_area*b.delta_e[t, x]*(1-b.voidage_emulsion[t, x]))
-
-        # Length of bubble, gas_emulsion, solid_emulsion
-        @self.Constraint(doc="Bubble Region Length")
-        def bubble_length(b):
-            return (b.bubble.length == b.bed_height)
-
-        @self.Constraint(doc="Gas Emulsion Region Length")
-        def gas_emulsion_length(b):
-            return (b.gas_emulsion.length == b.bed_height)
-
-        @self.Constraint(doc="Solid Emulsion Region Length")
-        def solid_emulsion_length(b):
-            return (b.solid_emulsion.length == b.bed_height)
 
         # ---------------------------------------------------------------------
         # Hydrodynamic contraints

--- a/idaes/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/moving_bed.py
@@ -326,6 +326,9 @@ see reaction package for documentation.}"""))
                                 initialize=self.config.length_domain_set,
                                 doc="Normalized length domain")
 
+        self.bed_height = Var(domain=Reals, initialize=1,
+                              doc='Bed length [m]')
+
     # =========================================================================
         """ Build Control volume 1D for gas phase and
             populate gas control volume"""
@@ -348,6 +351,7 @@ see reaction package for documentation.}"""))
         self.gas_phase.add_geometry(
                 length_domain=self.length_domain,
                 length_domain_set=self.config.length_domain_set,
+                length_var=self.bed_height,
                 flow_direction=set_direction_gas)
 
         self.gas_phase.add_state_blocks(
@@ -399,6 +403,7 @@ see reaction package for documentation.}"""))
         self.solid_phase.add_geometry(
                 length_domain=self.length_domain,
                 length_domain_set=self.config.length_domain_set,
+                length_var=self.bed_height,
                 flow_direction=set_direction_solid)
 
         self.solid_phase.add_state_blocks(
@@ -515,8 +520,6 @@ see reaction package for documentation.}"""))
         self.bed_area = Var(domain=Reals,
                             initialize=1,
                             doc='Reactor cross-sectional area [m2]')
-        self.bed_height = Var(domain=Reals, initialize=1,
-                              doc='Bed length [m]')
 
         # Phase specific variables
         self.velocity_superficial_gas = Var(
@@ -582,15 +585,6 @@ see reaction package for documentation.}"""))
         def solid_phase_area(b, t, x):
             return (b.solid_phase.area[t, x] ==
                     b.bed_area*(1-b.bed_voidage))
-
-        # Length of gas side, and solid side
-        @self.Constraint(doc="Gas side length")
-        def gas_phase_length(b):
-            return (b.gas_phase.length == b.bed_height)
-
-        @self.Constraint(doc="Solid side length")
-        def solid_phase_length(b):
-            return (b.solid_phase.length == b.bed_height)
 
         # ---------------------------------------------------------------------
         # Hydrodynamic contraints

--- a/idaes/gas_solid_contactors/unit_models/tests/test_BFB.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_BFB.py
@@ -210,8 +210,8 @@ class TestIronOC(object):
         assert isinstance(iron_oc.fs.unit.solid_emulsion_heat_transfer,
                           Constraint)
 
-        assert number_variables(iron_oc) == 1437
-        assert number_total_constraints(iron_oc) == 1392
+        assert number_variables(iron_oc) == 1434
+        assert number_total_constraints(iron_oc) == 1389
         assert number_unused_variables(iron_oc) == 19
 
     @pytest.mark.unit
@@ -417,8 +417,8 @@ class TestIronOC_EnergyBalanceType(object):
                           Constraint)
         assert isinstance(iron_oc.fs.unit.isothermal_bubble, Constraint)
 
-        assert number_variables(iron_oc) == 1157
-        assert number_total_constraints(iron_oc) == 1049
+        assert number_variables(iron_oc) == 1154
+        assert number_total_constraints(iron_oc) == 1046
         assert number_unused_variables(iron_oc) == 83
         print(unused_variables_set(iron_oc))
 

--- a/idaes/gas_solid_contactors/unit_models/tests/test_MB.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_MB.py
@@ -190,8 +190,6 @@ class TestIronOC(object):
         assert isinstance(iron_oc.fs.unit.bed_area_eqn, Constraint)
         assert isinstance(iron_oc.fs.unit.gas_phase_area, Constraint)
         assert isinstance(iron_oc.fs.unit.solid_phase_area, Constraint)
-        assert isinstance(iron_oc.fs.unit.gas_phase_length, Constraint)
-        assert isinstance(iron_oc.fs.unit.solid_phase_length, Constraint)
         assert isinstance(iron_oc.fs.unit.gas_super_vel, Constraint)
         assert isinstance(iron_oc.fs.unit.solid_super_vel, Constraint)
         assert isinstance(iron_oc.fs.unit.gas_phase_config_pressure_drop,
@@ -203,8 +201,8 @@ class TestIronOC(object):
                           Constraint)
         assert isinstance(iron_oc.fs.unit.gas_comp_hetero_rxn, Constraint)
 
-        assert number_variables(iron_oc) == 821
-        assert number_total_constraints(iron_oc) == 783
+        assert number_variables(iron_oc) == 819
+        assert number_total_constraints(iron_oc) == 781
         assert number_unused_variables(iron_oc) == 16
 
     @pytest.mark.unit
@@ -397,8 +395,8 @@ class TestIronOC_EnergyBalanceType(object):
         assert isinstance(iron_oc.fs.unit.isothermal_gas_phase, Constraint)
         assert isinstance(iron_oc.fs.unit.isothermal_solid_phase, Constraint)
 
-        assert number_variables(iron_oc) == 590
-        assert number_total_constraints(iron_oc) == 510
+        assert number_variables(iron_oc) == 588
+        assert number_total_constraints(iron_oc) == 508
         assert number_unused_variables(iron_oc) == 59
         print(unused_variables_set(iron_oc))
 


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
We have a number of unit models with multiple 1D control volumes where the length of each domain is equal. Previously, we needed to create a set of constraints to equate the length in each domain, and often added a separate unit level variable for length. This PR adds an optional argument to `CV1D.add_geometry` which allows the user to specify an existing component (Var, Param or Expression) to use for the length of the domain. If this argument is provided, `cv.length` becomes a reference to the provided component instead of a new variable.

## Changes proposed in this PR:
- Add new optional `length_var` argument to `CV1D.add_geometry` with tests.
- Add (short) reference to this feature in the docs
- Update gas-solids contactor models to make use of the new feature.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
