### PR TITLE
Fixing some Pyomo warnings

### DIFF
--- a/docs/technical_specs/core/util/model_serializer.rst
+++ b/docs/technical_specs/core/util/model_serializer.rst
@@ -41,7 +41,7 @@ test models.  The second model is a little more complicated and includes suffixe
   def setup_model01():
       model = ConcreteModel()
       model.b = Block([1,2,3])
-      a = model.b[1].a = Var(bounds=(-100, 100), initialize=2)
+      a = model.b[1].a = Var(bounds=(-1e5, 1e5), initialize=2)
       b = model.b[1].b = Var(bounds=(-100, 100), initialize=20)
       model.b[1].c = Constraint(expr=b==10*a)
       a.fix(2)

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1263,9 +1263,17 @@ class _GenericStateBlock(StateBlock):
                             blk[k].true_to_appr_species[p, j])
                     # Need to calculate all flows before doing mole fractions
                     for p, j in blk[k].params.apparent_phase_component_set:
-                        calculate_variable_from_constraint(
-                            blk[k].mole_frac_phase_comp_apparent[p, j],
-                            blk[k].appr_mole_frac_constraint[p, j])
+                        x = value(
+                            blk[k].flow_mol_phase_comp_apparent[p, j] /
+                            sum(blk[k].flow_mol_phase_comp_apparent[p, jj]
+                                for jj in blk[k].params.apparent_species_set))
+                        lb = blk[k].mole_frac_phase_comp_apparent[p, j]._lb
+                        if lb is not None and x <= lb:
+                            blk[k].mole_frac_phase_comp_apparent[
+                                p, j].set_value(lb)
+                        else:
+                            blk[k].mole_frac_phase_comp_apparent[
+                                p, j].set_value(x)
                 elif blk[k].params.config.state_components == \
                         StateIndex.apparent:
                     # First calculate initial values for true species flows
@@ -1275,9 +1283,15 @@ class _GenericStateBlock(StateBlock):
                             blk[k].appr_to_true_species[p, j])
                     # Need to calculate all flows before doing mole fractions
                     for p, j in blk[k].params.true_phase_component_set:
-                        calculate_variable_from_constraint(
-                            blk[k].mole_frac_phase_comp_true[p, j],
-                            blk[k].true_mole_frac_constraint[p, j])
+                        x = value(
+                            blk[k].flow_mol_phase_comp_true[p, j] /
+                            sum(blk[k].flow_mol_phase_comp_true[p, jj]
+                                for jj in blk[k].params.true_species_set))
+                        lb = blk[k].mole_frac_phase_comp_true[p, j]._lb
+                        if lb is not None and x <= lb:
+                            blk[k].mole_frac_phase_comp_true[p, j].set_value(lb)
+                        else:
+                            blk[k].mole_frac_phase_comp_true[p, j].set_value(x)
 
             # If state block has phase equilibrium, use the average of all
             # _teq's as an initial guess for T

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1267,7 +1267,7 @@ class _GenericStateBlock(StateBlock):
                             blk[k].flow_mol_phase_comp_apparent[p, j] /
                             sum(blk[k].flow_mol_phase_comp_apparent[p, jj]
                                 for jj in blk[k].params.apparent_species_set))
-                        lb = blk[k].mole_frac_phase_comp_apparent[p, j]._lb
+                        lb = blk[k].mole_frac_phase_comp_apparent[p, j].lb
                         if lb is not None and x <= lb:
                             blk[k].mole_frac_phase_comp_apparent[
                                 p, j].set_value(lb)
@@ -1287,7 +1287,7 @@ class _GenericStateBlock(StateBlock):
                             blk[k].flow_mol_phase_comp_true[p, j] /
                             sum(blk[k].flow_mol_phase_comp_true[p, jj]
                                 for jj in blk[k].params.true_species_set))
-                        lb = blk[k].mole_frac_phase_comp_true[p, j]._lb
+                        lb = blk[k].mole_frac_phase_comp_true[p, j].lb
                         if lb is not None and x <= lb:
                             blk[k].mole_frac_phase_comp_true[p, j].set_value(lb)
                         else:

--- a/idaes/generic_models/unit_models/column_models/tests/test_solvent_condenser.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_solvent_condenser.py
@@ -155,7 +155,7 @@ class TestStripperVaporFlow(object):
                 value(model.fs.unit.vapor_outlet.flow_mol[0]))
         assert (pytest.approx(0.976758, rel=1e-5) ==
                 value(model.fs.unit.vapor_outlet.mole_frac_comp[0, 'CO2']))
-        assert (pytest.approx(0.0232416, rel=1e-5) ==
+        assert (pytest.approx(0.0232423, rel=1e-5) ==
                 value(model.fs.unit.vapor_outlet.mole_frac_comp[0, 'H2O']))
         assert (pytest.approx(184360, rel=1e-5) ==
                 value(model.fs.unit.vapor_outlet.pressure[0]))
@@ -306,7 +306,7 @@ class TestStripperHeatDuty(object):
                 value(model.fs.unit.vapor_outlet.flow_mol[0]))
         assert (pytest.approx(0.976758, rel=1e-5) ==
                 value(model.fs.unit.vapor_outlet.mole_frac_comp[0, 'CO2']))
-        assert (pytest.approx(0.0232505, rel=1e-5) ==
+        assert (pytest.approx(0.0232509, rel=1e-5) ==
                 value(model.fs.unit.vapor_outlet.mole_frac_comp[0, 'H2O']))
         assert (pytest.approx(184360, rel=1e-5) ==
                 value(model.fs.unit.vapor_outlet.pressure[0]))

--- a/idaes/generic_models/unit_models/column_models/tests/test_solvent_condenser.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_solvent_condenser.py
@@ -70,6 +70,15 @@ class TestStripperVaporFlow(object):
         m.fs.unit.inlet.mole_frac_comp[0, "H2O"].fix(0.1183)
 
         m.fs.unit.reflux.flow_mol[0].fix(0.1083)
+        
+        iscale.set_scaling_factor(
+            m.fs.unit.vapor_phase.properties_out[0].fug_phase_comp[
+                "Vap", "CO2"], 1e-5)
+        iscale.set_scaling_factor(
+            m.fs.unit.vapor_phase.properties_out[0].fug_phase_comp[
+                "Vap", "H2O"], 1e-3)
+
+        iscale.calculate_scaling_factors(m.fs.unit)
 
         return m
 


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
The most recent version of Pyomo has begun emitting warnings when the value of a `Var` is set outside its bounds. Some IDAES code was triggering these warnings, so this PR addresses the cause of those.

## Changes proposed in this PR:
- When initializing mole fractions in the generic property package, ensure that the value is never set less than the lower bound.
- Correct bounds in one example code snippet where the value was being set outside the bounds.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
