### PR TITLE
Add global deprecation warning to 1.13 series to notify users before 2.0.0 is released

### DIFF
--- a/idaes/__init__.py
+++ b/idaes/__init__.py
@@ -25,6 +25,23 @@ from .ver import __version__  # noqa
 
 _log = logging.getLogger(__name__)
 
+
+_log.warning(
+f"""The v1 series of IDAES (including this version, {__version__}) is no longer supported.
+
+IDAES users should migrate their code to IDAES v2, which will become the default
+with the upcoming 2.0.0 final release.
+
+For more information, including step-by-step guides on how to migrate code to IDAES v2,
+visit https://github.com/IDAES/idaes-pse/wiki/idaes-v2.
+
+If you wish to continue using the unsupported IDAES v1 series without this warning,
+uninstall this version of IDAES and install the (functionally identical) 1.13.0 release:
+
+pip uninstall --yes idaes-pse && pip install idaes-pse==1.13.0
+"""
+)
+
 # Standard locations for config file, binary libraries and executables, ...
 data_directory, bin_directory, testing_directory = config.get_data_directory()
 # To avoid a circular import the config module doesn't import idaes, but

--- a/idaes/__init__.py
+++ b/idaes/__init__.py
@@ -30,7 +30,7 @@ _log.warning(
 f"""The v1 series of IDAES (including this version, {__version__}) is no longer supported.
 
 IDAES users should migrate their code to IDAES v2, which will become the default
-with the upcoming 2.0.0 final release.
+with the upcoming 2.0.0 stable release.
 
 For more information, including step-by-step guides on how to migrate code to IDAES v2,
 visit https://github.com/IDAES/idaes-pse/wiki/idaes-v2.

--- a/idaes/__init__.py
+++ b/idaes/__init__.py
@@ -35,6 +35,10 @@ with the upcoming 2.0.0 final release.
 For more information, including step-by-step guides on how to migrate code to IDAES v2,
 visit https://github.com/IDAES/idaes-pse/wiki/idaes-v2.
 
+To uninstall this version and start using IDAES v2 now, run:
+
+pip uninstall --yes idaes-pse && pip install idaes-pse --pre
+
 If you wish to continue using the unsupported IDAES v1 series without this warning,
 uninstall this version of IDAES and install the (functionally identical) 1.13.0 release:
 

--- a/idaes/ver.py
+++ b/idaes/ver.py
@@ -192,7 +192,7 @@ except NameError:  # eg, if invoked from setup.py
     pass
 
 #: Package's version as an object
-package_version = Version(1, 13, 0, "final", 0, gh)
+package_version = Version(1, 13, 2, "final", 0, gh)
 
 #: Package's version as a simple string
 __version__ = str(package_version)


### PR DESCRIPTION
## Fixes #1045

## Summary/Motivation:

- Until 2.0.0 (i.e. final) is released, running `pip install idaes-pse` will result in the latest stable release on the 1.x series (currently 1.13.0) to be installed
- This PR adds a deprecation message that is emitted whenever the root `idaes` module is imported (i.e. once per process)
- If users wish to continue using the unsupported v1 series without the message, they are provided instructions to install 1.13.0 (which is functionally identical, but without the warning)

## Changes proposed in this PR:
- Add deprecation warning to be displayed whenever `idaes` is imported (once per process)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
