### PR TITLE
DegeneracyHunter scaled Jacobian and SVD

### DIFF
--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -637,6 +637,3 @@ class DegeneracyHunter():
             nothing
         '''
         print(v,"\t\t",v.lb,"\t",v.value,"\t",v.ub)
-        
-def _special_svds():
-    pass

--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -63,7 +63,8 @@ class DegeneracyHunter():
             self.nlp = PyomoNLP(self.block)
 
             # Get the scaled Jacobian of equality constraints
-            self.jac_eq = iscale.get_jacobian(self.block)[0]
+            self.jac_eq = iscale.get_jacobian(self.block,
+                                              equality_constraints_only=True)[0]
         
             # Create a list of equality constraint names            
             self.eq_con_list = PyomoNLP.get_pyomo_equality_constraints(self.nlp)
@@ -506,10 +507,14 @@ class DegeneracyHunter():
         
         if self.n_eq > 1:
         
+            
+            # Since we're not using svds now, no reason to accomodate its
+            # foibles
+            
             # Determine the number of singular values to compute
             # The "-1" is needed to avoid an error with svds
-            n_sv = min(n_smallest_sv, min(self.n_eq, self.n_var) - 1)
-            print("Computing the",n_sv,"smallest singular value(s)")
+            #n_sv = min(n_smallest_sv, min(self.n_eq, self.n_var) - 1)
+            #print("Computing the",n_sv,"smallest singular value(s)")
         
             # Perform SVD
             # Recall J is a n_eq x n_var matrix
@@ -520,9 +525,9 @@ class DegeneracyHunter():
             #u, s, v = svds(self.jac_eq, k = n_sv, which='SM')#, solver='lobpcg')
             
             u, s, vT = svd(self.jac_eq.todense())
-            u = u[:,-1-n_smallest_sv:-1]
-            s = s[-1-n_smallest_sv:-1]
-            vT = vT[-1-n_smallest_sv:-1,:]
+            u = u[:,-1-n_smallest_sv:]
+            s = s[-1-n_smallest_sv:]
+            vT = vT[-1-n_smallest_sv:,:]
             # Save results
             self.u = u
             self.s = s

--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -506,7 +506,7 @@ def constraint_autoscale_large_jac(
         no_scale: just calculate the Jacobian and scaled Jacobian, don't scale
             anything
         equality_constraints_only: Only include the equality constraints in the
-        Jacobian calculated and scaled
+            Jacobian calculated and scaled
 
     Returns:
         unscaled Jacobian CSR from, scaled Jacobian CSR from, Pynumero NLP
@@ -574,7 +574,7 @@ def get_jacobian(m, scaled=True, equality_constraints_only=False):
         m: model to get Jacobian from
         scaled: if True return scaled Jacobian, else get unscaled
         equality_constraints_only: Only include equality constraints in the
-        Jacobian calculated and scaled
+            Jacobian calculated and scaled
 
     Returns:
         Jacobian matrix in Scipy CSR format, Pynumero nlp

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -243,7 +243,10 @@ def test_problem2_with_degenerate_constraint():
     
     # Check the rank
     n_rank_deficient = dh2.check_rank_equality_constraints()
-    
+    assert dh2.jac_eq.shape == (2,3)
+    assert dh2.u.shape == (2,2)
+    assert dh2.v.shape == (3,3)
+    assert dh2.s.shape == (2,)
     assert n_rank_deficient == 1
     
     # TODO: Add MILP solver to idaes get-extensions and add more tests

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -249,57 +249,11 @@ def test_problem2_with_degenerate_constraint():
     assert dh2.s.shape == (2,)
     assert n_rank_deficient == 1
     
-    # TODO: Add MILP solver to idaes get-extensions and add more tests
-@pytest.mark.skipif(not pyo.SolverFactory('ipopt').available(False), reason="no Ipopt")
-@pytest.mark.unit    
-def test_sparse_svd():
-    # Create test problem instance
-    m2 = example2(with_degenerate_constraint=True)
-    
-    # Specify Ipopt as the solver
-    opt = pyo.SolverFactory('ipopt')
-
-    # Specifying an iteration limit of 0 allows us to inspect the initial point
-    opt.options['max_iter'] = 0
-
-    # "Solving" the model with an iteration limit of 0 load the initial point and applies
-    # any preprocessors (e.g., enforces bounds)
-    opt.solve(m2, tee=True)
-    
-    # Create Degeneracy Hunter object
-    dh2 = DegeneracyHunter(m2)
-    
-    # Check for violated constraints at the initial point
-    initial_point_constraints = dh2.check_residuals(tol=0.1)
-    
-    # Check there are 2 constraints with large residuals
-    assert len(initial_point_constraints) == 2
-    
-    initial_point_constraint_names = extract_constraint_names(initial_point_constraints)
-    
-    # Check first constraint
-    assert initial_point_constraint_names[0] == 'con2'
-    
-    # Check first constraint
-    assert initial_point_constraint_names[1] == 'con5'
-    
-    # Resolve
-    opt.options['max_iter'] = 500
-    opt.solve(m2, tee=True)
-    
-    # Check solution
-    x_sln = []
-    
-    for i in m2.I:
-        x_sln.append(m2.x[i]())
-    
-    assert pytest.approx(x_sln[0], abs=1E-6) == 1.0
-    assert pytest.approx(x_sln[1], abs=1E-6) == 0.0
-    assert pytest.approx(x_sln[2], abs=1E-6) == 0.0
-    
-    # Check the rank
-    n_rank_deficient = dh2.check_rank_equality_constraints()
-    assert n_rank_deficient == 1
+    # Test DH with SVD
     # Is there any way to test whether the sparse SVD is actually used?
     # Trying to do an SVD of a 50000x50000 identity matrix would work, but
     # would produce an extremely slow test failure
+    dh3 = DegeneracyHunter(m2)
+    n_rank_deficient = dh3.check_rank_equality_constraints(dense=False)
+    assert n_rank_deficient == 1
+    # TODO: Add MILP solver to idaes get-extensions and add more tests


### PR DESCRIPTION
## Fixes
-Use dense SVD rather than sparse SVD
-Use scaled Jacobian rather than raw Jacobian to perform rank analysis

## Summary/Motivation:
Mitigate #597 by switching from Scipy's unreliable (for small singular values) sparse SVD to a dense SVD. Also, ensure that a scaled Jacobian is being used to detect nearly degenerate constraints.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
