### PR TITLE
Add in costing nonmethod

### DIFF
--- a/docs/reference_guides/model_libraries/power_generation/costing/power_plant_costing_netl.rst
+++ b/docs/reference_guides/model_libraries/power_generation/costing/power_plant_costing_netl.rst
@@ -244,11 +244,11 @@ Below is an example of how to add cost correlations to a flowsheet including a h
         flow_pattern=HeatExchangerFlowPattern.countercurrent)
     # set inputs
     m.fs.unit.shell_inlet.flow_mol[0].fix(100*pyunits.mol/pyunits.s)
-    m.fs.unit.shell_inlet.enth_mol[0].fix(3500*pyunits.mol/pyunits.s)
+    m.fs.unit.shell_inlet.enth_mol[0].fix(3500*pyunits.J/pyunits.mol)
     m.fs.unit.shell_inlet.pressure[0].fix(101325*pyunits.Pa)
     
     m.fs.unit.tube_inlet.flow_mol[0].fix(100*pyunits.mol/pyunits.s)
-    m.fs.unit.tube_inlet.enth_mol[0].fix(4000*pyunits.mol/pyunits.s)
+    m.fs.unit.tube_inlet.enth_mol[0].fix(4000*pyunits.J/pyunits.mol)
     m.fs.unit.tube_inlet.pressure[0].fix(101325*pyunits.Pa)
     
     m.fs.unit.area.fix(1000*pyunits.m**2)

--- a/idaes/core/base/costing_base.py
+++ b/idaes/core/base/costing_base.py
@@ -93,7 +93,7 @@ class DefaultCostingComponents(StrEnum):
 
 
 def assert_flowsheet_costing_block(val):
-    """Domain validator for fowhseet costing block attributes
+    """Domain validator for flowsheet costing block attributes
 
     Args:
         val : value to be checked
@@ -525,7 +525,7 @@ class UnitModelCostingBlockData(ProcessBlockData):
         "flowsheet_costing_block",
         ConfigValue(
             domain=assert_flowsheet_costing_block,
-            doc="Reference to assoicated FlowsheetCostingBlock to use.",
+            doc="Reference to associated FlowsheetCostingBlock to use.",
         ),
     )
     CONFIG.declare(
@@ -581,7 +581,7 @@ class UnitModelCostingBlockData(ProcessBlockData):
         if method is None:
             method = fcb._get_costing_method_for(unit_model)
 
-        # Assign obejct references for costing package and unit model
+        # Assign object references for costing package and unit model
         add_object_reference(self, "costing_package", fcb)
         add_object_reference(self, "unit_model", unit_model)
 
@@ -614,7 +614,7 @@ class UnitModelCostingBlockData(ProcessBlockData):
         Placeholder method for initialization
         """
         # TODO: Implement an initialization method
-        # TODO: Need to have a general pupose method (block triangularisation?)
+        # TODO: Need to have a general purpose method (block triangularisation?)
         # TODO: Should also allow registering custom methods
 
         # Vars and Constraints

--- a/idaes/models/costing/SSLW.py
+++ b/idaes/models/costing/SSLW.py
@@ -19,7 +19,7 @@ Costing package based on methods from:
     Chapter 22. Cost Accounting and Capital Cost Estimation
     22.2 Cost Indexes and Capital Investment
 
-Curently, this costing package only includes methods for capital costing of
+Currently, this costing package only includes methods for capital costing of
 unit operations.
 """
 import pyomo.environ as pyo
@@ -238,12 +238,18 @@ class SSLWCostingData(FlowsheetCostingBlockData):
     @staticmethod
     def initialize_build(self):
         """
-        Here we can add intialization steps for the things we built in
+        Here we can add initialization steps for the things we built in
         build_process_costs.
 
         Note that the aggregate costs will be initialized by the framework.
         """
         # TODO: For now,  no additional process level costs to initialize
+        pass
+
+    def cost_none(blk, integer=True):
+        """
+        Placeholder costing method for those who want to write their own costing method.
+        """
         pass
 
     def cost_heat_exchanger(

--- a/idaes/models/costing/tests/test_SSLW_costing.py
+++ b/idaes/models/costing/tests/test_SSLW_costing.py
@@ -36,7 +36,12 @@ from pyomo.common.config import ConfigValue
 
 from idaes.core import FlowsheetBlock, UnitModelBlock, UnitModelCostingBlock
 from idaes.core.solvers import get_solver
-from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.util.model_statistics import (
+    degrees_of_freedom,
+    number_variables,
+    number_expressions,
+    number_total_constraints,
+)
 from idaes.models.unit_models import (
     Compressor,
     CSTR,
@@ -961,3 +966,13 @@ class TestMapping:
         )
         assert hasattr(model.fs.unit.costing, "capital_cost")
         assert not hasattr(model.fs.unit.costing, "material_factor")
+
+    def test_none(self, model):
+        model.fs.unit = Heater(property_package=model.fs.pparams)
+        model.fs.unit.costing = UnitModelCostingBlock(
+            flowsheet_costing_block=model.fs.costing,
+            costing_method=SSLWCostingData.cost_none,
+        )
+        assert number_variables(model.fs.unit.costing) == 0
+        assert number_expressions(model.fs.unit.costing) == 0
+        assert number_total_constraints(model.fs.unit.costing) == 0


### PR DESCRIPTION
## Summary/Motivation:
Presently, [in a lot of the costing related to the SOFC-IES work](https://github.com/IDAES/examples-pse/blob/63dd7143d0dde9c8e345971b51b588f582d4ef94/src/Examples/Flowsheets/power_generation/ngcc/ngcc_soec_costing.py#L787), we're required to create a costing block on a model because other methods are looking for one, but then the cost produced by the costing method is superseded by one we specifically create. For example:

```
    m.fs.soec.soec_module.diameter = pyo.Var(initialize=0, units=pyunits.m)
    m.fs.soec.soec_module.length = pyo.Var(initialize=0, units=pyunits.m)
    m.fs.soec.soec_module.diameter.fix(0.1)
    m.fs.soec.soec_module.length.fix(0.1)
    m.fs.soec.soec_module.costing = UnitModelCostingBlock(
        flowsheet_costing_block=m.fs.costing,
        costing_method=SSLWCostingData.cost_vessel,
        costing_method_arguments={
            "include_platforms_ladders": False,
        },)

    @m.fs.soec.soec_module.costing.Expression()
    def total_plant_cost(c):
        extra_installed_area = 1.10  # accounts for cell degradation
        return pyunits.convert(60.87 * m.fs.soec.soec_module.number_cells *
                               extra_installed_area * pyunits.USD_2018,
                               CE_index_units)
```
There, `total_plant_cost` is the only thing ultimately used for capital cost estimation. 

As a result, I've added in a costing method that does nothing so we don't have to create these unnecessary variables and constraints.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
