### PR TITLE
Fixing bug in generic properties initialization

### DIFF
--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -1267,10 +1267,17 @@ class _GenericStateBlock(StateBlock):
                             blk[k].true_to_appr_species[p, j])
                     # Need to calculate all flows before doing mole fractions
                     for p, j in blk[k].params.apparent_phase_component_set:
-                        x = value(
-                            blk[k].flow_mol_phase_comp_apparent[p, j] /
-                            sum(blk[k].flow_mol_phase_comp_apparent[p, jj]
-                                for jj in blk[k].params.apparent_species_set))
+                        sum_flow = sum(
+                            blk[k].flow_mol_phase_comp_apparent[p, jj]
+                            for jj in blk[k].params.apparent_species_set
+                            if (p, jj) in
+                            blk[k].params.apparent_phase_component_set)
+                        if value(sum_flow) == 0:
+                            x = 1
+                        else:
+                            x = value(
+                                blk[k].flow_mol_phase_comp_apparent[p, j] /
+                                sum_flow)
                         lb = blk[k].mole_frac_phase_comp_apparent[p, j].lb
                         if lb is not None and x <= lb:
                             blk[k].mole_frac_phase_comp_apparent[
@@ -1287,10 +1294,17 @@ class _GenericStateBlock(StateBlock):
                             blk[k].appr_to_true_species[p, j])
                     # Need to calculate all flows before doing mole fractions
                     for p, j in blk[k].params.true_phase_component_set:
-                        x = value(
-                            blk[k].flow_mol_phase_comp_true[p, j] /
-                            sum(blk[k].flow_mol_phase_comp_true[p, jj]
-                                for jj in blk[k].params.true_species_set))
+                        sum_flow = sum(
+                            blk[k].flow_mol_phase_comp_true[p, jj]
+                            for jj in blk[k].params.true_species_set
+                            if (p, jj) in
+                            blk[k].params.true_phase_component_set)
+                        if value(sum_flow) == 0:
+                            x = 1
+                        else:
+                            x = value(
+                                blk[k].flow_mol_phase_comp_true[p, j] /
+                                sum_flow)
                         lb = blk[k].mole_frac_phase_comp_true[p, j].lb
                         if lb is not None and x <= lb:
                             blk[k].mole_frac_phase_comp_true[p, j].set_value(lb)

--- a/idaes/surrogate/pysmo/tests/test_utils.py
+++ b/idaes/surrogate/pysmo/tests/test_utils.py
@@ -52,24 +52,24 @@ class TestNumpyEvaluator:
         npe = NumpyEvaluator(cMap)
 
         result = npe.walk_expression(sin(m.x))
-        assert result[0] == sin(4)
-        assert result[1] == sin(5)
-        assert result[2] == sin(6)
+        assert pytest.approx(result[0], rel=1e-12) == sin(4)
+        assert pytest.approx(result[1], rel=1e-12) == sin(5)
+        assert pytest.approx(result[2], rel=1e-12) == sin(6)
 
         result = npe.walk_expression(abs(m.x * m.p[1] - m.p[2]))
-        assert result[0] == .1
-        assert result[1] == -((-1*5)-.2)
-        assert result[2] == (2*6-.3)
+        assert pytest.approx(result[0], rel=1e-12) == .1
+        assert pytest.approx(result[1], rel=1e-12) == -((-1*5)-.2)
+        assert pytest.approx(result[2], rel=1e-12) == (2*6-.3)
 
         result = npe.walk_expression(atan(m.x))
-        assert result[0] == atan(4)
-        assert result[1] == atan(5)
-        assert result[2] == atan(6)
+        assert pytest.approx(result[0], rel=1e-12) == atan(4)
+        assert pytest.approx(result[1], rel=1e-12) == atan(5)
+        assert pytest.approx(result[2], rel=1e-12) == atan(6)
 
         result = npe.walk_expression(atanh(m.p[2]))
-        assert result[0] == atanh(.1)
-        assert result[1] == atanh(.2)
-        assert result[2] == atanh(.3)
+        assert pytest.approx(result[0], rel=1e-12) == atanh(.1)
+        assert pytest.approx(result[1], rel=1e-12) == atanh(.2)
+        assert pytest.approx(result[2], rel=1e-12) == atanh(.3)
 
     @pytest.mark.unit
     def test_eval_constant(self):
@@ -84,11 +84,11 @@ class TestNumpyEvaluator:
         npe = NumpyEvaluator(cMap)
 
         expr = m.p[1] + m.p[2] + m.x + .5
-        assert npe.walk_expression(expr) == 6.75
+        assert npe.walk_expression(expr) == pytest.approx(6.75, rel=1e-12)
 
         m.p[1] = 2
         m.p[2] = 4
-        assert value(expr) == 6.75
+        assert value(expr) == pytest.approx(6.75, rel=1e-12)
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
## Part of https://github.com/watertap-org/watertap/issues/287


## Summary/Motivation:
There was a bug introduced in a recent PR that caused KeyErrors during initialization of generic property models due to sparse phase-component sets.

## Changes proposed in this PR:
- Add checks for sparse phase-component sets in the new code.
- Add a check for potential division-by-zero errors in cases with spare phase-component sets.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
