### PR TITLE
Fix BooleanVar in model serializer

### DIFF
--- a/idaes/core/util/model_serializer.py
+++ b/idaes/core/util/model_serializer.py
@@ -224,11 +224,13 @@ class StoreSpec(object):
         classes=(
             (Param, ("_mutable",)),
             (Var, ()),
+            (BooleanVar, ()),
             (Expression, ()),
             (Component, ("active",)),
         ),
         data_classes=(
             (pyomo.core.base.var._VarData, ("fixed", "stale", "value", "lb", "ub")),
+            (pyomo.core.base.boolean_var._BooleanVarData, ("fixed", "stale", "value")),
             (pyomo.core.base.param._ParamData, ("value",)),
             (int, ("value",)),
             (float, ("value",)),

--- a/idaes/core/util/tests/test_model_serializer.py
+++ b/idaes/core/util/tests/test_model_serializer.py
@@ -50,6 +50,7 @@ class TestModelSerialize(unittest.TestCase):
         model.b = Block([1, 2, 3])
         a = model.b[1].a = Var(bounds=(-100, 100), initialize=2)
         b = model.b[1].b = Var(bounds=(-100, 100), initialize=20)
+        x = model.x = BooleanVar(initialize=True)
         model.b[1].c = Constraint(expr=b == 10 * a)
         a.fix(2)
         return model
@@ -116,11 +117,13 @@ class TestModelSerialize(unittest.TestCase):
 
         model2.b[1].a = 0.11
         model2.b[1].b = 0.11
+        model2.x = False
         to_json(model, fname=self.fname, human_read=True)
         from_json(model2, fname=self.fname)
         # make sure they are right
         assert pytest.approx(20) == value(model2.b[1].b)
         assert pytest.approx(2) == value(model2.b[1].a)
+        assert value(model2.x) == True
 
     @pytest.mark.unit
     def test01(self):


### PR DESCRIPTION
## Fixes issue #725

Makes me wonder if I should rewrite the serializer.  BooleanVar is not a Var, so when serializing it was falling back on generic Component and causing an error.

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
