### PR TITLE
Add 2021 CEPCI Value

### DIFF
--- a/idaes/core/base/costing_base.py
+++ b/idaes/core/base/costing_base.py
@@ -82,6 +82,7 @@ def register_idaes_currency_units():
                 "USD_2018 = 500/603.1 * USD_CE500",
                 "USD_2019 = 500/607.5 * USD_CE500",
                 "USD_2020 = 500/596.2 * USD_CE500",
+                "USD_2021 = 500/677.7 * USD_CE500",
             ]
         )
 

--- a/idaes/core/base/costing_base.py
+++ b/idaes/core/base/costing_base.py
@@ -34,6 +34,7 @@ _log = idaeslog.getLogger(__name__)
 def register_idaes_currency_units():
     """
     Define conversion rates for US Dollars based on CE Index.
+    Source: https://www.toweringskills.com/financial-analysis/cost-indices/
     """
     if (
         "USD_CE500" in pyo.units._pint_registry
@@ -82,7 +83,7 @@ def register_idaes_currency_units():
                 "USD_2018 = 500/603.1 * USD_CE500",
                 "USD_2019 = 500/607.5 * USD_CE500",
                 "USD_2020 = 500/596.2 * USD_CE500",
-                "USD_2021 = 500/677.7 * USD_CE500",
+                "USD_2021 = 500/708.0 * USD_CE500",
             ]
         )
 

--- a/idaes/core/base/tests/test_costing_base.py
+++ b/idaes/core/base/tests/test_costing_base.py
@@ -71,7 +71,7 @@ def test_register_idaes_currency_units():
         "USD_2018": 603.1,
         "USD_2019": 607.5,
         "USD_2020": 596.2,
-        "USD_2021": 677.7,
+        "USD_2021": 708.0,
     }
 
     for c, conv in CEI.items():

--- a/idaes/core/base/tests/test_costing_base.py
+++ b/idaes/core/base/tests/test_costing_base.py
@@ -71,6 +71,7 @@ def test_register_idaes_currency_units():
         "USD_2018": 603.1,
         "USD_2019": 607.5,
         "USD_2020": 596.2,
+        "USD_2021": 677.7,
     }
 
     for c, conv in CEI.items():


### PR DESCRIPTION
## Fixes


## Summary/Motivation:


## Changes proposed in this PR:
- Adding `USD_2021` units to the IDAES currency dictionary, as these units will be required for applications in other subtasks.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
