### PR TITLE
Improving some expression tests

### DIFF
--- a/idaes/models/properties/modular_properties/eos/enrtl.py
+++ b/idaes/models/properties/modular_properties/eos/enrtl.py
@@ -429,7 +429,7 @@ class ENRTL(Ideal):
                         -alpha_rule(b, pobj, i, j, T) * tau_rule(b, pobj, i, j, T)
                     )
                 else:
-                    return 1
+                    return 1.0
 
             if (pname, i) not in b.params.true_phase_component_set or (
                 pname,
@@ -476,7 +476,7 @@ class ENRTL(Ideal):
                 else:
                     # This term does not exist for single cation systems
                     # However, need a valid result to calculate tau
-                    return 1
+                    return 1.0
             elif i in b.params.anion_set and j in b.params.cation_set:
                 # Eqn 43
                 if len(b.params.anion_set) > 1:
@@ -490,7 +490,7 @@ class ENRTL(Ideal):
                 else:
                     # This term does not exist for single anion systems
                     # However, need a valid result to calculate tau
-                    return 1
+                    return 1.0
             elif (i in b.params.cation_set and j in b.params.cation_set) or (
                 i in b.params.anion_set and j in b.params.anion_set
             ):

--- a/idaes/models/properties/modular_properties/eos/enrtl_reference_states.py
+++ b/idaes/models/properties/modular_properties/eos/enrtl_reference_states.py
@@ -64,7 +64,7 @@ class Unsymmetric(object):
     @staticmethod
     def ndIdn(b, pname, i):
         # Eqn 71
-        return 0
+        return 0.0
 
 
 class Symmetric(object):
@@ -81,7 +81,7 @@ class Symmetric(object):
                     b.mole_frac_phase_comp_true[pname, j] for j in b.params.ion_set
                 )
             else:
-                return 0
+                return 0.0
 
         b.add_component(
             pname + "_x_ref", Expression(b.params.true_species_set, rule=rule_x_ref)
@@ -101,9 +101,9 @@ def ndxdn(b, pname, i, j):
 
     # Delta function used in Eqns 73-76 (not defined in paper)
     if i == j:
-        delta = 1
+        delta = 1.0
     else:
-        delta = 0
+        delta = 0.0
 
     # Eqn 76
     return (delta - x0[j]) / sum(

--- a/idaes/models/properties/modular_properties/eos/tests/test_enrtl.py
+++ b/idaes/models/properties/modular_properties/eos/tests/test_enrtl.py
@@ -45,7 +45,7 @@ import idaes.logger as idaeslog
 
 
 def dummy_method(b, *args, **kwargs):
-    return 42 * pyunits.mol / pyunits.m**3
+    return 42.0 * pyunits.mol / pyunits.m**3
 
 
 configuration = {
@@ -388,7 +388,7 @@ class TestStateBlockSymmetric(object):
 
         assert isinstance(model.state[1].Liq_vol_mol_solvent, Expression)
         assert len(model.state[1].Liq_vol_mol_solvent) == 1
-        assert str(model.state[1].Liq_vol_mol_solvent.expr) == "1/(42*mol/m**3)"
+        assert str(model.state[1].Liq_vol_mol_solvent.expr) == "1/(42.0*mol/m**3)"
 
         assert isinstance(model.state[1].Liq_relative_permittivity_solvent, Expression)
         assert len(model.state[1].Liq_relative_permittivity_solvent) == 1
@@ -433,59 +433,6 @@ class TestStateBlockSymmetric(object):
                         * model.state[1].Liq_A_DH
                         * model.state[1].Liq_ionic_strength ** (3 / 2)
                         / (1 + 14.9 * model.state[1].Liq_ionic_strength ** (1 / 2))
-                    )
-                )
-            else:
-
-                def ndxdn(j, k):
-                    if j == k:
-                        return (1 - model.state[1].Liq_x_ref[k]) / (
-                            model.state[1].mole_frac_phase_comp_true["Liq", "Cl-"]
-                            + model.state[1].mole_frac_phase_comp_true["Liq", "OH-"]
-                            + model.state[1].mole_frac_phase_comp_true["Liq", "Na+"]
-                            + model.state[1].mole_frac_phase_comp_true["Liq", "H+"]
-                        )
-                    else:
-                        return -model.state[1].Liq_x_ref[k] / (
-                            model.state[1].mole_frac_phase_comp_true["Liq", "Cl-"]
-                            + model.state[1].mole_frac_phase_comp_true["Liq", "OH-"]
-                            + model.state[1].mole_frac_phase_comp_true["Liq", "Na+"]
-                            + model.state[1].mole_frac_phase_comp_true["Liq", "H+"]
-                        )
-
-                assert str(model.state[1].Liq_log_gamma_pdh[j].expr) == str(
-                    -model.state[1].Liq_A_DH
-                    * (
-                        (2 * model.params.get_component(j).config.charge ** 2 / 14.9)
-                        * log(
-                            (1 + 14.9 * model.state[1].Liq_ionic_strength ** 0.5)
-                            / (1 + 14.9 * model.state[1].Liq_ionic_strength_ref ** 0.5)
-                        )
-                        + (
-                            model.params.get_component(j).config.charge ** 2
-                            * model.state[1].Liq_ionic_strength ** 0.5
-                            - 2 * model.state[1].Liq_ionic_strength ** 1.5
-                        )
-                        / (1 + 14.9 * model.state[1].Liq_ionic_strength ** 0.5)
-                        - (
-                            2
-                            * model.state[1].Liq_ionic_strength
-                            * model.state[1].Liq_ionic_strength_ref ** -0.5
-                        )
-                        / (1 + 14.9 * model.state[1].Liq_ionic_strength_ref ** 0.5)
-                        * (
-                            0.5
-                            * (
-                                model.params.get_component("Cl-").config.charge ** 2
-                                * ndxdn(j, "Cl-")
-                                + model.params.get_component("OH-").config.charge ** 2
-                                * ndxdn(j, "OH-")
-                                + model.params.get_component("Na+").config.charge ** 2
-                                * ndxdn(j, "Na+")
-                                + model.params.get_component("H+").config.charge ** 2
-                                * ndxdn(j, "H+")
-                            )
-                        )
                     )
                 )
 

--- a/idaes/models/properties/modular_properties/eos/tests/test_ideal.py
+++ b/idaes/models/properties/modular_properties/eos/tests/test_ideal.py
@@ -40,11 +40,11 @@ from idaes.core.util.constants import Constants as const
 
 # Dummy method for property method calls
 def dummy_call(b, j, T):
-    return 42
+    return 42.0
 
 
 def dummy_call2(b, j, T):
-    return 7
+    return 7.0
 
 
 # Dummy method to avoid errors when setting metadata dict
@@ -177,8 +177,8 @@ def test_cp_mol_phase_comp(m):
         m.params.get_component(j).config.cp_mol_liq_comp = dummy_call
         m.params.get_component(j).config.cp_mol_ig_comp = dummy_call
 
-        assert str(Ideal.cp_mol_phase_comp(m.props[1], "Liq", j)) == str(42)
-        assert str(Ideal.cp_mol_phase_comp(m.props[1], "Vap", j)) == str(42)
+        assert str(Ideal.cp_mol_phase_comp(m.props[1], "Liq", j)) == str(42.0)
+        assert str(Ideal.cp_mol_phase_comp(m.props[1], "Vap", j)) == str(42.0)
 
 
 @pytest.mark.unit
@@ -201,9 +201,9 @@ def test_cv_mol_phase_comp(m):
         m.params.get_component(j).config.cp_mol_liq_comp = dummy_call
         m.params.get_component(j).config.cp_mol_ig_comp = dummy_call
 
-        assert str(Ideal.cv_mol_phase_comp(m.props[1], "Liq", j)) == str(42)
+        assert str(Ideal.cv_mol_phase_comp(m.props[1], "Liq", j)) == str(42.0)
         assert str(Ideal.cv_mol_phase_comp(m.props[1], "Vap", j)) == str(
-            42
+            42.0
             - pyunits.convert(
                 const.gas_constant,
                 to_units=pyunits.kg
@@ -301,10 +301,10 @@ def test_energy_internal_mol_phase_comp_no_h_form(m):
         m.params.get_component(j).config.enth_mol_ig_comp = dummy_call
 
         assert str(Ideal.energy_internal_mol_phase_comp(m.props[1], "Liq", j)) == str(
-            42
+            42.0
         )
         assert str(Ideal.energy_internal_mol_phase_comp(m.props[1], "Vap", j)) == str(
-            42
+            42.0
             - pyunits.convert(
                 const.gas_constant,
                 to_units=pyunits.kg
@@ -332,13 +332,13 @@ def test_energy_internal_mol_phase_comp_with_h_form(m):
         # For liquid phase, delta(n) should be 4 (2*He + 2*O2)
         assert (
             str(Ideal.energy_internal_mol_phase_comp(m.props[1], "Liq", j))
-            == "42 -4.0*("
+            == "42.0 -4.0*("
             + str(Ideal.gas_constant(m.props[1]))
             + ")*params.temperature_ref"
         )
         # For vapor phase, delta(n) should be 3 (2*He + 2*O2 - 1*component)
         assert str(Ideal.energy_internal_mol_phase_comp(m.props[1], "Vap", j)) == str(
-            42
+            42.0
             - pyunits.convert(
                 const.gas_constant,
                 to_units=pyunits.kg
@@ -375,7 +375,7 @@ def test_enth_mol_phase(m):
     )
     assert str(Ideal.enth_mol_phase(m.props[1], "Liq")) == str(
         sum(
-            m.props[1].mole_frac_phase_comp["Liq", j] * 42
+            m.props[1].mole_frac_phase_comp["Liq", j] * 42.0
             for j in m.params.component_list
         )
         + (m.props[1].pressure - m.params.pressure_ref)
@@ -392,11 +392,11 @@ def test_enth_mol_phase_comp(m):
 
     for j in m.params.component_list:
         assert str(Ideal.enth_mol_phase_comp(m.props[1], "Liq", j)) == str(
-            42
+            42.0
             + (m.props[1].pressure - m.params.pressure_ref)
             / m.props[1].dens_mol_phase["Liq"]
         )
-        assert str(Ideal.enth_mol_phase_comp(m.props[1], "Vap", j)) == str(42)
+        assert str(Ideal.enth_mol_phase_comp(m.props[1], "Vap", j)) == str(42.0)
 
 
 @pytest.mark.unit
@@ -408,7 +408,7 @@ def test_enth_mol_phase_sol(m_sol):
 
     for j in m_sol.params.component_list:
         assert str(Ideal.enth_mol_phase_comp(m_sol.props[1], "Sol", j)) == str(
-            42
+            42.0
             + (m_sol.props[1].pressure - m_sol.params.pressure_ref)
             / m_sol.props[1].dens_mol_phase["Sol"]
         )
@@ -434,9 +434,9 @@ def test_entr_mol_phase_comp(m):
         m.params.get_component(j).config.entr_mol_liq_comp = dummy_call
         m.params.get_component(j).config.entr_mol_ig_comp = dummy_call
 
-        assert str(Ideal.entr_mol_phase_comp(m.props[1], "Liq", j)) == str(42)
+        assert str(Ideal.entr_mol_phase_comp(m.props[1], "Liq", j)) == str(42.0)
         assert str(Ideal.entr_mol_phase_comp(m.props[1], "Vap", j)) == (
-            "42 - "
+            "42.0 - "
             + str(Ideal.gas_constant(m.props[1]))
             + "*log(props[1].mole_frac_phase_comp"
             "[Vap,{}]*props[1].pressure/params.pressure_ref)".format(j)
@@ -448,7 +448,7 @@ def test_entr_mol_phase_sol(m_sol):
     for j in m_sol.params.component_list:
         m_sol.params.get_component(j).config.entr_mol_sol_comp = dummy_call
 
-        assert str(Ideal.entr_mol_phase_comp(m_sol.props[1], "Sol", j)) == str(42)
+        assert str(Ideal.entr_mol_phase_comp(m_sol.props[1], "Sol", j)) == str(42.0)
 
 
 @pytest.mark.unit
@@ -457,7 +457,7 @@ def test_fug_phase_comp_liq(m):
         m.params.get_component(j).config.pressure_sat_comp = dummy_call
 
         assert str(Ideal.fug_phase_comp(m.props[1], "Liq", j)) == str(
-            m.props[1].mole_frac_phase_comp["Liq", j] * 42
+            m.props[1].mole_frac_phase_comp["Liq", j] * 42.0
         )
 
 
@@ -482,7 +482,7 @@ def test_fug_phase_comp_liq_eq(m):
 
         assert str(
             Ideal.fug_phase_comp_eq(m.props[1], "Liq", j, ("Vap", "Liq"))
-        ) == str(m.props[1].mole_frac_phase_comp["Liq", j] * 42)
+        ) == str(m.props[1].mole_frac_phase_comp["Liq", j] * 42.0)
 
 
 @pytest.mark.unit
@@ -562,16 +562,10 @@ def test_pressure_osm_phase(m):
     assert pytest.approx(value(const.gas_constant * 300 * 55e3), rel=1e-6) == value(
         m.props[1].pressure_osm_phase["Liq"]
     )
+    subexpr = m.props[1].conc_mol_phase_comp["Liq", "b"]
+    subexpr += m.props[1].conc_mol_phase_comp["Liq", "c"]
     assert str(m.props[1].pressure_osm_phase["Liq"]._expr) == (
-        str(Ideal.gas_constant(m.props[1]))
-        + "*"
-        + str(
-            m.props[1].temperature
-            * (
-                m.props[1].conc_mol_phase_comp["Liq", "b"]
-                + m.props[1].conc_mol_phase_comp["Liq", "c"]
-            )
-        )
+        str(Ideal.gas_constant(m.props[1]) * m.props[1].temperature * subexpr)
     )
     assert len(m.props[1].pressure_osm_phase) == 1
 
@@ -622,16 +616,11 @@ def test_pressure_osm_phase_w_apparent_component():
     assert pytest.approx(
         value(const.gas_constant * 300 * 1.5 * 55e3), rel=1e-6
     ) == value(m.props[1].pressure_osm_phase["Liq"])
+
+    subexpr = m.props[1].conc_mol_phase_comp["Liq", "b"]
+    subexpr += 2 * m.props[1].conc_mol_phase_comp["Liq", "c"]
     assert str(m.props[1].pressure_osm_phase["Liq"]._expr) == (
-        str(Ideal.gas_constant(m.props[1]))
-        + "*"
-        + str(
-            m.props[1].temperature
-            * (
-                m.props[1].conc_mol_phase_comp["Liq", "b"]
-                + 2 * m.props[1].conc_mol_phase_comp["Liq", "c"]
-            )
-        )
+        str(Ideal.gas_constant(m.props[1]) * m.props[1].temperature * subexpr)
     )
     assert len(m.props[1].pressure_osm_phase) == 1
 
@@ -693,7 +682,7 @@ def test_vol_mol_phase():
             )
         else:
             assert str(Ideal.vol_mol_phase(m.props[1], p)) == str(
-                1 / 42 * m.props[1].mole_frac_phase_comp["Liq", "a"]
-                + 1 / 42 * m.props[1].mole_frac_phase_comp["Liq", "b"]
-                + 42 * m.props[1].mole_frac_phase_comp["Liq", "c"]
+                1 / 42.0 * m.props[1].mole_frac_phase_comp["Liq", "a"]
+                + 1 / 42.0 * m.props[1].mole_frac_phase_comp["Liq", "b"]
+                + 42.0 * m.props[1].mole_frac_phase_comp["Liq", "c"]
             )

--- a/idaes/models/properties/modular_properties/reactions/tests/test_equilibrium_constant.py
+++ b/idaes/models/properties/modular_properties/reactions/tests/test_equilibrium_constant.py
@@ -675,7 +675,7 @@ class TestGibbsEnergy(object):
         assert str(rform1) == ("exp(rxn[1].log_k_eq[r1])")
         assert str(rform2) == (
             "rxn[1].log_k_eq[r1]  ==  "
-            "- rparams.reaction_r1.dh_rxn_ref/("
+            + "-1/("
             + str(
                 pyunits.convert(
                     c.gas_constant,
@@ -686,7 +686,8 @@ class TestGibbsEnergy(object):
                     / pyunits.K,
                 )
             )
-            + "*(300*K)) + 1/("
+            + "*(300*K))*rparams.reaction_r1.dh_rxn_ref"
+            + " + 1/("
             + str(
                 pyunits.convert(
                     c.gas_constant,

--- a/idaes/models/properties/modular_properties/reactions/tests/test_equilibrium_constant.py
+++ b/idaes/models/properties/modular_properties/reactions/tests/test_equilibrium_constant.py
@@ -673,32 +673,21 @@ class TestGibbsEnergy(object):
         )
 
         assert str(rform1) == ("exp(rxn[1].log_k_eq[r1])")
+        R = pyunits.convert(
+            c.gas_constant,
+            to_units=pyunits.kg
+            * pyunits.m**2
+            / pyunits.s**2
+            / pyunits.mol
+            / pyunits.K,
+        )
+        T = 300 * pyunits.K
         assert str(rform2) == (
             "rxn[1].log_k_eq[r1]  ==  "
-            + "-1/("
             + str(
-                pyunits.convert(
-                    c.gas_constant,
-                    to_units=pyunits.kg
-                    * pyunits.m**2
-                    / pyunits.s**2
-                    / pyunits.mol
-                    / pyunits.K,
-                )
+                (-model.rparams.reaction_r1.dh_rxn_ref / (R * T))
+                + (model.rparams.reaction_r1.ds_rxn_ref / R)
             )
-            + "*(300*K))*rparams.reaction_r1.dh_rxn_ref"
-            + " + 1/("
-            + str(
-                pyunits.convert(
-                    c.gas_constant,
-                    to_units=pyunits.kg
-                    * pyunits.m**2
-                    / pyunits.s**2
-                    / pyunits.mol
-                    / pyunits.K,
-                )
-            )
-            + ")*rparams.reaction_r1.ds_rxn_ref"
         )
 
         assert value(rform1) == pytest.approx(1, rel=1e-3)

--- a/idaes/models/properties/modular_properties/state_definitions/FPhx.py
+++ b/idaes/models/properties/modular_properties/state_definitions/FPhx.py
@@ -150,7 +150,7 @@ def define_state(b):
 
     b.phase_frac = Var(
         b.phase_list,
-        initialize=1 / len(b.phase_list),
+        initialize=1.0 / len(b.phase_list),
         bounds=(0, None),
         doc="Phase fractions",
         units=pyunits.dimensionless,
@@ -195,7 +195,7 @@ def define_state(b):
         )
 
         def rule_phase_frac(b, p):
-            return b.phase_frac[p] == 1
+            return b.phase_frac[p] == 1.0
 
         b.phase_fraction_constraint = Constraint(b.phase_list, rule=rule_phase_frac)
 

--- a/idaes/models/properties/modular_properties/state_definitions/FTPx.py
+++ b/idaes/models/properties/modular_properties/state_definitions/FTPx.py
@@ -149,7 +149,7 @@ def define_state(b):
 
     b.phase_frac = Var(
         b.phase_list,
-        initialize=1 / len(b.phase_list),
+        initialize=1.0 / len(b.phase_list),
         bounds=(0, None),
         doc="Phase fractions",
         units=pyunits.dimensionless,
@@ -163,7 +163,7 @@ def define_state(b):
     if b.config.defined_state is False:
         # applied at outlet only
         b.sum_mole_frac_out = Constraint(
-            expr=1 == sum(b.mole_frac_comp[i] for i in b.component_list)
+            expr=1.0 == sum(b.mole_frac_comp[i] for i in b.component_list)
         )
 
     if len(b.phase_list) == 1:
@@ -183,7 +183,7 @@ def define_state(b):
         )
 
         def rule_phase_frac(b, p):
-            return b.phase_frac[p] == 1
+            return b.phase_frac[p] == 1.0
 
         b.phase_fraction_constraint = Constraint(b.phase_list, rule=rule_phase_frac)
 

--- a/idaes/models/properties/modular_properties/state_definitions/FcPh.py
+++ b/idaes/models/properties/modular_properties/state_definitions/FcPh.py
@@ -152,7 +152,7 @@ def define_state(b):
 
     b.phase_frac = Var(
         b.phase_list,
-        initialize=1 / len(b.phase_list),
+        initialize=1.0 / len(b.phase_list),
         bounds=(0, None),
         doc="Phase fractions",
         units=pyunits.dimensionless,
@@ -171,7 +171,7 @@ def define_state(b):
                 b.flow_mol_comp[k] for k in b.component_list
             )
         else:
-            return b.mole_frac_comp[j] == 1
+            return b.mole_frac_comp[j] == 1.0
 
     b.mole_frac_comp_eq = Constraint(b.component_list, rule=rule_mole_frac_comp)
 
@@ -201,7 +201,7 @@ def define_state(b):
         )
 
         def rule_phase_frac(b, p):
-            return b.phase_frac[p] == 1
+            return b.phase_frac[p] == 1.0
 
         b.phase_fraction_constraint = Constraint(b.phase_list, rule=rule_phase_frac)
 

--- a/idaes/models/properties/modular_properties/state_definitions/FcTP.py
+++ b/idaes/models/properties/modular_properties/state_definitions/FcTP.py
@@ -140,7 +140,7 @@ def define_state(b):
 
     b.phase_frac = Var(
         b.phase_list,
-        initialize=1 / len(b.phase_list),
+        initialize=1.0 / len(b.phase_list),
         bounds=(0, None),
         doc="Phase fractions",
         units=pyunits.dimensionless,
@@ -157,7 +157,7 @@ def define_state(b):
                 b.flow_mol_comp[k] for k in b.component_list
             )
         else:
-            return b.mole_frac_comp[j] == 1
+            return b.mole_frac_comp[j] == 1.0
 
     b.mole_frac_comp_eq = Constraint(b.component_list, rule=rule_mole_frac_comp)
 
@@ -178,7 +178,7 @@ def define_state(b):
         )
 
         def rule_phase_frac(b, p):
-            return b.phase_frac[p] == 1
+            return b.phase_frac[p] == 1.0
 
         b.phase_fraction_constraint = Constraint(b.phase_list, rule=rule_phase_frac)
 

--- a/idaes/models/properties/modular_properties/state_definitions/FpcTP.py
+++ b/idaes/models/properties/modular_properties/state_definitions/FpcTP.py
@@ -157,7 +157,7 @@ def define_state(b):
                 == b.flow_mol_phase_comp[p, j]
             )
         else:
-            return b.mole_frac_phase_comp[p, j] == 1
+            return b.mole_frac_phase_comp[p, j] == 1.0
 
     b.mole_frac_phase_comp_eq = Constraint(
         b.phase_component_set, rule=rule_mole_frac_phase_comp
@@ -165,7 +165,7 @@ def define_state(b):
 
     def rule_phase_frac(b, p):
         if len(b.phase_list) == 1:
-            return 1
+            return 1.0
         else:
             return b.flow_mol_phase[p] / b.flow_mol
 


### PR DESCRIPTION
## Preparation for https://github.com/Pyomo/pyomo/pull/2722


## Summary/Motivation:
The upcoming PR #2722 in Pyomo changes how some expressions get rendered, which requires changes to some IDAES tests. This PR aims to make these tests more robust for the future.

## Changes proposed in this PR:
- Replace some constant `ints` in the code base with `floats` to match previous output (these should have been floats anyway).
- Rework some tests of expressions to build expected expression for comparison rather than testing hard-coded strings.
- Rework some other tests to get test expression to better align with expected expression.
- Remove checking of one very complex expression (eNRTL) - this model has sufficient verification testing to ensure form is correct.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
