### PR TITLE
Adding units of measurement to IDAES reporting tools

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -72,6 +72,17 @@ orig_environ = {
     "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
     "DYLD_LIBRARY_PATH": os.environ.get("DYLD_LIBRARY_PATH", ""),
 }
+# Define set of default units of measurmenet for common derived quantities
+default_uom = {
+    "pressure": "Pa",
+    "energy": "J",
+    "energy_mol": "J/mol",
+    "energy_mass": "J/kg",
+    "entropy": "J/K",
+    "entropy_mol": "J/mol/K",
+    "entropy_mass": "J/kg/K",
+    "power": "W",
+}
 
 def canonical_arch(arch):
     """Get the offical machine type in {x86_64, aarch64} if possible, otherwise
@@ -364,6 +375,14 @@ def _new_idaes_config_block():
         pyomo.common.config.ConfigValue(
             default=True,
             description="Solver output captured by logger?",
+        ),
+    )
+
+    cfg.declare(
+        "reporting_units",
+        pyomo.common.config.ConfigValue(
+            default=default_uom,
+            description="Units of measurement for reporting quantities",
         ),
     )
     return cfg

--- a/idaes/core/util/tests/test_units_of_measurement.py
+++ b/idaes/core/util/tests/test_units_of_measurement.py
@@ -1,0 +1,131 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+
+"""
+Tests for units of measurement utility functions
+"""
+import pytest
+
+from pyomo.environ import as_quantity, units
+
+from idaes.core.util.units_of_measurement import convert_quantity_to_reporting_units
+
+
+@pytest.mark.unit
+def test_convert_quantity_pressure():
+    q = as_quantity(1 * units.atm)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == 101325
+    assert str(q2.u) == "pascal"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_energy():
+    q = as_quantity(1 * units.BTU)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == 1055.056
+    assert str(q2.u) == "joule"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_energy_mass():
+    q = as_quantity(1 * units.BTU/units.pound)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == pytest.approx(1055.056/0.453592, rel=1e-6)
+    assert str(q2.u) == "joule / kilogram"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_energy_mole():
+    q = as_quantity(1 * units.BTU/units.mol)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == 1055.056
+    assert str(q2.u) == "joule / mole"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_entropy():
+    q = as_quantity(1 * units.BTU/units.degR)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == pytest.approx(1055.056*1.8, rel=1e-6)
+    assert str(q2.u) == "joule / kelvin"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_entropy_mass():
+    q = as_quantity(1 * units.BTU/units.pound/units.degR)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == pytest.approx(1055.056/0.453592*1.8, rel=1e-6)
+    assert str(q2.u) == "joule / kelvin / kilogram"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_entropy_mole():
+    q = as_quantity(1 * units.BTU/units.mol/units.degR)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == pytest.approx(1055.056*1.8, rel=1e-6)
+    assert str(q2.u) == "joule / kelvin / mole"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_power():
+    q = as_quantity(1 * units.BTU/units.hour)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == pytest.approx(0.2930711, rel=1e-6)
+    assert str(q2.u) == "watt"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_other():
+    q = as_quantity(1 * units.foot**0.5)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == 0.3048**0.5
+    assert str(q2.u) == "meter ** 0.5"
+    assert q is not q2
+
+
+@pytest.mark.unit
+def test_convert_quantity_dimensionless():
+    q = as_quantity(1 * units.dimensionless)
+
+    q2 = convert_quantity_to_reporting_units(q)
+
+    assert q2.m == 1
+    assert str(q2.u) == "dimensionless"
+    assert q is q2

--- a/idaes/core/util/units_of_measurement.py
+++ b/idaes/core/util/units_of_measurement.py
@@ -1,0 +1,55 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+
+"""
+This module contains utility functions for converting units of measurement and
+reporting model outputs.
+"""
+from pyomo.environ import units
+import idaes
+
+
+def convert_quantity_to_reporting_units(q):
+    """
+    Converts a pint quantity to the units defined in the IDAES config block.
+
+    Args:
+        q: pint quantity to be converted
+
+    Returns:
+        A new pint quantity in the untis defined by the IDAES config block.
+    """
+    # First, cehck if quantity is dimensionless
+    if q.dimensionless:
+        # No need to do anything here
+        return q
+
+    # Get definition of desired units from config block
+    def_units = idaes.cfg.reporting_units
+
+    # Get dimensionality of q
+    dim = q.dimensionality
+
+    # Iterate through unit definition to try to find matching dimensionality
+    for u in def_units.values():
+        # Get pint unit object from string
+        u_obj = getattr(units.pint_registry, u)
+        if str(u_obj.dimensionality) == str(dim):
+            # Found matching dimensionality
+            q2 = q.to(u_obj)
+            break
+    else:
+        # No matching dimensionality found, fall back to default system of units
+        q2 = q.to_base_units()
+
+    return q2


### PR DESCRIPTION
## Fixes #44


## Summary/Motivation:
Adding units of measurement to the IDAES reporting tools is long overdue.

## Changes proposed in this PR:
- Adds a new `reporting_units` entry in the IDAES config for defining desired reporting units of derived quantities,
- Adds new `units_of_measurement` module to `ideas.core.util` with methods for converting quantities to IDAES reporting units,

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
