### PR TITLE
Add smooth LMTD approximation

### DIFF
--- a/docs/reference_guides/model_libraries/generic/unit_models/heat_exchanger.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/heat_exchanger.rst
@@ -169,3 +169,5 @@ to avoid an evaluation error in the log function.
 .. autofunction:: delta_temperature_amtd_callback
 
 .. autofunction:: delta_temperature_underwood_callback
+
+.. autofunction:: delta_temperature_lmtd_smooth_callback


### PR DESCRIPTION
## Summary/Motivation:

Add the smooth LMTD approximation from

Kazi, S., M. Short, A.J. Isafiade,
    L.T. Biegler. "Heat exchanger network synthesus with detailed exchanger
    designs - 2. Hybrid optimization strategy for synthesis of heat exchanger
    networks". AIChE Journal, 2020.

This handles the case where the temperature difference at both ends of the heat exchanger is the same, and it doesn't deviate much from the standard LMTD calculation.  It's potentially more robust even when you don't expect there to be an issue with LMTD since you may evaluate LMTD near the singularity while solving.

This only adds a delta T callback, test and docs.  It doesn't change anything else, so at the very least it won't break anything. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
