### PR TITLE
Bug in initialization of FpcTP property packages

### DIFF
--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1506,6 +1506,8 @@ class _GenericStateBlock(StateBlock):
                         "component_flow_balances",
                         "sum_mole_frac",
                         "phase_fraction_constraint",
+                        "mole_frac_phase_comp_eq",
+                        "mole_frac_comp_eq",
                     ):
                         c.activate()
                     if c.local_name == "log_mole_frac_phase_comp_eqn":

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1516,6 +1516,21 @@ class _GenericStateBlock(StateBlock):
                                 blk[k].log_mole_frac_phase_comp[p, j],
                                 blk[k].log_mole_frac_phase_comp_eqn[p, j],
                             )
+                    elif c.local_name == "mole_frac_phase_comp_eq":
+                        c.activate()
+                        for p, j in blk[k].params._phase_component_set:
+                            calculate_variable_from_constraint(
+                                blk[k].mole_frac_phase_comp[p, j],
+                                blk[k].mole_frac_phase_comp_eq[p, j],
+                            )
+                    elif c.local_name == "mole_frac_comp_eq":
+                        c.activate()
+                        for j in blk[k].params.component_list:
+                            calculate_variable_from_constraint(
+                                blk[k].mole_frac_comp[j],
+                                blk[k].mole_frac_comp_eq[j],
+                            )
+
                 for pp in blk[k].params._pe_pairs:
                     # Activate formulation specific constraints
                     blk[k].params.config.phase_equilibrium_state[

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1505,7 +1505,6 @@ class _GenericStateBlock(StateBlock):
                         "total_flow_balance",
                         "component_flow_balances",
                         "sum_mole_frac",
-                        "equilibrium_constraint",
                         "phase_fraction_constraint",
                     ):
                         c.activate()
@@ -1516,20 +1515,12 @@ class _GenericStateBlock(StateBlock):
                                 blk[k].log_mole_frac_phase_comp[p, j],
                                 blk[k].log_mole_frac_phase_comp_eqn[p, j],
                             )
-                    elif c.local_name == "mole_frac_phase_comp_eq":
-                        c.activate()
-                        for p, j in blk[k].params._phase_component_set:
-                            calculate_variable_from_constraint(
-                                blk[k].mole_frac_phase_comp[p, j],
-                                blk[k].mole_frac_phase_comp_eq[p, j],
-                            )
-                    elif c.local_name == "mole_frac_comp_eq":
-                        c.activate()
-                        for j in blk[k].params.component_list:
-                            calculate_variable_from_constraint(
-                                blk[k].mole_frac_comp[j],
-                                blk[k].mole_frac_comp_eq[j],
-                            )
+                    elif c.local_name == "equilibrium_constraint":
+                        # For systems where the state variables fully define the
+                        # phase equilibrium, we cannot activate the equilibrium
+                        # constraint at this stage.
+                        if "flow_mol_phase_comp" not in blk[k].define_state_vars():
+                            c.activate()
 
                 for pp in blk[k].params._pe_pairs:
                     # Activate formulation specific constraints

--- a/idaes/models/properties/modular_properties/eos/tests/test_ceos_PR.py
+++ b/idaes/models/properties/modular_properties/eos/tests/test_ceos_PR.py
@@ -228,6 +228,7 @@ Hv = -779.305
 Ul = Hl - 8.314 * 300 * (Zl - 1)
 Uv = Hv - 8.314 * 300 * (Zv - 1)
 
+
 @pytest.mark.unit
 def test_wrong_phase():
     m = ConcreteModel()


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
The WaterTAP project identified a bug in the initialization of modular property packages using FpcTP state variables with phase equilibrium. Fundamentally, this system cannot be initialized with the phase equilibrium constraints active without unfixing some of the flowrate state variables, which would run against the normal assumptions we make for the initialization workflow.

For now, this PR addresses the higher level issues of ensuring zero degrees of freedom at each solve step by adding logic to skip activation of the phase equilibrium constraints for these systems, as well as adding in the flowrate-mole fraction constraints for this system (which had been missed previously). This gets the state block to initialize correctly, but leaves in in a non-equilibrium state which might cause issues at the unit model level (this is a good case for providing initial guesses via state args).

## Changes proposed in this PR:
- Adds logic to skip activation of the phase equilibrium constraint for Fpc systems.
- Adds in missing activation of the mole fraction constraints for Fpc and Fc systems
- Adds a test for initializing FpcTP systems with phase equilibrium based on the example from WaterTAP.
- Runs `black` on a couple of files.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
