### PR TITLE
Fixing string checking of Expressions

### DIFF
--- a/idaes/generic_models/properties/core/eos/tests/test_ideal.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_ideal.py
@@ -234,8 +234,8 @@ def test_dens_mol_phase_liq(m):
 @pytest.mark.unit
 def test_dens_mol_phase_vap(m):
     assert str(Ideal.dens_mol_phase(m.props[1], "Vap")) == (
-            'props[1].pressure/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K)'
-            '*props[1].temperature)')
+        'props[1].pressure/('+str(Ideal.gas_constant(m.props[1])) +
+        '*props[1].temperature)')
 
 
 @pytest.mark.unit
@@ -292,8 +292,8 @@ def test_energy_internal_mol_phase_comp_with_h_form(m):
         # For liquid phase, delta(n) should be 4 (2*He + 2*O2)
         assert (
             str(Ideal.energy_internal_mol_phase_comp(m.props[1], "Liq", j)) ==
-            "42 -4.0*(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))"
-            "*params.temperature_ref")
+            "42 -4.0*("+str(Ideal.gas_constant(m.props[1])) +
+            ")*params.temperature_ref")
         # For vapor phase, delta(n) should be 3 (2*He + 2*O2 - 1*component)
         assert (
             str(Ideal.energy_internal_mol_phase_comp(m.props[1], "Vap", j)) ==
@@ -373,7 +373,7 @@ def test_entr_mol_phase_comp(m):
 
         assert str(Ideal.entr_mol_phase_comp(m.props[1], "Liq", j)) == str(42)
         assert str(Ideal.entr_mol_phase_comp(m.props[1], "Vap", j)) == (
-            '42 - kg*m**2/J/s**2*(8.314462618*(J)/mol/K)'
+            '42 - '+str(Ideal.gas_constant(m.props[1])) +
             '*log(props[1].mole_frac_phase_comp'
             '[Vap,{}]*props[1].pressure/params.pressure_ref)'.format(j))
 
@@ -498,8 +498,7 @@ def test_pressure_osm_phase(m):
                          rel=1e-6) == value(
         m.props[1].pressure_osm_phase["Liq"])
     assert str(m.props[1].pressure_osm_phase["Liq"]._expr) == (
-        'kg*m**2/J/s**2*(' +
-        str(const.gas_constant)+')*' +
+        str(Ideal.gas_constant(m.props[1]))+'*' +
         str(m.props[1].temperature*(
             m.props[1].conc_mol_phase_comp["Liq", "b"] +
             m.props[1].conc_mol_phase_comp["Liq", "c"])))
@@ -552,8 +551,7 @@ def test_pressure_osm_phase_w_apparent_component():
                          rel=1e-6) == value(
         m.props[1].pressure_osm_phase["Liq"])
     assert str(m.props[1].pressure_osm_phase["Liq"]._expr) == (
-        'kg*m**2/J/s**2*(' +
-        str(const.gas_constant)+')*' +
+        str(Ideal.gas_constant(m.props[1]))+'*' +
         str(m.props[1].temperature*(
             m.props[1].conc_mol_phase_comp["Liq", "b"] +
             2*m.props[1].conc_mol_phase_comp["Liq", "c"])))
@@ -609,8 +607,8 @@ def test_vol_mol_phase():
     for p in m.params.phase_list:
         if p == "Vap":
             assert str(Ideal.vol_mol_phase(m.props[1], p)) == (
-                "kg*m**2/J/s**2*(8.314462618*(J)/mol/K)*"
-                "props[1].temperature/props[1].pressure")
+                str(Ideal.gas_constant(m.props[1])) +
+                "*props[1].temperature/props[1].pressure")
         else:
             assert str(Ideal.vol_mol_phase(m.props[1], p)) == str(
                 1/42*m.props[1].mole_frac_phase_comp["Liq", "a"] +

--- a/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
+++ b/idaes/generic_models/properties/core/reactions/tests/test_equilibrium_constant.py
@@ -586,10 +586,15 @@ class TestGibbsEnergy(object):
         assert str(rform1) == ('exp(rxn[1].log_k_eq[r1])')
         assert str(rform2) == (
             'rxn[1].log_k_eq[r1]  ==  '
-            '- rparams.reaction_r1.dh_rxn_ref/(kg*m**2/J/s**2*'
-            '(8.314462618*(J)/mol/K)*(300*K)) + '
-            '1/(kg*m**2/J/s**2*(8.314462618*(J)/mol/K))'
-            '*rparams.reaction_r1.ds_rxn_ref')
+            '- rparams.reaction_r1.dh_rxn_ref/(' +
+            str(pyunits.convert(
+                c.gas_constant,
+                to_units=pyunits.kg*pyunits.m**2/pyunits.s**2/pyunits.mol/pyunits.K)) +
+            '*(300*K)) + 1/(' +
+            str(pyunits.convert(
+                c.gas_constant,
+                to_units=pyunits.kg*pyunits.m**2/pyunits.s**2/pyunits.mol/pyunits.K)) +
+            ')*rparams.reaction_r1.ds_rxn_ref')
 
         assert value(rform1) == pytest.approx(1, rel=1e-3)
         assert_units_equivalent(rform1, pyunits.dimensionless)


### PR DESCRIPTION
## Replicates part of #695 


## Summary/Motivation:
Replicates part of #695 that was fixing some issues with checking some string comparisons for expression forms. I tried using `pyomo.core.expr.compare.compare_expressions()` with no success, and decided we needed this merged sooner rather than later so went with the old fix.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
