### PR TITLE
Making tensorflow optional in test_keras_surrogate

### DIFF
--- a/idaes/surrogate/keras_surrogate.py
+++ b/idaes/surrogate/keras_surrogate.py
@@ -16,7 +16,13 @@ Interface for importing Keras models into IDAES
 import numpy as np
 import json
 import os.path
-import tensorflow.keras as keras
+
+try:
+    import tensorflow.keras as keras
+    keras_available = True
+except:
+    keras_available = False
+    
 from enum import Enum
 import pandas as pd
 from idaes.surrogate.base.surrogate_base import SurrogateBase

--- a/idaes/surrogate/keras_surrogate.py
+++ b/idaes/surrogate/keras_surrogate.py
@@ -17,12 +17,9 @@ import numpy as np
 import json
 import os.path
 
-try:
-    import tensorflow.keras as keras
-    keras_available = True
-except:
-    keras_available = False
-    
+from pyomo.common.dependencies import attempt_import
+keras, keras_available = attempt_import('tensorflow.keras')
+
 from enum import Enum
 import pandas as pd
 from idaes.surrogate.base.surrogate_base import SurrogateBase

--- a/idaes/surrogate/tests/test_keras_surrogate.py
+++ b/idaes/surrogate/tests/test_keras_surrogate.py
@@ -15,14 +15,6 @@ Tests for KerasSurrogate
 """
 import pytest
 
-try:
-    import tensorflow.keras as keras
-    tensorflow_available = True
-except:
-    # tensorflow is not available, therefore, skip these tests
-    pytestmark = pytest.mark.skip
-    tensorflow_available = False
-
 import os.path
 import pandas as pd
 from pyomo.common.fileutils import this_file_dir
@@ -30,10 +22,12 @@ from pyomo.common.tempfiles import TempfileManager
 from pyomo.environ import (ConcreteModel, Var, SolverFactory,
                            assert_optimal_termination, value,
                            Objective)
-if tensorflow_available:
-    from idaes.surrogate.keras_surrogate import KerasSurrogate, load_keras_json_hd5
-    from idaes.surrogate.surrogate_block import SurrogateBlock
-    from idaes.surrogate.sampling.scaling import OffsetScaler
+from idaes.surrogate.keras_surrogate import KerasSurrogate, load_keras_json_hd5, keras_available
+from idaes.surrogate.surrogate_block import SurrogateBlock
+from idaes.surrogate.sampling.scaling import OffsetScaler
+
+if not keras_available:
+    pytestmark = pytest.mark.skip
 
 rtol = 1e-4
 atol = 1e-4

--- a/idaes/surrogate/tests/test_keras_surrogate.py
+++ b/idaes/surrogate/tests/test_keras_surrogate.py
@@ -27,7 +27,7 @@ from idaes.surrogate.surrogate_block import SurrogateBlock
 from idaes.surrogate.sampling.scaling import OffsetScaler
 
 if not keras_available:
-    pytestmark = pytest.mark.skip
+    pytestmark = pytest.mark.skip("tensorflow.keras not available")
 
 rtol = 1e-4
 atol = 1e-4

--- a/idaes/surrogate/tests/test_keras_surrogate.py
+++ b/idaes/surrogate/tests/test_keras_surrogate.py
@@ -14,6 +14,15 @@
 Tests for KerasSurrogate
 """
 import pytest
+
+try:
+    import tensorflow.keras as keras
+    tensorflow_available = True
+except:
+    # tensorflow is not available, therefore, skip these tests
+    pytestmark = pytest.mark.skip
+    tensorflow_available = False
+
 import os.path
 import pandas as pd
 from pyomo.common.fileutils import this_file_dir
@@ -21,10 +30,10 @@ from pyomo.common.tempfiles import TempfileManager
 from pyomo.environ import (ConcreteModel, Var, SolverFactory,
                            assert_optimal_termination, value,
                            Objective)
-from idaes.surrogate.keras_surrogate import KerasSurrogate, load_keras_json_hd5
-from idaes.surrogate.surrogate_block import SurrogateBlock
-from idaes.surrogate.sampling.scaling import OffsetScaler
-import tensorflow.keras as keras
+if tensorflow_available:
+    from idaes.surrogate.keras_surrogate import KerasSurrogate, load_keras_json_hd5
+    from idaes.surrogate.surrogate_block import SurrogateBlock
+    from idaes.surrogate.sampling.scaling import OffsetScaler
 
 rtol = 1e-4
 atol = 1e-4

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ kwargs = dict(
         "numpy",
         "networkx",
         "omlt==0.3", # fix the version for now as package evolves
-        "tensorflow",
         "pandas",
         "pint",
         "psutil",


### PR DESCRIPTION
## Fixes
- using pyomo attempt_import to make 'tensorflow.keras' an optional import and skipping all of test_keras_surrogate file to skip tests if tensorflow.keras is not available
- removing tensorflow from the list of required dependencies

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
