### PR TITLE
Fix #654 where tests in test_fsvis.py don't open browser windows anymore

### DIFF
--- a/idaes/ui/fsvis/tests/test_fsvis.py
+++ b/idaes/ui/fsvis/tests/test_fsvis.py
@@ -265,16 +265,23 @@ def test_visualize_save_loadfromsaved(flash_model, save_files_prefix):
     name = "flash_tvslfs"
     save_dir = Path(save_files_prefix).parent
     # save initial
-    result = fsvis.visualize(flowsheet, name, save_dir=save_dir)
+    result = fsvis.visualize(
+        flowsheet, name, save_dir=save_dir, browser=False
+    )
     path_base = save_dir / (name + ".json")
     assert path_base.exists()
     # this time, should use loaded one
     # there should still be only one file
-    result = fsvis.visualize(flowsheet, name, save_dir=save_dir)
+    result = fsvis.visualize(
+        flowsheet, name, save_dir=save_dir, browser=False
+    )
     path_v1 = save_dir / (name + "-1.json")
     assert not path_v1.exists()
     # same behavior with explicit flag
-    result = fsvis.visualize(flowsheet, name, save_dir=save_dir, load_from_saved=True)
+    result = fsvis.visualize(
+        flowsheet, name, save_dir=save_dir, browser=False,
+        load_from_saved=True
+    )
     assert not path_v1.exists()
 
 


### PR DESCRIPTION
## Fixes
#654 

## Summary/Motivation:
Disabling browser windows being opened by the `test_visualize_save_loadfromsaved` test at tes_fsvis.py

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
