### PR TITLE
Fix NumPy array creation error by specifying object type

### DIFF
--- a/idaes/core/surrogate/pysmo/kriging.py
+++ b/idaes/core/surrogate/pysmo/kriging.py
@@ -655,7 +655,7 @@ class KrigingModel:
             Pyomo Expression              : Pyomo expression of the Kriging model based on the variables provided in **variable_list**
 
         """
-        t1 = np.array([variable_list])
+        t1 = np.array([variable_list], dtype="object")
         # Reshaping of variable array is necessary when input variables are Pyomo scalar variables
         t1 = t1.reshape(1, len(variable_list)) if t1.ndim > 2 else t1
 

--- a/idaes/core/surrogate/pysmo/polynomial_regression.py
+++ b/idaes/core/surrogate/pysmo/polynomial_regression.py
@@ -1602,7 +1602,7 @@ class PolynomialRegression:
 
         """
         # Reshaping of array necessary when input variables are Pyomo scalar variables
-        vl = np.array([variable_list])
+        vl = np.array([variable_list], dtype="object")
         vl = vl.reshape(1, len(variable_list)) if vl.ndim > 2 else vl
 
         terms = PolynomialRegression.polygeneration(

--- a/idaes/core/surrogate/pysmo/radial_basis_function.py
+++ b/idaes/core/surrogate/pysmo/radial_basis_function.py
@@ -1163,7 +1163,7 @@ class RadialBasisFunctions:
             Pyomo Expression              : Pyomo expression of the RBF model based on the variables provided in **variable_list**
 
         """
-        t1 = np.array([variable_list])
+        t1 = np.array([variable_list], dtype="object")
         # Reshaping of variable array is necessary when input variables are Pyomo scalar variables
         t1 = t1.reshape(1, len(variable_list)) if t1.ndim > 2 else t1
 

--- a/idaes/core/surrogate/tests/test_pysmo_surrogate.py
+++ b/idaes/core/surrogate/tests/test_pysmo_surrogate.py
@@ -1645,9 +1645,7 @@ class TestPysmoSurrogate:
         m.surrogate.build_model(
             pysmo_surr1, input_vars=[m.x1, m.x2], output_vars=[m.z1]
         )
-        print(m)
         assert len(m.surrogate.pysmo_constraint) == 1
-        m.display()
 
     @pytest.mark.parametrize(
         "confidence_dict", [{0.99: 3.2498355440153697}, {0.90: 1.8331129326536335}]

--- a/idaes/core/surrogate/tests/test_pysmo_surrogate.py
+++ b/idaes/core/surrogate/tests/test_pysmo_surrogate.py
@@ -1633,6 +1633,22 @@ class TestPysmoSurrogate:
         cstr = cstr.replace("inputs[x2]", "5")
         assert eval(cstr) == pytest.approx(0, abs=1e-8)
 
+    @pytest.mark.unit
+    def test_populate_block_multisurrogate_poly_userdef_mixedtypes(self, pysmo_surr1):
+        # Test ``populate_block`` for input variables of mixed types, e.g scalar and indexed pyomo variables
+
+        m = ConcreteModel()
+        m.x1 = Var(initialize=0, bounds=(0, 5))
+        m.x2 = Var([0], initialize=0, bounds=(0, 10))
+        m.z1 = Var(initialize=0, bounds=(0, 10))
+        m.surrogate = SurrogateBlock(concrete=True)
+        m.surrogate.build_model(
+            pysmo_surr1, input_vars=[m.x1, m.x2], output_vars=[m.z1]
+        )
+        print(m)
+        assert len(m.surrogate.pysmo_constraint) == 1
+        m.display()
+
     @pytest.mark.parametrize(
         "confidence_dict", [{0.99: 3.2498355440153697}, {0.90: 1.8331129326536335}]
     )


### PR DESCRIPTION
## Fixes
#1065 

## Summary/Motivation:
Fixes potential NumPy errors in surrogate model expression generation when inputs are of mixed pyomo types, e.g scalar and indexed variables. 

## Changes proposed in this PR:
- specify ``dtype=object`` in PySMO when creating Numpy arrays from a list of pyomo variables.
- Add test for mixed variable input types.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
