### PR TITLE
Sphinx Documentation Build Issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ release = idaes.ver.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
## Fixes
- Recently, test runs have been failing due to Sphinx documentation build errors:
`142 WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).`
... long list of deprecated import path warnings (see #883 ) ...
`872 /home/runner/work/idaes-pse/idaes-pse/docs/tutorials/tutorials_examples.rst:3: WARNING: unknown document: howto/index`
- The cause may be related to Sphinx Issue #10474 and PR #10481 where `None` was removed as a supported flag for the `language` entry. This tests if updating the flag to 'en' (the new default) removes the warning and allows Sphinx to build the docs correctly, which may resolve the unknown document issue as well.

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
