### PR TITLE
Make IDAES compatible with Click 8

### DIFF
--- a/idaes/commands/base.py
+++ b/idaes/commands/base.py
@@ -60,7 +60,7 @@ def how_to_report_an_error(embed=False):
 
 
 @click.group()
-@click.version_option(version=None)
+@click.version_option(version=None, package_name="idaes-pse")
 @click.option(
     "--verbose",
     "-v",

--- a/idaes/commands/tests/test_commands.py
+++ b/idaes/commands/tests/test_commands.py
@@ -14,6 +14,7 @@
 Tests for idaes.commands
 """
 # stdlib
+from functools import partial
 import json
 import logging
 import os
@@ -29,7 +30,7 @@ from click.testing import CliRunner
 import pytest
 
 # package
-from idaes.commands import examples, extensions, convergence, config, env_info
+from idaes.commands import examples, extensions, convergence, config, env_info, base
 from idaes.util.system import TemporaryDirectory
 from . import create_module_scratch, rmtree_scratch
 import idaes
@@ -71,6 +72,26 @@ def tempdir(request):
     else:
         sub_path.mkdir()
     return sub_path
+
+
+class TestBaseCommand:
+
+    @pytest.fixture
+    def run_idaes(self, runner):
+        return partial(runner.invoke, base.command_base)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "flags",
+        [
+            ["--version"],
+            ["--help"],
+        ],
+        ids=" ".join,
+    )
+    def test_flags(self, run_idaes, flags):
+        result = run_idaes(flags)
+        assert result.exit_code == 0
 
 
 ################

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ kwargs = dict(
         # idaes core / dmf
         "backports.shutil_get_terminal_size",
         "bunch",
-        "click<=7.1.2", # problems with 8.x
+        "click", # problems with 8.x
         "colorama",
         "flask",  # for ui/fsvis
         "flask-cors",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ kwargs = dict(
         # idaes core / dmf
         "backports.shutil_get_terminal_size",
         "bunch",
-        "click", # problems with 8.x
+        "click",
         "colorama",
         "flask",  # for ui/fsvis
         "flask-cors",


### PR DESCRIPTION
## Summary/Motivation:
- Click 8 is a dependency of Black, which has recently released its first stable release
- As many of IDAES's dependencies depend on Black, this effectively results in IDAES having to support Click 8 as well
- The Click requirement for IDAES was fixed to `<8` because of an unspecified error occurring (at the time) with Click 8

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
