### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -45,7 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   # default Python version to use for checks that do not require multiple versions
-  DEFAULT_PYTHON_VERSION: '3.7'
+  DEFAULT_PYTHON_VERSION: '3.8'
   IDAES_CONDA_ENV_NAME_DEV: idaes-pse-dev
   PYTEST_ADDOPTS: "--color=yes"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -164,9 +164,7 @@ jobs:
           # TODO restore all Python versions once tests pass
           - '3.7'
           - '3.8'
-          # WHY anedoctally, we're aware of Python 3.9 having issues with the jupyter stack on Windows
-          # for this reason, we're leaving Python 3.9 commented out for the examples tests until we test properly
-          # - '3.9'
+          - '3.9'
         os:
           - ubuntu-18.04
           - windows-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,7 +126,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
@@ -163,7 +162,6 @@ jobs:
       matrix:
         python-version:
           # TODO restore all Python versions once tests pass
-          - '3.6'
           - '3.7'
           - '3.8'
           # WHY anedoctally, we're aware of Python 3.9 having issues with the jupyter stack on Windows

--- a/.pylint/idaes_reporters.py
+++ b/.pylint/idaes_reporters.py
@@ -29,7 +29,7 @@ class MultiReporter(BaseReporter):
 
     @property
     def elapsed(self):
-        f = time.perf_counter()
+        f = time.perf_counter
         if self._start is None:
             self._start = f()
             return 0.

--- a/.pylint/idaes_reporters.py
+++ b/.pylint/idaes_reporters.py
@@ -29,7 +29,7 @@ class MultiReporter(BaseReporter):
 
     @property
     def elapsed(self):
-        f = time.clock
+        f = time.perf_counter()
         if self._start is None:
             self._start = f()
             return 0.

--- a/README.md
+++ b/README.md
@@ -76,12 +76,11 @@ Most of the functionality is implemented in Python. In accordance with
 the end-of-life for many Python 2 libraries, the IDAES Toolkit is written
 for Python 3. The following sub-versions are supported:
 
-* Python 3.6
 * Python 3.7
 * Python 3.8
 * Python 3.9
 
-Note that Python 3.5 is *not* supported.
+Note that Python 3.6 is *not* supported.
 
 ## Contacts and more information
 

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -19,7 +19,7 @@ The OS specific instructions provide information about optionally installing
 Miniconda. If you already have a Python installation you prefer, you can skip
 the Miniconda install section.
 
-.. note:: IDAES supports Python 3.6 and above.
+.. note:: IDAES supports Python 3.7 and above.
 
 +------------------+-----------------------------+
 | System           | Section                     |

--- a/idaes/surrogate/alamopy.py
+++ b/idaes/surrogate/alamopy.py
@@ -667,13 +667,6 @@ class AlamoTrainer(SurrogateTrainer):
         if trace_fname is not None:
             stream.write(f"TRACEFNAME {trace_fname}\n")
 
-        def _trim_extra_whitespace(text, sep=' '):
-            trimmed_lines = []
-            for line in text.splitlines():
-                parts = [part.strip() for part in line.split()]
-                trimmed_lines.append(str.join(sep, parts))
-            return str.join('\n', trimmed_lines)
-
         def _df_to_data_fragment(df, **kwargs):
             text = df.to_string(
                 header=False,
@@ -681,10 +674,7 @@ class AlamoTrainer(SurrogateTrainer):
                 float_format=lambda x: str(x).format(":g"),
                 **kwargs
             )
-            # This is only needed to remove the extra spaces (from `justify`?)
-            # on python 3.6 since on 3.7 and up pandas.to_string() returns
-            # already the proper format without any further processing needed
-            return _trim_extra_whitespace(text, sep=' ')
+            return text
 
         stream.write("\nBEGIN_DATA\n")
         # Columns will be writen in order in input and output lists

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,6 @@ kwargs = dict(
         "Operating System :: Unix",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Fixes #444

## Changes proposed in this PR:
- Remove Python 3.6 from docs and CI and update Python versions accordingly
- Remove 3.6-specific workarounds from the codebase

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
