### PR TITLE
Change Slice Tags to Reference

### DIFF
--- a/idaes/core/util/tags.py
+++ b/idaes/core/util/tags.py
@@ -63,7 +63,10 @@ class ModelTag:
         """
         super().__init__()
         self._format = format_string  # format string for printing expression
-        self._expression = expr  # tag expression (can be unnamed)
+        if isinstance(expr, IndexedComponent_slice):
+            self._expression = pyo.Reference(expr)  # tag expression (can be unnamed)
+        else:
+            self._expression = expr
         self._doc = doc  # documentation for a tag
         self._display_units = display_units  # unit to display value in
         self._cache_validation_value = {}  # value when converted value stored
@@ -97,9 +100,7 @@ class ModelTag:
             raise KeyError(
                 f"{k} is not a valid index for tag {self._name}"
             ) from key_err
-        if (
-            self._root is None or self.is_slice
-        ):  # cache the unit conversion in root object
+        if (self._root is None):  # cache the unit conversion in root object
             tag._root = self
         else:
             tag._root = self._root
@@ -308,14 +309,6 @@ class ModelTag:
         """
         try:
             return issubclass(self._expression.ctype, pyo.Var)
-        except AttributeError:
-            return False
-
-    @property
-    def is_slice(self):
-        """Whether the tagged expression is a Pyomo slice."""
-        try:
-            return isinstance(self._expression, IndexedComponent_slice)
         except AttributeError:
             return False
 

--- a/idaes/core/util/tests/test_tags.py
+++ b/idaes/core/util/tests/test_tags.py
@@ -439,3 +439,19 @@ def test_doc_example_and_bound(model):
     assert str(g["x"][1]) == "2.000"
     assert abs(g["x"][1].expression.lb - 0.001) < 1e-5 # x is in kg
     assert abs(g["x"][1].expression.ub - 0.003) < 1e-5 # x is in kg
+
+@pytest.mark.unit
+def test_tag_slice(model):
+    m = model
+
+    tw = ModelTag(
+        expr=m.w[1,:],
+        format_string=lambda x: "{:,.0f}" if x >= 100 else "{:.2f}",
+        doc="Tag for x",
+        display_units=pyo.units.g
+    )
+
+    tw.set(1*pyo.units.g)
+    assert str(tw["a"]) == "1.00 g"
+    tw.set(1*pyo.units.kg)
+    assert str(tw["b"]) == "1,000 g"


### PR DESCRIPTION
In the ModeTag class, when you tag a slice convert it to a Reference instead of storing the slice.  That makes the tag value easier to deal with since the indexing is preserved better.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
