### PR TITLE
MEA solvent viscosity calculation correction

### DIFF
--- a/idaes/models_extra/column_models/properties/MEA_solvent.py
+++ b/idaes/models_extra/column_models/properties/MEA_solvent.py
@@ -517,7 +517,9 @@ class Viscosity:
     def return_expression(blk, phase):
         pobj = blk.params.get_phase(phase)
 
-        r = blk.mass_frac_phase_comp_apparent["Liq", "MEA"] * 100
+        r = (blk.mass_frac_phase_comp_apparent["Liq", "MEA"] /
+             (blk.mass_frac_phase_comp_apparent["Liq", "MEA"] +
+              blk.mass_frac_phase_comp_apparent["Liq", "H2O"])) * 100
         T = blk.temperature
         alpha = (
             blk.mole_frac_phase_comp_apparent["Liq", "CO2"]

--- a/idaes/models_extra/column_models/properties/tests/test_mea_solvent.py
+++ b/idaes/models_extra/column_models/properties/tests/test_mea_solvent.py
@@ -135,7 +135,7 @@ class TestStateBlock(object):
             model.props[1].vol_mol_phase["Liq"]
         )
 
-        assert pytest.approx(5.26403457e-4, rel=1e-8) == value(
+        assert pytest.approx(5.58038484e-4, rel=1e-8) == value(
             model.props[1].visc_d_phase["Liq"]
         )
 
@@ -163,9 +163,9 @@ class TestStateBlock(object):
         assert pytest.approx(4.47017415e-09, rel=1e-8) == value(
             model.props[1].diffus_phase_comp_true["Liq", "MEA"]
         )
-        assert pytest.approx(2.27073817e-09, rel=1e-8) == value(
+        assert pytest.approx(2.17984326e-09, rel=1e-8) == value(
             model.props[1].diffus_phase_comp_true["Liq", "MEACOO_-"]
         )
-        assert pytest.approx(2.27073817e-09, rel=1e-8) == value(
+        assert pytest.approx(2.17984326e-09, rel=1e-8) == value(
             model.props[1].diffus_phase_comp_true["Liq", "MEA_+"]
         )


### PR DESCRIPTION
## Fixes
A small correction is made to the MEA solvent viscosity model in the MEA_solvent property package.

## Summary/Motivation:
Correcting the MEA solvent viscosity model, to ensure accurate property calculations.

## Changes proposed in this PR:
- The definition of intermediate term r in the expression of MEA solvent viscosity model (apparent liquid phase mass fraction of MEA on a CO2 free basis)
- Liquid phase viscosity and diffusivity values are updated in the tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
