### PR TITLE
Temporarily skip failing integration test to address #493

### DIFF
--- a/idaes/commands/tests/test_commands.py
+++ b/idaes/commands/tests/test_commands.py
@@ -26,7 +26,6 @@ import uuid
 # third-party
 from click.testing import CliRunner
 import pytest
-pytestmark = pytest.mark.skip
 
 # package
 from idaes.commands import examples, extensions, convergence, config, env_info
@@ -126,6 +125,7 @@ def test_examples_cli_explicit_version(runner, tempdir):
     assert result.exit_code == 0
 
 
+@pytest.mark.skip("Erroneously fails when latest ideas version is a pre-release")
 @pytest.mark.integration()
 def test_examples_cli_default_version(runner, tempdir):
     dirname = str(tempdir / "examples")


### PR DESCRIPTION
## Fixes #493 (as a workaround)


## Summary/Motivation:


## Changes proposed in this PR:
- Move `pytest.mark.skip` from entire test module to individual failing test

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
