### PR TITLE
Prevent references from being descaled multiple times

### DIFF
--- a/idaes/core/solvers/petsc.py
+++ b/idaes/core/solvers/petsc.py
@@ -655,9 +655,11 @@ class PetscTrajectory(object):
         Returns:
             None
         """
+        # Variables might show up more than once because of References
+        already_scaled = set()
         for var in m.component_data_objects():
             vname = str(var)
-            if vname in self.vecs:
+            if vname in self.vecs and vname not in already_scaled:
                 s = None
                 if hasattr(var.parent_block(), "scaling_factor"):
                     s = var.parent_block().scaling_factor.get(var, s)
@@ -666,6 +668,7 @@ class PetscTrajectory(object):
                 if s is not None:
                     for i, x in enumerate(self.vecs[vname]):
                         self.vecs[vname][i] = x/s
+                already_scaled.add(vname)
 
     def delete_files(self):
         """Delete the trajectory data and variable information files.

--- a/idaes/core/solvers/tests/test_petsc.py
+++ b/idaes/core/solvers/tests/test_petsc.py
@@ -439,7 +439,8 @@ def test_petsc_read_trajectory():
     m, y1, y2, y3, y4, y5, y6 = dae_with_non_time_indexed_constraint()
     m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
     m.scaling_factor[m.y[180, 1]] = 10 # make sure unscale works
-
+    
+    m.y_ref = pyo.Reference(m.y) # make sure references don't get unscaled twice
     petsc.petsc_dae_by_time_element(
         m,
         time=m.t,


### PR DESCRIPTION
## Fixes

Previously, if a variable with multiple references had a scaling factor, it would get descaled once for each reference. This PR ensures they are descaled only once.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
