### PR TITLE
Updating solver convergence checks

### DIFF
--- a/idaes/apps/caprese/controller.py
+++ b/idaes/apps/caprese/controller.py
@@ -42,7 +42,7 @@ from idaes.core.util.model_statistics import degrees_of_freedom
 
 from pyomo.environ import (
         Objective,
-        TerminationCondition,
+        check_optimal_termination,
         Constraint,
         Block,
         )
@@ -137,7 +137,7 @@ class _ControllerBlockData(_DynamicBlockData):
         #    assert dof == (len(self.INPUT_SET) +
         #            len(self.DIFFERENTIAL_SET))
         results = solver.solve(self, tee=config.tee)
-        if results.solver.termination_condition == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             pass
         else:
             msg = 'Failed to solve for full state setpoint values'

--- a/idaes/apps/caprese/examples/cstr_model.py
+++ b/idaes/apps/caprese/examples/cstr_model.py
@@ -14,26 +14,18 @@
 Test for Cappresse's module for NMPC.
 """
 
-import pytest
-from pyomo.environ import (Block, ConcreteModel,  Constraint, Expression,
-                           Set, SolverFactory, Var, value, units as pyunits,
-                           TransformationFactory, TerminationCondition)
+from pyomo.environ import (
+    ConcreteModel, SolverFactory, units as pyunits, TransformationFactory)
 from pyomo.network import Arc
-from pyomo.common.collections import ComponentSet
 
 from idaes.core import (FlowsheetBlock, MaterialBalanceType, EnergyBalanceType,
-        MomentumBalanceType)
+                        MomentumBalanceType)
 from idaes.core.util.tests.test_initialization import (
-        AqueousEnzymeParameterBlock, EnzymeReactionParameterBlock,
-        EnzymeReactionBlock)
-from idaes.core.util.model_statistics import (degrees_of_freedom, 
-        activated_equalities_generator)
-from idaes.core.util.initialization import initialize_by_time_element
-from idaes.core.util.exceptions import ConfigurationError
+        AqueousEnzymeParameterBlock, EnzymeReactionParameterBlock)
+from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.generic_models.unit_models import CSTR, Mixer, MomentumMixingType
 from idaes.apps.caprese import nmpc
 from idaes.apps.caprese.nmpc import *
-import idaes.logger as idaeslog
 
 __author__ = "Robert Parker"
 

--- a/idaes/apps/caprese/tests/test_categorize_cstr.py
+++ b/idaes/apps/caprese/tests/test_categorize_cstr.py
@@ -15,23 +15,14 @@ Test for Caprese's module for NMPC.
 """
 
 import pytest
-from pyomo.environ import (Block, ConcreteModel,  Constraint, Expression,
-                           Set, SolverFactory, Var, value, 
-                           TransformationFactory, TerminationCondition)
-from pyomo.network import Arc
+from pyomo.environ import Var
 from pyomo.common.collections import ComponentSet
 from pyomo.dae.flatten import flatten_dae_components
 
-from idaes.core import (FlowsheetBlock, MaterialBalanceType, EnergyBalanceType,
-        MomentumBalanceType)
-from idaes.core.util.model_statistics import (degrees_of_freedom, 
-        activated_equalities_generator)
 from idaes.apps.caprese.categorize import (
         categorize_dae_variables,
-        categorize_dae_variables_and_constraints,
         )
 from idaes.apps.caprese.common.config import VariableCategory as VC
-import idaes.logger as idaeslog
 from idaes.apps.caprese.examples.cstr_model import make_model
 
 __author__ = "Robert Parker"

--- a/idaes/apps/caprese/util.py
+++ b/idaes/apps/caprese/util.py
@@ -16,9 +16,9 @@ A module of helper functions for working with flattened DAE models.
 """
 
 from pyomo.environ import (
+        check_optimal_termination,
         Constraint,
         Var,
-        TerminationCondition,
         SolverFactory,
         )
 from pyomo.common.collections import ComponentSet, ComponentMap
@@ -156,7 +156,7 @@ def initialize_by_element_in_range(model, time, t_start, t_end,
         assert degrees_of_freedom(model) == 0
         with idaeslog.solver_log(solver_log, level=idaeslog.DEBUG) as slc:
             results = solver.solve(model, tee=slc.tee)
-        if results.solver.termination_condition == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             pass
         else:
             raise ValueError(
@@ -245,7 +245,7 @@ def initialize_by_element_in_range(model, time, t_start, t_end,
 
         with idaeslog.solver_log(solver_log, level=idaeslog.DEBUG) as slc:
             results = solver.solve(model, tee=slc.tee)
-        if results.solver.termination_condition == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             pass
         else:
             raise ValueError(

--- a/idaes/core/unit_model.py
+++ b/idaes/core/unit_model.py
@@ -14,7 +14,7 @@
 Base class for unit models
 """
 
-from pyomo.environ import Reference, SolverStatus, TerminationCondition
+from pyomo.environ import check_optimal_termination, Reference
 from pyomo.network import Port
 from pyomo.common.config import ConfigValue
 
@@ -657,9 +657,7 @@ Must be True if dynamic = True,
         # Release Inlet state
         blk.control_volume.release_state(flags, outlvl)
 
-        if (results.solver.termination_condition !=
-                TerminationCondition.optimal or
-                results.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(results):
             raise InitializationError(
                 f"{blk.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/core/util/initialization.py
+++ b/idaes/core/util/initialization.py
@@ -16,7 +16,7 @@ This module contains utility functions for initialization of IDAES models.
 """
 
 from pyomo.environ import (
-    Block, Constraint, Param, TerminationCondition, Var, value)
+    Block, check_optimal_termination, Constraint, Param, Var, value)
 from pyomo.network import Arc
 from pyomo.dae import ContinuousSet
 from pyomo.core.expr.visitor import identify_variables
@@ -358,7 +358,7 @@ def initialize_by_time_element(fs, time, **kwargs):
     'Model is inactive except at t=0. Solving for consistent initial conditions.')
     with idaeslog.solver_log(solver_log, level=idaeslog.DEBUG) as slc:
         results = solver.solve(fs, tee=slc.tee)
-    if results.solver.termination_condition == TerminationCondition.optimal:
+    if check_optimal_termination(results):
         init_log.info('Successfully solved for consistent initial conditions')
     else:
         init_log.error('Failed to solve for consistent initial conditions')
@@ -456,7 +456,7 @@ def initialize_by_time_element(fs, time, **kwargs):
 
         with idaeslog.solver_log(solver_log, level=idaeslog.DEBUG) as slc:
             results = solver.solve(fs, tee=slc.tee)
-        if results.solver.termination_condition == TerminationCondition.optimal:
+        if check_optimal_termination(results):
            init_log.info(f'Successfully solved finite element {i}')
         else:
            init_log.error(f'Failed to solve finite element {i}')

--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -26,8 +26,6 @@ from scipy.sparse import issparse, find
 
 from idaes.core.util.model_statistics import large_residuals_set, variables_near_bounds_set
 
-from pyomo.opt import SolverStatus, TerminationCondition
-
 import matplotlib.pyplot as plt
 
 from operator import itemgetter

--- a/idaes/core/util/phase_equilibria.py
+++ b/idaes/core/util/phase_equilibria.py
@@ -19,7 +19,8 @@ plots.
 __author__ = "Alejandro Garciadiego"
 
 # Import objects from pyomo package
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            SolverFactory,
                            value,
                            Var,
@@ -28,7 +29,6 @@ from pyomo.environ import (ConcreteModel,
                            units as pyunits)
 import idaes.logger as idaeslog
 from idaes.core.util import get_solver
-from pyomo.opt import TerminationCondition, SolverStatus
 
 import idaes.logger as idaeslog
 
@@ -152,7 +152,7 @@ def Txy_data(model, component_1, component_2, pressure, num_points = 20, tempera
         # solve the model
         status = solver.solve(model, tee = False)
         # If solution is optimal store the concentration, and calculated temperatures in the created arrays
-        if (status.solver.status == SolverStatus.ok) and (status.solver.termination_condition == TerminationCondition.optimal):
+        if check_optimal_termination(status):
 
             print('Case: ',count,' Optimal. ', component_1, 'x = {:.2f}'.format(x_d[i]))
 

--- a/idaes/core/util/tests/test_initialization.py
+++ b/idaes/core/util/tests/test_initialization.py
@@ -17,7 +17,7 @@ Tests for math util methods.
 import pytest
 from pyomo.environ import (Block, ConcreteModel, Constraint, Expression, exp,
                            Set, Var, value, Param, Reals, units as pyunits,
-                           TransformationFactory, TerminationCondition)
+                           TransformationFactory, check_optimal_termination)
 from pyomo.network import Arc, Port
 
 from idaes.core import (FlowsheetBlock,
@@ -1021,4 +1021,4 @@ def test_initialize_by_time_element():
         assert value(con.lower) - value(con.body) < 1e-5
 
     results = solver.solve(m.fs)
-    assert results.solver.termination_condition == TerminationCondition.optimal
+    assert check_optimal_termination(results)

--- a/idaes/core/util/tests/test_pid_initialization.py
+++ b/idaes/core/util/tests/test_pid_initialization.py
@@ -17,27 +17,15 @@ and differential variables.
 """
 
 import pytest
-from pyomo.environ import (Block, ConcreteModel, Constraint, Expression,
-                           Set, SolverFactory, Var, value, Param, Reals,
-                           TransformationFactory, TerminationCondition,
-                           exp, units as pyunits)
-from pyomo.network import Arc, Port
-from pyomo.dae import DerivativeVar
+from pyomo.environ import (Block, ConcreteModel, Constraint, Var,
+                           TransformationFactory, units as pyunits)
+from pyomo.network import Arc
 from pyomo.common.collections import ComponentMap
 
-from idaes.core import (FlowsheetBlock, 
-                        MaterialBalanceType, 
+from idaes.core import (FlowsheetBlock,
+                        MaterialBalanceType,
                         EnergyBalanceType,
-                        MomentumBalanceType, 
-                        declare_process_block_class,
-                        PhysicalParameterBlock,
-                        StateBlock,
-                        StateBlockData,
-                        ReactionParameterBlock,
-                        ReactionBlockBase,
-                        ReactionBlockDataBase,
-                        MaterialFlowBasis)
-from idaes.core.util.testing import PhysicalParameterTestBlock
+                        MomentumBalanceType)
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.generic_models.unit_models import CSTR, Mixer, MomentumMixingType
 from idaes.generic_models.control import PIDBlock, PIDForm

--- a/idaes/core/util/tests/test_unit_costing.py
+++ b/idaes/core/util/tests/test_unit_costing.py
@@ -98,9 +98,7 @@ def test_costing_FH_solve():
                           abs=1e-2) == 962795.521)
     results = solver.solve(m, tee=False)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
     assert (pytest.approx(pyo.value(m.fs.unit.costing.purchase_cost),
                           abs=1e-2) == 962795.521)  # Example 22.1 Ref Book
 
@@ -158,9 +156,7 @@ def test_costing_distillation_solve():
 
     results = solver.solve(m, tee=False)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
     assert (pytest.approx(pyo.value(m.fs.unit.costing.base_cost),
                           abs=1e-2) == 636959.6929)  # Example 22.13 Ref Book
     assert (pytest.approx(pyo.value(m.fs.unit.costing.base_cost_platf_ladders),
@@ -216,9 +212,7 @@ def test_blower_build_and_solve():
     assert isinstance(m.fs.unit.costing.purchase_cost, pyo.Var)
     assert isinstance(m.fs.unit.costing.base_cost_per_unit, pyo.Var)
     results = solver.solve(m, tee=True)
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
     assert (pytest.approx(pyo.value(m.fs.unit.costing.base_cost),
                           abs=1e-2) == 56026.447)
     assert (pytest.approx(pyo.value(m.fs.unit.costing.purchase_cost),
@@ -272,9 +266,7 @@ def test_compressor_fan():
     assert isinstance(m.fs.unit.costing.purchase_cost, pyo.Var)
     assert isinstance(m.fs.unit.costing.base_cost_per_unit, pyo.Var)
     results = solver.solve(m, tee=True)
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
     assert (pytest.approx(pyo.value(m.fs.unit.costing.base_cost),
                           abs=1e-2) == 4543.6428)
     assert (pytest.approx(pyo.value(m.fs.unit.costing.purchase_cost),

--- a/idaes/core/util/tests/test_utility_minimization.py
+++ b/idaes/core/util/tests/test_utility_minimization.py
@@ -18,10 +18,9 @@ IDAES models.
 __author__ = "Alejandro Garciadiego"
 
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Objective,
-                           SolverStatus,
-                           TerminationCondition,
                            units as pyunits)
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util import get_solver
@@ -188,9 +187,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.initialize
     @pytest.mark.solver

--- a/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_gas_prop.py
+++ b/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_gas_prop.py
@@ -17,10 +17,7 @@ Author: Chinedu Okoli
 
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
-                           Var)
+from pyomo.environ import check_optimal_termination, ConcreteModel, Var
 
 from idaes.core import FlowsheetBlock
 
@@ -95,9 +92,7 @@ def test_solve(gas_prop):
     results = solver.solve(gas_prop)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
 
 @pytest.mark.solver

--- a/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_rxn_prop.py
+++ b/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_rxn_prop.py
@@ -17,10 +17,7 @@ Author: Chinedu Okoli
 
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
-                           Var)
+from pyomo.environ import check_optimal_termination, ConcreteModel, Var
 
 from idaes.core import FlowsheetBlock
 
@@ -115,9 +112,7 @@ def test_solve(rxn_prop):
     results = solver.solve(rxn_prop.fs.unit)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
 
 @pytest.mark.solver

--- a/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_solid_prop.py
+++ b/idaes/gas_solid_contactors/properties/methane_iron_OC_reduction/tests/test_CLC_solid_prop.py
@@ -17,10 +17,7 @@ Author: Chinedu Okoli
 
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
-                           Var)
+from pyomo.environ import check_optimal_termination, ConcreteModel, Var
 
 from idaes.core import FlowsheetBlock
 
@@ -80,6 +77,7 @@ def test_initialize(solid_prop):
     initialization_tester(
             solid_prop)
 
+
 @pytest.mark.solver
 @pytest.mark.skipif(solver is None, reason="Solver not available")
 @pytest.mark.component
@@ -92,9 +90,7 @@ def test_solve(solid_prop):
     results = solver.solve(solid_prop)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
 
 @pytest.mark.solver

--- a/idaes/gas_solid_contactors/properties/oxygen_iron_OC_oxidation/tests/test_CLC_gas_prop.py
+++ b/idaes/gas_solid_contactors/properties/oxygen_iron_OC_oxidation/tests/test_CLC_gas_prop.py
@@ -18,10 +18,9 @@ Author: Chinedu Okoli
 import pytest
 
 from pyomo.environ import (
+        check_optimal_termination,
         ConcreteModel,
         Constraint,
-        TerminationCondition,
-        SolverStatus,
         Var,
         Reference,
         value,
@@ -115,9 +114,7 @@ def test_solve(gas_prop):
     results = solver.solve(gas_prop)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
 
 @pytest.mark.solver

--- a/idaes/gas_solid_contactors/properties/oxygen_iron_OC_oxidation/tests/test_CLC_rxn_prop.py
+++ b/idaes/gas_solid_contactors/properties/oxygen_iron_OC_oxidation/tests/test_CLC_rxn_prop.py
@@ -18,9 +18,8 @@ Author: Chinedu Okoli
 import pytest
 
 from pyomo.environ import (
+        check_optimal_termination,
         ConcreteModel,
-        TerminationCondition,
-        SolverStatus,
         Var,
         Constraint,
         value,
@@ -129,9 +128,7 @@ def test_solve(rxn_prop):
     results = solver.solve(rxn_prop.fs.unit)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
 
 @pytest.mark.solver

--- a/idaes/gas_solid_contactors/properties/oxygen_iron_OC_oxidation/tests/test_CLC_solid_prop.py
+++ b/idaes/gas_solid_contactors/properties/oxygen_iron_OC_oxidation/tests/test_CLC_solid_prop.py
@@ -18,9 +18,8 @@ Author: Chinedu Okoli
 import pytest
 
 from pyomo.environ import (
+        check_optimal_termination,
         ConcreteModel,
-        TerminationCondition,
-        SolverStatus,
         Var,
         Constraint,
         value,
@@ -107,9 +106,7 @@ def test_solve(solid_prop):
     results = solver.solve(solid_prop)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
 
 @pytest.mark.solver

--- a/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
@@ -33,7 +33,7 @@ import matplotlib.pyplot as plt
 
 # Import Pyomo libraries
 from pyomo.environ import (Var, Param, Reals,
-                           TerminationCondition, Constraint,
+                           check_optimal_termination, Constraint,
                            TransformationFactory, sqrt, value)
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
@@ -1625,8 +1625,7 @@ see reaction package for documentation.}"""))
         init_log.info('Initialize Geometric Constraints')
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
             results = opt.solve(blk, tee=slc.tee)
-        if results.solver.termination_condition \
-                == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             init_log.info_high(
                 "Initialization Step 2 {}.".format(
                         idaeslog.condition(results))
@@ -1708,8 +1707,7 @@ see reaction package for documentation.}"""))
         init_log.info('Initialize Hydrodynamics')
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
             results = opt.solve(blk, tee=slc.tee)
-        if results.solver.termination_condition \
-                == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             init_log.info_high(
                 "Initialization Step 3 {}.".format(
                         idaeslog.condition(results))
@@ -1837,8 +1835,7 @@ see reaction package for documentation.}"""))
         init_log.info_high('initialize mass balances with no reactions')
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
             results = opt.solve(blk, tee=slc.tee)
-        if results.solver.termination_condition \
-                == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             init_log.info_high(
                 "Initialization Step 4a {}.".format(
                         idaeslog.condition(results))
@@ -1961,8 +1958,7 @@ see reaction package for documentation.}"""))
             init_log.info_high('initialize mass balances with reactions')
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = opt.solve(blk, tee=slc.tee)
-            if results.solver.termination_condition \
-                    == TerminationCondition.optimal:
+            if check_optimal_termination(results):
                 init_log.info_high(
                     "Initialization Step 4b {}.".format(
                             idaeslog.condition(results))
@@ -2024,8 +2020,7 @@ see reaction package for documentation.}"""))
             init_log.info('Initialize Energy Balances')
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = opt.solve(blk, tee=slc.tee)
-            if results.solver.termination_condition \
-                    == TerminationCondition.optimal:
+            if check_optimal_termination(results):
                 init_log.info_high(
                     "Initialization Step 5 {}.".format(
                             idaeslog.condition(results))
@@ -2049,8 +2044,7 @@ see reaction package for documentation.}"""))
             init_log.info('Initialize Energy Balances')
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = opt.solve(blk, tee=slc.tee)
-            if results.solver.termination_condition \
-                    == TerminationCondition.optimal:
+            if check_optimal_termination(results):
                 init_log.info_high(
                     "Initialization Step 5 {}.".format(
                             idaeslog.condition(results))
@@ -2089,8 +2083,7 @@ see reaction package for documentation.}"""))
         init_log.info('Initialize Outlet Conditions')
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
             results = opt.solve(blk, tee=slc.tee)
-        if results.solver.termination_condition \
-                == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             init_log.info_high(
                 "Initialization Step 6 {}.".format(
                         idaeslog.condition(results))

--- a/idaes/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/moving_bed.py
@@ -38,7 +38,7 @@ import matplotlib.pyplot as plt
 # Import Pyomo libraries
 from pyomo.environ import (Var, Param, Reals, value,
                            TransformationFactory, Constraint,
-                           TerminationCondition)
+                           check_optimal_termination)
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.dae import ContinuousSet
@@ -884,8 +884,7 @@ see reaction package for documentation.}"""))
         init_log.info('Initialize Hydrodynamics')
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
             results = opt.solve(blk, tee=slc.tee)
-        if results.solver.termination_condition \
-                == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             init_log.info_high(
                 "Initialization Step 2 {}.".format(
                         idaeslog.condition(results))
@@ -942,8 +941,7 @@ see reaction package for documentation.}"""))
                            'and no pressure drop')
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
             results = opt.solve(blk, tee=slc.tee)
-        if results.solver.termination_condition \
-                == TerminationCondition.optimal:
+        if check_optimal_termination(results):
             init_log.info_high(
                 "Initialization Step 3a {}.".format(
                         idaeslog.condition(results))
@@ -1052,8 +1050,7 @@ see reaction package for documentation.}"""))
                                'and no pressure drop')
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = opt.solve(blk, tee=slc.tee)
-            if results.solver.termination_condition \
-                    == TerminationCondition.optimal:
+            if check_optimal_termination(results):
                 init_log.info_high(
                     "Initialization Step 3b {}.".format(
                             idaeslog.condition(results))
@@ -1088,8 +1085,7 @@ see reaction package for documentation.}"""))
                                'and pressure drop')
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = opt.solve(blk, tee=slc.tee)
-            if results.solver.termination_condition \
-                    == TerminationCondition.optimal:
+            if check_optimal_termination(results):
                 init_log.info_high(
                     "Initialization Step 3c {}.".format(
                             idaeslog.condition(results))
@@ -1152,8 +1148,7 @@ see reaction package for documentation.}"""))
             init_log.info('Initialize Energy Balances')
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = opt.solve(blk, tee=slc.tee)
-            if results.solver.termination_condition \
-                    == TerminationCondition.optimal:
+            if check_optimal_termination(results):
                 init_log.info_high(
                     "Initialization Step 4 {}.".format(
                             idaeslog.condition(results))
@@ -1182,8 +1177,7 @@ see reaction package for documentation.}"""))
             init_log.info('Initialize Energy Balances')
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 results = opt.solve(blk, tee=slc.tee)
-            if results.solver.termination_condition \
-                    == TerminationCondition.optimal:
+            if check_optimal_termination(results):
                 init_log.info_high(
                     "Initialization Step 4 {}.".format(
                             idaeslog.condition(results))

--- a/idaes/gas_solid_contactors/unit_models/tests/test_BFB.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_BFB.py
@@ -19,9 +19,8 @@ Author: Chinedu Okoli
 
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            value,
                            Var,
                            Constraint)
@@ -238,9 +237,7 @@ class TestIronOC(object):
         results = solver.solve(iron_oc)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -446,9 +443,7 @@ class TestIronOC_EnergyBalanceType(object):
         results = solver.solve(iron_oc)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/gas_solid_contactors/unit_models/tests/test_FB0D.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_FB0D.py
@@ -18,10 +18,9 @@ Author: Brandon Paul
 
 import pytest
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            TransformationFactory,
-                           TerminationCondition,
-                           SolverStatus,
                            value,
                            units as pyunits,
                            Constraint)
@@ -185,9 +184,7 @@ class TestIronOC(object):
         results = solver.solve(iron_oc)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -401,9 +398,7 @@ class TestIronOC_EnergyBalanceType(object):
         results = solver.solve(iron_oc)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/gas_solid_contactors/unit_models/tests/test_MB.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_MB.py
@@ -18,9 +18,8 @@ Author: Chinedu Okoli
 
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            value,
                            Var,
                            Constraint)
@@ -229,9 +228,7 @@ class TestIronOC(object):
         results = solver.solve(iron_oc)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -424,9 +421,7 @@ class TestIronOC_EnergyBalanceType(object):
         results = solver.solve(iron_oc)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/properties/activity_coeff_models/activity_coeff_prop_pack.py
+++ b/idaes/generic_models/properties/activity_coeff_models/activity_coeff_prop_pack.py
@@ -42,7 +42,8 @@ References:
 """
 
 # Import Pyomo libraries
-from pyomo.environ import (Constraint,
+from pyomo.environ import (check_optimal_termination,
+                           Constraint,
                            log,
                            NonNegativeReals,
                            value,
@@ -51,9 +52,7 @@ from pyomo.environ import (Constraint,
                            Expression,
                            Param,
                            sqrt,
-                           units as pyunits,
-                           SolverStatus,
-                           TerminationCondition)
+                           units as pyunits)
 from pyomo.common.config import ConfigValue, In
 
 # Import IDAES cores
@@ -397,8 +396,7 @@ class _ActivityCoeffStateBlock(StateBlock):
             res = solve_indexed_blocks(opt, [blk], tee=slc.tee)
         init_log.info("Initialization Step 5 {}.".format(idaeslog.condition(res)))
 
-        if (res.solver.termination_condition != TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(res):
             raise InitializationError(
                 f"{blk.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/properties/activity_coeff_models/tests/test_ideal_ideal_FTPz.py
+++ b/idaes/generic_models/properties/activity_coeff_models/tests/test_ideal_ideal_FTPz.py
@@ -18,8 +18,7 @@ from VLE data to compute the activity coefficients.
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import ConcreteModel, TerminationCondition, \
-    SolverStatus, value
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -137,8 +136,7 @@ def test_solve():
     results = solver.solve(m.fs.state_block_ideal_vl_FTPz, tee=False)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
     # Check for VLE results
     assert value(m.fs.state_block_ideal_vl_FTPz.mole_frac_phase_comp['Liq',
@@ -153,8 +151,7 @@ def test_solve():
     results = solver.solve(m.fs.state_block_ideal_l, tee=False)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
     # Check for results
     assert value(m.fs.state_block_ideal_l.mole_frac_phase_comp['Liq',
@@ -169,8 +166,7 @@ def test_solve():
     results = solver.solve(m.fs.state_block_ideal_v, tee=False)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
     # Check for results
     assert value(m.fs.state_block_ideal_v.mole_frac_phase_comp['Vap',

--- a/idaes/generic_models/properties/activity_coeff_models/tests/test_ideal_ideal_FcTP.py
+++ b/idaes/generic_models/properties/activity_coeff_models/tests/test_ideal_ideal_FcTP.py
@@ -17,8 +17,7 @@ state vars tested are FcTP.
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import ConcreteModel, TerminationCondition, \
-    SolverStatus, value
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -136,8 +135,7 @@ def test_solve():
     results = solver.solve(m.fs.state_block_ideal_vl, tee=False)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
     # Check for VLE results
     assert value(m.fs.state_block_ideal_vl.
@@ -152,8 +150,7 @@ def test_solve():
     results = solver.solve(m.fs.state_block_ideal_l, tee=False)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
     # Check for results
     assert value(m.fs.state_block_ideal_l.flow_mol_phase_comp['Liq',
@@ -168,8 +165,7 @@ def test_solve():
     results = solver.solve(m.fs.state_block_ideal_v, tee=False)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
     # Check for results
     assert value(m.fs.state_block_ideal_v.flow_mol_phase_comp['Vap',

--- a/idaes/generic_models/properties/core/eos/tests/test_ceos_CO2_H2O.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_ceos_CO2_H2O.py
@@ -20,16 +20,15 @@ import pytest
 from sys import modules
 import os
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Expression,
                            Param,
                            Constraint,
                            value,
                            Var,
-                           units as pyunits,
-                           TerminationCondition,
-                           SolverStatus)
+                           units as pyunits)
 
 from idaes.core import (declare_process_block_class,
                         LiquidPhase, VaporPhase, SolidPhase)
@@ -93,9 +92,7 @@ def build_model():
     m.props.initialize(state_vars_fixed=True)
     results = get_solver(options={"bound_push": 1e-8}).solve(m)
 
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
     return m
 

--- a/idaes/generic_models/properties/core/eos/tests/test_haber_bosch_validation_PR.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_haber_bosch_validation_PR.py
@@ -42,7 +42,8 @@ import pandas as pd
 import pytest
 from pytest import approx
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Expression,
                            Constraint,
                            ExternalFunction,
@@ -50,8 +51,6 @@ from pyomo.environ import (ConcreteModel,
                            Param,
                            Reals,
                            SolverFactory,
-                           SolverStatus,
-                           TerminationCondition,
                            sqrt,
                            value,
                            Var,
@@ -280,8 +279,7 @@ def get_reference_entropy(comp):
     solver = SolverFactory('ipopt')
     results = solver.solve(m)
     
-    assert results.solver.termination_condition == TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
     assert (value(m.S_ref) 
             == approx(value(m.props.entr_mol_phase_comp["Vap",comp]), rel=1E-12))
     
@@ -443,8 +441,7 @@ def test_thermo(model,dataframe):
             prop.pressure.fix(row["P"]*1E6)
         tester.set_pressure(row["P"]*1E6)
         results = solver.solve(m)
-        assert results.solver.termination_condition == TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
         
         # Make sure that log mole fractions have been created and validated
         for comp in tester.component_list:

--- a/idaes/generic_models/properties/core/examples/reactions/tests/test_reaction_example.py
+++ b/idaes/generic_models/properties/core/examples/reactions/tests/test_reaction_example.py
@@ -14,11 +14,10 @@
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import (Block,
+from pyomo.environ import (check_optimal_termination,
+                           Block,
                            ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value)
 from pyomo.util.check_units import assert_units_consistent
 
@@ -153,9 +152,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.initialize
     @pytest.mark.solver

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR.py
@@ -14,10 +14,9 @@
 Author: Andrew Lee, Alejandro Garciadiego
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -239,9 +238,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     def test_solution(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_ASU_PR_Dowling_2015.py
@@ -14,10 +14,9 @@
 Author: Andrew Lee, Alejandro Garciadiego
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -243,9 +242,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     def test_solution(self, model):
@@ -284,9 +281,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
 
         assert model.props[1].mole_frac_phase_comp["Vap", "nitrogen"].value == \
@@ -317,9 +312,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
 
         assert model.props[1].mole_frac_phase_comp["Liq", "nitrogen"].value == \

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal.py
@@ -14,10 +14,9 @@
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -284,9 +283,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FPhx.py
@@ -14,10 +14,9 @@
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -376,9 +375,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcPh.py
@@ -14,11 +14,10 @@
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Expression,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -377,9 +376,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     def test_solution(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BTIdeal_FcTP.py
@@ -14,11 +14,10 @@
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Expression,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -364,9 +363,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     def test_solution(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_BT_PR.py
@@ -25,10 +25,9 @@ from idaes.generic_models.properties.core.generic.generic_property import (
         GenericParameterBlock)
 from pyomo.util.check_units import assert_units_consistent
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Objective,
-                           SolverStatus,
-                           TerminationCondition,
                            value)
 
 from idaes.core.util import get_solver
@@ -101,8 +100,7 @@ class TestBTExample(object):
 
             results = solver.solve(m)
 
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
+            assert check_optimal_termination(results)
             assert m.fs.state[1].flow_mol_phase["Liq"].value <= 1e-5
 
     @pytest.mark.integration
@@ -118,15 +116,13 @@ class TestBTExample(object):
 
             results = solver.solve(m)
 
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
+            assert check_optimal_termination(results)
 
             while m.fs.state[1].pressure.value <= 1e6:
                 m.fs.state[1].pressure.value = (
                     m.fs.state[1].pressure.value + 1e5)
                 results = solver.solve(m)
-                assert results.solver.termination_condition == \
-                    TerminationCondition.optimal
+                assert check_optimal_termination(results)
                 print(T, m.fs.state[1].pressure.value)
 
     @pytest.mark.component
@@ -146,9 +142,7 @@ class TestBTExample(object):
         results = solver.solve(m)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(value(
             m.fs.state[1]._teq[("Vap", "Liq")]), abs=1e-1) == 365
@@ -208,9 +202,7 @@ class TestBTExample(object):
         results = solver.solve(m)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(value(
             m.fs.state[1]._teq[("Vap", "Liq")]), 1e-5) == 431.47
@@ -270,9 +262,7 @@ class TestBTExample(object):
         results = solver.solve(m)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(value(
             m.fs.state[1]._teq[("Vap", "Liq")]), 1e-5) == 371.4
@@ -332,9 +322,7 @@ class TestBTExample(object):
         results = solver.solve(m)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(value(
             m.fs.state[1]._teq[("Vap", "Liq")]), 1e-5) == 436.93
@@ -394,9 +382,7 @@ class TestBTExample(object):
         results = solver.solve(m)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(value(
             m.fs.state[1]._teq[("Vap", "Liq")]), 1e-5) == 368
@@ -460,9 +446,7 @@ class TestBTExample(object):
         results = solver.solve(m)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(value(
             m.fs.state[1]._teq[("Vap", "Liq")]), 1e-5) == 376

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_H2O_Ideal_VLE.py
@@ -16,10 +16,9 @@ Authors: Anuja Deshpande, Andrew Lee
 import pytest
 import numpy as np
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -224,9 +223,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     def test_solution(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_CO2_bmimPF6_PR.py
@@ -14,10 +14,9 @@
 Author: Andrew Lee, Alejandro Garciadiego
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -291,9 +290,7 @@ class TestFlashIntegration(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     def test_solution(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR.py
@@ -15,10 +15,9 @@ Author: Andrew Lee, Alejandro Garciadiego
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -325,9 +324,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.integration
     def test_solution(self, model):

--- a/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
+++ b/idaes/generic_models/properties/core/examples/tests/test_HC_PR_vap.py
@@ -15,11 +15,10 @@ Author: Andrew Lee, Alejandro Garciadiego
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            Var,
                            units as pyunits)
@@ -345,9 +344,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/properties/core/generic/generic_property.py
+++ b/idaes/generic_models/properties/core/generic/generic_property.py
@@ -18,6 +18,7 @@ import types
 
 # Import Pyomo libraries
 from pyomo.environ import (Block,
+                           check_optimal_termination,
                            Constraint,
                            exp,
                            Expression,
@@ -27,9 +28,7 @@ from pyomo.environ import (Block,
                            value,
                            Var,
                            units as pyunits,
-                           Reference,
-                           TerminationCondition,
-                           SolverStatus)
+                           Reference)
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 
@@ -1429,10 +1428,7 @@ class _GenericStateBlock(StateBlock):
                         .state_definition.do_not_initialize):
                     c.activate()
 
-        if (res is not None and (
-                res.solver.termination_condition !=
-                TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok)):
+        if res is not None and not check_optimal_termination(res):
             raise InitializationError(
                 f"{blk.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/properties/core/generic/tests/test_generic_property_integration.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_generic_property_integration.py
@@ -19,8 +19,8 @@ import pytest
 
 # Import Pyomo units
 from pyomo.environ import (
-    ConcreteModel, Constraint, Expression, SolverStatus,
-    TerminationCondition, units as pyunits, value)
+    check_optimal_termination, ConcreteModel, Constraint, Expression, 
+    units as pyunits, value)
 
 # Import IDAES cores
 from idaes.core import (
@@ -178,9 +178,7 @@ class TestInherentReactions(object):
 
         results = solver.solve(frame)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert value(
             frame.fs.H101.control_volume.properties_out[0].k_eq["e1"]) == 2
@@ -228,9 +226,7 @@ class TestInherentReactions(object):
 
         results = solver.solve(frame)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert value(
             frame.fs.H101.control_volume.properties_out[0].k_eq["e1"]) == 2
@@ -292,9 +288,7 @@ class TestInherentReactions(object):
 
         results = solver.solve(frame)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(2, rel=1e-8) == value(
             frame.fs.cv.properties[0, 1].k_eq["e1"])
@@ -357,9 +351,7 @@ class TestInherentReactions(object):
 
         results = solver.solve(frame)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(2, rel=1e-8) == value(
             frame.fs.cv.properties[0, 1].k_eq["e1"])

--- a/idaes/generic_models/properties/core/generic/tests/test_noncondense.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_noncondense.py
@@ -19,10 +19,9 @@ Author: Andrew Lee
 import pytest
 
 # Import Pyomo components
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            units as pyunits)
 
@@ -263,9 +262,7 @@ class TestNonCondensable_Liquid(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     @pytest.mark.solver
@@ -375,9 +372,7 @@ class TestNonCondensable_Vapour(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     @pytest.mark.solver

--- a/idaes/generic_models/properties/core/generic/tests/test_noncondense_PR.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_noncondense_PR.py
@@ -19,10 +19,9 @@ Author: Andrew Lee
 import pytest
 
 # Import Pyomo components
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            units as pyunits)
 
@@ -254,9 +253,7 @@ class TestNonCondensable_Liquid(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     @pytest.mark.solver
@@ -365,9 +362,7 @@ class TestNonCondensable_Vapour(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     @pytest.mark.solver

--- a/idaes/generic_models/properties/core/generic/tests/test_nonvap.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_nonvap.py
@@ -19,10 +19,9 @@ Author: Andrew Lee
 import pytest
 
 # Import Pyomo components
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            units as pyunits)
 
@@ -264,9 +263,7 @@ class TestNonVapourisable_Vapour(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     @pytest.mark.solver
@@ -375,9 +372,7 @@ class TestNonVapourisable_Liquid(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     @pytest.mark.solver

--- a/idaes/generic_models/properties/core/generic/tests/test_nonvap_PR.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_nonvap_PR.py
@@ -19,10 +19,9 @@ Author: Andrew Lee
 import pytest
 
 # Import Pyomo components
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            units as pyunits)
 
@@ -253,9 +252,7 @@ class TestNonVapourisable_Vapour(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     @pytest.mark.solver
@@ -364,9 +361,7 @@ class TestNonVapourisable_Liquid(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.component
     @pytest.mark.solver

--- a/idaes/generic_models/properties/core/generic/tests/test_vle.py
+++ b/idaes/generic_models/properties/core/generic/tests/test_vle.py
@@ -19,10 +19,9 @@ Author: Andrew Lee
 import pytest
 
 # Import Pyomo components
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Set,
-                           SolverStatus,
-                           TerminationCondition,
                            value,
                            units as pyunits)
 
@@ -241,9 +240,7 @@ class TestNoHenryComps(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(365.35, abs=0.01) == value(
             model.props[1].temperature_bubble[("Vap", "Liq")])
@@ -491,9 +488,7 @@ class TestHenryComps0(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(365.35, abs=0.01) == value(
             model.props[1].temperature_bubble[("Vap", "Liq")])
@@ -648,9 +643,7 @@ class TestHenryComps(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(361.50, abs=0.01) == value(
             model.props[1].temperature_bubble[("Vap", "Liq")])

--- a/idaes/generic_models/properties/core/reactions/tests/test_solubility_product_verification.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_solubility_product_verification.py
@@ -17,7 +17,7 @@ Tests for rate forms
 import pytest
 
 from pyomo.environ import \
-    ConcreteModel, units as pyunits, value, SolverStatus, TerminationCondition
+    check_optimal_termination, ConcreteModel, units as pyunits, value
 
 # Import IDAES cores
 from idaes.generic_models.properties.core.generic.generic_property import \
@@ -138,9 +138,7 @@ class TestSingleState(object):
 
             results = solver.solve(model)
 
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
-            assert results.solver.status == SolverStatus.ok
+            assert check_optimal_termination(results)
 
             assert pytest.approx(8.235e-3, abs=1e-8) == value(
                 model.state[0].mole_frac_phase_comp["Liq", "Na+"] *
@@ -175,9 +173,7 @@ class TestSingleState(object):
 
                     results = solver.solve(model)
 
-                    assert results.solver.termination_condition == \
-                        TerminationCondition.optimal
-                    assert results.solver.status == SolverStatus.ok
+                    assert check_optimal_termination(results)
 
                     assert pytest.approx(0, abs=1e-5) == value(
                         model.state[0].flow_mol_phase_comp["Sol", "NaCl"])
@@ -225,9 +221,7 @@ class TestUnit(object):
 
             results = solver.solve(model)
 
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
-            assert results.solver.status == SolverStatus.ok
+            assert check_optimal_termination(results)
 
             assert pytest.approx(0, abs=1.1e-6) == value(
                 model.fs.R101.outlet.flow_mol_phase_comp[0, "Sol", "NaCl"])
@@ -242,9 +236,7 @@ class TestUnit(object):
 
         results = solver.solve(model)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert pytest.approx(0, abs=1.1e-3) == value(
             model.fs.R101.outlet.flow_mol_phase_comp[0, "Sol", "NaCl"])
@@ -260,9 +252,7 @@ class TestUnit(object):
 
             results = solver.solve(model)
 
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
-            assert results.solver.status == SolverStatus.ok
+            assert check_optimal_termination(results)
 
             assert pytest.approx(i, rel=1e-5) == value(
                 model.fs.R101.outlet.flow_mol_phase_comp[0, "Sol", "NaCl"] +

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FPhx_electrolyte.py
@@ -17,11 +17,10 @@ Tests for constructing and using component lists in electrolyte systems
 import pytest
 
 # Import Pyomo units
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
-                           TerminationCondition,
                            Set,
-                           SolverStatus,
                            value,
                            Var,
                            units as pyunits)
@@ -216,9 +215,7 @@ class TestApparentSpeciesBasisNoInherent():
         res = solver.solve(m.fs, tee=True)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         assert (value(m.fs.state[1].flow_mol_phase_comp_true["Vap", "H2O"]) ==
@@ -465,9 +462,7 @@ class TestApparentSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check apparent species flowrates
         for j in m.fs.state[1].mole_frac_comp:
@@ -900,9 +895,7 @@ class TestTrueSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         assert m.fs.state[1].temperature.value == 350
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FTPx_electrolyte.py
@@ -17,11 +17,10 @@ Tests for constructing and using component lists in electrolyte systems
 import pytest
 
 # Import Pyomo units
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
-                           TerminationCondition,
                            Set,
-                           SolverStatus,
                            value,
                            Var,
                            units as pyunits)
@@ -207,9 +206,7 @@ class TestApparentSpeciesBasisNoInherent():
         res = solver.solve(m.fs, tee=True)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         assert (value(m.fs.state[1].flow_mol_phase_comp_true["Vap", "H2O"]) ==
@@ -454,9 +451,7 @@ class TestApparentSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check apparent species flowrates
         for j in m.fs.state[1].mole_frac_comp:
@@ -882,9 +877,7 @@ class TestTrueSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         for j in m.fs.state[1].mole_frac_comp:
@@ -1164,9 +1157,7 @@ class TestApparentSpeciesBasisInherentIdeal():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check apparent species flowrates
         for j in m.fs.state[1].mole_frac_comp:
@@ -1457,9 +1448,7 @@ class TestTrueSpeciesBasisInherentIdeal():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         for j in m.fs.state[1].mole_frac_comp:

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcPh_electrolyte.py
@@ -17,11 +17,10 @@ Tests for constructing and using component lists in electrolyte systems
 import pytest
 
 # Import Pyomo units
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
-                           TerminationCondition,
                            Set,
-                           SolverStatus,
                            value,
                            Var,
                            units as pyunits)
@@ -215,9 +214,7 @@ class TestApparentSpeciesBasisNoInherent():
         res = solver.solve(m.fs, tee=True)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         assert (value(m.fs.state[1].flow_mol_phase_comp_true["Vap", "H2O"]) ==
@@ -463,9 +460,7 @@ class TestApparentSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check apparent species flowrates
         for j in m.fs.state[1].mole_frac_comp:
@@ -897,9 +892,7 @@ class TestTrueSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         assert m.fs.state[1].temperature.value == 350
 

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FcTP_electrolyte.py
@@ -17,12 +17,11 @@ Tests for constructing and using component lists in electrolyte systems
 import pytest
 
 # Import Pyomo units
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Expression,
-                           TerminationCondition,
                            Set,
-                           SolverStatus,
                            value,
                            Var,
                            units as pyunits)
@@ -208,9 +207,7 @@ class TestApparentSpeciesBasisNoInherent():
         res = solver.solve(m.fs, tee=True)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         assert (value(m.fs.state[1].flow_mol_phase_comp_true["Vap", "H2O"]) ==
@@ -454,9 +451,7 @@ class TestApparentSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check apparent species flowrates
         for j in m.fs.state[1].mole_frac_comp:
@@ -881,9 +876,7 @@ class TestTrueSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         for j in m.fs.state[1].mole_frac_comp:

--- a/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP_electrolyte.py
+++ b/idaes/generic_models/properties/core/state_definitions/tests/test_FpcTP_electrolyte.py
@@ -17,12 +17,11 @@ Tests for constructing and using component lists in electrolyte systems
 import pytest
 
 # Import Pyomo units
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Expression,
-                           TerminationCondition,
                            Set,
-                           SolverStatus,
                            value,
                            Var,
                            units as pyunits)
@@ -197,9 +196,7 @@ class TestApparentSpeciesBasisNoInherent():
         res = solver.solve(m.fs, tee=True)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         assert (value(m.fs.state[1].flow_mol_phase_comp_true["Vap", "H2O"]) ==
@@ -434,9 +431,7 @@ class TestApparentSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check apparent species flowrates
         for j in m.fs.state[1].mole_frac_comp:
@@ -845,9 +840,7 @@ class TestTrueSpeciesBasisInherent():
         res = solver.solve(m.fs)
 
         # Check for optimal solution
-        assert res.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert res.solver.status == SolverStatus.ok
+        assert check_optimal_termination(res)
 
         # Check true species flowrates
         for j in m.fs.state[1].mole_frac_comp:

--- a/idaes/generic_models/properties/cubic_eos/cubic_prop_pack.py
+++ b/idaes/generic_models/properties/cubic_eos/cubic_prop_pack.py
@@ -29,7 +29,8 @@ import os
 from enum import Enum
 
 # Import Pyomo libraries
-from pyomo.environ import (Constraint,
+from pyomo.environ import (check_optimal_termination,
+                           Constraint,
                            exp,
                            Expression,
                            ExternalFunction,
@@ -40,9 +41,7 @@ from pyomo.environ import (Constraint,
                            PositiveReals,
                            value,
                            Var,
-                           units as pyunits,
-                           SolverStatus,
-                           TerminationCondition)
+                           units as pyunits)
 from pyomo.common.config import ConfigValue, In
 
 # Import IDAES cores
@@ -558,9 +557,7 @@ class _CubicStateBlock(StateBlock):
         )
 
         # ---------------------------------------------------------------------
-        if (results.solver.termination_condition !=
-                TerminationCondition.optimal or
-                results.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(results):
             raise InitializationError(
                 f"{blk.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/properties/cubic_eos/tests/test_BT_example.py
+++ b/idaes/generic_models/properties/cubic_eos/tests/test_BT_example.py
@@ -18,10 +18,10 @@ from idaes.generic_models.properties.cubic_eos.cubic_prop_pack import \
 from idaes.generic_models.properties.cubic_eos import BT_PR
 from idaes.core.util.exceptions import InitializationError
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Objective,
-                           TerminationCondition,
                            value)
 from pyomo.util.check_units import assert_units_consistent
 
@@ -146,8 +146,7 @@ class TestBTExample(object):
 
             results = solver.solve(m, tee=True)
 
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
+            assert check_optimal_termination(results)
             assert m.fs.state.flow_mol_phase["Liq"].value <= 1e-5
 
     @pytest.mark.integration
@@ -173,15 +172,13 @@ class TestBTExample(object):
 
             results = solver.solve(m)
 
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
+            assert check_optimal_termination(results)
 
             while m.fs.state.pressure.value <= 1e6:
                 m.fs.state.pressure.value = m.fs.state.pressure.value + 1e5
 
                 results = solver.solve(m)
-                assert results.solver.termination_condition == \
-                    TerminationCondition.optimal
+                assert check_optimal_termination(results)
                 print(T, m.fs.state.pressure.value)
 
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/condenser.py
+++ b/idaes/generic_models/unit_models/column_models/condenser.py
@@ -33,8 +33,7 @@ from pyomo.environ import (
     Constraint,
     value,
     Set,
-    SolverStatus,
-    TerminationCondition)
+    check_optimal_termination)
 
 # Import IDAES cores
 import idaes.logger as idaeslog
@@ -754,9 +753,7 @@ see property package for documentation.}"""))
         init_log.info(
             "Initialization Complete, {}.".format(idaeslog.condition(res))
         )
-        if (res.solver.termination_condition !=
-                TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(res):
             raise InitializationError(
                 f"{self.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/column_models/reboiler.py
+++ b/idaes/generic_models/unit_models/column_models/reboiler.py
@@ -26,14 +26,13 @@ from pandas import DataFrame
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.network import Port
 from pyomo.environ import (
+    check_optimal_termination,
     Reference,
     Expression,
     Var,
     Constraint,
     value,
-    Set,
-    SolverStatus,
-    TerminationCondition)
+    Set)
 
 # Import IDAES cores
 import idaes.logger as idaeslog
@@ -642,9 +641,7 @@ see property package for documentation.}"""))
                 "initialization. Please ensure that the boilup_ratio "
                 "or the outlet temperature is fixed.")
 
-        if (res.solver.termination_condition !=
-                TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(res):
             raise InitializationError(
                 f"{self.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/column_models/solvent_condenser.py
+++ b/idaes/generic_models/unit_models/column_models/solvent_condenser.py
@@ -27,11 +27,10 @@ __author__ = "Andrew Lee, Paul Akula"
 
 # Import Pyomo libraries
 from pyomo.environ import (
+    check_optimal_termination,
     Constraint,
     Param,
     Reference,
-    SolverStatus,
-    TerminationCondition,
     units as pyunits,
     value)
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
@@ -553,9 +552,7 @@ see property package for documentation.}"""))
         blk.vapor_phase.release_state(flags, outlvl)
 
         # TODO : This fails in the current model
-        # if (results.solver.termination_condition !=
-        #         TerminationCondition.optimal or
-        #         results.solver.status != SolverStatus.ok):
+        # if not check_optimal_termination(results):
         #     raise InitializationError(
         #         f"{blk.name} failed to initialize successfully. Please check "
         #         f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/column_models/solvent_reboiler.py
+++ b/idaes/generic_models/unit_models/column_models/solvent_reboiler.py
@@ -27,11 +27,10 @@ __author__ = "Andrew Lee, Paul Akula"
 
 # Import Pyomo libraries
 from pyomo.environ import (
+    check_optimal_termination,
     Constraint,
     Param,
     Reference,
-    SolverStatus,
-    TerminationCondition,
     units as pyunits,
     value)
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
@@ -551,9 +550,7 @@ see property package for documentation.}"""))
         # Release Inlet state
         blk.liquid_phase.release_state(flags, outlvl)
 
-        if (results.solver.termination_condition !=
-                TerminationCondition.optimal or
-                results.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(results):
             raise InitializationError(
                 f"{blk.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/column_models/tests/test_conventional_tray.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_conventional_tray.py
@@ -16,8 +16,7 @@ Tests for conventional tray unit model (no feed, no side draws).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -246,16 +245,12 @@ class TestBTXIdeal():
         results = solver.solve(btx_ftpz)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         results = solver.solve(btx_fctp)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tests/test_feed_tray.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_feed_tray.py
@@ -16,8 +16,7 @@ Tests for feed tray unit model.
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -269,16 +268,12 @@ class TestBTXIdeal():
         results = solver.solve(btx_ftpz)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         results = solver.solve(btx_fctp)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tests/test_partial_condenser.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_partial_condenser.py
@@ -17,8 +17,7 @@ ideal property package (FTPz and FcTP).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock, MaterialBalanceType, EnergyBalanceType
@@ -209,16 +208,12 @@ class TestBTXIdeal():
         results = solver.solve(btx_ftpz)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         results = solver.solve(btx_fctp)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tests/test_reboiler.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_reboiler.py
@@ -17,8 +17,7 @@ ideal property package (FTPz and FcTP).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import \
@@ -188,16 +187,12 @@ class TestBTXIdeal():
         results = solver.solve(btx_ftpz)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         results = solver.solve(btx_fctp)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tests/test_solvent_column.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_solvent_column.py
@@ -17,8 +17,8 @@ Author: Paul Akula, Anuja Deshpande, Andrew Lee
 import pytest
 
 # Import Pyomo libraries
-from pyomo.environ import ConcreteModel, value, Param, TransformationFactory,\
-    SolverStatus, TerminationCondition, units as pyunits
+from pyomo.environ import ConcreteModel, value, Param, TransformationFactory, \
+    check_optimal_termination, units as pyunits
 
 # Import IDAES Libraries
 from idaes.core import FlowsheetBlock
@@ -196,8 +196,7 @@ class TestColumn(object):
         results=solver.solve(model_absorber_steady_state)
         
         # Solver status and condition
-        assert results.solver.status == SolverStatus.ok
-        assert results.solver.termination_condition == TerminationCondition.optimal
+        assert check_optimal_termination(results)
         
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -386,8 +385,7 @@ class TestColumn(object):
         results=solver.solve(model_stripper_steady_state)
         
         # Solver status and condition
-        assert results.solver.status == SolverStatus.ok
-        assert results.solver.termination_condition == TerminationCondition.optimal
+        assert check_optimal_termination(results)
         
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tests/test_solvent_condenser.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_solvent_condenser.py
@@ -16,11 +16,10 @@ Authors: Andrew Lee
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Param,
-                           TerminationCondition,
-                           SolverStatus,
                            units,
                            value)
 from pyomo.util.check_units import (assert_units_consistent,
@@ -156,9 +155,7 @@ class TestStripperVaporFlow(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -307,9 +304,7 @@ class TestStripperHeatDuty(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/column_models/tests/test_solvent_reboiler.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_solvent_reboiler.py
@@ -16,11 +16,10 @@ Authors: Andrew Lee
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Param,
-                           TerminationCondition,
-                           SolverStatus,
                            units,
                            value)
 from pyomo.util.check_units import (assert_units_consistent,
@@ -139,9 +138,7 @@ class TestAbsorberVaporFlow(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -304,9 +301,7 @@ class TestAbsorberHeatDuty(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/column_models/tests/test_total_condenser.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_total_condenser.py
@@ -17,8 +17,7 @@ property package (FTPz and FcTP).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock, MaterialBalanceType, EnergyBalanceType
@@ -194,16 +193,12 @@ class TestBTXIdeal(object):
         results = solver.solve(btx_ftpz)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         results = solver.solve(btx_fctp)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tests/test_tray_column.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_tray_column.py
@@ -16,8 +16,7 @@ Tests for tray column unit model (single feed tray, no side draws).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -185,15 +184,11 @@ class TestBTXIdeal():
     def test_solve(self, btx_ftpz, btx_fctp):
         results = solver.solve(btx_ftpz)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         results = solver.solve(btx_fctp)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -326,9 +321,7 @@ class TestBTXIdealGeneric():
     def test_solve(self, btx_ftpz_generic):
         results = solver.solve(btx_ftpz_generic)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tests/test_tray_side_liq_draw.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_tray_side_liq_draw.py
@@ -16,8 +16,7 @@ Tests for conventional tray unit model (no feed, has liq side draws).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (
-    ConcreteModel, TerminationCondition, SolverStatus, value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -247,16 +246,12 @@ class TestBTXIdeal():
         results = solver.solve(btx_ftpz)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         results = solver.solve(btx_fctp)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tests/test_tray_side_vap_draw.py
+++ b/idaes/generic_models/unit_models/column_models/tests/test_tray_side_vap_draw.py
@@ -16,8 +16,7 @@ Tests for conventional tray unit model (no feed, has vap side draw).
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (
-    ConcreteModel, TerminationCondition, SolverStatus, value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -248,16 +247,12 @@ class TestBTXIdeal():
         results = solver.solve(btx_ftpz)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         results = solver.solve(btx_fctp)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/column_models/tray.py
+++ b/idaes/generic_models/unit_models/column_models/tray.py
@@ -30,7 +30,7 @@ import idaes.logger as idaeslog
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.network import Port
 from pyomo.environ import (
-    Reference, Expression, Var, Set, value, SolverStatus, TerminationCondition)
+    Reference, Expression, Var, Set, value, check_optimal_termination)
 
 # Import IDAES cores
 from idaes.core import (declare_process_block_class,
@@ -905,9 +905,7 @@ see property package for documentation.}"""))
                             "for tray block is not zero during "
                             "initialization.")
 
-        if (res.solver.termination_condition !=
-                TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(res):
             raise InitializationError(
                 f"{self.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/column_models/tray_column.py
+++ b/idaes/generic_models/unit_models/column_models/tray_column.py
@@ -22,7 +22,7 @@ import idaes.logger as idaeslog
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.network import Arc, Port
 from pyomo.environ import value, Integers, RangeSet, TransformationFactory, \
-    Block, Reference, SolverStatus, TerminationCondition
+    Block, Reference, check_optimal_termination
 
 # Import IDAES cores
 from idaes.generic_models.unit_models.column_models import Tray, Condenser, \
@@ -555,9 +555,7 @@ see property package for documentation.}"""))
             release_state(flags=feed_flags, outlvl=outlvl)
 
         # TODO : This fails in the current model
-        # if (res.solver.termination_condition !=
-        #         TerminationCondition.optimal or
-        #         res.solver.status != SolverStatus.ok):
+        # if not check_optimal_termination(res):
         #     raise InitializationError(
         #         f"{self.name} failed to initialize successfully. Please check "
         #         f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/heat_exchanger.py
+++ b/idaes/generic_models/unit_models/heat_exchanger.py
@@ -27,8 +27,7 @@ from pyomo.environ import (
     ExternalFunction,
     Block,
     units as pyunits,
-    SolverStatus,
-    TerminationCondition
+    check_optimal_termination
 )
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 
@@ -612,10 +611,7 @@ class HeatExchangerData(UnitModelBlockData):
             self.costing.activate()
             costing.initialize(self.costing)
 
-        if (res is not None and (
-                res.solver.termination_condition !=
-                TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok)):
+        if not check_optimal_termination(res):
             raise InitializationError(
                 f"{self.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/heat_exchanger_1D.py
@@ -21,9 +21,8 @@ from enum import Enum
 # Import Pyomo libraries
 from pyomo.environ import (
     Var,
+    check_optimal_termination,
     Constraint,
-    SolverStatus,
-    TerminationCondition,
     value,
     units as pyunits
 )
@@ -725,10 +724,7 @@ thickness of the tube""",
         self.shell.release_state(flags_shell)
         self.tube.release_state(flags_tube)
 
-        if (res is not None and (
-                res.solver.termination_condition !=
-                TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok)):
+        if res is not None and not check_optimal_termination(res):
             raise InitializationError(
                 f"{self.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/heat_exchanger_ntu.py
+++ b/idaes/generic_models/unit_models/heat_exchanger_ntu.py
@@ -20,13 +20,12 @@ Assumptions:
 
 # Import Pyomo libraries
 from pyomo.environ import (Block,
+                           check_optimal_termination,
                            Constraint,
                            Expression,
                            Param,
                            PositiveReals,
                            Reference,
-                           SolverStatus,
-                           TerminationCondition,
                            units as pyunits,
                            Var)
 from pyomo.common.config import Bool, ConfigBlock, ConfigValue, In
@@ -425,10 +424,7 @@ constructed,
             self.costing.activate()
             costing.initialize(self.costing)
 
-        if (res is not None and (
-                res.solver.termination_condition !=
-                TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok)):
+        if not check_optimal_termination(res):
             raise InitializationError(
                 f"{self.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/mixer.py
+++ b/idaes/generic_models/unit_models/mixer.py
@@ -16,13 +16,11 @@ General purpose mixer block for IDAES models
 from enum import Enum
 
 from pyomo.environ import (
-    Constraint,
+    check_optimal_termination,
     Param,
     PositiveReals,
     Reals,
     RangeSet,
-    SolverStatus,
-    TerminationCondition,
     Var,
 )
 from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf, Bool
@@ -946,10 +944,7 @@ objects linked to all inlet states and the mixed state,
         else:
             init_log.info("Initialization Complete.")
 
-        if (res is not None and (
-                res.solver.termination_condition !=
-                TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok)):
+        if res is not None and not check_optimal_termination(res):
             raise InitializationError(
                 f"{blk.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/pressure_changer.py
+++ b/idaes/generic_models/unit_models/pressure_changer.py
@@ -26,8 +26,7 @@ from pyomo.environ import (
     Expression,
     Constraint,
     Reference,
-    SolverStatus,
-    TerminationCondition)
+    check_optimal_termination)
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
@@ -798,8 +797,7 @@ see property package for documentation.}""",
         # Release Inlet state
         blk.control_volume.release_state(flags, outlvl)
 
-        if (res.solver.termination_condition != TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(res):
             raise InitializationError(
                 f"{blk.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")
@@ -1007,8 +1005,7 @@ see property package for documentation.}""",
         # Release Inlet state
         blk.control_volume.release_state(flags, outlvl)
 
-        if (res.solver.termination_condition != TerminationCondition.optimal or
-                res.solver.status != SolverStatus.ok):
+        if not check_optimal_termination(res):
             raise InitializationError(
                 f"{blk.name} failed to initialize successfully. Please check "
                 f"the output logs for more information.")

--- a/idaes/generic_models/unit_models/separator.py
+++ b/idaes/generic_models/unit_models/separator.py
@@ -19,13 +19,12 @@ from pandas import DataFrame
 
 from pyomo.environ import (
     Block,
+    check_optimal_termination,
     Constraint,
     Param,
     Reals,
     Reference,
     Set,
-    SolverStatus,
-    TerminationCondition,
     Var,
     value,
 )
@@ -1578,9 +1577,7 @@ objects linked the mixed state and all outlet states,
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 res = opt.solve(blk, tee=slc.tee)
 
-            if (res.solver.termination_condition !=
-                    TerminationCondition.optimal or
-                    res.solver.status != SolverStatus.ok):
+            if not check_optimal_termination(res):
                 raise InitializationError(
                     f"{blk.name} failed to initialize successfully. Please "
                     f"check the output logs for more information.")

--- a/idaes/generic_models/unit_models/tests/test_cstr.py
+++ b/idaes/generic_models/unit_models/tests/test_cstr.py
@@ -16,9 +16,8 @@ Authors: Andrew Lee, Vibhav Dabadghao
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            units,
                            value,
                            Var)
@@ -164,9 +163,7 @@ class TestSaponification(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -222,9 +219,7 @@ class TestSaponification(object):
         sapon.fs.unit.diameter.fix(2)
         results = solver.solve(sapon)
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
         assert (pytest.approx(29790.11975, abs=1e3) ==
                 value(sapon.fs.unit.costing.base_cost))
         assert (pytest.approx(40012.2523, abs=1e3) ==

--- a/idaes/generic_models/unit_models/tests/test_equilibrium_reactor.py
+++ b/idaes/generic_models/unit_models/tests/test_equilibrium_reactor.py
@@ -16,9 +16,8 @@ Authors: Andrew Lee
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            value,
                            units)
 from idaes.core import (FlowsheetBlock,
@@ -167,9 +166,7 @@ class TestSaponification(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_feed_flash.py
+++ b/idaes/generic_models/unit_models/tests/test_feed_flash.py
@@ -16,10 +16,7 @@ Authors: Andrew Lee
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
-                           value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from idaes.core import FlowsheetBlock, MaterialBalanceType
 from idaes.generic_models.unit_models.feed_flash import FeedFlash, FlashType
 from idaes.generic_models.properties import iapws95
@@ -127,9 +124,7 @@ class TestBTXIdeal(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -212,9 +207,7 @@ class TestIAPWS(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_flash.py
+++ b/idaes/generic_models/unit_models/tests/test_flash.py
@@ -15,9 +15,8 @@ Tests for Flash unit model.
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            value,
                            units,
                            Var)
@@ -162,9 +161,7 @@ class TestBTXIdeal(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -280,9 +277,7 @@ class TestIAPWS(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -346,9 +341,7 @@ class TestIAPWS(object):
 
         results = solver.solve(iapws)
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
         assert (pytest.approx(63787.06525, abs=1e3) ==
                 value(iapws.fs.unit.costing.base_cost))
         assert (pytest.approx(97660.6169, abs=1e3) ==

--- a/idaes/generic_models/unit_models/tests/test_gibbs.py
+++ b/idaes/generic_models/unit_models/tests/test_gibbs.py
@@ -17,10 +17,9 @@ Author: Andrew Lee
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
-                           TerminationCondition,
-                           SolverStatus,
                            value,
                            units)
 from pyomo.util.check_units import (assert_units_consistent,
@@ -247,9 +246,7 @@ class TestMethane(object):
         results = solver.solve(methane)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -339,9 +336,7 @@ class TestMethane(object):
         results = solver.solve(methane, tee=True)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_heat_exchanger.py
+++ b/idaes/generic_models/unit_models/tests/test_heat_exchanger.py
@@ -17,11 +17,10 @@ Author: John Eslick
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Expression,
-                           TerminationCondition,
-                           SolverStatus,
                            value,
                            Var,
                            units as pyunits)
@@ -187,8 +186,7 @@ def test_costing():
     results = solver.solve(m)
 
     # Check for optimal solution
-    assert results.solver.termination_condition == TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
 
     # Check Solution
 
@@ -374,9 +372,7 @@ class TestBTX_cocurrent(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -525,9 +521,7 @@ class TestBTX_cocurrent_alt_name(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -710,9 +704,7 @@ class TestIAPWS_countercurrent(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -727,9 +719,7 @@ class TestIAPWS_countercurrent(object):
         results = solver.solve(iapws_underwood)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -883,9 +873,7 @@ class TestSaponification_crossflow(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -1140,9 +1128,7 @@ class TestBT_Generic_cocurrent(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
+++ b/idaes/generic_models/unit_models/tests/test_heat_exchanger_1D.py
@@ -16,8 +16,10 @@ Tests for Heat Exchanger 1D unit model.
 Author: Jaffer Ghouse
 """
 import pytest
-from pyomo.environ import (ConcreteModel, TerminationCondition,
-                           SolverStatus, value, units as pyunits)
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
+                           value,
+                           units as pyunits)
 from pyomo.common.config import ConfigBlock
 from pyomo.util.check_units import (assert_units_consistent,
                                     assert_units_equivalent)
@@ -269,9 +271,7 @@ class TestBTX_cocurrent(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -447,9 +447,7 @@ class TestBTX_countercurrent(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -609,9 +607,7 @@ class TestIAPWS_cocurrent(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -772,9 +768,7 @@ class TestIAPWS_countercurrent(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -943,9 +937,7 @@ class TestSaponification_cocurrent(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -1133,9 +1125,7 @@ class TestSaponification_countercurrent(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -1406,9 +1396,7 @@ class TestBT_Generic_cocurrent(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.integration

--- a/idaes/generic_models/unit_models/tests/test_heater.py
+++ b/idaes/generic_models/unit_models/tests/test_heater.py
@@ -17,9 +17,8 @@ Author: John Eslick
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           SolverStatus,
-                           TerminationCondition,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            value,
                            units as pyunits)
 from pyomo.util.check_units import (assert_units_consistent,
@@ -152,9 +151,7 @@ class TestBTX(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -261,9 +258,7 @@ class TestIAPWS(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -331,9 +326,7 @@ class TestIAPWS(object):
             results = solver.solve(iapws)
 
             # Check for optimal solution
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
-            assert results.solver.status == SolverStatus.ok
+            assert check_optimal_termination(results)
 
             assert Tin == pytest.approx(value(prop_in.temperature), rel=1e-3)
             assert Tout == pytest.approx(value(prop_out.temperature), rel=1e-3)
@@ -411,9 +404,7 @@ class TestSaponification(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -532,9 +523,7 @@ class TestBT_Generic(object):
         results = solver.solve(btg)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_hx_ntu.py
+++ b/idaes/generic_models/unit_models/tests/test_hx_ntu.py
@@ -16,12 +16,11 @@ Author: Akula Paul, Andrew Lee
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Expression,
                            Param,
-                           TerminationCondition,
-                           SolverStatus,
                            units as pyunits,
                            value,
                            Var)
@@ -172,9 +171,7 @@ class TestHXNTU(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_mixer.py
+++ b/idaes/generic_models/unit_models/tests/test_mixer.py
@@ -17,14 +17,13 @@ Author: Andrew Lee
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
                            Param,
                            RangeSet,
                            Set,
                            Var,
-                           TerminationCondition,
-                           SolverStatus,
                            value,
                            units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
@@ -785,9 +784,7 @@ class TestBTX(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -1021,9 +1018,7 @@ class TestIAPWS(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -1139,9 +1134,7 @@ class TestSaponification(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_pfr.py
+++ b/idaes/generic_models/unit_models/tests/test_pfr.py
@@ -17,9 +17,8 @@ Author: Andrew Lee
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            value,
                            Var,
                            units)
@@ -180,9 +179,7 @@ class TestSaponification(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -243,9 +240,7 @@ class TestSaponification(object):
         assert isinstance(sapon.fs.unit.costing.purchase_cost, Var)
         results = solver.solve(sapon)
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
         assert (pytest.approx(9869.51230, abs=1e3) ==
                 value(sapon.fs.unit.costing.base_cost))
         assert (pytest.approx(16025.42623, abs=1e3) ==

--- a/idaes/generic_models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/generic_models/unit_models/tests/test_pressure_changer.py
@@ -17,10 +17,9 @@ Author: Andrew Lee, Emmanuel Ogbe
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
-                           TerminationCondition,
-                           SolverStatus,
                            units,
                            value,
                            Var)
@@ -281,9 +280,7 @@ class TestBTX_isothermal(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -414,9 +411,7 @@ class TestIAPWS(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -504,9 +499,7 @@ class TestIAPWS(object):
             iapws.fs.unit.initialize(optarg={'tol': 1e-6})
             results = solver.solve(iapws)
             # Check for optimal solution
-            assert results.solver.termination_condition == \
-                TerminationCondition.optimal
-            assert results.solver.status == SolverStatus.ok
+            assert check_optimal_termination(results)
 
             Tout = pytest.approx(cases["Tout"][i], rel=1e-2)
             Pout = pytest.approx(cases["Pout"][i]*1000, rel=1e-2)
@@ -618,9 +611,7 @@ class TestSaponification(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -823,9 +814,7 @@ class Test_costing(object):
         m.fs.unit.initialize()
         results = solver.solve(m)
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert value(m.fs.unit.control_volume.work[0]) == \
             pytest.approx(101410.4, rel=1e-5)

--- a/idaes/generic_models/unit_models/tests/test_product.py
+++ b/idaes/generic_models/unit_models/tests/test_product.py
@@ -16,10 +16,7 @@ Authors: Andrew Lee
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
-                           value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -187,9 +184,7 @@ class TestBTX(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_rstoic.py
+++ b/idaes/generic_models/unit_models/tests/test_rstoic.py
@@ -17,9 +17,8 @@ Author: Chinedu Okoli, Andrew Lee
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            value,
                            units,
                            Var)
@@ -168,9 +167,7 @@ class TestSaponification(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -227,9 +224,7 @@ class TestSaponification(object):
         sapon.fs.unit.length.fix(3)
         results = solver.solve(sapon)
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
         assert (pytest.approx(56327.5803, abs=1e3) ==
                 value(sapon.fs.unit.costing.base_cost))
         assert (pytest.approx(85432.06008, abs=1e3) ==

--- a/idaes/generic_models/unit_models/tests/test_separator.py
+++ b/idaes/generic_models/unit_models/tests/test_separator.py
@@ -17,11 +17,10 @@ Author: Andrew Lee
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Constraint,
-                           TerminationCondition,
                            Set,
-                           SolverStatus,
                            value,
                            Var,
                            units as pyunits)
@@ -872,9 +871,7 @@ class TestSaponification(object):
         results = solver.solve(sapon)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -1091,9 +1088,7 @@ class TestBTXIdeal(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -1247,9 +1242,7 @@ class TestIAPWS(object):
         results = solver.solve(iapws)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
@@ -2913,9 +2906,7 @@ class TestBTX_Ideal(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_skeleton_unit_model.py
+++ b/idaes/generic_models/unit_models/tests/test_skeleton_unit_model.py
@@ -15,8 +15,8 @@ Test for skeleton unit model.
 """
 
 import pytest
-from pyomo.environ import ConcreteModel, Constraint, Var, Set, value, \
-    SolverStatus, TerminationCondition
+from pyomo.environ import (
+    check_optimal_termination, ConcreteModel, Constraint, Var, Set, value)
 from idaes.core import FlowsheetBlock
 from idaes.generic_models.unit_models import SkeletonUnitModel
 from idaes.core.util.model_statistics import degrees_of_freedom
@@ -149,9 +149,7 @@ class TestSkeletonDefault(object):
     def test_solve(self, skeleton_default):
         results = solver.solve(skeleton_default)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -311,9 +309,7 @@ class TestSkeletonCustom(object):
     def test_solve(self, skeleton_custom):
         results = solver.solve(skeleton_custom)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/generic_models/unit_models/tests/test_statejunction.py
+++ b/idaes/generic_models/unit_models/tests/test_statejunction.py
@@ -17,10 +17,7 @@ Authors: Andrew Lee
 
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           SolverStatus,
-                           TerminationCondition,
-                           value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -197,9 +194,7 @@ class TestBTX(object):
         results = solver.solve(btx)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/generic_models/unit_models/tests/test_valve.py
+++ b/idaes/generic_models/unit_models/tests/test_valve.py
@@ -15,9 +15,8 @@ Tests for valve model
 """
 import math
 import pytest
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            units,
                            value)
 from idaes.core import FlowsheetBlock
@@ -123,9 +122,7 @@ class GenericValve(object):
         results = solver.solve(valve_model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/power_generation/carbon_capture/compression_system/tests/test_compressor.py
+++ b/idaes/power_generation/carbon_capture/compression_system/tests/test_compressor.py
@@ -108,7 +108,6 @@ def test_run(build_unit):
     results = solver.solve(m, tee=True)
     # Check for optimal solution
     assert pyo.check_optimal_termination(results)
-    assert results.solver.status == pyo.SolverStatus.ok
     assert degrees_of_freedom(m) == 0
 
     # energy balance

--- a/idaes/power_generation/carbon_capture/compression_system/tests/test_compressor.py
+++ b/idaes/power_generation/carbon_capture/compression_system/tests/test_compressor.py
@@ -107,8 +107,7 @@ def test_run(build_unit):
     # solve model
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
+    assert pyo.check_optimal_termination(results)
     assert results.solver.status == pyo.SolverStatus.ok
     assert degrees_of_freedom(m) == 0
 

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/properties/tests/test_mea_solvent.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/properties/tests/test_mea_solvent.py
@@ -14,10 +14,7 @@
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
-                           SolverStatus,
-                           TerminationCondition,
-                           value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -94,9 +91,7 @@ class TestStateBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/properties/tests/test_mea_vapor.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/properties/tests/test_mea_vapor.py
@@ -14,10 +14,7 @@
 Author: Andrew Lee
 """
 import pytest
-from pyomo.environ import (ConcreteModel,
-                           SolverStatus,
-                           TerminationCondition,
-                           value)
+from pyomo.environ import check_optimal_termination, ConcreteModel, value
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core.util.model_statistics import (degrees_of_freedom,
@@ -96,9 +93,7 @@ class TestFlueGasBlock(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -179,9 +174,7 @@ class TestWetCO2Block(object):
         results = solver.solve(model)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
@@ -18,7 +18,7 @@ import pytest
 
 # Import Pyomo libraries
 from pyomo.environ import ConcreteModel, value, Param, TransformationFactory,\
-    TerminationCondition, units as pyunits
+    check_optimal_termination, units as pyunits
 
 # Import IDAES Libraries
 from idaes.core import FlowsheetBlock
@@ -388,7 +388,7 @@ class TestColumn:
         res = solver.solve(m)
 
         # Solver status/condition
-        assert res.solver.termination_condition == TerminationCondition.optimal
+        assert check_optimal_termination(res)
 
         # Outlet Stream Condition Testing
         assert m.fs.unit.vapor_phase.properties[0, 1].temperature.value ==\
@@ -416,7 +416,7 @@ class TestColumn:
         res = solver.solve(m)
 
         # Solver status/condition
-        assert res.solver.termination_condition == TerminationCondition.optimal
+        assert check_optimal_termination(res)
 
         # Performance Condition Testing at final time
         assert value(m.fs.unit.liquid_phase.properties[

--- a/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_plate_heat_exchanger.py
+++ b/idaes/power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_plate_heat_exchanger.py
@@ -16,11 +16,10 @@ Author: Akula Paul
 """
 
 import pytest
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Param,
                            RangeSet,
-                           SolverStatus,
-                           TerminationCondition,
                            units as pyunits,
                            value)
 from idaes.core import FlowsheetBlock
@@ -173,9 +172,7 @@ class TestPHE(object):
         results = solver.solve(phe)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/power_generation/costing/tests/test_NGCC_costing.py
+++ b/idaes/power_generation/costing/tests/test_NGCC_costing.py
@@ -109,9 +109,7 @@ def test_units1_costing(build_costing):
 
     # Solve the model
     results = solver.solve(m, tee=True)
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
      # Accounts with raw water withdrawal as reference parameter
     assert pytest.approx(26.435, abs=0.5) \
@@ -187,9 +185,7 @@ def test_units2_costing(build_costing):
 
     # Solve the model
     results = solver.solve(m, tee=True)
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
     # Accounts with HRSG duty as reference parameter
     assert pytest.approx(90.794, abs=0.1) \
         == sum(pyo.value(m.fs.b7.costing.total_plant_cost[ac])
@@ -309,9 +305,7 @@ def test_units3_costing(build_costing):
 
     # Solve the model
     results = solver.solve(m, tee=True)
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # Accounts with condenser duty as reference parameter
     assert pytest.approx(14.27, abs=0.1) \
@@ -337,9 +331,7 @@ def test_flowsheet_costing(build_costing):
 
     # Solve the model
     results = solver.solve(m, tee=True)
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # Verify total plant costs
     assert pytest.approx(574.85, abs=0.1) == pyo.value(m.fs.flowsheet_cost)

--- a/idaes/power_generation/costing/tests/test_power_plant_costing.py
+++ b/idaes/power_generation/costing/tests/test_power_plant_costing.py
@@ -122,8 +122,7 @@ def test_PP_costing():
     solver = get_solver()
     results = solver.solve(m, tee=True)
 
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
+    assert pyo.check_optimal_termination(results)
 
     #  all numbers come from the NETL excel file:
     # "201.001.001_BBR4 COE Spreadsheet_Rev0U_20190919_njk.xlsm"
@@ -284,8 +283,7 @@ def test_power_plant_costing():
     solver = get_solver()
     results = solver.solve(m, tee=True)
 
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
+    assert pyo.check_optimal_termination(results)
     #  all numbers come from the NETL excel file
     # "201.001.001_BBR4 COE Spreadsheet_Rev0U_20190919_njk.xlsm"
     assert pytest.approx(pyo.value(
@@ -483,8 +481,7 @@ def test_sCO2_costing():
     solver = get_solver()
     results = solver.solve(m, tee=True)
 
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
+    assert pyo.check_optimal_termination(results)
 
     assert pytest.approx(pyo.value(
         m.fs.boiler.costing.equipment_cost), abs=1e-1) == 216300/1e3
@@ -531,8 +528,7 @@ def test_ASU_costing():
     solver = get_solver()
     results = solver.solve(m, tee=True)
 
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
+    assert pyo.check_optimal_termination(results)
 
     m.fs.ASU.costing.bare_erected_cost.display()
 

--- a/idaes/power_generation/flowsheets/gas_turbine/tests/test_gas_turbine.py
+++ b/idaes/power_generation/flowsheets/gas_turbine/tests/test_gas_turbine.py
@@ -99,4 +99,4 @@ def test_initialize():
             ng_comp=ng_comp,
             initialize=True)
         res = run_full_load(m, solver)
-    assert res.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(res)

--- a/idaes/power_generation/flowsheets/subcritical_power_plant/subcritical_boiler.py
+++ b/idaes/power_generation/flowsheets/subcritical_power_plant/subcritical_boiler.py
@@ -382,8 +382,7 @@ def run_sensitivity():
                                   properties_out[0].vapor_frac))
         flow.append(pyo.value(m.fs.drum.feedwater_inlet.flow_mol[0]))
 
-        if results.solver.termination_condition == \
-            pyo.TerminationCondition.optimal:
+        if pyo.check_optimal_termination(results):
             print('iter '+str(count)+ ' = EXIT- Optimal Solution Found.')
         else:
             print('iter '+str(count) + ' = infeasible')

--- a/idaes/power_generation/flowsheets/test/test_scpc_plant.py
+++ b/idaes/power_generation/flowsheets/test/test_scpc_plant.py
@@ -67,4 +67,4 @@ def test_boiler(boiler):
 def test_power_plant():
     # SCPC.main imports and solves the SCPC Power Plant Flowsheet
     m, results = SCPC.main()
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)

--- a/idaes/power_generation/flowsheets/test/test_scpc_plant.py
+++ b/idaes/power_generation/flowsheets/test/test_scpc_plant.py
@@ -18,7 +18,7 @@ __author__ = "Miguel Zamarripa"
 
 import pytest
 from pyomo.environ import (
-    SolverFactory, SolverStatus, TerminationCondition, value)
+    check_optimal_termination, SolverFactory, value)
 from pyomo.util.check_units import assert_units_consistent
 
 import idaes.power_generation.flowsheets.\
@@ -58,9 +58,7 @@ def test_boiler(boiler):
     boiler.fs.ATMP1.outlet.enth_mol[0].fix(62710.01)
     boiler.fs.ATMP1.SprayWater.flow_mol[0].unfix()
     result = boiler.solver.solve(boiler, tee=False)
-    assert result.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert result.solver.status == SolverStatus.ok
+    assert check_optimal_termination(result)
     assert value(boiler.fs.ECON.side_1.properties_out[0].temperature) == \
         pytest.approx(521.009, 1)
 

--- a/idaes/power_generation/flowsheets/test/test_subcritical_boiler.py
+++ b/idaes/power_generation/flowsheets/test/test_subcritical_boiler.py
@@ -73,9 +73,7 @@ def test_init(model):
             model.fs.Waterwalls[i].heat_flux_conv[0], 1e-5)
     iscale.calculate_scaling_factors(model)
     results = solver.solve(model, tee=True)
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     assert (pyo.value(model.fs.downcomer.deltaP[0]) > 0)
 

--- a/idaes/power_generation/properties/tests/test_SOFC_ROM.py
+++ b/idaes/power_generation/properties/tests/test_SOFC_ROM.py
@@ -38,10 +38,9 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_unused_variables)
 from idaes.core.util import get_solver
 
-from pyomo.environ import (ConcreteModel,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            Block,
-                           SolverStatus,
-                           TerminationCondition,
                            value)
 from pyomo.util.check_units import assert_units_consistent
 
@@ -115,9 +114,7 @@ class TestSOFCROM(object):
 
         results = solver.solve(m)
 
-        assert results.solver.termination_condition == \
-            TerminationCondition.optimal
-        assert results.solver.status == SolverStatus.ok
+        assert check_optimal_termination(results)
 
         assert (pytest.approx(705.5, abs=1e-1) ==
                 value(m.SOFC.anode_outlet_temperature))

--- a/idaes/power_generation/unit_models/helm/turbine_stage.py
+++ b/idaes/power_generation/unit_models/helm/turbine_stage.py
@@ -21,8 +21,7 @@ Liese, (2014). "Modeling of a Steam Turbine Including Partial Arc Admission
 """
 __Author__ = "John Eslick"
 
-from pyomo.environ import Var, SolverFactory, value, units as pyunits
-from pyomo.opt import TerminationCondition
+from pyomo.environ import Var, units as pyunits
 
 from idaes.core import declare_process_block_class
 from idaes.power_generation.unit_models.helm.turbine import HelmIsentropicTurbineData

--- a/idaes/power_generation/unit_models/tests/test_boiler_heat_exchanger.py
+++ b/idaes/power_generation/unit_models/tests/test_boiler_heat_exchanger.py
@@ -17,11 +17,8 @@ Author: Miguel Zamarripa
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
-                           value,
-                           units as pyunits)
+from pyomo.environ import (
+    check_optimal_termination, ConcreteModel, value, units as pyunits)
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import FlowsheetBlock
@@ -145,9 +142,7 @@ def test_boiler_hx():
 
     results = solver.solve(m)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
     assert value(m.fs.unit.side_1.properties_out[0].temperature) == \
         pytest.approx(588.07, 1)
     assert value(m.fs.unit.side_2.properties_out[0].temperature) == \

--- a/idaes/power_generation/unit_models/tests/test_boilerfireside.py
+++ b/idaes/power_generation/unit_models/tests/test_boilerfireside.py
@@ -153,9 +153,7 @@ def test_solve_unit(build_unit):
 
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # flue gas outlet temperature
     assert (pytest.approx(1236.780228, abs=1e-3) == pyo.value(m.fs.unit.

--- a/idaes/power_generation/unit_models/tests/test_downcomer.py
+++ b/idaes/power_generation/unit_models/tests/test_downcomer.py
@@ -111,9 +111,7 @@ def test_solve_unit(build_downcomer):
 
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # check material balance
     assert (pytest.approx(pyo.value(m.fs.unit.control_volume.properties_in[0].

--- a/idaes/power_generation/unit_models/tests/test_drum.py
+++ b/idaes/power_generation/unit_models/tests/test_drum.py
@@ -143,7 +143,6 @@ def test_run_drum(build_drum):
     results = solver.solve(m, tee=True)
     # Check for optimal solution
     assert pyo.check_optimal_termination(results)
-    assert results.solver.status == pyo.SolverStatus.ok
     assert degrees_of_freedom(m) == 0
     assert (pytest.approx(0.6, abs=1e-3) ==
             pyo.value(m.fs.unit.drum_level[0]))

--- a/idaes/power_generation/unit_models/tests/test_drum.py
+++ b/idaes/power_generation/unit_models/tests/test_drum.py
@@ -142,8 +142,7 @@ def test_run_drum(build_drum):
     # solve model
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
+    assert pyo.check_optimal_termination(results)
     assert results.solver.status == pyo.SolverStatus.ok
     assert degrees_of_freedom(m) == 0
     assert (pytest.approx(0.6, abs=1e-3) ==

--- a/idaes/power_generation/unit_models/tests/test_drum1D.py
+++ b/idaes/power_generation/unit_models/tests/test_drum1D.py
@@ -135,9 +135,7 @@ def test_run_drum1D(build_drum1D):
     # solve model
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
     assert degrees_of_freedom(m) == 0
     assert (pytest.approx(0.6, abs=1e-3) ==
             pyo.value(m.fs.unit.level[0]))

--- a/idaes/power_generation/unit_models/tests/test_heat_exchanger2D.py
+++ b/idaes/power_generation/unit_models/tests/test_heat_exchanger2D.py
@@ -162,9 +162,7 @@ def test_run_unit(build_unit):
     # solve model
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # energy balance
     assert (pytest.approx(0, abs=1e-3) ==

--- a/idaes/power_generation/unit_models/tests/test_heat_exchanger_3streams.py
+++ b/idaes/power_generation/unit_models/tests/test_heat_exchanger_3streams.py
@@ -17,9 +17,8 @@ Author: Miguel Zamarripa
 """
 import pytest
 
-from pyomo.environ import (ConcreteModel,
-                           TerminationCondition,
-                           SolverStatus,
+from pyomo.environ import (check_optimal_termination,
+                           ConcreteModel,
                            value,
                            Param)
 from idaes.core import FlowsheetBlock
@@ -139,9 +138,7 @@ def test_run_unit(build_unit):
     # solve model
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        TerminationCondition.optimal
-    assert results.solver.status == SolverStatus.ok
+    assert check_optimal_termination(results)
     assert degrees_of_freedom(m) == 0
     assert (pytest.approx(434.650, abs=1e-3) ==
             value(m.fs.unit.side_1_outlet.temperature[0]))

--- a/idaes/power_generation/unit_models/tests/test_steamheater.py
+++ b/idaes/power_generation/unit_models/tests/test_steamheater.py
@@ -115,9 +115,7 @@ def test_solve_unit(build_unit):
 
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # check material balance
     assert (pytest.approx(pyo.value(m.fs.unit.control_volume.properties_in[0].

--- a/idaes/power_generation/unit_models/tests/test_waterpipe.py
+++ b/idaes/power_generation/unit_models/tests/test_waterpipe.py
@@ -100,9 +100,7 @@ def test_solve_unit(build_unit):
 
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # check material balance
     assert (pytest.approx(pyo.value(m.fs.unit.control_volume.properties_in[0].
@@ -156,9 +154,7 @@ def test_pipe_expansion():
 
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # check material balance
     assert (pytest.approx(pyo.value(m.fs.unit.control_volume.properties_in[0].
@@ -211,9 +207,7 @@ def test_pipe_noexpansion():
 
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     # check material balance
     assert (pytest.approx(pyo.value(m.fs.unit.control_volume.properties_in[0].
@@ -266,9 +260,7 @@ def test_pipe_vaporphase():
 
     results = solver.solve(m, tee=True)
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)
 
     assert pyo.value(m.fs.unit.control_volume.properties_in[0].vapor_frac) == 1
 

--- a/idaes/power_generation/unit_models/tests/test_watertank.py
+++ b/idaes/power_generation/unit_models/tests/test_watertank.py
@@ -191,9 +191,7 @@ def test_run_watertank(tank_models):
         results = solver.solve(m, tee=True)
 
         # Check for optimal solution
-        assert results.solver.termination_condition == \
-            pyo.TerminationCondition.optimal
-        assert results.solver.status == pyo.SolverStatus.ok
+        assert pyo.check_optimal_termination(results)
         assert degrees_of_freedom(m) == 0
         assert (pytest.approx(0.6, abs=1e-3) ==
                 pyo.value(m.fs.unit.tank_level[0]))

--- a/idaes/power_generation/unit_models/tests/test_waterwall.py
+++ b/idaes/power_generation/unit_models/tests/test_waterwall.py
@@ -27,7 +27,6 @@ import pytest
 # Import Pyomo libraries
 import pyomo.environ as pyo
 from pyomo.network import Arc
-from pyomo.util.check_units import assert_units_consistent
 
 # Import IDAES core
 from idaes.core import FlowsheetBlock
@@ -209,6 +208,4 @@ def test_waterwall(model):
                       properties_out[0].enth_mol))
     assert degrees_of_freedom(model) == 0
     # Check for optimal solution
-    assert results.solver.termination_condition == \
-        pyo.TerminationCondition.optimal
-    assert results.solver.status == pyo.SolverStatus.ok
+    assert pyo.check_optimal_termination(results)


### PR DESCRIPTION
## Comes from comments in #627 


## Summary/Motivation:
In PR #627 it was pointed out that our current approach for checking for solver convergence is somewhat specific to IPOPT, and may not work for other solvers. This PR updates our convergence checks to use Pyomo's `check_optimal_termination` method.

## Changes proposed in this PR:
- Replace all checks for `TerminationCondition.optimal` (and most `SolverStatus.ok`) with `check_optimal_termination`.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
