### PR TITLE
Allowing an InitializationError to be caught

### DIFF
--- a/idaes/core/base/unit_model.py
+++ b/idaes/core/base/unit_model.py
@@ -526,14 +526,19 @@ Must be True if dynamic = True,
             c.deactivate()
 
         # Remember to collect flags for fixed vars
-        flags = blk.initialize_build(*args, **kwargs)
+        try:
+            flags = blk.initialize_build(*args, **kwargs)
+        except InitializationError:
+            raise
+        finally:
+            # In case the InitializationError is caught,
+            # leave the unit unmodified
+            # If costing block exists, activate and initialize
+            for c in init_order:
+                c.activate()
 
-        # If costing block exists, activate and initialize
-        for c in init_order:
-            c.activate()
-
-            if hasattr(c, "initialize"):
-                c.initialize(**cost_args)
+                if hasattr(c, "initialize"):
+                    c.initialize(**cost_args)
 
         # Return any flags returned by initialize_build
         return flags


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
If a modeler want to catch a unit model `InitializationError`, the current `initialize` method can leave the unit in a modified state. This PR would ensure changes the unit are cleaned up before an `InitializationError` is raised.

## Changes proposed in this PR:
- Add `try/except/finally` around the call to `initialize_build`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
