### PR TITLE
Fixing `idaes get-examples` for non-final releases

### DIFF
--- a/idaes/commands/examples.py
+++ b/idaes/commands/examples.py
@@ -159,6 +159,7 @@ def get_examples(directory, no_install, list_releases, no_download, version,
                  unstable, local_dir):
     """Get the examples from Github and put them in a local directory.
     """
+    global PKG_VERSION
     # list-releases mode
     if list_releases:
         try:
@@ -198,6 +199,11 @@ def get_examples(directory, no_install, list_releases, no_download, version,
                 sys.exit(-1)
             ex_version = version if version else PKG_VERSION
         else:
+            if V.releaselevel not in ["final"]:
+                _log.debug(f'V.releaselevel: {V.releaselevel}')
+                unstable = True
+                PKG_VERSION += V.releaselevel
+                _log.debug(f'Forcing unstable: {PKG_VERSION}')
             try:
                 releases = get_releases(unstable)
             except GithubError as err:


### PR DESCRIPTION
## Addresses
#493 by trying to detect when the installed version is not a "final" release and then forcing on the unstable option.  Then, if there is an entry in the examples-pse/idaes-compatibility.json file for what would be the final release (say pointing to the release candidate of the examples-pse package, I think it might work.

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
