### PR TITLE
Configure GHA run serialization to automatically cancel redundant workflow runs

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -25,6 +25,17 @@ on:
       # synchronize occurs whenever commits are pushed to the PR branch
       - synchronize
 
+concurrency:
+  # NOTE: the value of `group` should be chosen carefully,
+  # otherwise we might end up over- or under-canceling workflow runs
+  # e.g. if we want to have Codecov results for each commit on `main`,
+  # we should use something `github.sha` instead of `github.ref_name`
+  # to avoid over-canceling runs from `main`
+  # in which case we'd need to access the PR number from somewhere else rather than `github.ref_name`
+  # to avoid under-canceling runs from PRs
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 env:
   # default Python version to use for checks that do not require multiple versions
   DEFAULT_PYTHON_VERSION: '3.8'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,6 +24,12 @@ on:
     types:
       - submitted
 
+concurrency:
+  # NOTE: the value of `group` should be chosen carefully,
+  # otherwise we might end up over- or under-canceling workflow runs
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 env:
   IDAES_CONDA_ENV_NAME_DEV: idaes-pse-dev
   PYTEST_ADDOPTS: "--color=yes"


### PR DESCRIPTION
## Summary/Motivation:

- At some point in the last few months (thanks to @andrewlee94 for the most recent suggestion to implement this) GitHub Actions added the functionality to tag workflows so that only one run is allowed at any given time
- If the `cancel-in-progress` option is set to `true`, already running workflows will be canceled
- This is very useful for us since it reduces the need of "manual corralling" workflow runs when merging several PRs one after the other
- By choosing the concurrency `group` opportunely, we can require that at most one workflow run per PR should be running at a given time, so whenever a new commit is pushed to the PR head branch (e.g. by merging the current `main` into it), outdated and therefore unneeded workflow runs are cancelled automatically


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
