### PR TITLE
Fixing definition of log in ALAMOpy

### DIFF
--- a/idaes/core/surrogate/alamopy.py
+++ b/idaes/core/surrogate/alamopy.py
@@ -38,7 +38,7 @@ _log = idaeslog.getLogger(__name__)
 alamo = Executable("alamo")
 
 # Define mapping of Pyomo function names for expression evaluation
-GLOBAL_FUNCS = {"sin": sin, "cos": cos, "log": log, "exp": exp}
+GLOBAL_FUNCS = {"sin": sin, "cos": cos, "ln": log, "exp": exp}
 
 
 # The values associated with these must match those expected in the .alm file
@@ -1187,8 +1187,7 @@ class AlamoSurrogate(SurrogateBase):
 
     def evaluate_surrogate(self, inputs):
         """
-        Method to method to evaluate the ALAMO surrogate model at a set of user
-        provided values.
+        Method to evaluate the ALAMO surrogate model at a set of user provided values.
 
         Args:
            dataframe: pandas DataFrame
@@ -1198,7 +1197,7 @@ class AlamoSurrogate(SurrogateBase):
 
         Returns:
             output: pandas Dataframe
-              Returns a dataframe of the the output values evaluated at the provided inputs.
+              Returns a dataframe of the output values evaluated at the provided inputs.
               The index of the output dataframe should match the index of the provided inputs.
         """
         # Create a set of lambda functions for evaluating the surrogate.

--- a/idaes/core/surrogate/tests/test_alamopy.py
+++ b/idaes/core/surrogate/tests/test_alamopy.py
@@ -1276,9 +1276,7 @@ class TestAlamoSurrogate:
     @pytest.fixture
     def alm_surr3(self):
         surrogate_expressions = {
-            "z1": (
-                " z1 == 2*sin(x1**2) - 3*cos(x2**3) - " "4*log(x1**4) + 5*exp(x2**5)"
-            )
+            "z1": (" z1 == 2*sin(x1**2) - 3*cos(x2**3) - " "4*ln(x1**4) + 5*exp(x2**5)")
         }
         input_labels = ["x1", "x2"]
         output_labels = ["z1"]


### PR DESCRIPTION
## Fixes #1058


## Summary/Motivation:
ALAMO uses `"ln"` to represent natural logarithms, however the interface was expecting `"log"`.

## Changes proposed in this PR:
- Update expression parser to correctly substitute `log` function for `"ln"`.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
