### PR TITLE
Create work term for Pressure Changer with EnergyBalanceType.none

### DIFF
--- a/idaes/models/unit_models/pressure_changer.py
+++ b/idaes/models/unit_models/pressure_changer.py
@@ -27,7 +27,7 @@ from pyomo.environ import (
     Constraint,
     Reference,
     check_optimal_termination,
-    Reals
+    Reals,
 )
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.common.deprecation import deprecated
@@ -324,7 +324,7 @@ see property package for documentation.}""",
 
         # Add energy balance
         eb = self.control_volume.add_energy_balances(
-             balance_type=self.config.energy_balance_type, has_work_transfer=True
+            balance_type=self.config.energy_balance_type, has_work_transfer=True
         )
 
         # add momentum balance
@@ -344,15 +344,19 @@ see property package for documentation.}""",
         # Set references to balance terms at unit level
         # Add Work transfer variable 'work'
         # If the 'work' variable wasn't already built on the control volume but is needed, create it now.
-        if not hasattr(self.control_volume, 'work') and self.config.thermodynamic_assumption == ThermodynamicAssumption.pump and eb is None:
-                units = self.config.property_package.get_metadata().get_derived_units
-                self.control_volume.work = Var(
-                    self.flowsheet().time,
-                    domain=Reals,
-                    initialize=0.0,
-                    doc="Work transferred into control volume",
-                    units=units("power"),
-                )
+        if (
+            not hasattr(self.control_volume, "work")
+            and self.config.thermodynamic_assumption == ThermodynamicAssumption.pump
+            and eb is None
+        ):
+            units = self.config.property_package.get_metadata().get_derived_units
+            self.control_volume.work = Var(
+                self.flowsheet().time,
+                domain=Reals,
+                initialize=0.0,
+                doc="Work transferred into control volume",
+                units=units("power"),
+            )
         self.work_mechanical = Reference(self.control_volume.work[:])
 
         # Add Momentum balance variable 'deltaP'
@@ -1151,7 +1155,7 @@ see property package for documentation.}""",
                     )
                     iscale.constraint_scaling_transform(c, sf)
             else:
-                # There are some other material balance types, but they create
+                # There are some other material balance types but they create
                 # constraints with different names.
                 _log.warning(f"Unknown material balance type {mb_type}")
 

--- a/idaes/models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/models/unit_models/tests/test_pressure_changer.py
@@ -568,7 +568,6 @@ class TestIAPWS(object):
 
             Tout = pytest.approx(cases["Tout"][i], rel=1e-2)
             Pout = pytest.approx(cases["Pout"][i] * 1000, rel=1e-2)
-            Pout = pytest.approx(cases["Pout"][i] * 1000, rel=1e-2)
             W = pytest.approx(cases["W"][i] * 1000, rel=1e-2)
             xout = pytest.approx(xout, rel=1e-2)
             prop_out = iapws.fs.unit.control_volume.properties_out[0]
@@ -845,6 +844,28 @@ class TestPump(object):
 
         assert_units_consistent(m.fs.unit)
 
+    @pytest.mark.unit
+    def test_work_term_added_w_energybalancetype_none(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m.fs.properties = PhysicalParameterTestBlock()
+
+        m.fs.unit = Pump(default={"property_package": m.fs.properties,
+                                  "energy_balance_type": EnergyBalanceType.none})
+
+        assert m.fs.unit.config.energy_balance_type == EnergyBalanceType.none
+        assert hasattr(m.fs.unit.control_volume, 'work')
+
+        m2 = ConcreteModel()
+        m2.fs = FlowsheetBlock(default={"dynamic": False})
+
+        m2.fs.properties = PhysicalParameterTestBlock()
+
+        m2.fs.unit = PressureChanger(default={"property_package": m2.fs.properties,
+                                              "thermodynamic_assumption": ThermodynamicAssumption.pump,
+                                              })
+        assert hasattr(m2.fs.unit.control_volume, 'work')
 
 @pytest.mark.skipif(not iapws95.iapws95_available(), reason="IAPWS not available")
 @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/models/unit_models/tests/test_pressure_changer.py
@@ -846,26 +846,36 @@ class TestPump(object):
 
     @pytest.mark.unit
     def test_work_term_added_w_energybalancetype_none(self):
+        # Check that work term is created when energy balance type none
         m = ConcreteModel()
         m.fs = FlowsheetBlock(default={"dynamic": False})
 
         m.fs.properties = PhysicalParameterTestBlock()
 
-        m.fs.unit = Pump(default={"property_package": m.fs.properties,
-                                  "energy_balance_type": EnergyBalanceType.none})
+        m.fs.unit = Pump(
+            default={
+                "property_package": m.fs.properties,
+                "energy_balance_type": EnergyBalanceType.none,
+            }
+        )
 
         assert m.fs.unit.config.energy_balance_type == EnergyBalanceType.none
-        assert hasattr(m.fs.unit.control_volume, 'work')
+        assert hasattr(m.fs.unit.control_volume, "work")
 
         m2 = ConcreteModel()
         m2.fs = FlowsheetBlock(default={"dynamic": False})
 
         m2.fs.properties = PhysicalParameterTestBlock()
 
-        m2.fs.unit = PressureChanger(default={"property_package": m2.fs.properties,
-                                              "thermodynamic_assumption": ThermodynamicAssumption.pump,
-                                              })
-        assert hasattr(m2.fs.unit.control_volume, 'work')
+        m2.fs.unit = PressureChanger(
+            default={
+                "property_package": m2.fs.properties,
+                "thermodynamic_assumption": ThermodynamicAssumption.pump,
+                "energy_balance_type": EnergyBalanceType.none,
+            }
+        )
+        assert hasattr(m2.fs.unit.control_volume, "work")
+
 
 @pytest.mark.skipif(not iapws95.iapws95_available(), reason="IAPWS not available")
 @pytest.mark.skipif(solver is None, reason="Solver not available")

--- a/idaes/models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/models/unit_models/tests/test_pressure_changer.py
@@ -845,7 +845,7 @@ class TestPump(object):
         assert_units_consistent(m.fs.unit)
 
     @pytest.mark.unit
-    def test_work_term_added_w_energybalancetype_none(self):
+    def test_pump_work_term_added_w_energybalancetype_none(self):
         # Check that work term is created when energy balance type none
         m = ConcreteModel()
         m.fs = FlowsheetBlock(default={"dynamic": False})
@@ -861,20 +861,24 @@ class TestPump(object):
 
         assert m.fs.unit.config.energy_balance_type == EnergyBalanceType.none
         assert hasattr(m.fs.unit.control_volume, "work")
+        assert hasattr(m.fs.unit, "work_mechanical")
 
-        m2 = ConcreteModel()
-        m2.fs = FlowsheetBlock(default={"dynamic": False})
+    @pytest.mark.unit
+    def test_pressure_changer_work_term_added_w_energybalancetype_none(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(default={"dynamic": False})
 
-        m2.fs.properties = PhysicalParameterTestBlock()
+        m.fs.properties = PhysicalParameterTestBlock()
 
-        m2.fs.unit = PressureChanger(
+        m.fs.unit = PressureChanger(
             default={
-                "property_package": m2.fs.properties,
+                "property_package": m.fs.properties,
                 "thermodynamic_assumption": ThermodynamicAssumption.pump,
                 "energy_balance_type": EnergyBalanceType.none,
             }
         )
-        assert hasattr(m2.fs.unit.control_volume, "work")
+        assert hasattr(m.fs.unit.control_volume, "work")
+        assert hasattr(m.fs.unit, "work_mechanical")
 
 
 @pytest.mark.skipif(not iapws95.iapws95_available(), reason="IAPWS not available")


### PR DESCRIPTION
## Fixes
## Summary/Motivation:
In WaterTAP, we noticed that having a property model with `EnergyBalanceType.none` would be incompatible with a Pump unit. Thus, to be compatible with the Pump, the property model currently needs to have  `EnergyBalanceType.enthalpyTotal` set. However, enthalpy is not necessary for the Pump; we only really care about volumetric flow rate, pressure (head) and efficiency to then calculate work. 

In short, the `work` variable is only ever created on a ControlVolume Block when `EnergyBalanceType.enthalpyTotal` is set which shouldn't always be the case. For more details, please have a look at this discussion in our WaterTAP repo: https://github.com/watertap-org/watertap/issues/651

## Changes proposed in this PR:
- add conditional check before Reference connecting `control_volume.work` to `self.work_mechanical` in pressure_changer unit
- if the conditional is true, then `work` variable is created on control volume
- the conditional ensures the following is true before creating `work` on control volume within pressure_changer unit:
1. `work` does not exist on control volume
2. `EnergyBalanceType` is none
3. `ThermodynamicAssumption` is `Pump`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
4. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
