### PR TITLE
Add Ipopt L1 solver factory

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -253,8 +253,8 @@ def _new_idaes_config_block():
         "ipopt_l1",
         pyomo.common.config.ConfigBlock(
             implicit=False,
-            description="Default config for 'ipopt' solver",
-            doc="Default config for 'ipopt' solver",
+            description="Default config for 'ipopt_l1' solver",
+            doc="Default config for 'ipopt_l1' solver",
         ),
     )
 
@@ -262,8 +262,8 @@ def _new_idaes_config_block():
         "options",
         pyomo.common.config.ConfigBlock(
             implicit=True,
-            description="Default solver options for 'ipopt'",
-            doc="Default solver options for 'ipopt' solver",
+            description="Default solver options for 'ipopt_l1'",
+            doc="Default solver options for 'ipopt_l1' solver",
         ),
     )
 
@@ -272,8 +272,8 @@ def _new_idaes_config_block():
         pyomo.common.config.ConfigValue(
             domain=str,
             default="gradient-based",
-            description="Ipopt NLP scaling method",
-            doc="Ipopt NLP scaling method",
+            description="Ipopt_l1 NLP scaling method",
+            doc="Ipopt_l1 NLP scaling method",
         ),
     )
 
@@ -282,8 +282,8 @@ def _new_idaes_config_block():
         pyomo.common.config.ConfigValue(
             domain=float,
             default=1e-6,
-            description="Ipopt tol option",
-            doc="Ipopt tol option",
+            description="Ipopt_l1 tol option",
+            doc="Ipopt_l1 tol option",
         ),
     )
 

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -250,6 +250,44 @@ def _new_idaes_config_block():
     )
 
     cfg.declare(
+        "ipopt_l1",
+        pyomo.common.config.ConfigBlock(
+            implicit=False,
+            description="Default config for 'ipopt' solver",
+            doc="Default config for 'ipopt' solver",
+        ),
+    )
+
+    cfg["ipopt_l1"].declare(
+        "options",
+        pyomo.common.config.ConfigBlock(
+            implicit=True,
+            description="Default solver options for 'ipopt'",
+            doc="Default solver options for 'ipopt' solver",
+        ),
+    )
+
+    cfg["ipopt_l1"]["options"].declare(
+        "nlp_scaling_method",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="gradient-based",
+            description="Ipopt NLP scaling method",
+            doc="Ipopt NLP scaling method",
+        ),
+    )
+
+    cfg["ipopt_l1"]["options"].declare(
+        "tol",
+        pyomo.common.config.ConfigValue(
+            domain=float,
+            default=1e-6,
+            description="Ipopt tol option",
+            doc="Ipopt tol option",
+        ),
+    )
+
+    cfg.declare(
         "petsc_ts",
         pyomo.common.config.ConfigBlock(
             implicit=False,

--- a/idaes/core/solvers/ipopt_l1.py
+++ b/idaes/core/solvers/ipopt_l1.py
@@ -14,18 +14,22 @@
 from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
 from pyomo.common import Executable
 from pyomo.opt.base.solvers import SolverFactory
-from pyomo.opt.solver import  SystemCallSolver
+from pyomo.opt.solver import SystemCallSolver
 
 import logging
-logger = logging.getLogger('pyomo.solvers')
 
-@SolverFactory.register('ipopt_l1', doc='The Ipopt NLP solver')
+logger = logging.getLogger("pyomo.solvers")
+
+
+@SolverFactory.register("ipopt_l1", doc="The Ipopt NLP solver")
 class IPOPT_L1(IPOPT):
     def _default_executable(self):
         executable = Executable("ipopt_l1")
         if not executable:
-            logger.warning("Could not locate the 'ipopt_l1' executable, "
-                            "which is required for solver %s" % self.name)
+            logger.warning(
+                "Could not locate the 'ipopt_l1' executable, "
+                "which is required for solver %s" % self.name
+            )
             self.enable = False
             return None
         return executable.path()

--- a/idaes/core/solvers/ipopt_l1.py
+++ b/idaes/core/solvers/ipopt_l1.py
@@ -1,0 +1,31 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES), and is copyright (c) 2018-2021
+# by the software owners: The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory,  National Technology & Engineering
+# Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia University
+# Research Corporation, et al.  All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
+# license information.
+#################################################################################
+
+from pyomo.solvers.plugins.solvers.IPOPT import IPOPT
+from pyomo.common import Executable
+from pyomo.opt.base.solvers import SolverFactory
+from pyomo.opt.solver import  SystemCallSolver
+
+import logging
+logger = logging.getLogger('pyomo.solvers')
+
+@SolverFactory.register('ipopt_l1', doc='The Ipopt NLP solver')
+class IPOPT_L1(IPOPT):
+    def _default_executable(self):
+        executable = Executable("ipopt_l1")
+        if not executable:
+            logger.warning("Could not locate the 'ipopt_l1' executable, "
+                            "which is required for solver %s" % self.name)
+            self.enable = False
+            return None
+        return executable.path()

--- a/idaes/core/solvers/tests/test_solver_config.py
+++ b/idaes/core/solvers/tests/test_solver_config.py
@@ -14,6 +14,7 @@ import pyomo.environ as pyo
 import pytest
 import idaes
 import idaes.core.solvers as isolve
+import idaes.core.solvers.ipopt_l1
 
 
 @pytest.mark.skipif(not pyo.SolverFactory("ipopt").available(False), reason="no Ipopt")
@@ -32,6 +33,24 @@ def test_ipopt_idaes_config():
         assert solver.options["tol"] == 1
         idaes.cfg.ipopt.options.tol = 1
         solver = pyo.SolverFactory("ipopt")
+        assert solver.options["tol"] == 1
+
+@pytest.mark.skipif(not pyo.SolverFactory("ipopt_l1").available(False), reason="no Ipopt_l1")
+@pytest.mark.unit
+def test_ipopt_l1_idaes_config():
+    """
+    Test that the default solver options are set
+    """
+    with idaes.temporary_config_ctx():
+        # in this context use idaes default solver options
+        isolve.use_idaes_solver_configuration_defaults()
+        idaes.cfg.ipopt_l1.options.nlp_scaling_method = "toast-based"
+        solver = pyo.SolverFactory("ipopt_l1")
+        assert solver.options["nlp_scaling_method"] == "toast-based"
+        solver = pyo.SolverFactory("ipopt_l1", options={"tol": 1})
+        assert solver.options["tol"] == 1
+        idaes.cfg.ipopt_l1.options.tol = 1
+        solver = pyo.SolverFactory("ipopt_l1")
         assert solver.options["tol"] == 1
 
 

--- a/idaes/core/solvers/tests/test_solver_config.py
+++ b/idaes/core/solvers/tests/test_solver_config.py
@@ -35,7 +35,10 @@ def test_ipopt_idaes_config():
         solver = pyo.SolverFactory("ipopt")
         assert solver.options["tol"] == 1
 
-@pytest.mark.skipif(not pyo.SolverFactory("ipopt_l1").available(False), reason="no Ipopt_l1")
+
+@pytest.mark.skipif(
+    not pyo.SolverFactory("ipopt_l1").available(False), reason="no Ipopt_l1"
+)
 @pytest.mark.unit
 def test_ipopt_l1_idaes_config():
     """

--- a/idaes/core/solvers/tests/test_solvers.py
+++ b/idaes/core/solvers/tests/test_solvers.py
@@ -15,6 +15,8 @@ import pytest
 from idaes.core.solvers.features import lp, milp, nlp, minlp, nle, dae
 from idaes.core.solvers import ipopt_has_linear_solver
 from idaes.core.solvers import petsc
+from idaes.core.solvers import ipopt_l1
+
 
 
 @pytest.mark.unit
@@ -54,6 +56,10 @@ def test_ipopt_idaes_available():
             "documentation for instructions on how to get IPOPT."
         )
 
+@pytest.mark.unit
+def test_ipopt_l1_available():
+    if not pyo.SolverFactory("ipopt_l1").available():
+        raise RuntimeError("Could not find ipopt_l1.")
 
 @pytest.mark.unit
 def test_cbc_available():
@@ -87,6 +93,17 @@ def test_ipopt_idaes_solve():
     """
     m, x = nlp()
     solver = pyo.SolverFactory("ipopt")
+    solver.solve(m)
+    assert pytest.approx(x) == pyo.value(m.x)
+
+@pytest.mark.unit
+def test_ipopt_l1_idaes_solve():
+    """
+    Make sure there is no issue with the solver class or default settings that
+    break the solver object.  Passing a bad solver option will result in failure
+    """
+    m, x = nlp()
+    solver = pyo.SolverFactory("ipopt_l1")
     solver.solve(m)
     assert pytest.approx(x) == pyo.value(m.x)
 

--- a/idaes/core/solvers/tests/test_solvers.py
+++ b/idaes/core/solvers/tests/test_solvers.py
@@ -18,7 +18,6 @@ from idaes.core.solvers import petsc
 from idaes.core.solvers import ipopt_l1
 
 
-
 @pytest.mark.unit
 def test_petsc_available():
     if not pyo.SolverFactory("petsc_snes").available():
@@ -56,10 +55,12 @@ def test_ipopt_idaes_available():
             "documentation for instructions on how to get IPOPT."
         )
 
+
 @pytest.mark.unit
 def test_ipopt_l1_available():
     if not pyo.SolverFactory("ipopt_l1").available():
         raise RuntimeError("Could not find ipopt_l1.")
+
 
 @pytest.mark.unit
 def test_cbc_available():
@@ -95,6 +96,7 @@ def test_ipopt_idaes_solve():
     solver = pyo.SolverFactory("ipopt")
     solver.solve(m)
     assert pytest.approx(x) == pyo.value(m.x)
+
 
 @pytest.mark.unit
 def test_ipopt_l1_idaes_solve():


### PR DESCRIPTION
## Fixes issue #1073 

## Summary/Motivation:

This adds a solver factory for ipopt_l1 and fills in some config blocks to make it easier to configure with the IDAES config system.  **To use this,** you need to ``from idaes.core.solvers import ipopt_l1`` 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
