### PR TITLE
Move helper function into core\util\misc

### DIFF
--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -251,3 +251,19 @@ class StrEnum(str, Enum):
 
     def __str__(self):
         return str(self.value)
+
+
+# Author: Douglas Allan
+def set_and_get_attr(obj, name, val):
+    """
+    Helper function to create an attribute on object and return a pointer to that attribute
+    Args:
+        obj (Object): Object upon which to create attribute
+        name (string): Name of attribute to create
+        val: Value to assign to new attribute (typically an Object)
+
+    Returns:
+        Attribute created on Object obj
+    """
+    setattr(obj, name, val)
+    return getattr(obj, name)

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -11,7 +11,7 @@
 # license information.
 #################################################################################
 """
-This module contains miscalaneous utility functions for use in IDAES models.
+This module contains miscellaneous utility functions for use in IDAES models.
 """
 
 import pytest
@@ -26,6 +26,7 @@ from idaes.core.util.misc import (
     copy_port_values,
     TagReference,
     set_param_from_config,
+    set_and_get_attr
 )
 import idaes.logger as idaeslog
 
@@ -474,3 +475,9 @@ class TestSetParamFromConfig:
             "b no units provided for parameter test_param - assuming "
             "default units" in caplog.text
         )
+
+@pytest.mark.unit
+def test_set_and_get_attr():
+    m = ConcreteModel()
+    x = set_and_get_attr(m, "x", Var(initialize=0))
+    assert m.x is x

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/common.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/common.py
@@ -25,6 +25,7 @@ import idaes.core.util.scaling as iscale
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
 import idaes.core.util.model_statistics as mstat
 from idaes.core.util.constants import Constants
+from idaes.core.util.misc import set_and_get_attr
 import idaes.logger as idaeslog
 
 _safe_log_eps = 1e-9
@@ -34,12 +35,6 @@ _safe_sqrt_eps = 1e-9
 class CV_Bound(enum.Enum):
     EXTRAPOLATE = 1
     NODE_VALUE = 2
-
-
-def _set_and_get_attr(obj, name, val):
-    setattr(obj, name, val)
-    return getattr(obj, name)
-
 
 def _set_default_factor(c, s):
     """Iterate over an indexed component, and set individual scaling factors
@@ -587,7 +582,7 @@ def _pure_component_visc(temperature, comp):
             1e-7
             * 16.64
             * bin_diff_M[comp] ** 0.5
-            * temperature
+            * temperature # FIXME this shouldn't depend linearly on temperature
             / (bin_diff_epsok[comp] ** 0.5 * bin_diff_sigma[comp] ** 2)
         )
         * pyo.units.Pa
@@ -931,7 +926,7 @@ def _face_initializer(blk, faces, direction):
                 "is not strictly increasing."
             )
 
-    face_set = _set_and_get_attr(
+    face_set = set_and_get_attr(
         blk,
         dfaces,
         pyo.Set(
@@ -940,7 +935,7 @@ def _face_initializer(blk, faces, direction):
             doc=f"{direction} coordinates for control volume faces",
         ),
     )
-    node_set = _set_and_get_attr(
+    node_set = set_and_get_attr(
         blk,
         dnodes,
         pyo.Set(
@@ -953,7 +948,7 @@ def _face_initializer(blk, faces, direction):
         ),
     )
     # This sets provide an integer index for nodes and faces
-    iface_set = _set_and_get_attr(
+    iface_set = set_and_get_attr(
         blk,
         "i" + dfaces,
         pyo.Set(
@@ -962,7 +957,7 @@ def _face_initializer(blk, faces, direction):
             doc=f"Integer index set for {dfaces}",
         ),
     )
-    inode_set = _set_and_get_attr(
+    inode_set = set_and_get_attr(
         blk,
         "i" + dnodes,
         pyo.Set(

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/solid_oxide_module_simple.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/solid_oxide_module_simple.py
@@ -54,6 +54,7 @@ from idaes.models_extra.power_generation.unit_models.soc_submodels.common import
 )
 import idaes.core.util.scaling as iscale
 from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.misc import set_and_get_attr
 from idaes.core.solvers import get_solver
 
 import idaes.logger as idaeslog
@@ -190,7 +191,7 @@ class SolidOxideModuleSimpleData(UnitModelBlockData):
             side_comps = getattr(self.solid_oxide_cell, f"{side}_component_list")
             # Support absent components in property package to support legacy property packages that do not
             # permit users to exclude components.
-            absent_comp_list = common._set_and_get_attr(
+            absent_comp_list = set_and_get_attr(
                 self,
                 f"absent_{side}_component_list",
                 pyo.Set(


### PR DESCRIPTION
## Summary/Motivation:
When working with Pyomo models, I've found a common design pattern where `setattr` is called in order to create a component on a model with a name given by a formatted string, then `getattr` is immediately called to work with the component just created. `set_and_get_attr` combines these into a single step, creating the attribute then returning it so it can be assigned to some variable.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
