### PR TITLE
add pytest importorskip for test that requires prescient

### DIFF
--- a/idaes/apps/grid_integration/tests/test_coordinator.py
+++ b/idaes/apps/grid_integration/tests/test_coordinator.py
@@ -1,4 +1,9 @@
 import pytest
+
+pytest.importorskip(
+    "prescient", reason="prescient is a requirement to run grid integration tests"
+)
+
 import pyomo.environ as pyo
 from idaes.apps.grid_integration.bidder import Bidder
 from idaes.apps.grid_integration.tracker import Tracker


### PR DESCRIPTION
## Fixes


## Summary/Motivation:
Given Prescient is an optional dependency, we need to skip the tests which require Prescient.

## Changes proposed in this PR:
- Add pytest.importorskip() for test that requires prescient.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
