### PR TITLE
Add dens_star_mol to Helmholtz Property Block

### DIFF
--- a/idaes/models/properties/general_helmholtz/helmholtz_functions.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_functions.py
@@ -2125,6 +2125,8 @@ change.
                 "pressure_crit": {"method": None, "units": "Pa"},
                 "dens_mass_crit": {"method": None, "units": "kg/m^3"},
                 "dens_mass_star": {"method": None, "units": "kg/m^3"},
+                "dens_mol_crit": {"method": None, "units": "mol/m^3"},
+                "dens_mol_star": {"method": None, "units": "mol/m^3"},
                 "specific_gas_constant": {"method": None, "units": "J/kg.K"},
                 "mw": {"method": None, "units": "kg/mol"},
                 "temperature_sat": {"method": "None", "units": "K"},

--- a/idaes/models/properties/general_helmholtz/helmholtz_state.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_state.py
@@ -570,6 +570,10 @@ class HelmholtzStateBlockData(StateBlockData):
         self.dens_mol_crit = pyo.Expression(
             expr=params.dens_mass_crit / params.mw, doc="critical mole density"
         )
+        self.dens_mol_star = pyo.Expression(
+            expr=params.dens_mass_star / params.mw,
+            doc="mole density for delta calculation",
+        )
         self.mw = pyo.Expression(expr=params.mw, doc="molecular weight")
         # create the appropriate state variables and expressions for anything
         # that could be a state variable (H, S, U, P, T, X) on a mass and mole


### PR DESCRIPTION
## Fixes

I was missing this property I need in some viscosity or thermal conductivity calculations.  I do have tests for those expressions, but somehow this got through. 


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
