### PR TITLE
Ensure that pytest is the only strict requirement for running test suite for all installation modes

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -23,6 +23,7 @@ on:
       # ready_for_review occurs when a draft PR is turned to non-draft
       - ready_for_review
       # synchronize occurs whenever commits are pushed to the PR branch
+      - synchronize
 
 env:
   # default Python version to use for checks that do not require multiple versions

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -23,7 +23,6 @@ on:
       # ready_for_review occurs when a draft PR is turned to non-draft
       - ready_for_review
       # synchronize occurs whenever commits are pushed to the PR branch
-      - synchronize
 
 env:
   # default Python version to use for checks that do not require multiple versions

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Set up idaes (non-editable installation)
         uses: ./.github/actions/setup-idaes
         with:
-          install-target: ${{ matrix.install-target }}
+          install-target: ${{ matrix.pip-install-target }}
       - name: Remove dependencies installable with pip but not with conda
         # NOTE some dependencies that are installed by default with pip are not available through conda
         # so they're not installed if IDAES is installed with `conda -c conda-forge -c IDAES-PSE idaes-pse`

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -235,4 +235,4 @@ jobs:
         run: |
           pushd "$(mktemp -d)"
           pip install pytest
-          pytest --pyargs idaes -W ignore
+          pytest --pyargs idaes -x -rs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -196,6 +196,13 @@ jobs:
     name: Run tests from site-packages (non-editable) installation${{ matrix.label }}
     # NOTE: using ubuntu-latest (20.04) instead of 18.04 results in failures in power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
     runs-on: ubuntu-18.04
+    needs: [precheck]
+    if: >-
+      (
+        needs.precheck.outputs.workflow-trigger == 'user_dispatch'
+        || needs.precheck.outputs.workflow-trigger == 'not_pr'
+        || needs.precheck.outputs.workflow-trigger == 'approved_pr'
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -222,7 +222,4 @@ jobs:
         run: |
           pushd "$(mktemp -d)"
           pip install pytest
-          # TODO downloading pytest.ini is still needed for the tests to pass
-          # eventually it will be moved to the root conftest.py so that is installed as Python code
-          wget https://raw.githubusercontent.com/IDAES/idaes-pse/main/pytest.ini 
-          pytest --pyargs idaes
+          pytest --pyargs idaes -W ignore -rs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -196,6 +196,13 @@ jobs:
     name: Run tests from site-packages (non-editable) installation (${{ matrix.install-mode }})
     # NOTE: using ubuntu-latest (20.04) instead of 18.04 results in failures in power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
     runs-on: ubuntu-18.04
+    needs: [precheck]
+    if: >-
+      (
+        needs.precheck.outputs.workflow-trigger == 'user_dispatch'
+        || needs.precheck.outputs.workflow-trigger == 'not_pr'
+        || needs.precheck.outputs.workflow-trigger == 'approved_pr'
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -196,13 +196,6 @@ jobs:
     name: Run tests from site-packages (non-editable) installation${{ matrix.label }}
     # NOTE: using ubuntu-latest (20.04) instead of 18.04 results in failures in power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
     runs-on: ubuntu-18.04
-    needs: [precheck]
-    if: >-
-      (
-        needs.precheck.outputs.workflow-trigger == 'user_dispatch'
-        || needs.precheck.outputs.workflow-trigger == 'not_pr'
-        || needs.precheck.outputs.workflow-trigger == 'approved_pr'
-      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -193,7 +193,7 @@ jobs:
           cat *errors.txt || echo "No error logs found"
 
   pytest-site-packages:
-    name: Run tests from site-packages (non-editable) installation
+    name: Run tests from site-packages (non-editable) installation${{ matrix.label }}
     # NOTE: using ubuntu-latest (20.04) instead of 18.04 results in failures in power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
     runs-on: ubuntu-18.04
     needs: [precheck]
@@ -203,6 +203,17 @@ jobs:
         || needs.precheck.outputs.workflow-trigger == 'not_pr'
         || needs.precheck.outputs.workflow-trigger == 'approved_pr'
       )
+    strategy:
+      fail-fast: false
+      matrix:
+        install-target:
+          - '.'
+          - '.[optional]'
+        include:
+          - install-target: '.'
+            label: ''
+          - install-target: '.[optional]'  
+            label: ' (with [optional])'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Conda environment
@@ -213,7 +224,7 @@ jobs:
       - name: Set up idaes (non-editable installation)
         uses: ./.github/actions/setup-idaes
         with:
-          install-target: '.[optional]'
+          install-target: ${{ matrix.install-target }}
       - name: Install and run pytest in empty directory
         run: |
           pushd "$(mktemp -d)"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -196,13 +196,6 @@ jobs:
     name: Run tests from site-packages (non-editable) installation (${{ matrix.install-mode }})
     # NOTE: using ubuntu-latest (20.04) instead of 18.04 results in failures in power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
     runs-on: ubuntu-18.04
-    needs: [precheck]
-    if: >-
-      (
-        needs.precheck.outputs.workflow-trigger == 'user_dispatch'
-        || needs.precheck.outputs.workflow-trigger == 'not_pr'
-        || needs.precheck.outputs.workflow-trigger == 'approved_pr'
-      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -235,4 +235,4 @@ jobs:
         run: |
           pushd "$(mktemp -d)"
           pip install pytest
-          pytest --pyargs idaes -W ignore -rs
+          pytest --pyargs idaes -W ignore

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -193,7 +193,7 @@ jobs:
           cat *errors.txt || echo "No error logs found"
 
   pytest-site-packages:
-    name: Run tests from site-packages (non-editable) installation${{ matrix.label }}
+    name: Run tests from site-packages (non-editable) installation (${{ matrix.install-mode }})
     # NOTE: using ubuntu-latest (20.04) instead of 18.04 results in failures in power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
     runs-on: ubuntu-18.04
     needs: [precheck]
@@ -206,14 +206,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        install-target:
-          - '.'
-          - '.[optional]'
+        install-mode:
+          - pip-default
+          - pip-optional
+          - conda-like
         include:
-          - install-target: '.'
-            label: ''
-          - install-target: '.[optional]'  
-            label: ' (with [optional])'
+          - install-mode: pip-default
+            pip-install-target: '.'
+          - install-mode: pip-optional
+            pip-install-target: .[optional]
+          - install-mode: conda-like
+            pip-install-target: '.'
+            dependencies-to-uninstall: omlt
     steps:
       - uses: actions/checkout@v2
       - name: Set up Conda environment
@@ -225,6 +229,15 @@ jobs:
         uses: ./.github/actions/setup-idaes
         with:
           install-target: ${{ matrix.install-target }}
+      - name: Remove dependencies installable with pip but not with conda
+        # NOTE some dependencies that are installed by default with pip are not available through conda
+        # so they're not installed if IDAES is installed with `conda -c conda-forge -c IDAES-PSE idaes-pse`
+        # to ensure this scenario is handled properly, since we don't have (yet) the conda-build process integrated with the CI,
+        # we manually remove the "pip-but-not-conda" dependencies after installing with pip
+        # as an approximation of the enviroment that we'd get from `conda install`
+        if: matrix.dependencies-to-uninstall
+        run: |
+          pip uninstall ${{ matrix.dependencies-to-uninstall }}
       - name: Install and run pytest in empty directory
         run: |
           pushd "$(mktemp -d)"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -230,7 +230,7 @@ jobs:
         # as an approximation of the enviroment that we'd get from `conda install`
         if: matrix.dependencies-to-uninstall
         run: |
-          pip uninstall ${{ matrix.dependencies-to-uninstall }}
+          pip uninstall --yes ${{ matrix.dependencies-to-uninstall }}
       - name: Install and run pytest in empty directory
         run: |
           pushd "$(mktemp -d)"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -235,4 +235,4 @@ jobs:
         run: |
           pushd "$(mktemp -d)"
           pip install pytest
-          pytest --pyargs idaes -x -rs
+          pytest --pyargs idaes -W ignore -rs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -214,11 +214,10 @@ jobs:
         uses: ./.github/actions/setup-idaes
         with:
           install-target: '.[optional]'
-      - name: Install test dependencies and run pytest in empty directory
+      - name: Install and run pytest in empty directory
         run: |
           pushd "$(mktemp -d)"
-          # TODO this could be an optional [testing] dependency
-          pip install pytest addheader
+          pip install pytest
           # TODO downloading pytest.ini is still needed for the tests to pass
           # eventually it will be moved to the root conftest.py so that is installed as Python code
           wget https://raw.githubusercontent.com/IDAES/idaes-pse/main/pytest.ini 

--- a/docs/tutorials/getting_started/index.rst
+++ b/docs/tutorials/getting_started/index.rst
@@ -190,13 +190,14 @@ Powershell Prompt.  Regardless of OS and shell, the following steps are the same
 4. The ``pytest`` package is required for running the test suite. After installing it using e.g. ``pip``, run the tests::
 
     pip install pytest
-    pytest --pyargs idaes -W ignore
+    pytest --pyargs idaes -W ignore -rs
 
-5. You should see the tests run and all should pass to ensure the installation worked. You
-   may see some "Error" level log messages, but they are okay, and produced by tests for
+5. You should see the tests run and all should pass to ensure the installation worked.
+   You may see some "Error" level log messages, but they are okay, and produced by tests for
    error handling. The number of tests that failed and succeeded is reported at the end of the pytest
-   output. You can report problems on the |github-issues|
-   (Please try to be specific about the command and the offending output.)
+   output. If the optional ``-rs`` flag is given, the output will also display tests that were skipped because of
+   e.g. optional requirements that can be installed separately if desired.
+   You can report problems on the |github-issues| (Please try to be specific about the command and the offending output.)
 
 **Install IDAES using Conda**
 

--- a/docs/tutorials/getting_started/index.rst
+++ b/docs/tutorials/getting_started/index.rst
@@ -187,7 +187,10 @@ Powershell Prompt.  Regardless of OS and shell, the following steps are the same
     Refer to the full :doc:`idaes get-examples command documentation <../../../reference_guides/commands/get_examples>`
     for more information.
 
-4. The ``pytest`` package is required for running the test suite. After installing it using e.g. ``pip``, run the tests::
+4. To test that the installation was successful, you can run the IDAES test suite.
+    This is not strictly required, but can offer more confidence that the installation environment is as expected (if the tests pass),
+    and more insight into possible issues (if any of the tests fail).
+    The ``pytest`` package is required for running the test suite. After installing it using e.g. ``pip``, run the tests::
 
     pip install pytest
     pytest --pyargs idaes -W ignore -rs
@@ -195,8 +198,9 @@ Powershell Prompt.  Regardless of OS and shell, the following steps are the same
 5. You should see the tests run and all should pass to ensure the installation worked.
    You may see some "Error" level log messages, but they are okay, and produced by tests for
    error handling. The number of tests that failed and succeeded is reported at the end of the pytest
-   output. If the optional ``-rs`` flag is given, the output will also display tests that were skipped because of
-   e.g. optional requirements that can be installed separately if desired.
+   output.
+   If the optional ``-rs`` flag is given, the output will also display tests that were skipped because of
+   e.g. optional dependencies that can be installed separately (see below).
    You can report problems on the |github-issues| (Please try to be specific about the command and the offending output.)
 
 **Install IDAES using Conda**

--- a/docs/tutorials/getting_started/index.rst
+++ b/docs/tutorials/getting_started/index.rst
@@ -187,8 +187,9 @@ Powershell Prompt.  Regardless of OS and shell, the following steps are the same
     Refer to the full :doc:`idaes get-examples command documentation <../../../reference_guides/commands/get_examples>`
     for more information.
 
-4. Run tests::
+4. The ``pytest`` package is required for running the test suite. After installing it using e.g. ``pip``, run the tests::
 
+    pip install pytest
     pytest --pyargs idaes -W ignore
 
 5. You should see the tests run and all should pass to ensure the installation worked. You

--- a/idaes/generic_models/properties/core/coolprop/tests/test_coolprop_wrapper.py
+++ b/idaes/generic_models/properties/core/coolprop/tests/test_coolprop_wrapper.py
@@ -800,7 +800,6 @@ class TestVerifyExcessLiq(object):
                         m.fs.state[0].entr_mol_phase["Liq"] - S0_I)
 
 
-@pytest.mark.skipif(not coolprop_available, reason="CoolProp not installed")
 class TestVerifyExcessVap(object):
     @pytest.fixture(scope="class")
     def m(self):

--- a/idaes/generic_models/properties/core/coolprop/tests/test_coolprop_wrapper.py
+++ b/idaes/generic_models/properties/core/coolprop/tests/test_coolprop_wrapper.py
@@ -41,7 +41,7 @@ from idaes.generic_models.properties.core.pure.ConstantProperties import \
     Constant
 
 
-Coolprop = pytest.importorskip("CoolProp.CoolProp", reason="CoolProp not installed")
+CoolProp = pytest.importorskip("CoolProp.CoolProp", reason="CoolProp not installed")
 
 from idaes.generic_models.properties.core.coolprop.coolprop_wrapper import (
     CoolPropWrapper,

--- a/idaes/generic_models/properties/core/coolprop/tests/test_coolprop_wrapper.py
+++ b/idaes/generic_models/properties/core/coolprop/tests/test_coolprop_wrapper.py
@@ -41,16 +41,16 @@ from idaes.generic_models.properties.core.pure.ConstantProperties import \
     Constant
 
 
+Coolprop = pytest.importorskip("CoolProp.CoolProp", reason="CoolProp not installed")
+
 from idaes.generic_models.properties.core.coolprop.coolprop_wrapper import (
     CoolPropWrapper,
     CoolPropExpressionError,
     CoolPropPropertyError)
 
-CoolProp, coolprop_available = attempt_import('CoolProp.CoolProp')
 solver = get_solver()
 
 
-@pytest.mark.skipif(not coolprop_available, reason="CoolProp not installed")
 class TestWrapper:
     @pytest.mark.unit
     def test_load_component(self):
@@ -233,7 +233,6 @@ class TestWrapper:
             CoolPropWrapper.pressure_sat_comp.build_parameters(m.TestComp)
 
 
-@pytest.mark.skipif(not coolprop_available, reason="CoolProp not installed")
 class TestCoolPropProperties(object):
     @pytest.fixture(scope="class")
     def m(self):
@@ -671,7 +670,6 @@ class TestCoolPropProperties(object):
                         m.fs.state[0].pressure_sat_comp["benzene"])
 
 
-@pytest.mark.skipif(not coolprop_available, reason="CoolProp not installed")
 class TestVerifyExcessLiq(object):
     @pytest.fixture(scope="class")
     def m(self):

--- a/idaes/generic_models/properties/core/eos/tests/test_enrtl.py
+++ b/idaes/generic_models/properties/core/eos/tests/test_enrtl.py
@@ -190,7 +190,7 @@ class TestParameters(object):
         caplog.set_level(
             idaeslog.INFO,
             logger=("idaes.generic_models.properties.core."
-                    "generic.generic_property"))
+                    "eos.enrtl_parameters"))
 
         test_config = dict(configuration)
         test_config["parameter_data"] = {}

--- a/idaes/surrogate/keras_surrogate.py
+++ b/idaes/surrogate/keras_surrogate.py
@@ -19,6 +19,7 @@ import os.path
 
 from pyomo.common.dependencies import attempt_import
 keras, keras_available = attempt_import('tensorflow.keras')
+omlt, omlt_available = attempt_import("omlt")
 
 from enum import Enum
 import pandas as pd

--- a/idaes/surrogate/keras_surrogate.py
+++ b/idaes/surrogate/keras_surrogate.py
@@ -13,21 +13,30 @@
 """
 Interface for importing Keras models into IDAES
 """
-import numpy as np
+from enum import Enum
 import json
 import os.path
+
+import numpy as np
+import pandas as pd
 
 from pyomo.common.dependencies import attempt_import
 keras, keras_available = attempt_import('tensorflow.keras')
 omlt, omlt_available = attempt_import("omlt")
 
-from enum import Enum
-import pandas as pd
+if omlt_available:
+    from omlt import OmltBlock, OffsetScaling
+    from omlt.neuralnet import (
+        FullSpaceContinuousFormulation,
+        ReducedSpaceContinuousFormulation,
+        ReLUBigMFormulation,
+        ReLUComplementarityFormulation,
+        load_keras_sequential
+    )
+
 from idaes.surrogate.base.surrogate_base import SurrogateBase
 from idaes.surrogate.sampling.scaling import OffsetScaler
-from omlt import OmltBlock, OffsetScaling
-from omlt.neuralnet import (FullSpaceContinuousFormulation, ReducedSpaceContinuousFormulation,
-                            ReLUBigMFormulation, ReLUComplementarityFormulation, load_keras_sequential)
+
 
 class KerasSurrogate(SurrogateBase):
     def __init__(self, keras_model, input_labels, output_labels, input_bounds,

--- a/idaes/surrogate/tests/test_keras_surrogate.py
+++ b/idaes/surrogate/tests/test_keras_surrogate.py
@@ -15,6 +15,9 @@ Tests for KerasSurrogate
 """
 import pytest
 
+pytest.importorskip("tensorflow.keras", reason="tensorflow.keras not available")
+pytest.importorskip("omlt", reason="omlt not available")
+
 import os.path
 import pandas as pd
 from pyomo.common.fileutils import this_file_dir
@@ -22,12 +25,10 @@ from pyomo.common.tempfiles import TempfileManager
 from pyomo.environ import (ConcreteModel, Var, SolverFactory,
                            assert_optimal_termination, value,
                            Objective)
-from idaes.surrogate.keras_surrogate import KerasSurrogate, load_keras_json_hd5, keras_available
+from idaes.surrogate.keras_surrogate import KerasSurrogate, load_keras_json_hd5
 from idaes.surrogate.surrogate_block import SurrogateBlock
 from idaes.surrogate.sampling.scaling import OffsetScaler
 
-if not keras_available:
-    pytestmark = pytest.mark.skip("tensorflow.keras not available")
 
 rtol = 1e-4
 atol = 1e-4

--- a/idaes/tests/test_headers.py
+++ b/idaes/tests/test_headers.py
@@ -17,9 +17,11 @@ Test that headers are on all files
 from pathlib import Path
 import os
 # third-party
-from addheader.add import FileFinder, detect_files
 import pytest
 import yaml
+
+
+addheader_add = pytest.importorskip("addheader.add", reason="`addheader` package is not available")
 
 
 @pytest.fixture
@@ -50,8 +52,8 @@ def test_headers(package_root, patterns):
         print(f"ERROR: Did not get glob patterns: skipping test")
     else:
         # modify patterns to match the files that should have headers
-        ff = FileFinder(package_root, glob_patterns=patterns)
-        has_header, missing_header = detect_files(ff)
+        ff = addheader_add.FileFinder(package_root, glob_patterns=patterns)
+        has_header, missing_header = addheader_add.detect_files(ff)
         # ignore empty files (probably should add option in 'detect_files' for this)
         nonempty_missing_header = list(filter(lambda p: p.stat().st_size > 0, missing_header))
         #
@@ -62,4 +64,3 @@ def test_headers(package_root, patterns):
             print(f"Missing headers from files under '{pfx}{os.path.sep}': {file_list}")
         # uncomment to require all files to have headers
         assert len(nonempty_missing_header) == 0
-        

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ kwargs = dict(
         "nbformat",
         "numpy",
         "networkx",
+        "omlt==0.3.1", # fix the version for now as package evolves
         "pandas",
         "pint",
         "psutil",
@@ -106,7 +107,6 @@ kwargs = dict(
     extras_require={
         "prerelease": DEPENDENCIES_FOR_PRERELEASE_VERSION,
         "optional": [
-            "omlt==0.3.1", # fix the version for now as package evolves
             "tensorflow",  # idaes.surrogate.keras_surrogate
             # A Lee 11-Jan-22: no precompiled version of CoolProp available for Pyhton 3.9
             "coolprop; python_version < '3.9'"  # idaes.generic_models.properties.general.coolprop

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ kwargs = dict(
             "tensorflow",  # idaes.surrogate.keras_surrogate
             # A Lee 11-Jan-22: no precompiled version of CoolProp available for Pyhton 3.9
             "coolprop; python_version < '3.9'"  # idaes.generic_models.properties.general.coolprop
-        ]
+        ],
     },
     package_data={
         # If any package contains these files, include them:

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ kwargs = dict(
         "nbformat",
         "numpy",
         "networkx",
-        "omlt==0.3.1", # fix the version for now as package evolves
         "pandas",
         "pint",
         "psutil",
@@ -107,6 +106,7 @@ kwargs = dict(
     extras_require={
         "prerelease": DEPENDENCIES_FOR_PRERELEASE_VERSION,
         "optional": [
+            "omlt==0.3.1", # fix the version for now as package evolves
             "tensorflow",  # idaes.surrogate.keras_surrogate
             # A Lee 11-Jan-22: no precompiled version of CoolProp available for Pyhton 3.9
             "coolprop; python_version < '3.9'"  # idaes.generic_models.properties.general.coolprop


### PR DESCRIPTION
## Fixes #740, #537, #530 (and possibly many others)

- Test failures caused by `addheader/omlt not available` errors

## Summary/Motivation:

- Being able to run (a reasonable subset of) the IDAES test suite regardless of how it was installed is very valuable to validate installation
- We want this process to be as reliable and simple as possible
- Therefore, for simplicity, we should implement a policy that the test suite should run without errors having only `pytest` as a strict requirement
- In other words, any test that requires extra dependencies should be seamlessly skipped when that dependency is not available

## Changes proposed in this PR:

- Add `pytest.importorskip()` to skip `test_headers` module if `addheader` package is not available
- Move `omlt` to `optional` dependencies similarly to `tensorflow` in `setup.py` to match Conda package
- Add optional import logic to `keras_surrogate` and `test_keras_surrogate` to account for `omlt` being optional
- Update documentation and CI check for site-packages/non-editable/"user mode" installation to use `pip install pytest` as only extra step

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
