### PR TITLE
Fixing skipping tests for prescient

### DIFF
--- a/idaes/apps/grid_integration/coordinator.py
+++ b/idaes/apps/grid_integration/coordinator.py
@@ -10,15 +10,13 @@
 # Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
 # license information.
 #################################################################################
-from pyomo.common.dependencies import attempt_import
+from itertools import zip_longest
 
-prescient, prescient_avail = attempt_import("prescient")
-if prescient_avail:
-    import prescient.plugins as pplugins
-    from prescient.simulator.config import PrescientConfig
+from pyomo.common.dependencies import attempt_import
 from pyomo.common.config import ConfigDict, ConfigValue
 import pyomo.environ as pyo
-from itertools import zip_longest
+
+prescient, prescient_avail = attempt_import("prescient")
 
 
 class DoubleLoopCoordinator:

--- a/idaes/apps/grid_integration/examples/thermal_generator.py
+++ b/idaes/apps/grid_integration/examples/thermal_generator.py
@@ -19,9 +19,7 @@ from idaes.apps.grid_integration import PlaceHolderForecaster
 
 from pyomo.common.dependencies import attempt_import
 
-prescient, prescient_avail = attempt_import("prescient")
-if prescient_avail:
-    from prescient.simulator import Prescient
+prescient, prescient_avail = attempt_import("prescient.simulator.Prescient")
 
 
 class ThermalGenerator:

--- a/idaes/apps/grid_integration/examples/thermal_generator.py
+++ b/idaes/apps/grid_integration/examples/thermal_generator.py
@@ -19,7 +19,7 @@ from idaes.apps.grid_integration import PlaceHolderForecaster
 
 from pyomo.common.dependencies import attempt_import
 
-prescient, prescient_avail = attempt_import("prescient.simulator.Prescient")
+Prescient, prescient_avail = attempt_import("prescient.simulator.Prescient")
 
 
 class ThermalGenerator:

--- a/idaes/apps/grid_integration/tests/test_bidder.py
+++ b/idaes/apps/grid_integration/tests/test_bidder.py
@@ -17,7 +17,7 @@ from idaes.apps.grid_integration.tests.util import TestingModel
 from idaes.apps.grid_integration.tests.util import TestingForecaster
 from pyomo.common import unittest as pyo_unittest
 
-egret = pytest.importorskip("egret", reason="egret (optional dependency) not available")
+from idaes.apps.grid_integration.coordinator import prescient_avail
 
 
 class TestMissingModel:
@@ -159,6 +159,8 @@ def bidder_object():
 
 
 @pytest.mark.component
+@pytest.mark.skipif(not prescient_avail,
+                    reason="Prescient (optional dependency) not available")
 def test_compute_bids(bidder_object):
 
     marginal_cost = bidder_object.bidding_model_object.marginal_cost

--- a/idaes/apps/grid_integration/tests/test_coordinator.py
+++ b/idaes/apps/grid_integration/tests/test_coordinator.py
@@ -12,10 +12,6 @@
 #################################################################################
 import pytest
 
-pytest.importorskip(
-    "prescient", reason="prescient is a requirement to run grid integration tests"
-)
-
 import pyomo.environ as pyo
 from idaes.apps.grid_integration.bidder import Bidder
 from idaes.apps.grid_integration.tracker import Tracker

--- a/idaes/apps/grid_integration/tests/test_integration.py
+++ b/idaes/apps/grid_integration/tests/test_integration.py
@@ -19,16 +19,10 @@ except ImportError:
     import importlib_resources as resources
 from numbers import Number
 from pathlib import Path
-from typing import Dict, Union, List
+from typing import Dict, Union
 import os
 
 import pytest
-import pandas as pd
-
-
-prescient_simulator = pytest.importorskip(
-    "prescient.simulator", reason="prescient (optional dependency) not available"
-)
 
 
 # define custom type for type hinting
@@ -149,9 +143,11 @@ class TestDoubleLoopIntegration:
 
     @pytest.fixture
     def run_bidder_simulator(self, bidder_sim_options: PrescientOptions) -> None:
-        from prescient.simulator import Prescient
+        prescient = pytest.importorskip(
+            "prescient.simulator.Prescient",
+            reason="Prescient (optional dependency) not available")
 
-        sim = Prescient()
+        sim = prescient()
         sim.simulate(**bidder_sim_options)
 
     @pytest.fixture

--- a/idaes/apps/grid_integration/tests/test_integration.py
+++ b/idaes/apps/grid_integration/tests/test_integration.py
@@ -143,11 +143,11 @@ class TestDoubleLoopIntegration:
 
     @pytest.fixture
     def run_bidder_simulator(self, bidder_sim_options: PrescientOptions) -> None:
-        prescient = pytest.importorskip(
+        Prescient = pytest.importorskip(
             "prescient.simulator.Prescient",
             reason="Prescient (optional dependency) not available")
 
-        sim = prescient()
+        sim = Prescient()
         sim.simulate(**bidder_sim_options)
 
     @pytest.fixture

--- a/idaes/tests/prescient/test_prescient.py
+++ b/idaes/tests/prescient/test_prescient.py
@@ -25,9 +25,6 @@ import pytest
 import pandas as pd
 
 
-prescient_simulator = pytest.importorskip("prescient.simulator", reason="prescient (optional dependency) not available")
-
-
 # define custom type for type hinting
 PrescientOptions = Dict[str, Union[str, bool, Number, dict]]
 
@@ -82,9 +79,11 @@ class Test5Bus:
 
     @pytest.fixture
     def run_simulator(self, prescient_options: PrescientOptions) -> None:
-        from prescient.simulator import Prescient
+        prescient = pytest.importorskip(
+            "prescient.simulator.Prescient", 
+            reason="Prescient (optional dependency) not available")
 
-        sim = Prescient()
+        sim = prescient()
         sim.simulate(**prescient_options)
 
     @pytest.fixture

--- a/idaes/tests/prescient/test_prescient.py
+++ b/idaes/tests/prescient/test_prescient.py
@@ -79,11 +79,11 @@ class Test5Bus:
 
     @pytest.fixture
     def run_simulator(self, prescient_options: PrescientOptions) -> None:
-        prescient = pytest.importorskip(
+        Prescient = pytest.importorskip(
             "prescient.simulator.Prescient", 
             reason="Prescient (optional dependency) not available")
 
-        sim = prescient()
+        sim = Prescient()
         sim.simulate(**prescient_options)
 
     @pytest.fixture


### PR DESCRIPTION
## Summary/Motivation:
The `grid_integration` code requires `prescient` to work and imports it as part of the code. The existing code and tests were not correctly handling cases where `prescient` was not available resulting in test failures for systems without it.

## Changes proposed in this PR:
- Fixed misuse of `pytest.importortest`
- Fixing some other issues with conditional importing of `prescient`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
