### PR TITLE
Add a way to register new helmholtz components

### DIFF
--- a/idaes/models/properties/general_helmholtz/components/__init__.py
+++ b/idaes/models/properties/general_helmholtz/components/__init__.py
@@ -16,13 +16,13 @@ some properties not implimented as external functions.
 
 __author__ = "John Eslick"
 
-from idaes.models.properties.general_helmholtz.components.registry import(
+from idaes.models.properties.general_helmholtz.components.registry import (
     register_helmholtz_component,
     get_transport_module,
     component_registered,
 )
 
-# These modules register themselves 
+# These modules register themselves
 import idaes.models.properties.general_helmholtz.components.h2o as h2o
 import idaes.models.properties.general_helmholtz.components.co2 as co2
 import idaes.models.properties.general_helmholtz.components.r134a as r134a

--- a/idaes/models/properties/general_helmholtz/components/__init__.py
+++ b/idaes/models/properties/general_helmholtz/components/__init__.py
@@ -16,19 +16,19 @@ some properties not implimented as external functions.
 
 __author__ = "John Eslick"
 
+from idaes.models.properties.general_helmholtz.components.registry import(
+    register_helmholtz_component,
+    get_transport_module,
+    component_registered,
+)
+
+# These modules register themselves 
 import idaes.models.properties.general_helmholtz.components.h2o as h2o
 import idaes.models.properties.general_helmholtz.components.co2 as co2
 import idaes.models.properties.general_helmholtz.components.r134a as r134a
 import idaes.models.properties.general_helmholtz.components.r1234ze as r1234ze
 
-_components = {
-    "h2o": h2o,
-    "co2": co2,
-    "r134a": r134a,
-    "r1234ze": r1234ze,
-}
-
-
-def get_component_module(comp_str):
-    comp_str = comp_str.lower()
-    return _components.get(comp_str, None)
+register_helmholtz_component("h2o", h2o)
+register_helmholtz_component("co2", co2)
+register_helmholtz_component("r134a", r134a)
+register_helmholtz_component("r1234ze", r1234ze)

--- a/idaes/models/properties/general_helmholtz/components/__init__.py
+++ b/idaes/models/properties/general_helmholtz/components/__init__.py
@@ -22,7 +22,6 @@ from idaes.models.properties.general_helmholtz.components.registry import (
     component_registered,
 )
 
-# These modules register themselves
 import idaes.models.properties.general_helmholtz.components.h2o as h2o
 import idaes.models.properties.general_helmholtz.components.co2 as co2
 import idaes.models.properties.general_helmholtz.components.r134a as r134a

--- a/idaes/models/properties/general_helmholtz/components/co2.py
+++ b/idaes/models/properties/general_helmholtz/components/co2.py
@@ -21,7 +21,6 @@ Fenghour, A., W.A. Wakeham, V. Vesovic, (1998). "The Viscosity of Carbon
 
 import pyomo.environ as pyo
 
-
 def _thermal_conductivity(blk, delta, tau, on_blk=None):
     b = {
         0: 0.4226159,

--- a/idaes/models/properties/general_helmholtz/components/co2.py
+++ b/idaes/models/properties/general_helmholtz/components/co2.py
@@ -21,6 +21,7 @@ Fenghour, A., W.A. Wakeham, V. Vesovic, (1998). "The Viscosity of Carbon
 
 import pyomo.environ as pyo
 
+
 def _thermal_conductivity(blk, delta, tau, on_blk=None):
     b = {
         0: 0.4226159,

--- a/idaes/models/properties/general_helmholtz/components/registry.py
+++ b/idaes/models/properties/general_helmholtz/components/registry.py
@@ -1,0 +1,39 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+"""This module provides functions to register and retrieve component information
+"""
+
+import os
+import idaes
+
+_default_data_dir = os.path.join(idaes.bin_directory, "helm_data")
+_default_data_dir = os.path.join(_default_data_dir, "")
+
+_components = {}
+
+class _ComponentStruct(object):
+    def __init__(self, transport_module=None, path=None):
+        self.transport_module = transport_module
+
+def register_helmholtz_component(comp_str, transport_module=None):
+    _components[comp_str] = _ComponentStruct(transport_module=transport_module)
+    
+def get_transport_module(comp_str):
+    comp_str = comp_str.lower()
+    if component_registered(comp_str):
+        return _components[comp_str].transport_module
+    return None
+
+def component_registered(comp_str):
+    comp_str = comp_str.lower()
+    return comp_str in _components

--- a/idaes/models/properties/general_helmholtz/components/registry.py
+++ b/idaes/models/properties/general_helmholtz/components/registry.py
@@ -23,7 +23,7 @@ _components = {}
 
 
 class _ComponentStruct(object):
-    def __init__(self, transport_module=None, path=None):
+    def __init__(self, transport_module=None):
         self.transport_module = transport_module
 
 

--- a/idaes/models/properties/general_helmholtz/components/registry.py
+++ b/idaes/models/properties/general_helmholtz/components/registry.py
@@ -21,18 +21,22 @@ _default_data_dir = os.path.join(_default_data_dir, "")
 
 _components = {}
 
+
 class _ComponentStruct(object):
     def __init__(self, transport_module=None, path=None):
         self.transport_module = transport_module
 
+
 def register_helmholtz_component(comp_str, transport_module=None):
     _components[comp_str] = _ComponentStruct(transport_module=transport_module)
-    
+
+
 def get_transport_module(comp_str):
     comp_str = comp_str.lower()
     if component_registered(comp_str):
         return _components[comp_str].transport_module
     return None
+
 
 def component_registered(comp_str):
     comp_str = comp_str.lower()

--- a/idaes/models/properties/general_helmholtz/helmholtz_functions.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_functions.py
@@ -918,18 +918,14 @@ class HelmholtzThermoExpressions(object):
         tmod = get_transport_module(c)
         if tmod is None:
             raise RuntimeError(f"Transport roperties not available for {c}")
-        return tmod._thermal_conductivity(
-            self.param, delta_liq, tau, blk
-        )
+        return tmod._thermal_conductivity(self.param, delta_liq, tau, blk)
 
     def thermal_conductivity_vap(self, **kwargs):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
         tmod = get_transport_module(c)
         if tmod is None:
             raise RuntimeError(f"Transport roperties not available for {c}")
-        return tmod._thermal_conductivity(
-            self.param, delta_vap, tau, blk
-        )
+        return tmod._thermal_conductivity(self.param, delta_vap, tau, blk)
 
     def p_sat(self, T=None, tau=None):
         """Return saturation pressure as a function of T or tau"""

--- a/idaes/models/properties/general_helmholtz/helmholtz_functions.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_functions.py
@@ -903,28 +903,28 @@ class HelmholtzThermoExpressions(object):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
         tmod = get_transport_module(c)
         if tmod is None:
-            raise RuntimeError(f"Transport roperties not available for {c}")
+            raise RuntimeError(f"Transport properties not available for {c}")
         return tmod._viscosity(self.param, delta_liq, tau, blk)
 
     def viscosity_vap(self, **kwargs):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
         tmod = get_transport_module(c)
         if tmod is None:
-            raise RuntimeError(f"Transport roperties not available for {c}")
+            raise RuntimeError(f"Transport properties not available for {c}")
         return tmod._viscosity(self.param, delta_vap, tau, blk)
 
     def thermal_conductivity_liq(self, **kwargs):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
         tmod = get_transport_module(c)
         if tmod is None:
-            raise RuntimeError(f"Transport roperties not available for {c}")
+            raise RuntimeError(f"Transport properties not available for {c}")
         return tmod._thermal_conductivity(self.param, delta_liq, tau, blk)
 
     def thermal_conductivity_vap(self, **kwargs):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
         tmod = get_transport_module(c)
         if tmod is None:
-            raise RuntimeError(f"Transport roperties not available for {c}")
+            raise RuntimeError(f"Transport properties not available for {c}")
         return tmod._thermal_conductivity(self.param, delta_vap, tau, blk)
 
     def p_sat(self, T=None, tau=None):

--- a/idaes/models/properties/general_helmholtz/helmholtz_functions.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_functions.py
@@ -39,7 +39,8 @@ from idaes.core import (
     Component,
 )
 from idaes.models.properties.general_helmholtz.components import (
-    get_component_module,
+    get_transport_module,
+    component_registered,
 )
 import idaes.logger as idaeslog
 
@@ -900,21 +901,33 @@ class HelmholtzThermoExpressions(object):
 
     def viscosity_liq(self, **kwargs):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
-        return get_component_module(c)._viscosity(self.param, delta_liq, tau, blk)
+        tmod = get_transport_module(c)
+        if tmod is None:
+            raise RuntimeError(f"Transport roperties not available for {c}")
+        return tmod._viscosity(self.param, delta_liq, tau, blk)
 
     def viscosity_vap(self, **kwargs):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
-        return get_component_module(c)._viscosity(self.param, delta_vap, tau, blk)
+        tmod = get_transport_module(c)
+        if tmod is None:
+            raise RuntimeError(f"Transport roperties not available for {c}")
+        return tmod._viscosity(self.param, delta_vap, tau, blk)
 
     def thermal_conductivity_liq(self, **kwargs):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
-        return get_component_module(c)._thermal_conductivity(
+        tmod = get_transport_module(c)
+        if tmod is None:
+            raise RuntimeError(f"Transport roperties not available for {c}")
+        return tmod._thermal_conductivity(
             self.param, delta_liq, tau, blk
         )
 
     def thermal_conductivity_vap(self, **kwargs):
         blk, delta_liq, delta_vap, tau, x, c = self.basic_calculations(**kwargs)
-        return get_component_module(c)._thermal_conductivity(
+        tmod = get_transport_module(c)
+        if tmod is None:
+            raise RuntimeError(f"Transport roperties not available for {c}")
+        return tmod._thermal_conductivity(
             self.param, delta_vap, tau, blk
         )
 
@@ -1287,7 +1300,7 @@ change.
     def build(self):
         super().build()
         # Check if the specified compoent is supported
-        if get_component_module(self.config.pure_component) is None:
+        if not component_registered(self.config.pure_component):
             raise ConfigurationError(
                 f"Component {self.config.pure_component} not supported."
             )

--- a/idaes/models/properties/general_helmholtz/helmholtz_state.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_state.py
@@ -42,7 +42,7 @@ from idaes.models.properties.general_helmholtz.helmholtz_functions import (
     _data_dir,
 )
 from idaes.models.properties.general_helmholtz.components import (
-    get_component_module,
+    get_transport_module,
 )
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
@@ -980,33 +980,35 @@ class HelmholtzStateBlockData(StateBlockData):
             pub_phlist, component_list, rule=rule_mole_frac_phase_comp
         )
 
-        # Phase Thermal conductiviy
-        def rule_tc(b, p):
-            return get_component_module(cmp)._thermal_conductivity(
-                self, delta[p], tau, on_blk=self
+        tmod = get_transport_module(cmp)
+        if tmod is not None:
+            # Phase Thermal conductiviy
+            def rule_tc(b, p):
+                return tmod._thermal_conductivity(
+                    self, delta[p], tau, on_blk=self
+                )
+
+            self.therm_cond_phase = pyo.Expression(
+                phlist, rule=rule_tc, doc="Thermal conductivity"
             )
 
-        self.therm_cond_phase = pyo.Expression(
-            phlist, rule=rule_tc, doc="Thermal conductivity"
-        )
+            # Phase dynamic viscosity
+            def rule_mu(b, p):
+                return tmod._viscosity(
+                    self, delta[p], tau, on_blk=self
+                )
 
-        # Phase dynamic viscosity
-        def rule_mu(b, p):
-            return get_component_module(cmp)._viscosity(
-                self, delta[p], tau, on_blk=self
+            self.visc_d_phase = pyo.Expression(
+                phlist, rule=rule_mu, doc="Viscosity (dynamic)"
             )
 
-        self.visc_d_phase = pyo.Expression(
-            phlist, rule=rule_mu, doc="Viscosity (dynamic)"
-        )
+            # Phase kinimatic viscosity
+            def rule_nu(b, p):
+                return self.visc_d_phase[p] / self.dens_mass_phase[p]
 
-        # Phase kinimatic viscosity
-        def rule_nu(b, p):
-            return self.visc_d_phase[p] / self.dens_mass_phase[p]
-
-        self.visc_k_phase = pyo.Expression(
-            phlist, rule=rule_nu, doc="Kinematic viscosity"
-        )
+            self.visc_k_phase = pyo.Expression(
+                phlist, rule=rule_nu, doc="Kinematic viscosity"
+            )
 
         # Define some expressions for the balance terms returned by functions
         # This is just to allow assigning scale factors to the expressions

--- a/idaes/models/properties/general_helmholtz/helmholtz_state.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_state.py
@@ -984,9 +984,7 @@ class HelmholtzStateBlockData(StateBlockData):
         if tmod is not None:
             # Phase Thermal conductiviy
             def rule_tc(b, p):
-                return tmod._thermal_conductivity(
-                    self, delta[p], tau, on_blk=self
-                )
+                return tmod._thermal_conductivity(self, delta[p], tau, on_blk=self)
 
             self.therm_cond_phase = pyo.Expression(
                 phlist, rule=rule_tc, doc="Thermal conductivity"
@@ -994,9 +992,7 @@ class HelmholtzStateBlockData(StateBlockData):
 
             # Phase dynamic viscosity
             def rule_mu(b, p):
-                return tmod._viscosity(
-                    self, delta[p], tau, on_blk=self
-                )
+                return tmod._viscosity(self, delta[p], tau, on_blk=self)
 
             self.visc_d_phase = pyo.Expression(
                 phlist, rule=rule_mu, doc="Viscosity (dynamic)"

--- a/idaes/models/properties/general_helmholtz/helmholtz_state.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_state.py
@@ -995,7 +995,7 @@ class HelmholtzStateBlockData(StateBlockData):
                 return tmod._viscosity(self, delta[p], tau, on_blk=self)
 
             self.visc_d_phase = pyo.Expression(
-                phlist, rule=rule_mu, doc="Viscosity (dynamic)"
+                phlist, rule=rule_mu, doc="Dynamic viscosity"
             )
 
             # Phase kinimatic viscosity


### PR DESCRIPTION
## Fixes Issue #1016

This lets you register new components.  Right now if you get new data files, you need to add them to the directory with the rest of the Helmholtz data files that get installed with the binaries, but when I get a chance, I want to let you specify alternate directories and maybe alternate names when you register components.  Also would be good to look into using the DMF, but I need a quick fix for now.

This also lets you have thermo properties for a component without implementing transport properties.

I have tested this with other components that we are not currently making available and don't have transport properties and it works.  I know I need to rework the Helmholtz docs, so I'll do that in another new PR ASAP. 

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
