### PR TITLE
Fix multistage turbine test

### DIFF
--- a/idaes/models_extra/power_generation/unit_models/helm/tests/test_turbine_multistage.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/tests/test_turbine_multistage.py
@@ -32,7 +32,7 @@ import idaes.logger as idaeslog
 from idaes.core.solvers import get_solver
 
 # Set up solver
-solver = get_solver(options={"max_iter":20})
+solver = get_solver(options={"max_iter": 20})
 
 
 @pytest.mark.unit
@@ -126,7 +126,7 @@ def test_initialize():
 
     pyo.TransformationFactory("network.expand_arcs").apply_to(m)
     iscale.calculate_scaling_factors(m)
-    turb.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter":20})
+    turb.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter": 20})
     turb.ip_stages[1].inlet.unfix()
 
     for t in m.fs.time:
@@ -139,7 +139,6 @@ def test_initialize():
         m.fs.reheat.inlet.pressure[t].value = pyo.value(
             turb.hp_split[7].outlet_1_state[t].pressure
         )
-    m.fs.reheat.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter":20})
 
     def reheat_T_rule(b, t):
         return m.fs.reheat.control_volume.properties_out[t].temperature == 880
@@ -147,6 +146,8 @@ def test_initialize():
     m.fs.reheat.temperature_out_equation = pyo.Constraint(
         m.fs.reheat.flowsheet().time, rule=reheat_T_rule
     )
+
+    m.fs.reheat.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter": 20})
 
     m.fs.turb.outlet_stage.control_volume.properties_out[0].pressure.fix()
 
@@ -179,7 +180,7 @@ def test_initialize_calc_cf():
     hin = pyo.value(iapws95.htpx(T=880 * pyo.units.K, P=p * pyo.units.Pa))
     m.fs.turb.ip_stages[1].inlet.enth_mol[0].value = hin
     # m.fs.turb.ip_stages[1].inlet.flow_mol[0].value = 25220.0
-    #m.fs.turb.ip_stages[1].inlet.pressure[0].value = p
+    # m.fs.turb.ip_stages[1].inlet.pressure[0].value = p
 
     for i, s in turb.hp_stages.items():
         s.ratioP[:] = 0.88
@@ -202,7 +203,6 @@ def test_initialize_calc_cf():
     turb.lp_split[11].split_fraction[0, "outlet_2"].fix(0.04)
 
     # Congiure with reheater for a full test
-    #turb.ip_stages[1].inlet.fix()
     turb.inlet_split.inlet.flow_mol.unfix()
     turb.inlet_mix.use_equal_pressure_constraint()
     for i in m.fs.turb.inlet_stage:
@@ -230,7 +230,7 @@ def test_initialize_calc_cf():
         calculate_outlet_cf=True,
         copy_disconneted_flow=True,
         copy_disconneted_pressure=True,
-        optarg={"max_iter":20}
+        optarg={"max_iter": 20},
     )
     turb.ip_stages[1].inlet.unfix()
 
@@ -247,13 +247,12 @@ def test_initialize_calc_cf():
 
     def reheat_T_rule(b, t):
         return m.fs.reheat.control_volume.properties_out[t].temperature == 880
+
     m.fs.reheat.temperature_out_equation = pyo.Constraint(
         m.fs.reheat.flowsheet().time, rule=reheat_T_rule
     )
 
-    m.fs.reheat.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter":20})
-
-
+    m.fs.reheat.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter": 20})
 
     m.fs.turb.outlet_stage.control_volume.properties_out[0].pressure.fix()
 

--- a/idaes/models_extra/power_generation/unit_models/helm/tests/test_turbine_multistage.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/tests/test_turbine_multistage.py
@@ -179,8 +179,6 @@ def test_initialize_calc_cf():
     p = 1.4e06
     hin = pyo.value(iapws95.htpx(T=880 * pyo.units.K, P=p * pyo.units.Pa))
     m.fs.turb.ip_stages[1].inlet.enth_mol[0].value = hin
-    # m.fs.turb.ip_stages[1].inlet.flow_mol[0].value = 25220.0
-    # m.fs.turb.ip_stages[1].inlet.pressure[0].value = p
 
     for i, s in turb.hp_stages.items():
         s.ratioP[:] = 0.88

--- a/idaes/models_extra/power_generation/unit_models/helm/tests/test_turbine_multistage.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/tests/test_turbine_multistage.py
@@ -28,34 +28,33 @@ from idaes.core.util.model_statistics import (
     activated_equalities_generator,
 )
 import idaes.core.util.scaling as iscale
+import idaes.logger as idaeslog
 from idaes.core.solvers import get_solver
 
 # Set up solver
-solver = get_solver()
+solver = get_solver(options={"max_iter":20})
 
 
 @pytest.mark.unit
 def build_turbine_for_run_test():
     m = pyo.ConcreteModel()
-    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs = FlowsheetBlock(dynamic=False)
     m.fs.properties = iapws95.Iapws95ParameterBlock()
     # roughly based on NETL baseline studies
     m.fs.turb = HelmTurbineMultistage(
-        default={
-            "property_package": m.fs.properties,
-            "num_hp": 7,
-            "num_ip": 14,
-            "num_lp": 11,
-            "hp_split_locations": [4, 7],
-            "ip_split_locations": [5, 14],
-            "lp_split_locations": [4, 7, 9, 11],
-            "hp_disconnect": [7],
-            "ip_split_num_outlets": {14: 3},
-        }
+        property_package=m.fs.properties,
+        num_hp=7,
+        num_ip=14,
+        num_lp=11,
+        hp_split_locations=[4, 7],
+        ip_split_locations=[5, 14],
+        lp_split_locations=[4, 7, 9, 11],
+        hp_disconnect=[7],
+        ip_split_num_outlets={14: 3},
     )
 
     # Add reheater
-    m.fs.reheat = Heater(default={"property_package": m.fs.properties})
+    m.fs.reheat = Heater(property_package=m.fs.properties)
     m.fs.hp_to_reheat = Arc(
         source=m.fs.turb.hp_split[7].outlet_1, destination=m.fs.reheat.inlet
     )
@@ -114,8 +113,20 @@ def test_initialize():
     turb.inlet_split.inlet.flow_mol.unfix()
     turb.inlet_mix.use_equal_pressure_constraint()
 
+    for i, s in turb.inlet_stage.items():
+        iscale.set_scaling_factor(s.control_volume.work, 1e-5)
+    for i, s in turb.hp_stages.items():
+        iscale.set_scaling_factor(s.control_volume.work, 1e-5)
+    for i, s in turb.ip_stages.items():
+        iscale.set_scaling_factor(s.control_volume.work, 1e-5)
+    for i, s in turb.lp_stages.items():
+        iscale.set_scaling_factor(s.control_volume.work, 1e-5)
+    iscale.set_scaling_factor(turb.outlet_stage.control_volume.work, 1e-5)
+    iscale.set_scaling_factor(m.fs.reheat.control_volume.heat, 1e-5)
+
+    pyo.TransformationFactory("network.expand_arcs").apply_to(m)
     iscale.calculate_scaling_factors(m)
-    turb.initialize(outlvl=1)
+    turb.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter":20})
     turb.ip_stages[1].inlet.unfix()
 
     for t in m.fs.time:
@@ -128,7 +139,7 @@ def test_initialize():
         m.fs.reheat.inlet.pressure[t].value = pyo.value(
             turb.hp_split[7].outlet_1_state[t].pressure
         )
-    m.fs.reheat.initialize(outlvl=4)
+    m.fs.reheat.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter":20})
 
     def reheat_T_rule(b, t):
         return m.fs.reheat.control_volume.properties_out[t].temperature == 880
@@ -137,7 +148,6 @@ def test_initialize():
         m.fs.reheat.flowsheet().time, rule=reheat_T_rule
     )
 
-    pyo.TransformationFactory("network.expand_arcs").apply_to(m)
     m.fs.turb.outlet_stage.control_volume.properties_out[0].pressure.fix()
 
     assert degrees_of_freedom(m) == 0
@@ -165,11 +175,11 @@ def test_initialize_calc_cf():
 
     # Set the inlet of the ip section, which is disconnected
     # here to insert reheater
-    p = 7.802e06
+    p = 1.4e06
     hin = pyo.value(iapws95.htpx(T=880 * pyo.units.K, P=p * pyo.units.Pa))
     m.fs.turb.ip_stages[1].inlet.enth_mol[0].value = hin
     # m.fs.turb.ip_stages[1].inlet.flow_mol[0].value = 25220.0
-    m.fs.turb.ip_stages[1].inlet.pressure[0].value = p
+    #m.fs.turb.ip_stages[1].inlet.pressure[0].value = p
 
     for i, s in turb.hp_stages.items():
         s.ratioP[:] = 0.88
@@ -192,15 +202,36 @@ def test_initialize_calc_cf():
     turb.lp_split[11].split_fraction[0, "outlet_2"].fix(0.04)
 
     # Congiure with reheater for a full test
-    turb.ip_stages[1].inlet.fix()
+    #turb.ip_stages[1].inlet.fix()
     turb.inlet_split.inlet.flow_mol.unfix()
     turb.inlet_mix.use_equal_pressure_constraint()
     for i in m.fs.turb.inlet_stage:
         m.fs.turb.inlet_stage[i].ratioP[0] = 0.6
         turb.throttle_valve[i].Cv.fix()
         turb.throttle_valve[i].valve_opening.fix()
+
+    for i, s in turb.inlet_stage.items():
+        iscale.set_scaling_factor(s.control_volume.work, 1e-5)
+    for i, s in turb.hp_stages.items():
+        iscale.set_scaling_factor(s.control_volume.work, 1e-5)
+    for i, s in turb.ip_stages.items():
+        iscale.set_scaling_factor(s.control_volume.work, 1e-5)
+    for i, s in turb.lp_stages.items():
+        iscale.set_scaling_factor(s.control_volume.work, 1e-5)
+    iscale.set_scaling_factor(turb.outlet_stage.control_volume.work, 1e-5)
+    iscale.set_scaling_factor(m.fs.reheat.control_volume.heat, 1e-5)
+
+    pyo.TransformationFactory("network.expand_arcs").apply_to(m)
+
     iscale.calculate_scaling_factors(m)
-    turb.initialize(outlvl=1, calculate_inlet_cf=True, calculate_outlet_cf=True)
+    turb.initialize(
+        outlvl=idaeslog.DEBUG,
+        calculate_inlet_cf=True,
+        calculate_outlet_cf=True,
+        copy_disconneted_flow=True,
+        copy_disconneted_pressure=True,
+        optarg={"max_iter":20}
+    )
     turb.ip_stages[1].inlet.unfix()
 
     for t in m.fs.time:
@@ -213,17 +244,23 @@ def test_initialize_calc_cf():
         m.fs.reheat.inlet.pressure[t].value = pyo.value(
             turb.hp_split[7].outlet_1_state[t].pressure
         )
-    m.fs.reheat.initialize(outlvl=4)
 
     def reheat_T_rule(b, t):
         return m.fs.reheat.control_volume.properties_out[t].temperature == 880
-
     m.fs.reheat.temperature_out_equation = pyo.Constraint(
         m.fs.reheat.flowsheet().time, rule=reheat_T_rule
     )
 
-    pyo.TransformationFactory("network.expand_arcs").apply_to(m)
+    m.fs.reheat.initialize(outlvl=idaeslog.ERROR, optarg={"max_iter":20})
+
+
+
     m.fs.turb.outlet_stage.control_volume.properties_out[0].pressure.fix()
+
+    eq_cons = activated_equalities_generator(m)
+    for c in eq_cons:
+        if abs(c.body() - c.lower) > 1e-4:
+            print(f"{c}, {abs(c.body() - c.lower)}")
 
     assert degrees_of_freedom(m) == 0
     solver.solve(m, tee=True)

--- a/idaes/models_extra/power_generation/unit_models/helm/turbine_multistage.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/turbine_multistage.py
@@ -272,17 +272,17 @@ class HelmTurbineMultistageData(UnitModelBlockData):
 
         # Splitter to inlet that splits main flow into parallel flows for
         # paritial arc admission to the turbine
-        self.inlet_split = HelmSplitter(default=self._split_cfg(unit_cfg, ni))
-        self.throttle_valve = SteamValve(inlet_idx, default=thrtl_cfg)
-        self.inlet_stage = HelmTurbineInletStage(inlet_idx, default=unit_cfg)
+        self.inlet_split = HelmSplitter(**self._split_cfg(unit_cfg, ni))
+        self.throttle_valve = SteamValve(inlet_idx, **thrtl_cfg)
+        self.inlet_stage = HelmTurbineInletStage(inlet_idx, **unit_cfg)
         # mixer to combine the parallel flows back together
-        self.inlet_mix = HelmMixer(default=self._mix_cfg(unit_cfg, ni))
+        self.inlet_mix = HelmMixer(**self._mix_cfg(unit_cfg, ni))
         # add turbine sections.
         # inlet stage -> hp stages -> ip stages -> lp stages -> outlet stage
-        self.hp_stages = HelmTurbineStage(pyo.RangeSet(config.num_hp), default=unit_cfg)
-        self.ip_stages = HelmTurbineStage(pyo.RangeSet(config.num_ip), default=unit_cfg)
-        self.lp_stages = HelmTurbineStage(pyo.RangeSet(config.num_lp), default=unit_cfg)
-        self.outlet_stage = HelmTurbineOutletStage(default=unit_cfg)
+        self.hp_stages = HelmTurbineStage(pyo.RangeSet(config.num_hp), **unit_cfg)
+        self.ip_stages = HelmTurbineStage(pyo.RangeSet(config.num_ip), **unit_cfg)
+        self.lp_stages = HelmTurbineStage(pyo.RangeSet(config.num_lp), **unit_cfg)
+        self.outlet_stage = HelmTurbineOutletStage(**unit_cfg)
 
         for i in self.hp_stages:
             self.hp_stages[i].ratioP.fix()
@@ -310,19 +310,19 @@ class HelmTurbineMultistageData(UnitModelBlockData):
         # put in splitters for turbine steam extractions
         if config.hp_split_locations:
             self.hp_split = HelmSplitter(
-                config.hp_split_locations, default=s_sfg_default, initialize=hp_splt_cfg
+                config.hp_split_locations, **s_sfg_default, initialize=hp_splt_cfg
             )
         else:
             self.hp_split = {}
         if config.ip_split_locations:
             self.ip_split = HelmSplitter(
-                config.ip_split_locations, default=s_sfg_default, initialize=ip_splt_cfg
+                config.ip_split_locations, **s_sfg_default, initialize=ip_splt_cfg
             )
         else:
             self.ip_split = {}
         if config.lp_split_locations:
             self.lp_split = HelmSplitter(
-                config.lp_split_locations, default=s_sfg_default, initialize=lp_splt_cfg
+                config.lp_split_locations, **s_sfg_default, initialize=lp_splt_cfg
             )
         else:
             self.lp_split = {}


### PR DESCRIPTION
## Fixes

This fixes up the multistage steam turbine test.  It's required for new IAPWS binaries to pass, but it's also an improvement in general.  The main change is including the reheater temperature constraint before initializing the reheater.  This keeps the turbine from seeing a weird temperature.  It also cleans up a little out dated code.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
