### PR TITLE
Fix redundant deprecation in warning

### DIFF
--- a/idaes/core/util/tags.py
+++ b/idaes/core/util/tags.py
@@ -721,7 +721,7 @@ def svg_tag(
     # Deal with soon to be depricated input by converting it to new style
     if tags is not None:
         deprecation_warning(
-            "DEPRECATED: svg_tag, the tags, tag_format and "
+            "svg_tag, the tags, tag_format and "
             "tag_format_default arguments are deprecated use tag_group instead.",
             version=1.12,
         )


### PR DESCRIPTION
## Fixes

Just fix a warning that has a redundant deprecated "DEPRECATED: DEPRECATED:".   

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
