### PR TITLE
Fixing print statement in SurrogateBlock

### DIFF
--- a/idaes/core/surrogate/surrogate_block.py
+++ b/idaes/core/surrogate/surrogate_block.py
@@ -13,6 +13,10 @@
 from pyomo.core.base.block import declare_custom_block, _BlockData
 from pyomo.environ import Var, Set
 import collections
+import idaes.logger as idaeslog
+
+__author__ = "Carl Laird, Andrew Lee"
+_log = idaeslog.getLogger(__name__)
 
 
 @declare_custom_block(name="SurrogateBlock")
@@ -57,7 +61,7 @@ class SurrogateBlockData(_BlockData):
         input_vars=None,
         output_vars=None,
         use_surrogate_bounds=True,
-        **kwargs
+        **kwargs,
     ):
         """
         Build an EO model of the surrogate on the block. This method will build the
@@ -107,7 +111,7 @@ class SurrogateBlockData(_BlockData):
                 ub = bnd[1]
                 if v.ub is not None:
                     ub = min(ub, v.ub)
-                print("Setting bound of {} to {}.".format(v, (lb, ub)))
+                _log.debug(f"Setting bound of {v} to ({lb}, {ub}).")
                 v.setlb(lb)
                 v.setub(ub)
 


### PR DESCRIPTION
## Fixes #1048

## Summary/Motivation:
There was a stray print statement in `SurrogateBlock`.

## Changes proposed in this PR:
- Replace print statement with `log.debug`
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
