### PR TITLE
Fixing indexing issue in separator initialization

### DIFF
--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -1436,17 +1436,20 @@ objects linked the mixed state and all outlet states,
                                             == SplittingType.phaseComponentFlow):
                                         s_vars[v][k].fix(
                                             value(m_var[k] *
-                                            blk.split_fraction[(t, o)+k]))
+                                                  blk.split_fraction[
+                                                      (t, o)+(k,)]))
                                     elif (blk.config.split_basis
                                             == SplittingType.phaseFlow):
                                         s_vars[v][k].fix(value(
                                             m_var[k] *
-                                            blk.split_fraction[(t, o)+k[0]]))
+                                            blk.split_fraction[(t, o)+(k[0],)]
+                                            ))
                                     elif (blk.config.split_basis
                                             == SplittingType.componentFlow):
                                         s_vars[v][k].fix(value(
                                             m_var[k] *
-                                            blk.split_fraction[(t, o)+k[1]]))
+                                            blk.split_fraction[(t, o)+(k[1],)]
+                                            ))
                                     else:
                                         raise BurntToast(
                                             "{} encountered unrecognised "
@@ -1468,7 +1471,7 @@ objects linked the mixed state and all outlet states,
                                             == SplittingType.phaseFlow):
                                         s_vars[v][k].fix(value(
                                             m_var[k] *
-                                            blk.split_fraction[(t, o)+k]))
+                                            blk.split_fraction[(t, o)+(k,)]))
                                     elif (blk.config.split_basis
                                             == SplittingType.componentFlow):
                                         # Need average split fraction
@@ -1508,7 +1511,7 @@ objects linked the mixed state and all outlet states,
                                             == SplittingType.componentFlow):
                                         s_vars[v][k].fix(value(
                                             m_var[k] *
-                                            blk.split_fraction[(t, o)+k]))
+                                            blk.split_fraction[(t, o)+(k,)]))
                                     else:
                                         raise BurntToast(
                                             "{} encountered unrecognised "


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Jinliang found a bug in the separator initialization code when assembling indexing tuples from time, outlet and an arbitrary set of keys from a given state variable.

## Changes proposed in this PR:
- Fixes indexing bugs
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
