### PR TITLE
Adding Exception for models to raise if initialization fails

### DIFF
--- a/idaes/core/util/exceptions.py
+++ b/idaes/core/util/exceptions.py
@@ -21,7 +21,7 @@ __author__ = "Andrew Lee"
 class IdaesError(Exception):
     """
     General exception for all IDAES errors. Intended to be used for multiple
-    inheritance in derived expcetions to allow catching of all IDAES-related
+    inheritance in derived exceptions to allow catching of all IDAES-related
     exceptions.
     """
     pass  # Problem with toaster

--- a/idaes/core/util/exceptions.py
+++ b/idaes/core/util/exceptions.py
@@ -68,11 +68,11 @@ class PropertyPackageError(AttributeError):
     pass  # Bread stuck
 
 
-class InitializationError(ValueError):
+class InitializationError(ArithmeticError):
     """
     IDAES exception to be used when initialization routines fail. All
     initialization routines should raise this Exception if the final step
-    fails ot converge, and can raise this exception earlier if the routine
+    fails to converge, and can raise this exception earlier if the routine
     enters a state from which recovery is impossible.
     """
     pass

--- a/idaes/core/util/exceptions.py
+++ b/idaes/core/util/exceptions.py
@@ -20,7 +20,7 @@ __author__ = "Andrew Lee"
 
 class BalanceTypeNotSupportedError(NotImplementedError):
     """
-    IDAES exception to be used when a control volumedoes not support a given
+    IDAES exception to be used when a control volume does not support a given
     type of balance equation.
     """
     pass  # Tried to put bagel in normal toaster
@@ -66,3 +66,13 @@ class PropertyPackageError(AttributeError):
     Needs to inherit from AttributeError for Pyomo interactions.
     """
     pass  # Bread stuck
+
+
+class InitializationError(ValueError):
+    """
+    IDAES exception to be used when initialization routines fail. All
+    initialization routines should raise this Exception if the final step
+    fails ot converge, and can raise this exception earlier if the routine
+    enters a state from which recovery is impossible.
+    """
+    pass

--- a/idaes/core/util/exceptions.py
+++ b/idaes/core/util/exceptions.py
@@ -18,7 +18,16 @@ This module contains custom IDAES exceptions.
 __author__ = "Andrew Lee"
 
 
-class BalanceTypeNotSupportedError(NotImplementedError):
+class IdaesError(Exception):
+    """
+    General exception for all IDAES errors. Intended to be used for multiple
+    inheritance in derived expcetions to allow catching of all IDAES-related
+    exceptions.
+    """
+    pass  # Problem with toaster
+
+
+class BalanceTypeNotSupportedError(NotImplementedError, IdaesError):
     """
     IDAES exception to be used when a control volume does not support a given
     type of balance equation.
@@ -26,7 +35,7 @@ class BalanceTypeNotSupportedError(NotImplementedError):
     pass  # Tried to put bagel in normal toaster
 
 
-class ConfigurationError(ValueError):
+class ConfigurationError(ValueError, IdaesError):
     """
     IDAES exception to be used when configuration arguments are incorrect
     or inconsistent.
@@ -34,7 +43,7 @@ class ConfigurationError(ValueError):
     pass  # Too many buttons, burnt toast
 
 
-class DynamicError(ValueError):
+class DynamicError(ValueError, IdaesError):
     """
     IDAES exception for cases where settings associated with dynamic models
     are incorrect.
@@ -42,14 +51,14 @@ class DynamicError(ValueError):
     pass  # Incorrect browness setting
 
 
-class BurntToast(Exception):
+class BurntToast(IdaesError):
     """
     General exception for when something breaks badly in the core.
     """
     pass  # Toaster on fire
 
 
-class PropertyNotSupportedError(AttributeError):
+class PropertyNotSupportedError(AttributeError, IdaesError):
     """
     IDAES exception for cases when a models calls for a property which is
     not supported by the chosen property package.
@@ -59,7 +68,7 @@ class PropertyNotSupportedError(AttributeError):
     pass  # Could not find bread
 
 
-class PropertyPackageError(AttributeError):
+class PropertyPackageError(AttributeError, IdaesError):
     """
     IDAES exception for generic errors arising from property packages.
 
@@ -68,7 +77,7 @@ class PropertyPackageError(AttributeError):
     pass  # Bread stuck
 
 
-class InitializationError(ArithmeticError):
+class InitializationError(ArithmeticError, IdaesError):
     """
     IDAES exception to be used when initialization routines fail. All
     initialization routines should raise this Exception if the final step

--- a/idaes/core/util/tests/test_exceptions.py
+++ b/idaes/core/util/tests/test_exceptions.py
@@ -59,5 +59,5 @@ def test_PropertyPackageError():
 
 @pytest.mark.unit
 def test_InitializationError():
-    with pytest.raises(ValueError):
+    with pytest.raises(ArithmeticError):
         raise InitializationError()

--- a/idaes/core/util/tests/test_exceptions.py
+++ b/idaes/core/util/tests/test_exceptions.py
@@ -24,11 +24,15 @@ __author__ = "Andrew Lee"
 def test_BalanceTypeNotSupportedError():
     with pytest.raises(NotImplementedError):
         raise BalanceTypeNotSupportedError()
+    with pytest.raises(IdaesError):
+        raise BalanceTypeNotSupportedError()
 
 
 @pytest.mark.unit
 def test_ConfigurationError():
     with pytest.raises(ValueError):
+        raise ConfigurationError()
+    with pytest.raises(IdaesError):
         raise ConfigurationError()
 
 
@@ -36,17 +40,21 @@ def test_ConfigurationError():
 def test_DynamicError():
     with pytest.raises(ValueError):
         raise DynamicError()
+    with pytest.raises(IdaesError):
+        raise DynamicError()
 
 
 @pytest.mark.unit
 def test_BurntToast():
-    with pytest.raises(Exception):
+    with pytest.raises(IdaesError):
         raise BurntToast()
 
 
 @pytest.mark.unit
 def test_PropertyNotSupportedError():
     with pytest.raises(AttributeError):
+        raise PropertyNotSupportedError()
+    with pytest.raises(IdaesError):
         raise PropertyNotSupportedError()
 
 
@@ -55,9 +63,13 @@ def test_PropertyPackageError():
     with pytest.raises(AttributeError):
         # This MUST be an AttributeError due to behaviour in Pyomo
         raise PropertyPackageError()
+    with pytest.raises(IdaesError):
+        raise PropertyPackageError()
 
 
 @pytest.mark.unit
 def test_InitializationError():
     with pytest.raises(ArithmeticError):
+        raise InitializationError()
+    with pytest.raises(IdaesError):
         raise InitializationError()

--- a/idaes/core/util/tests/test_exceptions.py
+++ b/idaes/core/util/tests/test_exceptions.py
@@ -55,3 +55,9 @@ def test_PropertyPackageError():
     with pytest.raises(AttributeError):
         # This MUST be an AttributeError due to behaviour in Pyomo
         raise PropertyPackageError()
+
+
+@pytest.mark.unit
+def test_InitializationError():
+    with pytest.raises(ValueError):
+        raise InitializationError()

--- a/idaes/generic_models/properties/activity_coeff_models/activity_coeff_prop_pack.py
+++ b/idaes/generic_models/properties/activity_coeff_models/activity_coeff_prop_pack.py
@@ -397,6 +397,12 @@ class _ActivityCoeffStateBlock(StateBlock):
             res = solve_indexed_blocks(opt, [blk], tee=slc.tee)
         init_log.info("Initialization Step 5 {}.".format(idaeslog.condition(res)))
 
+        if (res.solver.termination_condition != TerminationCondition.optimal or
+                res.solver.status != SolverStatus.ok):
+            raise InitializationError(
+                f"{blk.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
+
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
@@ -404,12 +410,6 @@ class _ActivityCoeffStateBlock(StateBlock):
                 blk.release_state(flags, outlvl=outlvl)
 
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
-        
-        if (res.solver.termination_condition != TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
-            raise InitializationError(
-                f"{blk.name} failed to initialize successfully. Please check "
-                f"the output logs for more information.")
 
 
     def release_state(blk, flags, outlvl=idaeslog.NOTSET):

--- a/idaes/generic_models/properties/activity_coeff_models/activity_coeff_prop_pack.py
+++ b/idaes/generic_models/properties/activity_coeff_models/activity_coeff_prop_pack.py
@@ -42,8 +42,18 @@ References:
 """
 
 # Import Pyomo libraries
-from pyomo.environ import Constraint, log, NonNegativeReals, value, Var, exp,\
-    Expression, Param, sqrt, SolverFactory, units as pyunits
+from pyomo.environ import (Constraint,
+                           log,
+                           NonNegativeReals,
+                           value,
+                           Var,
+                           exp,
+                           Expression,
+                           Param,
+                           sqrt,
+                           units as pyunits,
+                           SolverStatus,
+                           TerminationCondition)
 from pyomo.common.config import ConfigValue, In
 
 # Import IDAES cores
@@ -59,7 +69,7 @@ from idaes.core import (declare_process_block_class,
 from idaes.core.util.initialization import (fix_state_vars,
                                             revert_state_vars,
                                             solve_indexed_blocks)
-from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.exceptions import ConfigurationError, InitializationError
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.constants import Constants as const
 from idaes.core.util import get_solver
@@ -394,6 +404,12 @@ class _ActivityCoeffStateBlock(StateBlock):
                 blk.release_state(flags, outlvl=outlvl)
 
         init_log.info("Initialization Complete: {}".format(idaeslog.condition(res)))
+        
+        if (res.solver.termination_condition != TerminationCondition.optimal or
+                res.solver.status != SolverStatus.ok):
+            raise InitializationError(
+                f"{blk.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
 
 
     def release_state(blk, flags, outlvl=idaeslog.NOTSET):

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
@@ -39,6 +39,9 @@ from idaes.generic_models.properties.core.phase_equil import SmoothVLE
 from idaes.generic_models.properties.core.examples.ASU_PR \
     import configuration
 
+from idaes.generic_models.properties.tests.test_harness import \
+    PropertyTestHarness
+
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -49,6 +52,16 @@ def _as_quantity(x):
     if unit is None:
         unit = pyunits.dimensionless
     return value(x) * unit._get_pint_unit()
+
+
+@pytest.mark.unit
+class TestASUPR(PropertyTestHarness):
+    def configure(self):
+        self.prop_pack = GenericParameterBlock
+        self.param_args = configuration
+        self.prop_args = {}
+        self.has_density_terms = False
+
 
 # Test for configuration dictionaries with parameters from Properties of Gases
 # and liquids 4th edition

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
@@ -39,6 +39,9 @@ from idaes.generic_models.properties.core.phase_equil import SmoothVLE
 from idaes.generic_models.properties.core.examples.ASU_PR \
     import configuration_Dowling_2015
 
+from idaes.generic_models.properties.tests.test_harness import \
+    PropertyTestHarness
+
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -49,6 +52,16 @@ def _as_quantity(x):
     if unit is None:
         unit = pyunits.dimensionless
     return value(x) * unit._get_pint_unit()
+
+
+@pytest.mark.unit
+class TestASUPR(PropertyTestHarness):
+    def configure(self):
+        self.prop_pack = GenericParameterBlock
+        self.param_args = configuration_Dowling_2015
+        self.prop_args = {}
+        self.has_density_terms = False
+
 
 # Test for configuration dictionaries with parameters from Properties of Gases
 # and liquids 3rd edition and Dowling 2015

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -39,6 +39,9 @@ from idaes.generic_models.properties.core.phase_equil import SmoothVLE
 from idaes.generic_models.properties.core.examples.BT_ideal \
     import configuration
 
+from idaes.generic_models.properties.tests.test_harness import \
+    PropertyTestHarness
+
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -49,6 +52,16 @@ def _as_quantity(x):
     if unit is None:
         unit = pyunits.dimensionless
     return value(x) * unit._get_pint_unit()
+
+
+@pytest.mark.unit
+class TestBTIdeal(PropertyTestHarness):
+    def configure(self):
+        self.prop_pack = GenericParameterBlock
+        self.param_args = configuration
+        self.prop_args = {}
+        self.has_density_terms = True
+
 
 class TestParamBlock(object):
     @pytest.mark.unit

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -45,6 +45,9 @@ from idaes.generic_models.properties.core.phase_equil.forms import fugacity
 import idaes.generic_models.properties.core.pure.Perrys as Perrys
 import idaes.generic_models.properties.core.pure.RPP4 as RPP4
 
+from idaes.generic_models.properties.tests.test_harness import \
+    PropertyTestHarness
+
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -137,6 +140,15 @@ config_dict = {
     "phases_in_equilibrium": [("Vap", "Liq")],
     "phase_equilibrium_state": {("Vap", "Liq"): SmoothVLE},
     "bubble_dew_method": IdealBubbleDew}
+
+
+@pytest.mark.unit
+class TestBTIdeal_FPhx(PropertyTestHarness):
+    def configure(self):
+        self.prop_pack = GenericParameterBlock
+        self.param_args = config_dict
+        self.prop_args = {}
+        self.has_density_terms = False
 
 
 class TestParamBlock(object):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
@@ -46,6 +46,9 @@ from idaes.generic_models.properties.core.phase_equil.forms import fugacity
 import idaes.generic_models.properties.core.pure.Perrys as Perrys
 import idaes.generic_models.properties.core.pure.RPP4 as RPP4
 
+from idaes.generic_models.properties.tests.test_harness import \
+    PropertyTestHarness
+
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -138,6 +141,15 @@ config_dict = {
     "phases_in_equilibrium": [("Vap", "Liq")],
     "phase_equilibrium_state": {("Vap", "Liq"): SmoothVLE},
     "bubble_dew_method": IdealBubbleDew}
+
+
+@pytest.mark.unit
+class TestBTIdeal_FcPh(PropertyTestHarness):
+    def configure(self):
+        self.prop_pack = GenericParameterBlock
+        self.param_args = config_dict
+        self.prop_args = {}
+        self.has_density_terms = False
 
 
 class TestParamBlock(object):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
@@ -47,6 +47,9 @@ import idaes.generic_models.properties.core.pure.Perrys as Perrys
 import idaes.generic_models.properties.core.pure.RPP4 as RPP4
 import idaes.generic_models.properties.core.pure.NIST as NIST
 
+from idaes.generic_models.properties.tests.test_harness import \
+    PropertyTestHarness
+
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
@@ -136,6 +139,15 @@ config_dict = {
     "phases_in_equilibrium": [("Vap", "Liq")],
     "phase_equilibrium_state": {("Vap", "Liq"): SmoothVLE},
     "bubble_dew_method": IdealBubbleDew}
+
+
+@pytest.mark.unit
+class TestBTIdeal_FcTP(PropertyTestHarness):
+    def configure(self):
+        self.prop_pack = GenericParameterBlock
+        self.param_args = config_dict
+        self.prop_args = {}
+        self.has_density_terms = False
 
 
 class TestParamBlock(object):

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -32,6 +32,8 @@ from pyomo.environ import (ConcreteModel,
                            value)
 
 from idaes.core.util import get_solver
+from idaes.generic_models.properties.tests.test_harness import \
+    PropertyTestHarness
 
 import idaes.logger as idaeslog
 SOUT = idaeslog.INFO
@@ -46,6 +48,15 @@ prop_available = cubic_roots_available()
 solver = get_solver()
 # Limit iterations to make sure sweeps aren;t getting out of hand
 solver.options["max_iter"] = 50
+
+
+@pytest.mark.unit
+class TestBTPR(PropertyTestHarness):
+    def configure(self):
+        self.prop_pack = GenericParameterBlock
+        self.param_args = configuration
+        self.prop_args = {}
+        self.has_density_terms = False
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1133,6 +1133,8 @@ class _GenericStateBlock(StateBlock):
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="properties")
 
         init_log.info('Starting initialization')
+        
+        res = None
 
         for k in blk.keys():
             # Deactivate the constraints specific for outlet block i.e.
@@ -1376,6 +1378,14 @@ class _GenericStateBlock(StateBlock):
                         .state_definition.do_not_initialize):
                     c.activate()
 
+        if (res is not None and (
+                res.solver.termination_condition !=
+                TerminationCondition.optimal or
+                res.solver.status != SolverStatus.ok)):
+            raise InitializationError(
+                f"{blk.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
+
         if state_vars_fixed is False:
             if hold_state is True:
                 return flag_dict
@@ -1384,12 +1394,6 @@ class _GenericStateBlock(StateBlock):
 
         init_log.info("Property package initialization: {}.".format(
             idaeslog.condition(res)))
-
-        if (res.solver.termination_condition != TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
-            raise InitializationError(
-                f"{blk.name} failed to initialize successfully. Please check "
-                f"the output logs for more information.")
 
     def release_state(blk, flags, outlvl=idaeslog.NOTSET):
         '''

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -15,7 +15,6 @@ Framework for generic property packages
 """
 # Import Python libraries
 import types
-from enum import Enum
 
 # Import Pyomo libraries
 from pyomo.environ import (Block,

--- a/idaes/generic_models/properties/core/generic/utility.py
+++ b/idaes/generic_models/properties/core/generic/utility.py
@@ -20,7 +20,7 @@ from enum import Enum
 from pyomo.environ import units as pyunits
 
 from idaes.core.util.exceptions import \
-    BurntToast, ConfigurationError, PropertyPackageError, IdaesError
+    BurntToast, ConfigurationError, PropertyPackageError
 import idaes.logger as idaeslog
 
 # Set up logger
@@ -32,7 +32,7 @@ class StateIndex(Enum):
     apparent = 2
 
 
-class GenericPropertyPackageError(PropertyPackageError, IdaesError):
+class GenericPropertyPackageError(PropertyPackageError):
     # Error message for when a property is called for but no option provided
     def __init__(self, block, prop):
         self.prop = prop

--- a/idaes/generic_models/properties/core/generic/utility.py
+++ b/idaes/generic_models/properties/core/generic/utility.py
@@ -20,7 +20,7 @@ from enum import Enum
 from pyomo.environ import units as pyunits
 
 from idaes.core.util.exceptions import \
-    BurntToast, ConfigurationError, PropertyPackageError
+    BurntToast, ConfigurationError, PropertyPackageError, IdaesError
 import idaes.logger as idaeslog
 
 # Set up logger
@@ -32,7 +32,7 @@ class StateIndex(Enum):
     apparent = 2
 
 
-class GenericPropertyPackageError(PropertyPackageError):
+class GenericPropertyPackageError(PropertyPackageError, IdaesError):
     # Error message for when a property is called for but no option provided
     def __init__(self, block, prop):
         self.prop = prop

--- a/idaes/generic_models/properties/cubic_eos/cubic_prop_pack.py
+++ b/idaes/generic_models/properties/cubic_eos/cubic_prop_pack.py
@@ -558,6 +558,13 @@ class _CubicStateBlock(StateBlock):
         )
 
         # ---------------------------------------------------------------------
+        if (results.solver.termination_condition !=
+                TerminationCondition.optimal or
+                results.solver.status != SolverStatus.ok):
+            raise InitializationError(
+                f"{blk.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
+
         if state_vars_fixed is False:
             if hold_state is True:
                 return flags
@@ -565,12 +572,6 @@ class _CubicStateBlock(StateBlock):
                 blk.release_state(flags, outlvl=outlvl)
 
         init_log.info("Initialization complete.")
-
-        if (res.solver.termination_condition != TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
-            raise InitializationError(
-                f"{blk.name} failed to initialize successfully. Please check "
-                f"the output logs for more information.")
 
     def release_state(blk, flags, outlvl=idaeslog.NOTSET):
         '''

--- a/idaes/generic_models/properties/tests/test_harness.py
+++ b/idaes/generic_models/properties/tests/test_harness.py
@@ -52,14 +52,15 @@ class PropertyTestHarness(object):
 
         self.has_density_terms = True
 
-        self.skip_initialization_exception = False
+        self.skip_initialization_raises_exception_test = False
 
         self.configure()
 
         # Need to attach these to m for later use
         m.has_density_terms = self.has_density_terms
         m.prop_args = self.prop_args
-        m.skip_initialization_exception = self.skip_initialization_exception
+        m.skip_initialization_raises_exception_test = \
+            self.skip_initialization_raises_exception_test
 
     def configure(self):
         # Placeholder method to allow user to setup test harness
@@ -279,7 +280,7 @@ class PropertyTestHarness(object):
                 "degrees of freedom.")
 
     def test_initialize_failure(self, frame):
-        if not frame.skip_initialization_exception:
+        if not frame.skip_initialization_raises_exception_test:
             for n, v in frame.fs.props[1].define_state_vars().items():
                 for i in v:
                     frame.fs.props[1].add_component(

--- a/idaes/generic_models/properties/tests/test_iapws95_with_harness.py
+++ b/idaes/generic_models/properties/tests/test_iapws95_with_harness.py
@@ -27,6 +27,8 @@ class TestBasicMix(PropertyTestHarness):
         self.param_args = {"phase_presentation": iapws95.PhaseType.MIX}
         self.prop_args = {}
         self.has_density_terms = True
+        # Helmholt package initialization has not solver calls, so can't fail
+        self.skip_initialization_exception = True
 
 
 @pytest.mark.unit
@@ -36,6 +38,8 @@ class TestBasicLV(PropertyTestHarness):
         self.param_args = {"phase_presentation": iapws95.PhaseType.LG}
         self.prop_args = {}
         self.has_density_terms = True
+        # Helmholt package initialization has not solver calls, so can't fail
+        self.skip_initialization_exception = True
 
 
 @pytest.mark.unit
@@ -45,6 +49,8 @@ class TestBasicL(PropertyTestHarness):
         self.param_args = {"phase_presentation": iapws95.PhaseType.L}
         self.prop_args = {}
         self.has_density_terms = True
+        # Helmholt package initialization has not solver calls, so can't fail
+        self.skip_initialization_exception = True
 
 
 @pytest.mark.unit
@@ -54,3 +60,5 @@ class TestBasicV(PropertyTestHarness):
         self.param_args = {"phase_presentation": iapws95.PhaseType.G}
         self.prop_args = {}
         self.has_density_terms = True
+        # Helmholt package initialization has not solver calls, so can't fail
+        self.skip_initialization_exception = True

--- a/idaes/generic_models/properties/tests/test_iapws95_with_harness.py
+++ b/idaes/generic_models/properties/tests/test_iapws95_with_harness.py
@@ -27,8 +27,8 @@ class TestBasicMix(PropertyTestHarness):
         self.param_args = {"phase_presentation": iapws95.PhaseType.MIX}
         self.prop_args = {}
         self.has_density_terms = True
-        # Helmholt package initialization has not solver calls, so can't fail
-        self.skip_initialization_exception = True
+        # Helmholtz package initialization has no solver calls, so can't fail
+        self.skip_initialization_raises_exception_test = True
 
 
 @pytest.mark.unit
@@ -38,8 +38,8 @@ class TestBasicLV(PropertyTestHarness):
         self.param_args = {"phase_presentation": iapws95.PhaseType.LG}
         self.prop_args = {}
         self.has_density_terms = True
-        # Helmholt package initialization has not solver calls, so can't fail
-        self.skip_initialization_exception = True
+        # Helmholtz package initialization has no solver calls, so can't fail
+        self.skip_initialization_raises_exception_test = True
 
 
 @pytest.mark.unit
@@ -49,8 +49,8 @@ class TestBasicL(PropertyTestHarness):
         self.param_args = {"phase_presentation": iapws95.PhaseType.L}
         self.prop_args = {}
         self.has_density_terms = True
-        # Helmholt package initialization has not solver calls, so can't fail
-        self.skip_initialization_exception = True
+        # Helmholtz package initialization has no solver calls, so can't fail
+        self.skip_initialization_raises_exception_test = True
 
 
 @pytest.mark.unit
@@ -60,5 +60,5 @@ class TestBasicV(PropertyTestHarness):
         self.param_args = {"phase_presentation": iapws95.PhaseType.G}
         self.prop_args = {}
         self.has_density_terms = True
-        # Helmholt package initialization has not solver calls, so can't fail
-        self.skip_initialization_exception = True
+        # Helmholtz package initialization has no solver calls, so can't fail
+        self.skip_initialization_raises_exception_test = True

--- a/idaes/generic_models/properties/tests/test_swco2_with_harness.py
+++ b/idaes/generic_models/properties/tests/test_swco2_with_harness.py
@@ -27,8 +27,8 @@ class TestBasicMix(PropertyTestHarness):
         self.param_args = {"phase_presentation": swco2.PhaseType.MIX}
         self.prop_args = {}
         self.has_density_terms = True
-        # Helmholt package initialization has not solver calls, so can't fail
-        self.skip_initialization_exception = True
+        # Helmholtz package initialization has no solver calls, so can't fail
+        self.skip_initialization_raises_exception_test = True
 
 
 @pytest.mark.unit
@@ -38,8 +38,8 @@ class TestBasicLV(PropertyTestHarness):
         self.param_args = {"phase_presentation": swco2.PhaseType.LG}
         self.prop_args = {}
         self.has_density_terms = True
-        # Helmholt package initialization has not solver calls, so can't fail
-        self.skip_initialization_exception = True
+        # Helmholtz package initialization has no solver calls, so can't fail
+        self.skip_initialization_raises_exception_test = True
 
 
 @pytest.mark.unit
@@ -49,8 +49,8 @@ class TestBasicL(PropertyTestHarness):
         self.param_args = {"phase_presentation": swco2.PhaseType.L}
         self.prop_args = {}
         self.has_density_terms = True
-        # Helmholt package initialization has not solver calls, so can't fail
-        self.skip_initialization_exception = True
+        # Helmholtz package initialization has no solver calls, so can't fail
+        self.skip_initialization_raises_exception_test = True
 
 
 @pytest.mark.unit
@@ -60,5 +60,5 @@ class TestBasicV(PropertyTestHarness):
         self.param_args = {"phase_presentation": swco2.PhaseType.G}
         self.prop_args = {}
         self.has_density_terms = True
-        # Helmholt package initialization has not solver calls, so can't fail
-        self.skip_initialization_exception = True
+        # Helmholtz package initialization has no solver calls, so can't fail
+        self.skip_initialization_raises_exception_test = True

--- a/idaes/generic_models/properties/tests/test_swco2_with_harness.py
+++ b/idaes/generic_models/properties/tests/test_swco2_with_harness.py
@@ -27,6 +27,8 @@ class TestBasicMix(PropertyTestHarness):
         self.param_args = {"phase_presentation": swco2.PhaseType.MIX}
         self.prop_args = {}
         self.has_density_terms = True
+        # Helmholt package initialization has not solver calls, so can't fail
+        self.skip_initialization_exception = True
 
 
 @pytest.mark.unit
@@ -36,6 +38,8 @@ class TestBasicLV(PropertyTestHarness):
         self.param_args = {"phase_presentation": swco2.PhaseType.LG}
         self.prop_args = {}
         self.has_density_terms = True
+        # Helmholt package initialization has not solver calls, so can't fail
+        self.skip_initialization_exception = True
 
 
 @pytest.mark.unit
@@ -45,6 +49,8 @@ class TestBasicL(PropertyTestHarness):
         self.param_args = {"phase_presentation": swco2.PhaseType.L}
         self.prop_args = {}
         self.has_density_terms = True
+        # Helmholt package initialization has not solver calls, so can't fail
+        self.skip_initialization_exception = True
 
 
 @pytest.mark.unit
@@ -54,3 +60,5 @@ class TestBasicV(PropertyTestHarness):
         self.param_args = {"phase_presentation": swco2.PhaseType.G}
         self.prop_args = {}
         self.has_density_terms = True
+        # Helmholt package initialization has not solver calls, so can't fail
+        self.skip_initialization_exception = True


### PR DESCRIPTION
## Part of #356 


## Summary/Motivation:
Currently, initialization routines have no way of telling the user that they failed beyond logger messages. This PR adds a new InitializationError that all initialization routines should raise if there is a failure during initiation (e.g. the final solve is not feasible).

## Changes proposed in this PR:
- Adds new InitializaitonError
- Implements code to raise InitializationErrors in most core property packages.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
