### PR TITLE
Update how petsc binary io interface is imported

### DIFF
--- a/idaes/core/solvers/petsc.py
+++ b/idaes/core/solvers/petsc.py
@@ -41,29 +41,46 @@ import idaes.logger as idaeslog
 from idaes.core.solvers import get_solver
 import idaes.config as icfg
 
-PetscBinaryIOTrajectory = None
-PetscBinaryIO = None
 
+def petsc_binary_io():
+    if petsc_binary_io.PetscBinaryIOTrajectory is not None:
+        return petsc_binary_io.PetscBinaryIOTrajectory
 
-def _import_petsc_binary_io():
-    global PetscBinaryIOTrajectory
-    global PetscBinaryIO
+    # First see if the python IO helpers are directly importable
     try:
         import PetscBinaryIOTrajectory
         import PetscBinaryIO
+        petsc_binary_io.PetscBinaryIOTrajectory = PetscBinaryIOTrajectory
+        return PetscBinaryIOTrajectory
     except ImportError:
-        petsc_dir = os.path.join(icfg.bin_directory, "petscpy")
-        if not os.path.isdir(petsc_dir):
-            return
-        sys.path.append(petsc_dir)
+        pass
+    # Next, look for a 'petscpy' directory alongside the 'petsc'
+    # executable: first look at the petsc we found on the path, then
+    # look in the IDAES bin dir.  Casting the Executable path to a
+    # string will map None to '' in the case where there is no petsc
+    # executable found.
+    for petsc_exe_dir in (os.path.dirname(str(Executable("petsc").path())),
+                          icfg.bin_directory):
+        if not petsc_exe_dir:
+            continue
+        petscpy_dir = os.path.join(petsc_exe_dir, 'petscpy')
         try:
+            sys.path.insert(0, petscpy_dir)
             import PetscBinaryIOTrajectory
             import PetscBinaryIO
+            # Import the petsc_conf so that it is cached in sys.modules
+            # (because we will be removing petscpy from sys.path)
+            import petsc_conf
+            petsc_binary_io.PetscBinaryIOTrajectory = PetscBinaryIOTrajectory
+            return PetscBinaryIOTrajectory
         except ImportError:
             pass
+        finally:
+            sys.path.remove(petscpy_dir)
+    return None
 
 
-_import_petsc_binary_io()
+petsc_binary_io.PetscBinaryIOTrajectory = None
 
 
 class DaeVarTypes(enum.IntEnum):
@@ -687,7 +704,7 @@ class PetscTrajectory(object):
         """
         if no_read:
             return
-        if PetscBinaryIOTrajectory is None and stub is not None:
+        if petsc_binary_io() is None and stub is not None:
             raise RuntimeError("PetscBinaryIOTrajectory could not be imported")
         # if unscale is True, use model as scale factor source
         if model is not None and unscale is True:
@@ -721,7 +738,7 @@ class PetscTrajectory(object):
         with open(f"{self.stub}.typ") as f:
             typ = list(map(int, f.readlines()))
         vars = [name for i, name in enumerate(names) if typ[i] in [0, 1]]
-        (t, v, names) = PetscBinaryIOTrajectory.ReadTrajectory("Visualization-data")
+        (t, v, names) = petsc_binary_io().ReadTrajectory("Visualization-data")
         self.time = t
         self.vecs_by_time = v
         self.vecs = dict.fromkeys(vars, None)

--- a/idaes/core/solvers/petsc.py
+++ b/idaes/core/solvers/petsc.py
@@ -50,6 +50,7 @@ def petsc_binary_io():
     try:
         import PetscBinaryIOTrajectory
         import PetscBinaryIO
+
         petsc_binary_io.PetscBinaryIOTrajectory = PetscBinaryIOTrajectory
         return PetscBinaryIOTrajectory
     except ImportError:
@@ -59,18 +60,22 @@ def petsc_binary_io():
     # look in the IDAES bin dir.  Casting the Executable path to a
     # string will map None to '' in the case where there is no petsc
     # executable found.
-    for petsc_exe_dir in (os.path.dirname(str(Executable("petsc").path())),
-                          icfg.bin_directory):
+    for petsc_exe_dir in (
+        os.path.dirname(str(Executable("petsc").path())),
+        icfg.bin_directory,
+    ):
         if not petsc_exe_dir:
             continue
-        petscpy_dir = os.path.join(petsc_exe_dir, 'petscpy')
+        petscpy_dir = os.path.join(petsc_exe_dir, "petscpy")
         try:
             sys.path.insert(0, petscpy_dir)
             import PetscBinaryIOTrajectory
             import PetscBinaryIO
+
             # Import the petsc_conf so that it is cached in sys.modules
             # (because we will be removing petscpy from sys.path)
             import petsc_conf
+
             petsc_binary_io.PetscBinaryIOTrajectory = PetscBinaryIOTrajectory
             return PetscBinaryIOTrajectory
         except ImportError:


### PR DESCRIPTION
## Fixes


## Summary/Motivation:
I ran across an issue with the petsc interface where the petsc interface tests fail if petsc is installed in the system (and not just locally in the IDAES configuration directory).  This PR resolves that (it will look for `petscpy` both along side the `petsc` found in the system PATH as well as the IDAES configuration directory).  In addition, it defers the import of the petsc binary interfaces until they are actually needed.

## Changes proposed in this PR:
- look in additional locations for the `petscpy` interface
- Do not permanently change the `sys.path`
- Defer the import of the petsc binary interfaces until their first use

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
