### PR TITLE
Update to the derived_units method in property_meta.

### DIFF
--- a/idaes/core/property_meta.py
+++ b/idaes/core/property_meta.py
@@ -153,6 +153,8 @@ class PropertyClassMetadata(object):
         # which has not defined units.
         if self._derived_units is None:
             self._create_derived_units()
+            # Update derived_units dict with default_units dict
+            self._derived_units.update(self.default_units)
         return self._derived_units
 
     @property


### PR DESCRIPTION
## Fixes


## Summary/Motivation:
This update allows non-base default units such as energy, pressure defined in property packages to override unit declarations in the _create_derived_units method.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
