### PR TITLE
Adding InitializationErrors to core UnitModels

### DIFF
--- a/idaes/generic_models/unit_models/heat_exchanger.py
+++ b/idaes/generic_models/unit_models/heat_exchanger.py
@@ -21,17 +21,14 @@ from enum import Enum
 # Import Pyomo libraries
 from pyomo.environ import (
     Var,
-    Param,
-    Expression,
     log,
     Reference,
     PositiveReals,
-    SolverFactory,
     ExternalFunction,
     Block,
     units as pyunits,
-    NonNegativeReals,
-    value,
+    SolverStatus,
+    TerminationCondition
 )
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 
@@ -52,7 +49,7 @@ from idaes.generic_models.unit_models.heater import (
 import idaes.core.util.unit_costing as costing
 from idaes.core.util.misc import add_object_reference
 from idaes.core.util import get_solver, scaling as iscale
-from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.exceptions import ConfigurationError, InitializationError
 
 _log = idaeslog.getLogger(__name__)
 
@@ -614,6 +611,14 @@ class HeatExchangerData(UnitModelBlockData):
         if hasattr(self, "costing"):
             self.costing.activate()
             costing.initialize(self.costing)
+
+        if (res is not None and (
+                res.solver.termination_condition !=
+                TerminationCondition.optimal or
+                res.solver.status != SolverStatus.ok)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
 
     def _get_performance_contents(self, time_point=0):
         var_dict = {

--- a/idaes/generic_models/unit_models/heat_exchanger_ntu.py
+++ b/idaes/generic_models/unit_models/heat_exchanger_ntu.py
@@ -25,6 +25,8 @@ from pyomo.environ import (Block,
                            Param,
                            PositiveReals,
                            Reference,
+                           SolverStatus,
+                           TerminationCondition,
                            units as pyunits,
                            Var)
 from pyomo.common.config import Bool, ConfigBlock, ConfigValue, In
@@ -41,6 +43,7 @@ from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.math import smooth_min, smooth_max
 from idaes.core.util import get_solver
+from idaes.core.util.exceptions import InitializationError
 import idaes.core.util.unit_costing as costing
 import idaes.logger as idaeslog
 
@@ -421,6 +424,14 @@ constructed,
         if hasattr(self, "costing"):
             self.costing.activate()
             costing.initialize(self.costing)
+
+        if (res is not None and (
+                res.solver.termination_condition !=
+                TerminationCondition.optimal or
+                res.solver.status != SolverStatus.ok)):
+            raise InitializationError(
+                f"{self.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
 
     def _get_stream_table_contents(self, time_point=0):
         return create_stream_table_dataframe(

--- a/idaes/generic_models/unit_models/pressure_changer.py
+++ b/idaes/generic_models/unit_models/pressure_changer.py
@@ -19,7 +19,15 @@ Standard IDAES pressure changer model.
 from enum import Enum
 
 # Import Pyomo libraries
-from pyomo.environ import value, Var, Block, Expression, Constraint, Reference
+from pyomo.environ import (
+    value,
+    Var,
+    Block,
+    Expression,
+    Constraint,
+    Reference,
+    SolverStatus,
+    TerminationCondition)
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
@@ -33,7 +41,8 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
-from idaes.core.util.exceptions import PropertyNotSupportedError
+from idaes.core.util.exceptions import (
+    PropertyNotSupportedError, InitializationError)
 from idaes.core.util.config import is_physical_parameter_block
 import idaes.logger as idaeslog
 import idaes.core.util.unit_costing as costing
@@ -793,6 +802,15 @@ see property package for documentation.}""",
         # ---------------------------------------------------------------------
         # Release Inlet state
         blk.control_volume.release_state(flags, outlvl)
+
+        if (res is not None and (
+                res.solver.termination_condition !=
+                TerminationCondition.optimal or
+                res.solver.status != SolverStatus.ok)):
+            raise InitializationError(
+                f"{blk.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
+
         init_log.info(f"Initialization Complete: {idaeslog.condition(res)}")
 
     def init_isentropic(blk, state_args, outlvl, solver, optarg):
@@ -994,6 +1012,15 @@ see property package for documentation.}""",
         # ---------------------------------------------------------------------
         # Release Inlet state
         blk.control_volume.release_state(flags, outlvl)
+
+        if (res is not None and (
+                res.solver.termination_condition !=
+                TerminationCondition.optimal or
+                res.solver.status != SolverStatus.ok)):
+            raise InitializationError(
+                f"{blk.name} failed to initialize successfully. Please check "
+                f"the output logs for more information.")
+
         init_log.info(f"Initialization Complete: {idaeslog.condition(res)}")
 
     def _get_performance_contents(self, time_point=0):

--- a/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
@@ -45,8 +45,7 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_unused_variables)
 from idaes.core.util.testing import (PhysicalParameterTestBlock,
                                      initialization_tester)
-from idaes.core.util import get_solver
-from idaes.core.util import scaling as iscale
+from idaes.core.util import get_solver, scaling as iscale
 
 
 # Imports to assemble BT-PR with different units
@@ -349,6 +348,8 @@ class TestBTX_countercurrent(object):
         m.fs.unit.tube_inlet.pressure[0].fix(101325)  # Pa
         m.fs.unit.tube_inlet.mole_frac_comp[0, "benzene"].fix(0.5)
         m.fs.unit.tube_inlet.mole_frac_comp[0, "toluene"].fix(0.5)
+
+        iscale.calculate_scaling_factors(m.fs.unit)
 
         return m
 


### PR DESCRIPTION
## Fixes part of # 356


## Summary/Motivation:
Adds core to raise InitializationErrors if solvers fail to converge during initialization to all core unit models

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
