### PR TITLE
Removing backwards compatibility for default argument

### DIFF
--- a/idaes/core/base/process_block.py
+++ b/idaes/core/base/process_block.py
@@ -91,27 +91,13 @@ def _process_kwargs(o, kwargs):
     o._block_data_config_initialize = ConfigBlock(implicit=True)
     o._block_data_config_initialize.set_value(kwargs.pop("initialize", None))
     o._idx_map = kwargs.pop("idx_map", None)
-    _default = kwargs.pop("default", None)
-    if _default is not None:
-        deprecation_warning(
-            "The default argument for the ProcessBlock class is deprecated. "
-            "Arguments can now be passed directly as keyword arguments."
-        )
-    _block_data_config_default = _default
+
     _pyomo_kwargs = {}
     for arg in _pyomo_block_keywords:
         if arg in kwargs:
             _pyomo_kwargs[arg] = kwargs.pop(arg)
-    if kwargs:
-        # left over args for IDAES
-        if _block_data_config_default is None:
-            _block_data_config_default = kwargs
-        else:
-            raise RuntimeError(
-                "Do not supply both keyword arguments and the "
-                "'default' argument to ProcessBlock init. Default is deprecated."
-            )
-    o._block_data_config_default = _block_data_config_default
+
+    o._block_data_config_default = kwargs
     return _pyomo_kwargs
 
 


### PR DESCRIPTION
## Part of #748


## Summary/Motivation:
The PR removed the backwards compatibility code to support the deprecated `default` argument when constructing `ProcessBlocks`

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
