### PR TITLE
Grid integration: update bounds of AGC bid

### DIFF
--- a/idaes/apps/grid_integration/bidder.py
+++ b/idaes/apps/grid_integration/bidder.py
@@ -1276,6 +1276,8 @@ class Bidder(StochasticProgramBidder):
                 full_bids[t][gen]["p_cost"] = bids[t_idx][gen]
                 full_bids[t][gen]["p_min"] = min([p[0] for p in bids[t_idx][gen]])
                 full_bids[t][gen]["p_max"] = max([p[0] for p in bids[t_idx][gen]])
+                full_bids[t][gen]["p_min_agc"] = min([p[0] for p in bids[t_idx][gen]])
+                full_bids[t][gen]["p_max_agc"] = max([p[0] for p in bids[t_idx][gen]])
                 full_bids[t][gen]["startup_capacity"] = full_bids[t][gen]["p_min"]
                 full_bids[t][gen]["shutdown_capacity"] = full_bids[t][gen]["p_min"]
 

--- a/idaes/apps/grid_integration/coordinator.py
+++ b/idaes/apps/grid_integration/coordinator.py
@@ -241,6 +241,8 @@ class DoubleLoopCoordinator:
             "p_cost": _update_p_cost,
             "p_max": _update_time_series_params,
             "p_min": _update_time_series_params,
+            "p_min_agc": _update_time_series_params,
+            "p_max_agc": _update_time_series_params,
             "fixed_commitment": _update_time_series_params,
             "min_up_time": _update_non_time_series_params,
             "min_down_time": _update_non_time_series_params,

--- a/idaes/apps/grid_integration/tests/test_bidder.py
+++ b/idaes/apps/grid_integration/tests/test_bidder.py
@@ -200,6 +200,8 @@ def test_compute_DA_bids(bidder_object):
             gen: {
                 "p_min": pmin,
                 "p_max": pmax,
+                "p_min_agc": pmin,
+                "p_max_agc": pmax,
                 "startup_capacity": pmin,
                 "shutdown_capacity": pmin,
                 "p_cost": [
@@ -225,6 +227,8 @@ def test_compute_DA_bids(bidder_object):
         expected_bids[t][gen] = {
             "p_min": pmin,
             "p_max": pmax,
+            "p_min_agc": pmin,
+            "p_max_agc": pmax,
             "startup_capacity": pmin,
             "shutdown_capacity": pmin,
         }
@@ -280,6 +284,8 @@ def test_compute_RT_bids(bidder_object):
             gen: {
                 "p_min": pmin,
                 "p_max": pmax,
+                "p_min_agc": pmin,
+                "p_max_agc": pmax,
                 "startup_capacity": pmin,
                 "shutdown_capacity": pmin,
                 "p_cost": [(p, (p - pmin) * marginal_cost) for p, _ in default_bids],


### PR DESCRIPTION
## Fixes
for thermal generators that are `agc_capable` there could be an attribute called `p_min_agc` and `p_max_agc`. Prescient/Egret will expect these to be such that:
`p_min <= p_min_agc <= p_max_agc <= p_max`

While assembling the bids, update the min and max agc power to be equal to the min and max power.

## Summary/Motivation:
Nuclear double loop example runs into this problem


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
