### PR TITLE
Fix missing property mole_frac_comp for NGCC example

### DIFF
--- a/idaes/models/properties/general_helmholtz/helmholtz_state.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_state.py
@@ -544,6 +544,10 @@ class HelmholtzStateBlockData(StateBlockData):
         component_list = params.component_list
         phase_set = params.config.phase_presentation
         self.phase_equilibrium_list = params.phase_equilibrium_list
+        # Add component mole fraction for standardization
+        def mole_frac_comp_rule(b, i):
+            return 1.0
+        self.mole_frac_comp = pyo.Expression(component_list, rule=mole_frac_comp_rule)
         # Expressions that link to some parameters in the param block, which
         # are commonly needed, this lets you get the parameters with scale
         # factors directly from the state block

--- a/idaes/models/properties/general_helmholtz/helmholtz_state.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_state.py
@@ -547,6 +547,7 @@ class HelmholtzStateBlockData(StateBlockData):
         # Add component mole fraction for standardization
         def mole_frac_comp_rule(b, i):
             return 1.0
+
         self.mole_frac_comp = pyo.Expression(component_list, rule=mole_frac_comp_rule)
         # Expressions that link to some parameters in the param block, which
         # are commonly needed, this lets you get the parameters with scale

--- a/idaes/models/properties/general_helmholtz/tests/test_with_heater.py
+++ b/idaes/models/properties/general_helmholtz/tests/test_with_heater.py
@@ -59,6 +59,7 @@ def test_heater_ph_mixed_byphase():
     assert value(prop_out.phase_frac["Liq"]) == pytest.approx(0.5953219, rel=1e-5)
     assert value(prop_in.phase_frac["Vap"]) == pytest.approx(0, abs=1e-6)
     assert value(prop_out.phase_frac["Vap"]) == pytest.approx(0.4046781, rel=1e-4)
+    assert value(prop_out.mole_frac_comp["h2o"]) ==  pytest.approx(1.0, rel=1e-4)
 
 
 @pytest.mark.integration

--- a/idaes/models/properties/general_helmholtz/tests/test_with_heater.py
+++ b/idaes/models/properties/general_helmholtz/tests/test_with_heater.py
@@ -59,7 +59,7 @@ def test_heater_ph_mixed_byphase():
     assert value(prop_out.phase_frac["Liq"]) == pytest.approx(0.5953219, rel=1e-5)
     assert value(prop_in.phase_frac["Vap"]) == pytest.approx(0, abs=1e-6)
     assert value(prop_out.phase_frac["Vap"]) == pytest.approx(0.4046781, rel=1e-4)
-    assert value(prop_out.mole_frac_comp["h2o"]) ==  pytest.approx(1.0, rel=1e-4)
+    assert value(prop_out.mole_frac_comp["h2o"]) == pytest.approx(1.0, rel=1e-4)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Fixes
NGCC example need the mole_frac_comp property in the pure component Helmholtz EoS, so this adds it. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
