### PR TITLE
Fixing check for kaug in uncertainty tests

### DIFF
--- a/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
+++ b/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
@@ -78,7 +78,9 @@ class TestUncertaintyPropagation:
         np.testing.assert_array_almost_equal(
             results.cov, np.array([[6.30579403, -0.4395341], [-0.4395341, 0.04193591]])
         )
-        assert results.propagation_f == pytest.approx(5.45439337747349)
+        assert results.propagation_f == pytest.approx(
+            5.45439337747349, abs=1e-8, rel=1e-8
+        )
 
     @pytest.mark.component
     def test_quantify_propagate_uncertainty2(self):
@@ -116,7 +118,7 @@ class TestUncertaintyPropagation:
             rooney_biegler_model, model_uncertain, data, variable_name, SSE
         )
 
-        assert results.obj == pytest.approx(4.331711213656886)
+        assert results.obj == pytest.approx(4.331711213656886, abs=1e-8, rel=1e-8)
         np.testing.assert_array_almost_equal(
             results.theta, [19.142575284617866, 0.53109137696521]
         )

--- a/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
+++ b/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
@@ -10,13 +10,20 @@
 # Please see the files COPYRIGHT.md and LICENSE.md for full copyright and
 # license information.
 #################################################################################
-import sys
 import os
 import numpy as np
 import pandas as pd
 import pytest
 
-from pyomo.environ import *
+from pyomo.environ import (
+    ConcreteModel,
+    Constraint,
+    exp,
+    Objective,
+    SolverFactory,
+    Suffix,
+    Var,
+)
 import pyomo.contrib.parmest.parmest as parmest
 
 from idaes.apps.uncertainty_propagation.uncertainties import (
@@ -24,8 +31,6 @@ from idaes.apps.uncertainty_propagation.uncertainties import (
     propagate_uncertainty,
     clean_variable_name,
 )
-
-sys.path.append(os.path.abspath(".."))  # current folder is ~/tests
 
 ipopt_available = SolverFactory("ipopt").available(exception_flag=False)
 kaug_available = SolverFactory("k_aug").available(exception_flag=False)
@@ -111,7 +116,6 @@ class TestUncertaintyPropagation:
         model_uncertain.obj = Objective(
             expr=model_uncertain.asymptote
             * (1 - exp(-model_uncertain.rate_constant * 10)),
-            sense=minimize,
         )
 
         results = quantify_propagate_uncertainty(
@@ -165,7 +169,6 @@ class TestUncertaintyPropagation:
         model_uncertain.obj = Objective(
             expr=model_uncertain.asymptote
             * (1 - exp(-model_uncertain.rate_constant * 10)),
-            sense=minimize,
         )
 
         propagate_results = propagate_uncertainty(
@@ -215,9 +218,7 @@ class TestUncertaintyPropagation:
         m.con2 = Constraint(expr=m.x2 + m.x3 - m.p2 == 0)
 
         # Define objective
-        m.obj = Objective(
-            expr=m.p1 * m.x1 + m.p2 * (m.x2**2) + m.p1 * m.p2, sense=minimize
-        )
+        m.obj = Objective(expr=m.p1 * m.x1 + m.p2 * (m.x2**2) + m.p1 * m.p2)
 
         ### Solve optimization model
         opt = SolverFactory("ipopt", tee=True)
@@ -422,7 +423,6 @@ class TestUncertaintyPropagation:
         model_uncertain.obj = Objective(
             expr=model_uncertain.asymptote
             * (1 - exp(-model_uncertain.rate_constant * 10)),
-            sense=minimize,
         )
         with pytest.raises(TypeError):
             propagate_results = propagate_uncertainty(1, theta, cov, variable_name)

--- a/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
+++ b/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
@@ -12,26 +12,24 @@
 #################################################################################
 import sys
 import os
-from unittest.mock import patch
-
-sys.path.append(os.path.abspath(".."))  # current folder is ~/tests
 import numpy as np
 import pandas as pd
-from scipy import sparse
 import pytest
-from pytest import approx
+
+from pyomo.environ import *
+import pyomo.contrib.parmest.parmest as parmest
+
 from idaes.apps.uncertainty_propagation.uncertainties import (
     quantify_propagate_uncertainty,
     propagate_uncertainty,
     clean_variable_name,
 )
-from pyomo.opt import SolverFactory
-from pyomo.environ import *
-import pyomo.contrib.parmest.parmest as parmest
 
-ipopt_available = SolverFactory("ipopt").available()
-kaug_available = SolverFactory("k_aug").available()
-dotsens_available = SolverFactory("dot_sens").available()
+sys.path.append(os.path.abspath(".."))  # current folder is ~/tests
+
+ipopt_available = SolverFactory("ipopt").available(exception_flag=False)
+kaug_available = SolverFactory("k_aug").available(exception_flag=False)
+dotsens_available = SolverFactory("dot_sens").available(exception_flag=False)
 
 
 @pytest.mark.skipif(not ipopt_available, reason="The 'ipopt' command is not available")
@@ -67,7 +65,7 @@ class TestUncertaintyPropagation:
             rooney_biegler_model, rooney_biegler_model_opt, data, variable_name, SSE
         )
 
-        assert results.obj == approx(4.331711213656886)
+        assert results.obj == pytest.approx(4.331711213656886)
         np.testing.assert_array_almost_equal(
             results.theta, [19.142575284617866, 0.53109137696521]
         )
@@ -118,7 +116,7 @@ class TestUncertaintyPropagation:
             rooney_biegler_model, model_uncertain, data, variable_name, SSE
         )
 
-        assert results.obj == approx(4.331711213656886)
+        assert results.obj == pytest.approx(4.331711213656886)
         np.testing.assert_array_almost_equal(
             results.theta, [19.142575284617866, 0.53109137696521]
         )

--- a/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
+++ b/idaes/apps/uncertainty_propagation/tests/test_uncertainties.py
@@ -65,7 +65,7 @@ class TestUncertaintyPropagation:
             rooney_biegler_model, rooney_biegler_model_opt, data, variable_name, SSE
         )
 
-        assert results.obj == pytest.approx(4.331711213656886)
+        assert results.obj == pytest.approx(4.331711213656886, abs=1e-8, rel=1e-8)
         np.testing.assert_array_almost_equal(
             results.theta, [19.142575284617866, 0.53109137696521]
         )


### PR DESCRIPTION
## Addresses issue raised in https://github.com/IDAES/idaes-pse/pull/1086


## Summary/Motivation:
PR #1086 identified an issue where tests for the uncertainty propagation tool failed if `kaug` was not installed. The cause was identified as an error in how the test was checking for the presence of `kaug`.

## Changes proposed in this PR:
- Add `exception_flag=False` to all checks for solver presence in `test_uncertainties.py`
- Clean up some imports at the same time

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
