### PR TITLE
Require Click version 8 or greater

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ kwargs = dict(
         # idaes core / dmf
         "backports.shutil_get_terminal_size",
         "bunch",
-        "click",
+        "click>=8",
         "colorama",
         "flask",  # for ui/fsvis
         "flask-cors",


### PR DESCRIPTION
## Fixes #696 

## Summary/Motivation:

- The changes introduced in #683 turned out to be not backwards-compatible with Click 7 and below, so we should specify Click 8 as the minimum version

## Changes proposed in this PR:
- Add version constraint for Click version 8 or greater

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
