### PR TITLE
Deprecating categorize_dae_variables

### DIFF
--- a/idaes/apps/caprese/categorize.py
+++ b/idaes/apps/caprese/categorize.py
@@ -21,9 +21,9 @@ from pyomo.environ import (
 )
 from pyomo.dae import DerivativeVar
 from pyomo.common.collections import ComponentSet, ComponentMap
-from pyomo.util.slices import slice_component_along_sets
 from pyomo.core.expr.visitor import identify_variables
 from pyomo.contrib.incidence_analysis.interface import IncidenceGraphInterface
+from pyomo.common.deprecation import deprecated
 
 import idaes.apps.caprese.nmpc_var as nmpc_var
 from idaes.apps.caprese.common.config import (
@@ -318,6 +318,11 @@ def categorize_dae_variables_and_constraints(
     return var_category_dict, con_category_dict
 
 
+@deprecated(
+    "categorize_dae_variables has been replaced by "
+    "categorize_dae_variables_and_constraints",
+    version="2.0.0",
+)
 def categorize_dae_variables(dae_vars, time, inputs, measurements=None):
     t0 = time.first()
     t1 = time.get_finite_elements()[1]


### PR DESCRIPTION
## Fixes #945 


## Summary/Motivation:
As discussed in issue #945, the `categorize_dae_variables` method has been superseded by another method and should be deprecated.

## Changes proposed in this PR:
- Deprecate `categorize_dae_variables` - this method was untested so no change in tests.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
