### PR TITLE
Update pyomo to the 6.4.1 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.4.1.rc2.idaes.2022.05.13.zip"
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.4.1.zip"
 ]
 
 # For included DMF data

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ kwargs = dict(
         "pandas",
         "pint",
         "psutil",
-        "pyomo>=6.3",
+        "pyomo>=6.4.1",
         "pytest",
         "pyyaml",
         "requests",  # for ui/fsvis


### PR DESCRIPTION
## Fixes


## Summary/Motivation:
This updates the IDAES pyomo reference to the final 6.4.1 release

## Changes proposed in this PR:
- Update pyomo prerelease tag to 6.4.1.zip
- Update minimum Pyomo version

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
