### PR TITLE
Fixing some inter-dependency between component and unit tests

### DIFF
--- a/idaes/generic_models/properties/core/generic/tests/test_vle.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_vle.py
@@ -143,6 +143,10 @@ class TestNoHenryComps(object):
         model.props[1].mole_frac_comp["A"].fix(0.5)
         model.props[1].mole_frac_comp["B"].fix(0.5)
 
+        # Trigger construction of some things we will test later
+        model.props[1].pressure_bubble
+        model.props[1].pressure_dew
+
         return model
 
     @pytest.mark.unit
@@ -387,6 +391,10 @@ class TestHenryComps0(object):
         model.props[1].mole_frac_comp["B"].fix(0.5)
         model.props[1].mole_frac_comp["C"].fix(1e-10)
 
+        # Trigger construction of some things we will test later
+        model.props[1].pressure_bubble
+        model.props[1].pressure_dew
+
         return model
 
     @pytest.mark.unit
@@ -531,6 +539,10 @@ class TestHenryComps(object):
         model.props[1].mole_frac_comp["A"].fix(0.45)
         model.props[1].mole_frac_comp["B"].fix(0.45)
         model.props[1].mole_frac_comp["C"].fix(0.1)
+
+        # Trigger construction of some things we will test later
+        model.props[1].pressure_bubble
+        model.props[1].pressure_dew
 
         return model
 

--- a/idaes/generic_models/unit_models/tests/test_skeleton_unit_model.py
+++ b/idaes/generic_models/unit_models/tests/test_skeleton_unit_model.py
@@ -73,24 +73,24 @@ class TestSkeletonDefault(object):
             expr=m.fs.skeleton.pressure_out[0] ==
             m.fs.skeleton.pressure_in[0] - 10)
 
+        inlet_dict = \
+            {"flow_mol_comp": m.fs.skeleton.flow_comp_in,
+             "temperature": m.fs.skeleton.temperature_in,
+             "pressure": m.fs.skeleton.pressure_in}
+        outlet_dict = \
+            {"flow_mol_comp": m.fs.skeleton.flow_comp_out,
+             "temperature": m.fs.skeleton.temperature_out,
+             "pressure": m.fs.skeleton.pressure_out}
+
+        m.fs.skeleton.add_ports(
+            name="inlet", member_dict=inlet_dict)
+        m.fs.skeleton.add_ports(
+            name="outlet", member_dict=outlet_dict)
+
         return m
 
     @pytest.mark.unit
     def test_ports(self, skeleton_default):
-
-        inlet_dict = \
-            {"flow_mol_comp": skeleton_default.fs.skeleton.flow_comp_in,
-             "temperature": skeleton_default.fs.skeleton.temperature_in,
-             "pressure": skeleton_default.fs.skeleton.pressure_in}
-        outlet_dict = \
-            {"flow_mol_comp": skeleton_default.fs.skeleton.flow_comp_out,
-             "temperature": skeleton_default.fs.skeleton.temperature_out,
-             "pressure": skeleton_default.fs.skeleton.pressure_out}
-
-        skeleton_default.fs.skeleton.add_ports(
-            name="inlet", member_dict=inlet_dict)
-        skeleton_default.fs.skeleton.add_ports(
-            name="outlet", member_dict=outlet_dict)
 
         # Check inlet port and port members
         assert hasattr(skeleton_default.fs.skeleton, "inlet")
@@ -213,24 +213,24 @@ class TestSkeletonCustom(object):
             expr=m.fs.skeleton.pressure_out[0] ==
             m.fs.skeleton.pressure_in[0] - 10)
 
+        inlet_dict = \
+            {"flow_mol_comp": m.fs.skeleton.flow_comp_in,
+             "temperature": m.fs.skeleton.temperature_in,
+             "pressure": m.fs.skeleton.pressure_in}
+        outlet_dict = \
+            {"flow_mol_comp": m.fs.skeleton.flow_comp_out,
+             "temperature": m.fs.skeleton.temperature_out,
+             "pressure": m.fs.skeleton.pressure_out}
+
+        m.fs.skeleton.add_ports(
+            name="inlet", member_dict=inlet_dict)
+        m.fs.skeleton.add_ports(
+            name="outlet", member_dict=outlet_dict)
+
         return m
 
     @pytest.mark.unit
     def test_ports(self, skeleton_custom):
-
-        inlet_dict = \
-            {"flow_mol_comp": skeleton_custom.fs.skeleton.flow_comp_in,
-             "temperature": skeleton_custom.fs.skeleton.temperature_in,
-             "pressure": skeleton_custom.fs.skeleton.pressure_in}
-        outlet_dict = \
-            {"flow_mol_comp": skeleton_custom.fs.skeleton.flow_comp_out,
-             "temperature": skeleton_custom.fs.skeleton.temperature_out,
-             "pressure": skeleton_custom.fs.skeleton.pressure_out}
-
-        skeleton_custom.fs.skeleton.add_ports(
-            name="inlet", member_dict=inlet_dict)
-        skeleton_custom.fs.skeleton.add_ports(
-            name="outlet", member_dict=outlet_dict)
 
         # Check inlet port and port members
         assert hasattr(skeleton_custom.fs.skeleton, "inlet")

--- a/idaes/power_generation/costing/tests/test_NGCC_costing.py
+++ b/idaes/power_generation/costing/tests/test_NGCC_costing.py
@@ -43,7 +43,7 @@ def build_costing():
     return m
 
 
-@pytest.mark.unit
+@pytest.mark.component
 def test_get_costing(build_costing):
     m = build_costing
     assert hasattr(m.fs.costing, "CE_index")


### PR DESCRIPTION
## Fixes https://github.com/IDAES/examples-pse/issues/78


## Summary/Motivation:
There were a few cases where the outcome of some `component` tests relied on effects of `unit` tests. This resulted in failures of these tests if the `component` tests were run in isolation. This slipped through testing as we almost never run `component` tests in isolation (at least not as part of the CI).

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
