### PR TITLE
Get rid of spurious time index

### DIFF
--- a/idaes/models/unit_models/heat_exchanger_1D.py
+++ b/idaes/models/unit_models/heat_exchanger_1D.py
@@ -502,10 +502,8 @@ cold side flows from 1 to 0""",
         add_object_reference(self, "length", self.hot_side.length)
 
         # Equate hot and cold side lengths
-        @self.Constraint(
-            self.flowsheet().time, doc="Equating hot and cold side lengths"
-        )
-        def length_equality(self, t):
+        @self.Constraint(doc="Equating hot and cold side lengths")
+        def length_equality(self):
             return (
                 pyunits.convert(
                     self.cold_side.length, to_units=hot_side_units("length")


### PR DESCRIPTION
## Fixes
Gets rid of time index for equation in `HeatExchanger1D` equating hot and cold side flow lengths.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
