### PR TITLE
Switch Linux CI jobs to ubuntu-20.04 runner image

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -72,7 +72,7 @@ jobs:
   pytest:
     # description: Run pytest with dev dependencies
     name: pytest (py${{ matrix.python-version }}/${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner-image }}
     needs: [code-formatting]
     strategy:
       fail-fast: false
@@ -83,9 +83,13 @@ jobs:
           - '3.9'
           - '3.10'
         os:
-          - ubuntu-18.04
-          - windows-latest
+          - linux
+          - win64
         include:
+          - os: linux
+            runner-image: ubuntu-20.04
+          - os: win64
+            runner-image: windows-2022
           - python-version: '3.8'
             # only generate coverage report for a single python version in the matrix
             # to avoid overloading Codecov

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -120,7 +120,7 @@ jobs:
 
   pytest:
     name: pytest (py${{ matrix.python-version }}/${{ matrix.os }}/integration)
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner-image }}
     needs: [precheck]
     if: >-
       (
@@ -137,8 +137,13 @@ jobs:
           - '3.9'
           - '3.10'
         os:
-          - ubuntu-18.04
-          - windows-latest
+          - linux
+          - win64
+        include:
+          - os: linux
+            runner-image: ubuntu-20.04
+          - os: win64
+            runner-image: windows-2022
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/display-debug-info
@@ -156,7 +161,7 @@ jobs:
 
   examples:
     name: Run examples (py${{ matrix.python-version }}/${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner-image }}
     needs: [precheck]
     if: >-
       (
@@ -173,8 +178,13 @@ jobs:
           - '3.9'
           - '3.10'
         os:
-          - ubuntu-18.04
-          - windows-latest
+          - linux
+          - win64
+        include:
+          - os: linux
+            runner-image: ubuntu-20.04
+          - os: win64
+            runner-image: windows-2022
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/display-debug-info
@@ -199,9 +209,9 @@ jobs:
           cat *errors.txt || echo "No error logs found"
 
   pytest-site-packages:
-    name: Run tests from site-packages (non-editable) installation (${{ matrix.install-mode }})
+    name: Run tests from site-packages (non-editable) installation (${{ matrix.install-mode }}/${{ matrix.os }})
     # NOTE: using ubuntu-latest (20.04) instead of 18.04 results in failures in power_generation/carbon_capture/mea_solvent_system/unit_models/tests/test_column.py
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.runner-image }}
     needs: [precheck]
     if: >-
       (
@@ -216,7 +226,11 @@ jobs:
           - pip-default
           - pip-optional
           - conda-like
+        os:
+          - linux
         include:
+          - os: linux
+            runner-image: ubuntu-20.04
           - install-mode: pip-default
             pip-install-target: '.'
           - install-mode: pip-optional


### PR DESCRIPTION
## Resolves: #987

## Summary/Motivation:

- `ubuntu-18.04` is deprecated

## Changes proposed in this PR

- Switch from `ubuntu-18.04` to `ubuntu-20.04`
- Decouple readable labels (`linux`, `win64`) from runner image keys (`ubuntu-20.04`, `windows-2022`) to avoid having to update CI job names (e.g. in the branch protection rules) after future updates

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
