### PR TITLE
Only aggregating flows with at least one registered flow

### DIFF
--- a/idaes/core/base/costing_base.py
+++ b/idaes/core/base/costing_base.py
@@ -145,6 +145,7 @@ class FlowsheetCostingBlockData(ProcessBlockData):
         # Set up attributes for registering units and flows
         self._registered_unit_costing = []
         self.flow_types = pyo.Set()
+        self.used_flows = pyo.Set()
         self._registered_flows = {}
         self.defined_flows = {}
 
@@ -307,18 +308,15 @@ class FlowsheetCostingBlockData(ProcessBlockData):
             calculate_variable_from_constraint(var, cons)
 
         # Initialize aggregate flows and costs
-        for f in self.flow_types:
-            try:
-                fvar = getattr(self, f"aggregate_flow_{f}")
-                fconst = getattr(self, f"aggregate_flow_{f}_constraint")
-                calculate_variable_from_constraint(fvar, fconst)
+        for f in self.used_flows:
+            fvar = getattr(self, f"aggregate_flow_{f}")
+            fconst = getattr(self, f"aggregate_flow_{f}_constraint")
+            calculate_variable_from_constraint(fvar, fconst)
 
-                calculate_variable_from_constraint(
-                    self.aggregate_flow_costs[f],
-                    self.aggregate_flow_costs_constraint[f],
-                )
-            except AttributeError:
-                self.aggregate_flow_costs[f].set_value(0)
+            calculate_variable_from_constraint(
+                self.aggregate_flow_costs[f],
+                self.aggregate_flow_costs_constraint[f],
+            )
 
         # Call costing package initialization
         try:
@@ -418,6 +416,7 @@ class FlowsheetCostingBlockData(ProcessBlockData):
         for f in self.flow_types:
             # We will use the first costed flow as representative of the whole
             if len(self._registered_flows[f]) > 0:
+                self.used_flows.add(f)
                 f1 = self._registered_flows[f][0]
                 funits = pyo.units.get_units(f1)
                 agg_var = pyo.Var(units=funits, doc=f"Aggregate flow for {f}")
@@ -435,21 +434,17 @@ class FlowsheetCostingBlockData(ProcessBlockData):
                 self.add_component(f"aggregate_flow_{f}_constraint", agg_const)
 
         # TODO : More complex cost functions
-        self.aggregate_flow_costs = pyo.Var(self.flow_types, units=c_units / t_units)
+        self.aggregate_flow_costs = pyo.Var(self.used_flows, units=c_units / t_units)
 
         @self.Constraint(
-            self.flow_types, doc="Aggregation constraint for material flow costs"
+            self.used_flows, doc="Aggregation constraint for material flow costs"
         )
         def aggregate_flow_costs_constraint(blk, ftype):
-            try:
-                agg_var = getattr(blk, f"aggregate_flow_{ftype}")
-                cost_var = getattr(blk, f"{ftype}_cost")
-                return blk.aggregate_flow_costs[ftype] == (
-                    pyo.units.convert(agg_var * cost_var, to_units=c_units / t_units)
-                )
-            except AttributeError:
-                blk.aggregate_flow_costs[ftype].fix(0 * c_units / t_units)
-                return pyo.Constraint.Skip
+            agg_var = getattr(blk, f"aggregate_flow_{ftype}")
+            cost_var = getattr(blk, f"{ftype}_cost")
+            return blk.aggregate_flow_costs[ftype] == (
+                pyo.units.convert(agg_var * cost_var, to_units=c_units / t_units)
+            )
 
     def _build_costing_methods_map(self):
         """

--- a/idaes/core/base/costing_base.py
+++ b/idaes/core/base/costing_base.py
@@ -448,7 +448,8 @@ class FlowsheetCostingBlockData(ProcessBlockData):
                     pyo.units.convert(agg_var * cost_var, to_units=c_units / t_units)
                 )
             except AttributeError:
-                return blk.aggregate_flow_costs[ftype] == 0 * c_units / t_units
+                blk.aggregate_flow_costs[ftype].fix(0 * c_units / t_units)
+                return pyo.Constraint.Skip
 
     def _build_costing_methods_map(self):
         """

--- a/idaes/core/base/tests/test_costing_base.py
+++ b/idaes/core/base/tests/test_costing_base.py
@@ -640,7 +640,7 @@ class TestFlowsheetCostingBlock:
         )
         assert len(costing.costing.aggregate_flow_costs) == 2
         assert isinstance(costing.costing.aggregate_flow_costs_constraint, Constraint)
-        assert len(costing.costing.aggregate_flow_costs_constraint) == 2
+        assert len(costing.costing.aggregate_flow_costs_constraint) == 1
 
     @pytest.mark.unit
     def test_unit_consistency(self, costing):

--- a/idaes/core/base/tests/test_costing_base.py
+++ b/idaes/core/base/tests/test_costing_base.py
@@ -633,12 +633,14 @@ class TestFlowsheetCostingBlock:
         # This should have been skipped
         assert not hasattr(costing.costing, "aggregate_flow_test_flow_1")
         assert not hasattr(costing.costing, "aggregate_flow_test_flow_1_constraint")
+        # unused flows do not get added to aggregate_flow_costs
+        assert "test_flow_1" not in costing.costing.aggregate_flow_costs
 
         assert isinstance(costing.costing.aggregate_flow_costs, Var)
         assert str(pyunits.USD_test / pyunits.year) == str(
             costing.costing.aggregate_flow_costs.get_units()
         )
-        assert len(costing.costing.aggregate_flow_costs) == 2
+        assert len(costing.costing.aggregate_flow_costs) == 1
         assert isinstance(costing.costing.aggregate_flow_costs_constraint, Constraint)
         assert len(costing.costing.aggregate_flow_costs_constraint) == 1
 
@@ -681,4 +683,3 @@ class TestFlowsheetCostingBlock:
                 10 * 42, from_units=1 / pyunits.s, to_units=1 / pyunits.year
             )
         )
-        assert costing.costing.aggregate_flow_costs["test_flow_1"].value == (0)


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
Defining additional unused flows in a costing package can cause additional variables and constraints to be passed to Ipopt for flowsheets not utilizing those flows. This can sometime cause "spooky action at a distance" on sensitive flowsheets. See watertap-org/watertap#684 for more detail.

## Changes proposed in this PR:
- ~~Fix unneeded `aggregate_flow_costs[ftype]` variables on the flowsheet costing block to `0` instead of constraining them to be `0`, eliminating (a) unneeded variable(s)/constraint(s) from the model.~~
- Define a new set, `used_flows` of flows which have been registered with the costing package. This allows for the elimination of unneeded variable(s) and constraint(s) as well as two `try/except` blocks in the costing package.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
