### PR TITLE
Enable derived costing package to define a flow cost

### DIFF
--- a/idaes/core/base/costing_base.py
+++ b/idaes/core/base/costing_base.py
@@ -337,13 +337,19 @@ class FlowsheetCostingBlockData(ProcessBlockData):
         """
         self.flow_types.add(flow_type)
 
-        # Create a Var to hold the cost
-        # Units will be different between flows, so have to use scalar Vars
-        fvar = pyo.Var(
-            units=pyo.units.get_units(cost), doc=f"Cost parameter for {flow_type} flow"
-        )
-        self.add_component(f"{flow_type}_cost", fvar)
-        fvar.fix(cost)
+        name = f"{flow_type}_cost"
+        current_component = self.component(name)
+        if current_component is not None and current_component is cost:
+            pass
+        else:
+            # Create a Var to hold the cost
+            # Units will be different between flows, so have to use scalar Vars
+            fvar = pyo.Var(
+                units=pyo.units.get_units(cost),
+                doc=f"Cost parameter for {flow_type} flow",
+            )
+            self.add_component(name, fvar)
+            fvar.fix(cost)
 
         self._registered_flows[flow_type] = []
 

--- a/idaes/core/base/tests/test_costing_base.py
+++ b/idaes/core/base/tests/test_costing_base.py
@@ -15,7 +15,7 @@ Tests for costing base classes
 """
 import pytest
 
-from pyomo.environ import ConcreteModel, Constraint, Set, units as pyunits, Var
+from pyomo.environ import ConcreteModel, Constraint, Set, units as pyunits, Var, Param
 from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
 
 from idaes.core import declare_process_block_class, UnitModelBlockData
@@ -165,7 +165,12 @@ class TestCostingPackageData(FlowsheetCostingBlockData):
         self.base_currency = pyunits.USD_test
         self.base_period = pyunits.year
 
-        self.defined_flows = {"test_flow_1": 0.2 * pyunits.J}
+        self.test_flow_2_cost = Param(initialize=0.07, units=pyunits.kW)
+
+        self.defined_flows = {
+            "test_flow_1": 0.2 * pyunits.J,
+            "test_flow_2": self.test_flow_2_cost,
+        }
 
         self._bgp = True
 
@@ -219,9 +224,12 @@ class TestFlowsheetCostingBlock:
     def test_basic_attributes(self, costing):
         assert costing.costing._registered_unit_costing == []
         assert isinstance(costing.costing.flow_types, Set)
-        assert len(costing.costing.flow_types) == 1
+        assert len(costing.costing.flow_types) == 2
         assert "test_flow_1" in costing.costing.flow_types
-        assert costing.costing._registered_flows == {"test_flow_1": []}
+        assert costing.costing._registered_flows == {
+            "test_flow_1": [],
+            "test_flow_2": [],
+        }
 
         assert costing.costing._costing_methods_map == {
             TypeAData: TestCostingPackageData.method_1,
@@ -233,6 +241,8 @@ class TestFlowsheetCostingBlock:
         assert isinstance(costing.costing.test_flow_1_cost, Var)
         assert costing.costing.test_flow_1_cost.value == 0.2
         assert_units_equivalent(costing.costing.test_flow_1_cost.get_units(), pyunits.J)
+
+        assert isinstance(costing.costing.test_flow_2_cost, Param)
 
         # Test that build_global_parameters was called successfully
         assert costing.costing._bgp
@@ -250,7 +260,11 @@ class TestFlowsheetCostingBlock:
         )
         assert "test_flow" in costing.costing.flow_types
 
-        assert costing.costing._registered_flows == {"test_flow_1": [], "test_flow": []}
+        assert costing.costing._registered_flows == {
+            "test_flow_1": [],
+            "test_flow_2": [],
+            "test_flow": [],
+        }
 
     @pytest.mark.unit
     def test_cost_flow_invalid_type(self, costing):


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
In the WaterTAP costing package, we have names like `electricity_base_cost` for predefining flow costs. It would be less brittle and error-prone if the WaterTAP costing package could just use the name `electricity_cost` directly:
https://github.com/watertap-org/watertap/blob/c71b898cf490b7dc6f7a0115e95b8dbb6a771adf/watertap/costing/watertap_costing_package.py#L122-L128. Here, changing this mutable Param doesn't actually do anything, because its value is extracted when the `electricity_cost` `Var` is created.

## Changes proposed in this PR:
- When registering a flow, if the name `{flow_type}_cost` is already on the global costing block, just use it instead of creating a new `Var`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
