### PR TITLE
Improving docs for stoichiometric reactor

### DIFF
--- a/docs/technical_specs/model_libraries/generic/unit_models/stoichiometric_reactor.rst
+++ b/docs/technical_specs/model_libraries/generic/unit_models/stoichiometric_reactor.rst
@@ -13,6 +13,11 @@ Typical fixed variables are:
 * reaction extents or yields (1 per reaction),
 * reactor heat duty (has_heat_transfer = True only).
 
+Alternative Specifications
+==========================
+
+Alternative approaches for specifying the performance of stoichiometric reactors are parameters such as conversion or selectivity. However, these parameters are defined with respect to a specific key component within the system, which is difficult to implement in a general fashion. Users are encouraged to implement additional variables and constraints to represent these parameters if desired.
+
 Model Structure
 ---------------
 
@@ -23,12 +28,13 @@ Variables
 
 Stoichiometric reactors units add the following variables:
 
-================ ==================== ===========================================================================
-Variable         Name                 Notes
-================ ==================== ===========================================================================
-:math:`Q_t`      heat                 Only if has_heat_transfer = True, reference to control_volume.heat
-:math:`deltaP_t` pressure change      Only if has_pressure_change = True, reference to control_volume.deltaP
-================ ==================== ===========================================================================
+================ ===================== ===========================================================================
+Variable         Name                  Notes
+================ ===================== ===========================================================================
+:math:`X_t`      rate_reaction_extent  Extent of reaction, indexed by time and reactions
+:math:`Q_t`      heat                  Only if has_heat_transfer = True, reference to control_volume.heat
+:math:`deltaP_t` pressure change       Only if has_pressure_change = True, reference to control_volume.deltaP
+================ ===================== ===========================================================================
 
 Constraints
 -----------


### PR DESCRIPTION
## Fixes #243


## Summary/Motivation:
The docs for the stoichiometric reactor were missing variable names for the extent of reaction terms which are common performance specs.

## Changes proposed in this PR:
- Added mention of names for extent of reaction terms.
- Also added mention of adding conversion/selectivity terms.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
