### PR TITLE
Moving bed with bidirectional spatial discretization

### DIFF
--- a/docs/reference_guides/model_libraries/gas_solid_contactors/unit_models/moving_bed.rst
+++ b/docs/reference_guides/model_libraries/gas_solid_contactors/unit_models/moving_bed.rst
@@ -33,6 +33,16 @@ Model Structure
 The core MBR unit model consists of two ControlVolume1DBlock Blocks (named gas_phase and solid_phase), each with one 
 Inlet Port (named gas_inlet and solid_inlet) and one Outlet Port (named gas_outlet and solid_outlet).
 
+Discretization
+--------------
+
+The default spatial discretization is a backward finite difference with respect
+to increasing :math:`x` coordinate. For dynamic operation, we recommend a
+discretization that is backward with respect to direction of flow, i.e.
+backward for the gas phase and forward for the solid phase. Discretizations may
+be set for gas and solid phases individually using the
+``gas_transformation_scheme`` and ``solid_transformation_scheme`` config options.
+
 Constraints
 -----------
 

--- a/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
@@ -154,7 +154,10 @@ and to "LAGRANGE-RADAU" for collocation transformation method,
             domain=In([None, "BACKWARD", "FORWARD"]),
             description="Scheme to use for DAE transformation",
             doc="""Scheme to use when transforming length domain of the gas
-phase. See Pyomo documentation for supported schemes,
+phase. If this option is supplied, ``solid_transformation_scheme`` must be
+supplied as well. This cannot be set (other than to ``None``) if the
+``transformation_scheme`` option is set.
+See Pyomo documentation for supported schemes.
 **default** - None.
 **Valid values:** {
 **None** - defaults to the value of the ``transformation_scheme`` option,
@@ -169,7 +172,10 @@ phase. See Pyomo documentation for supported schemes,
             domain=In([None, "BACKWARD", "FORWARD"]),
             description="Scheme to use for DAE transformation",
             doc="""Scheme to use when transforming length domain of the solid
-phase. See Pyomo documentation for supported schemes,
+phase. If this option is supplied, ``gas_transformation_scheme`` must be
+supplied as well. This cannot be set (other than to ``None``) if the
+``transformation_scheme`` option is set.
+See Pyomo documentation for supported schemes,
 **default** - None.
 **Valid values:** {
 **None** - defaults to the value of the ``transformation_scheme`` option,

--- a/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
@@ -721,13 +721,13 @@ see reaction package for documentation.}""",
                     self,
                     wrt=self.gas_length_domain,
                     nfe=self.config.finite_elements,
-                    scheme=self.config.transformation_scheme,
+                    scheme=self._gas_tr_scheme,
                 )
                 self.discretizer.apply_to(
                     self,
                     wrt=self.solid_length_domain,
                     nfe=self.config.finite_elements,
-                    scheme=self.config.transformation_scheme,
+                    scheme=self._solid_tr_scheme,
                 )
             else:
                 self.discretizer.apply_to(

--- a/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
@@ -136,8 +136,10 @@ by the Pyomo TransformationFactory,
             default=None,
             domain=In([None, "BACKWARD", "FORWARD", "LAGRANGE-RADAU"]),
             description="Scheme to use for DAE transformation",
-            doc="""Scheme to use when transforming domain. See Pyomo
-documentation for supported schemes,
+            doc="""Scheme to use when transforming domain. If specified,
+this scheme is applied to discretizations in both the gas and solid phases.
+In this case, ``gas_transformation_scheme`` and ``solid_transformation_scheme``
+cannot be specified. See Pyomo documentation for supported schemes.
 **default** - None.
 **Valid values:** {
 **None** - defaults to "BACKWARD" for finite difference transformation method,

--- a/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
@@ -410,21 +410,17 @@ see reaction package for documentation.}""",
                 "dae.collocation"
                 ".".format(self.name)
             )
-        elif (
-            self.config.transformation_method != "dae.finite_difference"
-            and (
-                self.config.gas_transformation_scheme is not None
-                or self.config.solid_transformation_scheme is not None
-            )
+        elif self.config.transformation_method != "dae.finite_difference" and (
+            self.config.gas_transformation_scheme is not None
+            or self.config.solid_transformation_scheme is not None
         ):
             raise ConfigurationError(
                 "Invalid configuration of {}. transformation_method must be"
-                " \"dae.finite_difference\" if gas_transformation_scheme or"
+                ' "dae.finite_difference" if gas_transformation_scheme or'
                 " solid_transformation_scheme are set".format(self.name)
             )
-        elif (
-            (self.config.gas_transformation_scheme is None)
-            != (self.config.solid_transformation_scheme is None)
+        elif (self.config.gas_transformation_scheme is None) != (
+            self.config.solid_transformation_scheme is None
         ):
             raise ConfigurationError(
                 "Invalid configuration of {}. Either both"
@@ -435,12 +431,9 @@ see reaction package for documentation.}""",
                     self.config.solid_transformation_scheme,
                 )
             )
-        elif (
-            (self.config.transformation_scheme is not None)
-            and (
-                (self.config.gas_transformation_scheme is not None)
-                or (self.config.solid_transformation_scheme is not None)
-            )
+        elif (self.config.transformation_scheme is not None) and (
+            (self.config.gas_transformation_scheme is not None)
+            or (self.config.solid_transformation_scheme is not None)
         ):
             raise ConfigurationError(
                 "Invalid configuration of {}. transformation_scheme cannot be"
@@ -547,9 +540,7 @@ see reaction package for documentation.}""",
             super(_BlockData, self).__setattr__(
                 "solid_length_domain", self.length_domain
             )
-            super(_BlockData, self).__setattr__(
-                "gas_length_domain", self.length_domain
-            )
+            super(_BlockData, self).__setattr__("gas_length_domain", self.length_domain)
 
         self.bed_height = Var(
             domain=Reals,
@@ -713,9 +704,8 @@ see reaction package for documentation.}""",
 
         if self.config.transformation_method == "dae.finite_difference":
             self.discretizer = TransformationFactory(self.config.transformation_method)
-            if (
-                (self.config.gas_transformation_scheme is not None)
-                and (self.config.solid_transformation_scheme is not None)
+            if (self.config.gas_transformation_scheme is not None) and (
+                self.config.solid_transformation_scheme is not None
             ):
                 self.discretizer.apply_to(
                     self,

--- a/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
@@ -157,11 +157,9 @@ and to "LAGRANGE-RADAU" for collocation transformation method,
 phase. See Pyomo documentation for supported schemes,
 **default** - None.
 **Valid values:** {
-**None** - defaults to "BACKWARD" for finite difference transformation method,
-and to "LAGRANGE-RADAU" for collocation transformation method,
+**None** - defaults to the value of the ``transformation_scheme`` option,
 **"BACKWARD"** - Use a finite difference transformation method,
-**"FORWARD""** - use a finite difference transformation method,
-**"LAGRANGE-RADAU""** - use a collocation transformation method}""",
+**"FORWARD""** - use a finite difference transformation method}""",
         ),
     )
     CONFIG.declare(
@@ -174,11 +172,9 @@ and to "LAGRANGE-RADAU" for collocation transformation method,
 phase. See Pyomo documentation for supported schemes,
 **default** - None.
 **Valid values:** {
-**None** - defaults to "BACKWARD" for finite difference transformation method,
-and to "LAGRANGE-RADAU" for collocation transformation method,
+**None** - defaults to the value of the ``transformation_scheme`` option,
 **"BACKWARD"** - Use a finite difference transformation method,
-**"FORWARD""** - use a finite difference transformation method,
-**"LAGRANGE-RADAU""** - use a collocation transformation method}""",
+**"FORWARD""** - use a finite difference transformation method}""",
         ),
     )
     CONFIG.declare(

--- a/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
@@ -122,7 +122,7 @@ provided (default = [0.0, 1.0])""",
         ConfigValue(
             default="dae.finite_difference",
             description="Method to use for DAE transformation",
-            doc="""Method to use to transform domain. Must be a method recognised
+            doc="""Method to use to transform domain. Must be a method recognized
 by the Pyomo TransformationFactory,
 **default** - "dae.finite_difference".
 **Valid values:** {
@@ -675,7 +675,7 @@ see reaction package for documentation.}""",
         self.add_outlet_port(name="solid_outlet", block=self.solid_phase)
 
         # =========================================================================
-        """ Add performace equation method"""
+        """ Add performance equation method"""
         self._apply_transformation()
         self._make_performance()
 
@@ -828,7 +828,7 @@ see reaction package for documentation.}""",
         # Add performance equations
 
         # ---------------------------------------------------------------------
-        # Geometry contraints
+        # Geometry constraints
 
         # Bed area
         @self.Constraint(doc="Bed area")
@@ -851,7 +851,7 @@ see reaction package for documentation.}""",
             return b.solid_phase.area[t, x] == b.bed_area * (1 - b.bed_voidage)
 
         # ---------------------------------------------------------------------
-        # Hydrodynamic contraints
+        # Hydrodynamic constraints
 
         # Gas superficial velocity
         @self.Constraint(
@@ -975,7 +975,7 @@ see reaction package for documentation.}""",
                 " developers with this bug.".format(self.name)
             )
         # ---------------------------------------------------------------------
-        # Reaction contraints
+        # Reaction constraints
 
         # Build homogeneous reaction constraints
         if gas_phase.reaction_package is not None:
@@ -992,7 +992,7 @@ see reaction package for documentation.}""",
                     * b.gas_phase.area[t, x]
                 )
 
-        # Build hetereogeneous reaction constraints
+        # Build heterogeneous reaction constraints
         if solid_phase.reaction_package is not None:
             # Solid side rate reaction extent
             @self.Constraint(
@@ -1211,7 +1211,7 @@ see reaction package for documentation.}""",
         solid_phase = blk.config.solid_phase_config
 
         # Keep all unit model geometry constraints, derivative_var constraints,
-        # and property block constraints active. Additionaly, in control
+        # and property block constraints active. Additionally, in control
         # volumes - keep conservation linking constraints and
         # holdup calculation (for dynamic flowsheets) constraints active
 

--- a/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
@@ -524,9 +524,7 @@ see reaction package for documentation.}""",
             # Arbitrarily, use the solid phase length domain.
             #
             # We do not use Reference as it does not work for Sets.
-            add_object_reference(
-                self, "length_domain", self.solid_length_domain
-            )
+            add_object_reference(self, "length_domain", self.solid_length_domain)
         else:
             # Neither gas nor solid transformation schemes are specified
             self._gas_tr_scheme = self.config.transformation_scheme
@@ -537,9 +535,7 @@ see reaction package for documentation.}""",
                 doc="Moving bed normalized length domain",
             )
             # Create instance attributes for gas and solid length domains
-            add_object_reference(
-                self, "solid_length_domain", self.length_domain
-            )
+            add_object_reference(self, "solid_length_domain", self.length_domain)
             add_object_reference(self, "gas_length_domain", self.length_domain)
 
         self.bed_height = Var(

--- a/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/moving_bed.py
@@ -53,7 +53,6 @@ from pyomo.environ import (
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.dae import ContinuousSet
-from pyomo.core.base.block import _BlockData
 
 # Import IDAES cores
 from idaes.core import (
@@ -78,6 +77,7 @@ from idaes.core.util.exceptions import (
 from idaes.core.util.tables import create_stream_table_dataframe
 from idaes.core.util.constants import Constants as constants
 from idaes.core.util.math import smooth_abs
+from idaes.core.util.misc import add_object_reference
 import idaes.logger as idaeslog
 from idaes.core.util import scaling as iscale
 from idaes.core.solvers import get_solver
@@ -524,8 +524,8 @@ see reaction package for documentation.}""",
             # Arbitrarily, use the solid phase length domain.
             #
             # We do not use Reference as it does not work for Sets.
-            super(_BlockData, self).__setattr__(
-                "length_domain", self.solid_length_domain
+            add_object_reference(
+                self, "length_domain", self.solid_length_domain
             )
         else:
             # Neither gas nor solid transformation schemes are specified
@@ -537,10 +537,10 @@ see reaction package for documentation.}""",
                 doc="Moving bed normalized length domain",
             )
             # Create instance attributes for gas and solid length domains
-            super(_BlockData, self).__setattr__(
-                "solid_length_domain", self.length_domain
+            add_object_reference(
+                self, "solid_length_domain", self.length_domain
             )
-            super(_BlockData, self).__setattr__("gas_length_domain", self.length_domain)
+            add_object_reference(self, "gas_length_domain", self.length_domain)
 
         self.bed_height = Var(
             domain=Reals,

--- a/idaes/models_extra/gas_solid_contactors/unit_models/tests/test_MB.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/tests/test_MB.py
@@ -1166,8 +1166,8 @@ class TestBidirectionalSpatialDiscretization:
             m.fs.unit2.build()
 
         with pytest.raises(
-           ConfigurationError,
-           match="transformation_scheme cannot be specified",
+            ConfigurationError,
+            match="transformation_scheme cannot be specified",
         ):
             m.fs.unit3 = MBR(
                 transformation_scheme="BACKWARD",

--- a/idaes/models_extra/gas_solid_contactors/unit_models/tests/test_MB.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/tests/test_MB.py
@@ -26,10 +26,14 @@ from pyomo.environ import (
     Var,
     Constraint,
     TransformationFactory,
+    Reference,
     units as pyo_units,
 )
+from pyomo.core.expr.visitor import identify_variables
+from pyomo.dae.flatten import slice_component_along_sets
 from pyomo.util.check_units import assert_units_consistent
 from pyomo.common.config import ConfigBlock
+from pyomo.common.collections import ComponentSet
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from idaes.core import (
     FlowsheetBlock,
@@ -1131,7 +1135,6 @@ class TestIronOC_TransformationMethod(object):
 
 
 class TestBidirectionalSpatialDiscretization:
-
     @pytest.mark.unit
     def test_config_errors(self):
         m = ConcreteModel()
@@ -1162,10 +1165,10 @@ class TestBidirectionalSpatialDiscretization:
         ):
             m.fs.unit2.build()
 
-        #with pytest.raises(
+        # with pytest.raises(
         #    ConfigurationError,
         #    match="transformation_scheme cannot be specified",
-        #):
+        # ):
         #    m.fs.unit3 = MBR(
         #        transformation_scheme="BACKWARD",
         #        gas_transformation_scheme="BACKWARD",
@@ -1186,7 +1189,7 @@ class TestBidirectionalSpatialDiscretization:
         nxcp = 1
 
         time_set = [0.0, horizon]
-        ntfe = round(horizon/tfe_width)
+        ntfe = round(horizon / tfe_width)
 
         model = ConcreteModel()
         model.fs = FlowsheetBlock(
@@ -1200,7 +1203,7 @@ class TestBidirectionalSpatialDiscretization:
         model.fs.hetero_reactions = HeteroReactionParameterBlock(
             solid_property_package=model.fs.solid_properties,
             gas_property_package=model.fs.gas_properties,
-        )  
+        )
 
         model.fs.MB = MBR(
             finite_elements=nxfe,
@@ -1243,7 +1246,221 @@ class TestBidirectionalSpatialDiscretization:
             assert x in solid_length
             assert x in bed_length
 
+    @pytest.mark.unit
+    def test_var_indices(self):
+        horizon = 300.0
+        tfe_width = 100.0
+        ntcp = 3
 
-if __name__ == "__main__":
-    TestBidirectionalSpatialDiscretization().test_config_errors()
-    TestBidirectionalSpatialDiscretization().test_construct_dynamic()
+        nxfe = 3
+        nxcp = 1
+
+        time_set = [0.0, horizon]
+        ntfe = round(horizon / tfe_width)
+
+        model = ConcreteModel()
+        model.fs = FlowsheetBlock(
+            dynamic=True,
+            time_set=time_set,
+            time_units=pyo_units.s,
+        )
+
+        model.fs.gas_properties = GasPhaseParameterBlock()
+        model.fs.solid_properties = SolidPhaseParameterBlock()
+        model.fs.hetero_reactions = HeteroReactionParameterBlock(
+            solid_property_package=model.fs.solid_properties,
+            gas_property_package=model.fs.gas_properties,
+        )
+
+        model.fs.MB = MBR(
+            finite_elements=nxfe,
+            has_holdup=True,
+            length_domain_set=[],
+            transformation_method="dae.finite_difference",
+            collocation_points=nxcp,
+            gas_transformation_scheme="BACKWARD",
+            solid_transformation_scheme="FORWARD",
+            pressure_drop_type="ergun_correlation",
+            gas_phase_config={"property_package": model.fs.gas_properties},
+            solid_phase_config={
+                "property_package": model.fs.solid_properties,
+                "reaction_package": model.fs.hetero_reactions,
+            },
+        )
+
+        time = model.fs.time
+        discretizer = TransformationFactory("dae.collocation")
+        discretizer.apply_to(
+            model, wrt=time, nfe=ntfe, ncp=ntcp, scheme="LAGRANGE-RADAU"
+        )
+
+        gas_phase = model.fs.MB.gas_phase
+        solid_phase = model.fs.MB.solid_phase
+
+        gas_length = model.fs.MB.gas_phase.length_domain
+        solid_length = model.fs.MB.solid_phase.length_domain
+        bed_length = model.fs.MB.length_domain
+
+        gas_components = model.fs.gas_properties.component_list
+        solid_components = model.fs.solid_properties.component_list
+        gas_phases = model.fs.gas_properties.phase_list
+        solid_phases = model.fs.solid_properties.phase_list
+
+        gas_disc_eqs = [
+            gas_phase.material_flow_dx_disc_eq,
+            gas_phase.enthalpy_flow_dx_disc_eq,
+        ]
+        gas_flow_vars = [gas_phase._flow_terms, gas_phase._enthalpy_flow]
+
+        gas_disc_eqs = [
+            dict(
+                (idx, Reference(slice_))
+                for idx, slice_ in slice_component_along_sets(
+                    eq, (gas_length, solid_length)
+                )
+            )
+            for eq in gas_disc_eqs
+        ]
+        gas_flow_vars = [
+            dict(
+                (idx, Reference(slice_))
+                for idx, slice_ in slice_component_along_sets(
+                    var, (gas_length, solid_length)
+                )
+            )
+            for var in gas_flow_vars
+        ]
+
+        for eq_dict, var_dict in zip(gas_disc_eqs, gas_flow_vars):
+            # NOTE: I am relying on fact that equations and variables
+            # here have same non-space indices, and that they are in
+            # the same order.
+            for idx in eq_dict:
+                for x in gas_length:
+                    if x != gas_length.first():
+                        x_prev = gas_length.prev(x)
+                        eqdata = eq_dict[idx][x]
+                        vardata = var_dict[idx][x]
+                        vardata_prev = var_dict[idx][x_prev]
+                        var_set = ComponentSet(identify_variables(eqdata.expr))
+                        assert len(var_set) == 3
+                        assert vardata in var_set
+                        assert vardata_prev in var_set
+
+        solid_disc_eqs = [
+            solid_phase.material_flow_dx_disc_eq,
+            solid_phase.enthalpy_flow_dx_disc_eq,
+        ]
+        solid_flow_vars = [
+            solid_phase._flow_terms,
+            solid_phase._enthalpy_flow,
+        ]
+
+        solid_disc_eqs = [
+            dict(
+                (idx, Reference(slice_))
+                for idx, slice_ in slice_component_along_sets(
+                    eq, (gas_length, solid_length)
+                )
+            )
+            for eq in solid_disc_eqs
+        ]
+        solid_flow_vars = [
+            dict(
+                (idx, Reference(slice_))
+                for idx, slice_ in slice_component_along_sets(
+                    var, (gas_length, solid_length)
+                )
+            )
+            for var in solid_flow_vars
+        ]
+
+        gas_disc_eqs = [
+            gas_phase.material_flow_dx_disc_eq,
+            gas_phase.enthalpy_flow_dx_disc_eq,
+        ]
+        gas_flow_vars = [
+            gas_phase._flow_terms,
+            gas_phase._enthalpy_flow,
+        ]
+
+        gas_disc_eqs = [
+            dict(
+                (idx, Reference(slice_))
+                for idx, slice_ in slice_component_along_sets(
+                    eq, (gas_length, solid_length)
+                )
+            )
+            for eq in gas_disc_eqs
+        ]
+        gas_flow_vars = [
+            dict(
+                (idx, Reference(slice_))
+                for idx, slice_ in slice_component_along_sets(
+                    var, (gas_length, solid_length)
+                )
+            )
+            for var in gas_flow_vars
+        ]
+
+        #
+        # Test that discretization equations contain variables at the correct
+        # indices
+        #
+        for eq_dict, var_dict in zip(gas_disc_eqs, gas_flow_vars):
+            for idx in eq_dict:
+                for x in gas_length:
+                    if x != gas_length.first():
+                        x_prev = gas_length.prev(x)
+                        eqdata = eq_dict[idx][x]
+                        vardata = var_dict[idx][x]
+                        vardata_prev = var_dict[idx][x_prev]
+                        var_set = ComponentSet(identify_variables(eqdata.expr))
+                        assert len(var_set) == 3
+                        assert vardata in var_set
+                        assert vardata_prev in var_set
+
+        solid_disc_eqs = [
+            solid_phase.material_flow_dx_disc_eq,
+            solid_phase.enthalpy_flow_dx_disc_eq,
+        ]
+        solid_flow_vars = [
+            solid_phase._flow_terms,
+            solid_phase._enthalpy_flow,
+        ]
+
+        solid_disc_eqs = [
+            dict(
+                (idx, Reference(slice_))
+                for idx, slice_ in slice_component_along_sets(
+                    eq, (gas_length, solid_length)
+                )
+            )
+            for eq in solid_disc_eqs
+        ]
+        solid_flow_vars = [
+            dict(
+                (idx, Reference(slice_))
+                for idx, slice_ in slice_component_along_sets(
+                    var, (gas_length, solid_length)
+                )
+            )
+            for var in solid_flow_vars
+        ]
+
+        #
+        # Test that discretization equations contain variables at the correct
+        # indices
+        #
+        for eq_dict, var_dict in zip(solid_disc_eqs, solid_flow_vars):
+            for idx in eq_dict:
+                for x in solid_length:
+                    if x != solid_length.last():
+                        x_prev = solid_length.next(x)
+                        eqdata = eq_dict[idx][x]
+                        vardata = var_dict[idx][x]
+                        vardata_prev = var_dict[idx][x_prev]
+                        var_set = ComponentSet(identify_variables(eqdata.expr))
+                        assert len(var_set) == 3
+                        assert vardata in var_set
+                        assert vardata_prev in var_set

--- a/idaes/models_extra/gas_solid_contactors/unit_models/tests/test_MB.py
+++ b/idaes/models_extra/gas_solid_contactors/unit_models/tests/test_MB.py
@@ -1154,30 +1154,29 @@ class TestBidirectionalSpatialDiscretization:
             )
             m.fs.unit1.build()
 
-        m.fs.unit2 = MBR(
-            gas_transformation_scheme="BACKWARD",
-            gas_phase_config={"property_package": m.fs.gas_properties},
-            solid_phase_config={"property_package": m.fs.solid_properties},
-        )
         with pytest.raises(
             ConfigurationError,
             match=r"Either both.*must be set",
         ):
+            m.fs.unit2 = MBR(
+                gas_transformation_scheme="BACKWARD",
+                gas_phase_config={"property_package": m.fs.gas_properties},
+                solid_phase_config={"property_package": m.fs.solid_properties},
+            )
             m.fs.unit2.build()
 
-        # with pytest.raises(
-        #    ConfigurationError,
-        #    match="transformation_scheme cannot be specified",
-        # ):
-        #    m.fs.unit3 = MBR(
-        #        transformation_scheme="BACKWARD",
-        #        gas_transformation_scheme="BACKWARD",
-        #        solid_transformation_scheme="BACKWARD",
-        #        gas_phase_config={"property_package": m.fs.gas_properties},
-        #        solid_phase_config={"property_package": m.fs.solid_properties},
-        #    )
-        #    # For some reason, just constructing MBR here appears to call build...
-        #    #m.fs.unit3.build()
+        with pytest.raises(
+           ConfigurationError,
+           match="transformation_scheme cannot be specified",
+        ):
+            m.fs.unit3 = MBR(
+                transformation_scheme="BACKWARD",
+                gas_transformation_scheme="BACKWARD",
+                solid_transformation_scheme="BACKWARD",
+                gas_phase_config={"property_package": m.fs.gas_properties},
+                solid_phase_config={"property_package": m.fs.solid_properties},
+            )
+            m.fs.unit3.build()
 
     @pytest.mark.unit
     def test_construct_dynamic(self):


### PR DESCRIPTION
## Fixes singularities due to incompatible discretization for counter-current flow

## Summary/Motivation:
For counter-current flow systems, spatial discretizations of the two phases should have "opposite direction", e.g. forward for the solid phase and backward for the gas. To approximate finite volume methods, these should be "upwind" with respect to direction of flow. This PR adds options to the moving bed unit model to allow users to specify discretizations of the two phases independently.

## Changes proposed in this PR:
- Add `gas_transformation_scheme` and `solid_transformation_scheme` config options to the moving bed unit model. These are only supported if `dae.finite_difference` is used for `transformation_method`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
