### PR TITLE
Rework control volume code to remove unneeded terms.

### DIFF
--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -562,64 +562,52 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         if balance_type == MaterialBalanceType.componentPhase:
 
             def user_term_mol(b, t, p, j):
-                if custom_molar_term is not None:
-                    flow_basis = b.properties_out[t].get_material_flow_basis()
-                    if flow_basis == MaterialFlowBasis.molar:
-                        return custom_molar_term(t, p, j)
-                    elif flow_basis == MaterialFlowBasis.mass:
-                        try:
-                            return (
-                                custom_molar_term(t, p, j)
-                                * b.properties_out[t].mw_comp[j]
-                            )
-                        except AttributeError:
-                            raise PropertyNotSupportedError(
-                                "{} property package does not support "
-                                "molecular weight (mw), which is required for "
-                                "using custom terms in material balances.".format(
-                                    self.name
-                                )
-                            )
-                    else:
-                        raise ConfigurationError(
-                            "{} contained a custom_molar_term argument, but "
-                            "the property package used an undefined basis "
-                            "(MaterialFlowBasis.other). Custom terms can "
-                            "only be used when the property package declares "
-                            "a molar or mass flow basis.".format(self.name)
+                flow_basis = b.properties_out[t].get_material_flow_basis()
+                if flow_basis == MaterialFlowBasis.molar:
+                    return custom_molar_term(t, p, j)
+                elif flow_basis == MaterialFlowBasis.mass:
+                    try:
+                        return (
+                            custom_molar_term(t, p, j) * b.properties_out[t].mw_comp[j]
+                        )
+                    except AttributeError:
+                        raise PropertyNotSupportedError(
+                            "{} property package does not support "
+                            "molecular weight (mw), which is required for "
+                            "using custom terms in material balances.".format(self.name)
                         )
                 else:
-                    return 0
+                    raise ConfigurationError(
+                        "{} contained a custom_molar_term argument, but "
+                        "the property package used an undefined basis "
+                        "(MaterialFlowBasis.other). Custom terms can "
+                        "only be used when the property package declares "
+                        "a molar or mass flow basis.".format(self.name)
+                    )
 
             def user_term_mass(b, t, p, j):
-                if custom_mass_term is not None:
-                    flow_basis = b.properties_out[t].get_material_flow_basis()
-                    if flow_basis == MaterialFlowBasis.mass:
-                        return custom_mass_term(t, p, j)
-                    elif flow_basis == MaterialFlowBasis.molar:
-                        try:
-                            return (
-                                custom_mass_term(t, p, j)
-                                / b.properties_out[t].mw_comp[j]
-                            )
-                        except AttributeError:
-                            raise PropertyNotSupportedError(
-                                "{} property package does not support "
-                                "molecular weight (mw), which is required for "
-                                "using custom terms in material balances.".format(
-                                    self.name
-                                )
-                            )
-                    else:
-                        raise ConfigurationError(
-                            "{} contained a custom_mass_term argument, but "
-                            "the property package used an undefined basis "
-                            "(MaterialFlowBasis.other). Custom terms can "
-                            "only be used when the property package declares "
-                            "a molar or mass flow basis.".format(self.name)
+                flow_basis = b.properties_out[t].get_material_flow_basis()
+                if flow_basis == MaterialFlowBasis.mass:
+                    return custom_mass_term(t, p, j)
+                elif flow_basis == MaterialFlowBasis.molar:
+                    try:
+                        return (
+                            custom_mass_term(t, p, j) / b.properties_out[t].mw_comp[j]
+                        )
+                    except AttributeError:
+                        raise PropertyNotSupportedError(
+                            "{} property package does not support "
+                            "molecular weight (mw), which is required for "
+                            "using custom terms in material balances.".format(self.name)
                         )
                 else:
-                    return 0
+                    raise ConfigurationError(
+                        "{} contained a custom_mass_term argument, but "
+                        "the property package used an undefined basis "
+                        "(MaterialFlowBasis.other). Custom terms can "
+                        "only be used when the property package declares "
+                        "a molar or mass flow basis.".format(self.name)
+                    )
 
             @self.Constraint(self.flowsheet().time, pc_set, doc="Material balances")
             def material_balances(b, t, p, j):
@@ -630,7 +618,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
                     if has_rate_reactions:
                         rhs += b.rate_reaction_generation[t, p, j] * b._rxn_rate_conv(
-                            t, j, has_rate_reactions
+                            t, j
                         )
 
                     if has_equilibrium_reactions:
@@ -662,62 +650,48 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
         elif balance_type == MaterialBalanceType.componentTotal:
 
             def user_term_mol(b, t, j):
-                if custom_molar_term is not None:
-                    flow_basis = b.properties_out[t].get_material_flow_basis()
-                    if flow_basis == MaterialFlowBasis.molar:
-                        return custom_molar_term(t, j)
-                    elif flow_basis == MaterialFlowBasis.mass:
-                        try:
-                            return (
-                                custom_molar_term(t, j) * b.properties_out[t].mw_comp[j]
-                            )
-                        except AttributeError:
-                            raise PropertyNotSupportedError(
-                                "{} property package does not support "
-                                "molecular weight (mw), which is required for "
-                                "using custom terms in material balances.".format(
-                                    self.name
-                                )
-                            )
-                    else:
-                        raise ConfigurationError(
-                            "{} contained a custom_molar_term argument, but "
-                            "the property package used an undefined basis "
-                            "(MaterialFlowBasis.other). Custom terms can "
-                            "only be used when the property package declares "
-                            "a molar or mass flow basis.".format(self.name)
+                flow_basis = b.properties_out[t].get_material_flow_basis()
+                if flow_basis == MaterialFlowBasis.molar:
+                    return custom_molar_term(t, j)
+                elif flow_basis == MaterialFlowBasis.mass:
+                    try:
+                        return custom_molar_term(t, j) * b.properties_out[t].mw_comp[j]
+                    except AttributeError:
+                        raise PropertyNotSupportedError(
+                            "{} property package does not support "
+                            "molecular weight (mw), which is required for "
+                            "using custom terms in material balances.".format(self.name)
                         )
                 else:
-                    return 0
+                    raise ConfigurationError(
+                        "{} contained a custom_molar_term argument, but "
+                        "the property package used an undefined basis "
+                        "(MaterialFlowBasis.other). Custom terms can "
+                        "only be used when the property package declares "
+                        "a molar or mass flow basis.".format(self.name)
+                    )
 
             def user_term_mass(b, t, j):
-                if custom_mass_term is not None:
-                    flow_basis = b.properties_out[t].get_material_flow_basis()
-                    if flow_basis == MaterialFlowBasis.mass:
-                        return custom_mass_term(t, j)
-                    elif flow_basis == MaterialFlowBasis.molar:
-                        try:
-                            return (
-                                custom_mass_term(t, j) / b.properties_out[t].mw_comp[j]
-                            )
-                        except AttributeError:
-                            raise PropertyNotSupportedError(
-                                "{} property package does not support "
-                                "molecular weight (mw), which is required for "
-                                "using custom terms in material balances.".format(
-                                    self.name
-                                )
-                            )
-                    else:
-                        raise ConfigurationError(
-                            "{} contained a custom_mass_term argument, but "
-                            "the property package used an undefined basis "
-                            "(MaterialFlowBasis.other). Custom terms can "
-                            "only be used when the property package declares "
-                            "a molar or mass flow basis.".format(self.name)
+                flow_basis = b.properties_out[t].get_material_flow_basis()
+                if flow_basis == MaterialFlowBasis.mass:
+                    return custom_mass_term(t, j)
+                elif flow_basis == MaterialFlowBasis.molar:
+                    try:
+                        return custom_mass_term(t, j) / b.properties_out[t].mw_comp[j]
+                    except AttributeError:
+                        raise PropertyNotSupportedError(
+                            "{} property package does not support "
+                            "molecular weight (mw), which is required for "
+                            "using custom terms in material balances.".format(self.name)
                         )
                 else:
-                    return 0
+                    raise ConfigurationError(
+                        "{} contained a custom_mass_term argument, but "
+                        "the property package used an undefined basis "
+                        "(MaterialFlowBasis.other). Custom terms can "
+                        "only be used when the property package declares "
+                        "a molar or mass flow basis.".format(self.name)
+                    )
 
             @self.Constraint(
                 self.flowsheet().time, component_list, doc="Material balances"
@@ -737,7 +711,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 if has_rate_reactions:
                     rhs += sum(
                         b.rate_reaction_generation[t, p, j] for p in cplist
-                    ) * b._rxn_rate_conv(t, j, has_rate_reactions)
+                    ) * b._rxn_rate_conv(t, j)
 
                 if has_equilibrium_reactions:
                     rhs += sum(
@@ -1594,13 +1568,13 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             def phase_fraction(self, t, p):
                 return 1
 
-    def _rxn_rate_conv(b, t, j, has_rate_reactions):
+    def _rxn_rate_conv(b, t, j):
         """
         Wrapper method for the _rxn_rate_conv method to hide the x argument
         required for 1D control volumes.
         """
         # Call the method in control_volume_base with x=None
-        return super()._rxn_rate_conv(t, None, j, has_rate_reactions)
+        return super()._rxn_rate_conv(t, None, j)
 
     def _get_performance_contents(self, time_point=0):
         """

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -438,55 +438,23 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 else 0
             )
 
-        def kinetic_term(b, t, p, j):
-            return b.rate_reaction_generation[t, p, j] if has_rate_reactions else 0
-
-        def equilibrium_term(b, t, p, j):
-            return (
-                b.equilibrium_reaction_generation[t, p, j]
-                if has_equilibrium_reactions
-                else 0
-            )
-
-        def inherent_term(b, t, p, j):
-            return (
-                b.inherent_reaction_generation[t, p, j]
-                if b.properties_out.include_inherent_reactions
-                else 0
-            )
-
         def phase_equilibrium_term(b, t, p, j):
-            if (
-                has_phase_equilibrium
-                and balance_type == MaterialBalanceType.componentPhase
-            ):
-                sd = {}
-                for r in b.config.property_package.phase_equilibrium_idx:
-                    if b.config.property_package.phase_equilibrium_list[r][0] == j:
-                        if (
-                            b.config.property_package.phase_equilibrium_list[r][1][0]
-                            == p
-                        ):
-                            sd[r] = 1
-                        elif (
-                            b.config.property_package.phase_equilibrium_list[r][1][1]
-                            == p
-                        ):
-                            sd[r] = -1
-                        else:
-                            sd[r] = 0
+            sd = {}
+            for r in b.config.property_package.phase_equilibrium_idx:
+                if b.config.property_package.phase_equilibrium_list[r][0] == j:
+                    if b.config.property_package.phase_equilibrium_list[r][1][0] == p:
+                        sd[r] = 1
+                    elif b.config.property_package.phase_equilibrium_list[r][1][1] == p:
+                        sd[r] = -1
                     else:
                         sd[r] = 0
+                else:
+                    sd[r] = 0
 
-                return sum(
-                    b.phase_equilibrium_generation[t, r] * sd[r]
-                    for r in b.config.property_package.phase_equilibrium_idx
-                )
-            else:
-                return 0
-
-        def transfer_term(b, t, p, j):
-            return b.mass_transfer_term[t, p, j] if has_mass_transfer else 0
+            return sum(
+                b.phase_equilibrium_generation[t, r] * sd[r]
+                for r in b.config.property_package.phase_equilibrium_idx
+            )
 
         # TODO: Need to set material_holdup = 0 for non-present component-phase
         # pairs. Not ideal, but needed to close DoF. Is there a better way?
@@ -656,18 +624,38 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             @self.Constraint(self.flowsheet().time, pc_set, doc="Material balances")
             def material_balances(b, t, p, j):
                 if (p, j) in pc_set:
-                    return accumulation_term(b, t, p, j) == (
-                        b.properties_in[t].get_material_flow_terms(p, j)
-                        - b.properties_out[t].get_material_flow_terms(p, j)
-                        + kinetic_term(b, t, p, j)
-                        * b._rxn_rate_conv(t, j, has_rate_reactions)
-                        + equilibrium_term(b, t, p, j)
-                        + inherent_term(b, t, p, j)
-                        + phase_equilibrium_term(b, t, p, j)
-                        + transfer_term(b, t, p, j)
-                        + user_term_mol(b, t, p, j)
-                        + user_term_mass(b, t, p, j)
-                    )
+                    rhs = b.properties_in[t].get_material_flow_terms(
+                        p, j
+                    ) - b.properties_out[t].get_material_flow_terms(p, j)
+
+                    if has_rate_reactions:
+                        rhs += b.rate_reaction_generation[t, p, j] * b._rxn_rate_conv(
+                            t, j, has_rate_reactions
+                        )
+
+                    if has_equilibrium_reactions:
+                        rhs += b.equilibrium_reaction_generation[t, p, j]
+
+                    if b.properties_out.include_inherent_reactions:
+                        rhs += b.inherent_reaction_generation[t, p, j]
+
+                    if (
+                        has_phase_equilibrium
+                        and balance_type == MaterialBalanceType.componentPhase
+                    ):
+                        rhs += phase_equilibrium_term(b, t, p, j)
+
+                    if has_mass_transfer:
+                        rhs += b.mass_transfer_term[t, p, j]
+
+                    if custom_molar_term is not None:
+                        rhs += user_term_mol(b, t, p, j)
+
+                    if custom_mass_term is not None:
+                        rhs += user_term_mass(b, t, p, j)
+
+                    return accumulation_term(b, t, p, j) == rhs
+
                 else:
                     return Constraint.Skip
 
@@ -739,25 +727,36 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 for p in phase_list:
                     if (p, j) in pc_set:
                         cplist.append(p)
-                return sum(accumulation_term(b, t, p, j) for p in cplist) == sum(
+
+                rhs = sum(
                     b.properties_in[t].get_material_flow_terms(p, j) for p in cplist
                 ) - sum(
                     b.properties_out[t].get_material_flow_terms(p, j) for p in cplist
-                ) + sum(
-                    kinetic_term(b, t, p, j) for p in cplist
-                ) * b._rxn_rate_conv(
-                    t, j, has_rate_reactions
-                ) + sum(
-                    equilibrium_term(b, t, p, j) for p in cplist
-                ) + sum(
-                    inherent_term(b, t, p, j) for p in cplist
-                ) + sum(
-                    transfer_term(b, t, p, j) for p in cplist
-                ) + user_term_mol(
-                    b, t, j
-                ) + user_term_mass(
-                    b, t, j
                 )
+
+                if has_rate_reactions:
+                    rhs += sum(
+                        b.rate_reaction_generation[t, p, j] for p in cplist
+                    ) * b._rxn_rate_conv(t, j, has_rate_reactions)
+
+                if has_equilibrium_reactions:
+                    rhs += sum(
+                        b.equilibrium_reaction_generation[t, p, j] for p in cplist
+                    )
+
+                if b.properties_out.include_inherent_reactions:
+                    rhs += sum(b.inherent_reaction_generation[t, p, j] for p in cplist)
+
+                if has_mass_transfer:
+                    rhs += sum(b.mass_transfer_term[t, p, j] for p in cplist)
+
+                if custom_molar_term is not None:
+                    rhs += user_term_mol(b, t, j)
+
+                if custom_mass_term is not None:
+                    rhs += user_term_mass(b, t, j)
+
+                return sum(accumulation_term(b, t, p, j) for p in cplist) == rhs
 
         else:
             raise BurntToast()
@@ -1089,28 +1088,22 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 else 0
             )
 
-        # Mass transfer term
-        def transfer_term(b, t, e):
-            return b.elemental_mass_transfer_term[t, e] if has_mass_transfer else 0
-
-        # Custom term
-        def user_term(t, e):
-            if custom_elemental_term is not None:
-                return custom_elemental_term(t, e)
-            else:
-                return 0
-
         # Element balances
         @self.Constraint(
             self.flowsheet().time, e_index, doc="Elemental material balances"
         )
         def element_balances(b, t, e):
-            return accumulation_term(b, t, e) == (
-                sum(b.elemental_flow_in[t, p, e] for p in phase_list)
-                - sum(b.elemental_flow_out[t, p, e] for p in phase_list)
-                + transfer_term(b, t, e)
-                + user_term(t, e)
+            rhs = sum(b.elemental_flow_in[t, p, e] for p in phase_list) - sum(
+                b.elemental_flow_out[t, p, e] for p in phase_list
             )
+
+            if has_mass_transfer:
+                rhs += b.elemental_mass_transfer_term[t, e]
+
+            if custom_elemental_term is not None:
+                rhs += custom_elemental_term(t, e)
+
+            return accumulation_term(b, t, e) == rhs
 
         # Elemental Holdup
         if has_holdup:
@@ -1300,39 +1293,29 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 else 0
             )
 
-        def heat_term(b, t):
-            return b.heat[t] if has_heat_transfer else 0
-
-        def work_term(b, t):
-            return b.work[t] if has_work_transfer else 0
-
-        def enthalpy_transfer_term(b, t):
-            return b.enthalpy_transfer[t] if has_enthalpy_transfer else 0
-
-        def rxn_heat_term(b, t):
-            return b.heat_of_reaction[t] if has_heat_of_reaction else 0
-
-        # Custom term
-        def user_term(t):
-            if custom_term is not None:
-                return custom_term(t)
-            else:
-                return 0
-
         # Energy balance equation
         @self.Constraint(self.flowsheet().time, doc="Energy balances")
         def enthalpy_balances(b, t):
-            return sum(accumulation_term(b, t, p) for p in phase_list) == (
-                sum(b.properties_in[t].get_enthalpy_flow_terms(p) for p in phase_list)
-                - sum(
-                    b.properties_out[t].get_enthalpy_flow_terms(p) for p in phase_list
-                )
-                + heat_term(b, t)
-                + work_term(b, t)
-                + enthalpy_transfer_term(b, t)
-                + rxn_heat_term(b, t)
-                + user_term(t)
-            )
+            rhs = sum(
+                b.properties_in[t].get_enthalpy_flow_terms(p) for p in phase_list
+            ) - sum(b.properties_out[t].get_enthalpy_flow_terms(p) for p in phase_list)
+
+            if has_heat_transfer:
+                rhs += b.heat[t]
+
+            if has_work_transfer:
+                rhs += b.work[t]
+
+            if has_enthalpy_transfer:
+                rhs += b.enthalpy_transfer[t]
+
+            if has_heat_of_reaction:
+                rhs += b.heat_of_reaction[t]
+
+            if custom_term is not None:
+                rhs += custom_term(t)
+
+            return sum(accumulation_term(b, t, p) for p in phase_list) == rhs
 
         # Energy Holdup
         if has_holdup:
@@ -1396,27 +1379,18 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 units=units("pressure"),
             )
 
-        # Create rules to substitute energy balance terms
-        # Pressure change term
-        def deltaP_term(b, t):
-            return b.deltaP[t] if has_pressure_change else 0
-
-        # Custom term
-        def user_term(t):
-            if custom_term is not None:
-                return custom_term(t)
-            else:
-                return 0
-
         # Momentum balance equation
         @self.Constraint(self.flowsheet().time, doc="Momentum balance")
         def pressure_balance(b, t):
-            return 0 == (
-                b.properties_in[t].pressure
-                - b.properties_out[t].pressure
-                + deltaP_term(b, t)
-                + user_term(t)
-            )
+            rhs = b.properties_in[t].pressure - b.properties_out[t].pressure
+
+            if has_pressure_change:
+                rhs += b.deltaP[t]
+
+            if custom_term is not None:
+                rhs += custom_term(t)
+
+            return 0 == rhs
 
         return self.pressure_balance
 

--- a/idaes/core/base/control_volume1d.py
+++ b/idaes/core/base/control_volume1d.py
@@ -834,64 +834,53 @@ argument).""",
         if balance_type == MaterialBalanceType.componentPhase:
 
             def user_term_mol(b, t, x, p, j):
-                if custom_molar_term is not None:
-                    flow_basis = b.properties[t, x].get_material_flow_basis()
-                    if flow_basis == MaterialFlowBasis.molar:
-                        return custom_molar_term(t, x, p, j)
-                    elif flow_basis == MaterialFlowBasis.mass:
-                        try:
-                            return (
-                                custom_molar_term(t, x, p, j)
-                                * b.properties[t, x].mw_comp[j]
-                            )
-                        except AttributeError:
-                            raise PropertyNotSupportedError(
-                                "{} property package does not support "
-                                "molecular weight (mw), which is required for "
-                                "using custom terms in material balances.".format(
-                                    self.name
-                                )
-                            )
-                    else:
-                        raise ConfigurationError(
-                            "{} contained a custom_molar_term argument, but "
-                            "the property package used an undefined basis "
-                            "(MaterialFlowBasis.other). Custom terms can "
-                            "only be used when the property package declares "
-                            "a molar or mass flow basis.".format(self.name)
+                flow_basis = b.properties[t, x].get_material_flow_basis()
+                if flow_basis == MaterialFlowBasis.molar:
+                    return custom_molar_term(t, x, p, j)
+                elif flow_basis == MaterialFlowBasis.mass:
+                    try:
+                        return (
+                            custom_molar_term(t, x, p, j)
+                            * b.properties[t, x].mw_comp[j]
+                        )
+                    except AttributeError:
+                        raise PropertyNotSupportedError(
+                            "{} property package does not support "
+                            "molecular weight (mw), which is required for "
+                            "using custom terms in material balances.".format(self.name)
                         )
                 else:
-                    return 0
+                    raise ConfigurationError(
+                        "{} contained a custom_molar_term argument, but "
+                        "the property package used an undefined basis "
+                        "(MaterialFlowBasis.other). Custom terms can "
+                        "only be used when the property package declares "
+                        "a molar or mass flow basis.".format(self.name)
+                    )
 
             def user_term_mass(b, t, x, p, j):
-                if custom_mass_term is not None:
-                    flow_basis = b.properties[t, x].get_material_flow_basis()
-                    if flow_basis == MaterialFlowBasis.mass:
-                        return custom_mass_term(t, x, p, j)
-                    elif flow_basis == MaterialFlowBasis.molar:
-                        try:
-                            return (
-                                custom_mass_term(t, x, p, j)
-                                / b.properties[t, x].mw_comp[j]
-                            )
-                        except AttributeError:
-                            raise PropertyNotSupportedError(
-                                "{} property package does not support "
-                                "molecular weight (mw), which is required for "
-                                "using custom terms in material balances.".format(
-                                    self.name
-                                )
-                            )
-                    else:
-                        raise ConfigurationError(
-                            "{} contained a custom_mass_term argument, but "
-                            "the property package used an undefined basis "
-                            "(MaterialFlowBasis.other). Custom terms can "
-                            "only be used when the property package declares "
-                            "a molar or mass flow basis.".format(self.name)
+                flow_basis = b.properties[t, x].get_material_flow_basis()
+                if flow_basis == MaterialFlowBasis.mass:
+                    return custom_mass_term(t, x, p, j)
+                elif flow_basis == MaterialFlowBasis.molar:
+                    try:
+                        return (
+                            custom_mass_term(t, x, p, j) / b.properties[t, x].mw_comp[j]
+                        )
+                    except AttributeError:
+                        raise PropertyNotSupportedError(
+                            "{} property package does not support "
+                            "molecular weight (mw), which is required for "
+                            "using custom terms in material balances.".format(self.name)
                         )
                 else:
-                    return 0
+                    raise ConfigurationError(
+                        "{} contained a custom_mass_term argument, but "
+                        "the property package used an undefined basis "
+                        "(MaterialFlowBasis.other). Custom terms can "
+                        "only be used when the property package declares "
+                        "a molar or mass flow basis.".format(self.name)
+                    )
 
             @self.Constraint(
                 self.flowsheet().time,
@@ -924,7 +913,7 @@ argument).""",
                             rhs += (
                                 b.length
                                 * b.rate_reaction_generation[t, x, p, j]
-                                * b._rxn_rate_conv(t, x, j, has_rate_reactions)
+                                * b._rxn_rate_conv(t, x, j)
                             )
 
                         if has_equilibrium_reactions:
@@ -958,64 +947,50 @@ argument).""",
         elif balance_type == MaterialBalanceType.componentTotal:
 
             def user_term_mol(b, t, x, j):
-                if custom_molar_term is not None:
-                    flow_basis = b.properties[t, x].get_material_flow_basis()
-                    if flow_basis == MaterialFlowBasis.molar:
-                        return custom_molar_term(t, x, j)
-                    elif flow_basis == MaterialFlowBasis.mass:
-                        try:
-                            return (
-                                custom_molar_term(t, x, j)
-                                * b.properties[t, x].mw_comp[j]
-                            )
-                        except AttributeError:
-                            raise PropertyNotSupportedError(
-                                "{} property package does not support "
-                                "molecular weight (mw), which is required for "
-                                "using custom terms in material balances.".format(
-                                    self.name
-                                )
-                            )
-                    else:
-                        raise ConfigurationError(
-                            "{} contained a custom_molar_term argument, but "
-                            "the property package used an undefined basis "
-                            "(MaterialFlowBasis.other). Custom terms can "
-                            "only be used when the property package declares "
-                            "a molar or mass flow basis.".format(self.name)
+                flow_basis = b.properties[t, x].get_material_flow_basis()
+                if flow_basis == MaterialFlowBasis.molar:
+                    return custom_molar_term(t, x, j)
+                elif flow_basis == MaterialFlowBasis.mass:
+                    try:
+                        return (
+                            custom_molar_term(t, x, j) * b.properties[t, x].mw_comp[j]
+                        )
+                    except AttributeError:
+                        raise PropertyNotSupportedError(
+                            "{} property package does not support "
+                            "molecular weight (mw), which is required for "
+                            "using custom terms in material balances.".format(self.name)
                         )
                 else:
-                    return 0
+                    raise ConfigurationError(
+                        "{} contained a custom_molar_term argument, but "
+                        "the property package used an undefined basis "
+                        "(MaterialFlowBasis.other). Custom terms can "
+                        "only be used when the property package declares "
+                        "a molar or mass flow basis.".format(self.name)
+                    )
 
             def user_term_mass(b, t, x, j):
-                if custom_mass_term is not None:
-                    flow_basis = b.properties[t, x].get_material_flow_basis()
-                    if flow_basis == MaterialFlowBasis.mass:
-                        return custom_mass_term(t, x, j)
-                    elif flow_basis == MaterialFlowBasis.molar:
-                        try:
-                            return (
-                                custom_mass_term(t, x, j)
-                                / b.properties[t, x].mw_comp[j]
-                            )
-                        except AttributeError:
-                            raise PropertyNotSupportedError(
-                                "{} property package does not support "
-                                "molecular weight (mw), which is required for "
-                                "using custom terms in material balances.".format(
-                                    self.name
-                                )
-                            )
-                    else:
-                        raise ConfigurationError(
-                            "{} contained a custom_mass_term argument, but "
-                            "the property package used an undefined basis "
-                            "(MaterialFlowBasis.other). Custom terms can "
-                            "only be used when the property package declares "
-                            "a molar or mass flow basis.".format(self.name)
+                flow_basis = b.properties[t, x].get_material_flow_basis()
+                if flow_basis == MaterialFlowBasis.mass:
+                    return custom_mass_term(t, x, j)
+                elif flow_basis == MaterialFlowBasis.molar:
+                    try:
+                        return custom_mass_term(t, x, j) / b.properties[t, x].mw_comp[j]
+                    except AttributeError:
+                        raise PropertyNotSupportedError(
+                            "{} property package does not support "
+                            "molecular weight (mw), which is required for "
+                            "using custom terms in material balances.".format(self.name)
                         )
                 else:
-                    return 0
+                    raise ConfigurationError(
+                        "{} contained a custom_mass_term argument, but "
+                        "the property package used an undefined basis "
+                        "(MaterialFlowBasis.other). Custom terms can "
+                        "only be used when the property package declares "
+                        "a molar or mass flow basis.".format(self.name)
+                    )
 
             # Add component balances
             @self.Constraint(
@@ -1057,7 +1032,7 @@ argument).""",
                             * sum(
                                 b.rate_reaction_generation[t, x, p, j] for p in cplist
                             )
-                            * b._rxn_rate_conv(t, x, j, has_rate_reactions)
+                            * b._rxn_rate_conv(t, x, j)
                         )
 
                     if has_equilibrium_reactions:

--- a/idaes/core/base/control_volume_base.py
+++ b/idaes/core/base/control_volume_base.py
@@ -876,16 +876,12 @@ have a config block which derives from CONFIG_Base,
             "developer of the ControlVolume class you are using.".format(self.name)
         )
 
-    def _rxn_rate_conv(b, t, x, j, has_rate_reactions):
+    def _rxn_rate_conv(b, t, x, j):
         """
         Method to determine conversion term for reaction rate terms in material
         balance equations. This method gets the basis of the material flow
         and reaction rate terms and determines the correct conversion factor.
         """
-        # If rate reactions are not required, skip the rest and return 1
-        if not has_rate_reactions:
-            return 1
-
         if x is None:
             # 0D control volume
             flow_basis = b.properties_out[t].get_material_flow_basis()

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -310,25 +310,6 @@ def test_add_phase_fractions_single_phase():
 # -----------------------------------------------------------------------------
 # Test reaction rate conversion method
 @pytest.mark.unit
-def test_rxn_rate_conv_no_rxns():
-    m = ConcreteModel()
-    m.fs = Flowsheet(dynamic=False)
-    m.fs.pp = PhysicalParameterTestBlock()
-    m.fs.pp.basis_switch = 3
-    m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
-
-    m.fs.cv = ControlVolume0DBlock(property_package=m.fs.pp, reaction_package=m.fs.rp)
-
-    m.fs.cv.add_geometry()
-    m.fs.cv.add_state_blocks(has_phase_equilibrium=True)
-    m.fs.cv.add_reaction_blocks(has_equilibrium=False)
-
-    for t in m.fs.time:
-        for j in m.fs.pp.component_list:
-            assert m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=False) == 1
-
-
-@pytest.mark.unit
 def test_rxn_rate_conv_property_basis_other():
     m = ConcreteModel()
     m.fs = Flowsheet(dynamic=False)
@@ -345,7 +326,7 @@ def test_rxn_rate_conv_property_basis_other():
     for t in m.fs.time:
         for j in m.fs.pp.component_list:
             with pytest.raises(ConfigurationError):
-                m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=True)
+                m.fs.cv._rxn_rate_conv(t, j)
 
 
 @pytest.mark.unit
@@ -365,7 +346,7 @@ def test_rxn_rate_conv_reaction_basis_other():
     for t in m.fs.time:
         for j in m.fs.pp.component_list:
             with pytest.raises(ConfigurationError):
-                m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=True)
+                m.fs.cv._rxn_rate_conv(t, j)
 
 
 @pytest.mark.unit
@@ -383,7 +364,7 @@ def test_rxn_rate_conv_both_molar():
 
     for t in m.fs.time:
         for j in m.fs.pp.component_list:
-            assert m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=True) == 1
+            assert m.fs.cv._rxn_rate_conv(t, j) == 1
 
 
 @pytest.mark.unit
@@ -403,7 +384,7 @@ def test_rxn_rate_conv_both_mass():
 
     for t in m.fs.time:
         for j in m.fs.pp.component_list:
-            assert m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=True) == 1
+            assert m.fs.cv._rxn_rate_conv(t, j) == 1
 
 
 @pytest.mark.unit
@@ -424,7 +405,7 @@ def test_rxn_rate_conv_mole_mass_no_mw():
     for t in m.fs.time:
         for j in m.fs.pp.component_list:
             with pytest.raises(PropertyNotSupportedError):
-                m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=True)
+                m.fs.cv._rxn_rate_conv(t, j)
 
 
 @pytest.mark.unit
@@ -445,7 +426,7 @@ def test_rxn_rate_conv_mass_mole_no_mw():
     for t in m.fs.time:
         for j in m.fs.pp.component_list:
             with pytest.raises(PropertyNotSupportedError):
-                m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=True)
+                m.fs.cv._rxn_rate_conv(t, j)
 
 
 @pytest.mark.unit
@@ -467,8 +448,7 @@ def test_rxn_rate_conv_mole_mass():
         m.fs.cv.properties_out[t].mw_comp = {"c1": 2, "c2": 3}
         for j in m.fs.pp.component_list:
             assert (
-                m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=True)
-                == 1 / m.fs.cv.properties_out[t].mw_comp[j]
+                m.fs.cv._rxn_rate_conv(t, j) == 1 / m.fs.cv.properties_out[t].mw_comp[j]
             )
 
 
@@ -490,10 +470,7 @@ def test_rxn_rate_conv_mass_mole():
     for t in m.fs.time:
         m.fs.cv.properties_out[t].mw_comp = {"c1": 2, "c2": 3}
         for j in m.fs.pp.component_list:
-            assert (
-                m.fs.cv._rxn_rate_conv(t, j, has_rate_reactions=True)
-                == m.fs.cv.properties_out[t].mw_comp[j]
-            )
+            assert m.fs.cv._rxn_rate_conv(t, j) == m.fs.cv.properties_out[t].mw_comp[j]
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/core/base/tests/test_control_volume_1d.py
+++ b/idaes/core/base/tests/test_control_volume_1d.py
@@ -848,32 +848,6 @@ def test_add_phase_fractions_single_phase():
 # -----------------------------------------------------------------------------
 # Test reaction rate conversion method
 @pytest.mark.unit
-def test_rxn_rate_conv_no_rxns():
-    m = ConcreteModel()
-    m.fs = Flowsheet(dynamic=False)
-    m.fs.pp = PhysicalParameterTestBlock()
-    m.fs.pp.basis_switch = 3
-    m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
-
-    m.fs.cv = ControlVolume1DBlock(
-        property_package=m.fs.pp,
-        reaction_package=m.fs.rp,
-        transformation_method="dae.finite_difference",
-        transformation_scheme="BACKWARD",
-        finite_elements=10,
-    )
-
-    m.fs.cv.add_geometry()
-    m.fs.cv.add_state_blocks(has_phase_equilibrium=True)
-    m.fs.cv.add_reaction_blocks(has_equilibrium=False)
-
-    for t in m.fs.time:
-        for x in m.fs.cv.length_domain:
-            for j in m.fs.pp.component_list:
-                assert m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=False) == 1
-
-
-@pytest.mark.unit
 def test_rxn_rate_conv_property_basis_other():
     m = ConcreteModel()
     m.fs = Flowsheet(dynamic=False)
@@ -897,7 +871,7 @@ def test_rxn_rate_conv_property_basis_other():
         for x in m.fs.cv.length_domain:
             for j in m.fs.pp.component_list:
                 with pytest.raises(ConfigurationError):
-                    m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=True)
+                    m.fs.cv._rxn_rate_conv(t, x, j)
 
 
 @pytest.mark.unit
@@ -924,7 +898,7 @@ def test_rxn_rate_conv_reaction_basis_other():
         for x in m.fs.cv.length_domain:
             for j in m.fs.pp.component_list:
                 with pytest.raises(ConfigurationError):
-                    m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=True)
+                    m.fs.cv._rxn_rate_conv(t, x, j)
 
 
 @pytest.mark.unit
@@ -949,7 +923,7 @@ def test_rxn_rate_conv_both_molar():
     for t in m.fs.time:
         for x in m.fs.cv.length_domain:
             for j in m.fs.pp.component_list:
-                assert m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=True) == 1
+                assert m.fs.cv._rxn_rate_conv(t, x, j) == 1
 
 
 @pytest.mark.unit
@@ -976,7 +950,7 @@ def test_rxn_rate_conv_both_mass():
     for t in m.fs.time:
         for x in m.fs.cv.length_domain:
             for j in m.fs.pp.component_list:
-                assert m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=True) == 1
+                assert m.fs.cv._rxn_rate_conv(t, x, j) == 1
 
 
 @pytest.mark.unit
@@ -1004,7 +978,7 @@ def test_rxn_rate_conv_mole_mass_no_mw():
         for x in m.fs.cv.length_domain:
             for j in m.fs.pp.component_list:
                 with pytest.raises(PropertyNotSupportedError):
-                    m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=True)
+                    m.fs.cv._rxn_rate_conv(t, x, j)
 
 
 @pytest.mark.unit
@@ -1032,7 +1006,7 @@ def test_rxn_rate_conv_mass_mole_no_mw():
         for x in m.fs.cv.length_domain:
             for j in m.fs.pp.component_list:
                 with pytest.raises(PropertyNotSupportedError):
-                    m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=True)
+                    m.fs.cv._rxn_rate_conv(t, x, j)
 
 
 @pytest.mark.unit
@@ -1061,7 +1035,7 @@ def test_rxn_rate_conv_mole_mass():
             m.fs.cv.properties[t, x].mw_comp = {"c1": 2, "c2": 3}
             for j in m.fs.pp.component_list:
                 assert (
-                    m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=True)
+                    m.fs.cv._rxn_rate_conv(t, x, j)
                     == 1 / m.fs.cv.properties[t, x].mw_comp[j]
                 )
 
@@ -1092,7 +1066,7 @@ def test_rxn_rate_conv_mass_mole():
             m.fs.cv.properties[t, x].mw_comp = {"c1": 2, "c2": 3}
             for j in m.fs.pp.component_list:
                 assert (
-                    m.fs.cv._rxn_rate_conv(t, x, j, has_rate_reactions=True)
+                    m.fs.cv._rxn_rate_conv(t, x, j)
                     == m.fs.cv.properties[t, x].mw_comp[j]
                 )
 

--- a/idaes/core/util/model_statistics.py
+++ b/idaes/core/util/model_statistics.py
@@ -1378,7 +1378,7 @@ def large_residuals_set(block, tol=1e-5, return_residual_values=False):
 
                 if return_residual_values:
                     residual_values[c] = r
-        except (AttributeError, ValueError):
+        except (AttributeError, TypeError, ValueError):
             large_residuals_set.add(c)
 
             if return_residual_values:

--- a/idaes/models/properties/modular_properties/eos/ceos.py
+++ b/idaes/models/properties/modular_properties/eos/ceos.py
@@ -267,19 +267,16 @@ class Cubic(EoSBase):
                 a = getattr(m, cname + "_a")
                 da_dT = getattr(m, cname + "_da_dT")
                 d2a_dT2 = getattr(m, cname + "_d2a_dT2")
-                # Placeholders for if temperature dependent k is needed
-                dk_dT = 0
-                d2k_dT2 = 0
 
                 # Initialize loop variable
-                d2am_dT2 = 0
+                d2am_dT2 = None
 
                 for i in m.components_in_phase(p):
                     for j in m.components_in_phase(p):
                         d2aij_dT2 = sqrt(a[i] * a[j]) * (
-                            -d2k_dT2
-                            - dk_dT * (da_dT[i] / a[i] + da_dT[j] / a[j])
-                            + (1 - k[i, j])
+                            # -d2k_dT2  # TODO: Placeholder for if temperature dependent k is needed
+                            # - dk_dT * (da_dT[i] / a[i] + da_dT[j] / a[j])
+                            +(1 - k[i, j])
                             / 2
                             * (
                                 d2a_dT2[i] / a[i]
@@ -287,11 +284,15 @@ class Cubic(EoSBase):
                                 - 1 / 2 * (da_dT[i] / a[i] - da_dT[j] / a[j]) ** 2
                             )
                         )
-                        d2am_dT2 += (
+                        d2am_dT2_term = (
                             m.mole_frac_phase_comp[p, i]
                             * m.mole_frac_phase_comp[p, j]
                             * d2aij_dT2
                         )
+                        if d2am_dT2 is None:
+                            d2am_dT2 = d2am_dT2_term
+                        else:
+                            d2am_dT2 += d2am_dT2_term
                 return d2am_dT2
 
             b.add_component(


### PR DESCRIPTION
## Addresses some upcoming changes in https://github.com/Pyomo/pyomo/pull/2722


## Summary/Motivation:
Pyomo is working on some changes to how expressions are generated, and in the process is changing some behaviours that IDAES has unconsciously relied upon. The most significant change is that `0*` terms will remain within the expression during unit consistency checks whereas before they were ignored. Control volumes (written before units) used this behaviour to drop unnecessary terms, but this will now cause issues when asserting unit consistency.

## Changes proposed in this PR:
- Rewrite methods in control volumes which generate balance expressions to only include terms if required (rather than adding a 0 term).
- Comment out two placeholder terms in modular CEOS code for potential future functionality.
- Updated `large_residual_set` method to catch `TypeErrors` that now occur when constraints have a body containing a `None` variable.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
