### PR TITLE
Change the OMLT version to 1.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ kwargs = dict(
         "nbformat",
         "numpy",
         "networkx",
-        "omlt==0.3.1",  # fix the version for now as package evolves
+        "omlt==1.0",  # fix the version for now as package evolves
         "pandas<1.5",
         "pint",
         "psutil",


### PR DESCRIPTION
## Fixes


## Summary/Motivation:
Open this draft PR to test that if there are some errors in the tests when the OMLT is updated to v1.0 in setup.py.
This is the issue related to this draft PR.
https://github.com/IDAES/idaes-pse/issues/982

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
