### PR TITLE
Adding a toggle to hide the stream names and show them

### DIFF
--- a/idaes/ui/fsvis/static/css/main.css
+++ b/idaes/ui/fsvis/static/css/main.css
@@ -54,7 +54,7 @@ hr {
   position: absolute;
   top: 20px;
   right: 40px;
-  width: 350px;
+  width: 500px;
   height: 40px;
   z-index: 1;
 }

--- a/idaes/ui/fsvis/static/js/toolbar.js
+++ b/idaes/ui/fsvis/static/js/toolbar.js
@@ -155,6 +155,32 @@ export class Toolbar {
             };
         });
 
+        // Streams toggle event listener
+        document.querySelector("#stream-names-toggle").addEventListener("change", function() {
+            if (this.checked) {
+                app._paper._graph.getLinks().forEach(function (link) {
+                    link.label(1, {
+                        attrs: {
+                            text: {
+                                display: "block",
+                            }
+                        }
+                    });
+                });
+            }
+            else {
+                app._paper._graph.getLinks().forEach(function (link) {
+                    link.label(1, {
+                        attrs: {
+                            text: {
+                                display: "none",
+                            }
+                        }
+                    });
+                });
+            };
+        });
+
         // Grid toggle event listener
         document.querySelector("#grid-toggle").addEventListener("change", function() {
             if (this.checked) {

--- a/idaes/ui/fsvis/templates/index.html
+++ b/idaes/ui/fsvis/templates/index.html
@@ -96,6 +96,15 @@
             </div>
             <div class="p-2">
               <div class="btn-label">
+                Stream Names
+              </div>
+              <label class="switch">
+                <input type="checkbox" checked="true" id="stream-names-toggle">
+                <span class="slider round"></span>
+              </label>
+            </div>
+            <div class="p-2">
+              <div class="btn-label">
                 Grid
               </div>
               <label class="switch">


### PR DESCRIPTION
## Fixes


## Summary/Motivation:
Adds Toggle to Streams' names in the flowsheet canvas

![Screen Shot 2022-02-09 at 11 34 08 AM](https://user-images.githubusercontent.com/1439632/153246553-2c55ced2-7a49-4783-920a-b482ccce49c2.png)
![Screen Shot 2022-02-09 at 11 34 15 AM](https://user-images.githubusercontent.com/1439632/153246558-60c1d88c-a2bb-46e7-b008-98a3423abc78.png)


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
