### PR TITLE
Fix serializing with top level BlockData

### DIFF
--- a/idaes/core/util/model_serializer.py
+++ b/idaes/core/util/model_serializer.py
@@ -317,6 +317,12 @@ class StoreSpec(object):
                 alist = self.classes[cl][0]
                 ff = self.classes[cl][1]
                 break
+        if isinstance(o, Block._ComponentDataClass):
+            # If you're here you are trying to serialize an element of an
+            # indexed block at the top level.  We do want to allow that, so
+            # we'll pretend it's a block.
+            alist = self.classes[Block][0]
+            ff = self.classes[Block][1]
         return (alist, ff)
 
     def get_data_class_attr_list(self, o):

--- a/idaes/core/util/tests/test_model_serializer.py
+++ b/idaes/core/util/tests/test_model_serializer.py
@@ -183,13 +183,12 @@ class TestModelSerialize(unittest.TestCase):
     @pytest.mark.unit
     def test01c(self):
         """
-        Simple test of load save json
+        Simple test of load save json for a _BlockData
         """
         model = self.setup_model01b()
         a = model.b["1"].a
         b = model.b["1"].b
         sd = to_json(model.b["1"], return_dict=True, human_read=True)
-        print(sd)
         # change variable values
         a.value = 0.11
         b.value = 0.11

--- a/idaes/core/util/tests/test_model_serializer.py
+++ b/idaes/core/util/tests/test_model_serializer.py
@@ -181,6 +181,33 @@ class TestModelSerialize(unittest.TestCase):
         assert b.ub == 100
 
     @pytest.mark.unit
+    def test01c(self):
+        """
+        Simple test of load save json
+        """
+        model = self.setup_model01b()
+        a = model.b["1"].a
+        b = model.b["1"].b
+        sd = to_json(model.b["1"], return_dict=True, human_read=True)
+        print(sd)
+        # change variable values
+        a.value = 0.11
+        b.value = 0.11
+        a.unfix()
+        model.b["1"].deactivate()
+        b.setlb(2)
+        b.setub(4)
+        # reload values
+        from_json(model.b["1"], sd=sd)
+        # make sure they are right
+        assert a.fixed
+        assert model.b["1"].active
+        assert value(b) == 20
+        assert value(a) == 2
+        assert b.lb == -100
+        assert b.ub == 100
+
+    @pytest.mark.unit
     def test02(self):
         """Test with suffixes"""
         model = self.setup_model02()


### PR DESCRIPTION
## Fixes #826

_BlockData is not in the components to serialize (since it is component data), so if you wanted to serialize a block data object as the root object, it wouldn't work since _BlockData isn't in the list of component classes to serialize.  I fixed this by catching _BlockData and pretending it's a Block when looking at the list of components to serialize.  This should only happen when a _BlockData object is the root object.  Otherwise, it only shows up as component data.  Sorry I know that's confusing, but it fixes #826

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
