### PR TITLE
Set default ipopt iteration limit to 200

### DIFF
--- a/data/config.yaml
+++ b/data/config.yaml
@@ -1,8 +1,8 @@
 _id: d779730c7cc94155877a24e2e8be2ad1
-created: '2023-02-22T12:23:34.478902'
+created: '2022-04-18T14:36:30.754421'
 description: Built-in IDAES workspace
 htmldocs:
 - https://idaes-pse.readthedocs.io/en/stable
 - '{dmf_root}/docs/build/html'
-modified: '2023-02-22T12:23:34.478902'
+modified: '2022-04-18T14:36:30.754421'
 name: IDAES

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -1,8 +1,8 @@
 _id: d779730c7cc94155877a24e2e8be2ad1
-created: '2022-04-18T14:36:30.754421'
+created: '2023-02-22T12:23:34.478902'
 description: Built-in IDAES workspace
 htmldocs:
 - https://idaes-pse.readthedocs.io/en/stable
 - '{dmf_root}/docs/build/html'
-modified: '2022-04-18T14:36:30.754421'
+modified: '2023-02-22T12:23:34.478902'
 name: IDAES

--- a/idaes/apps/caprese/examples/cstr_model.py
+++ b/idaes/apps/caprese/examples/cstr_model.py
@@ -44,7 +44,7 @@ __author__ = "Robert Parker"
 # See if ipopt is available and set up solver
 if SolverFactory("ipopt").available():
     solver = get_solver(
-        solver="ipopt", 
+        solver="ipopt",
         options={"tol": 1e-6, "mu_init": 1e-8, "bound_push": 1e-8},
     )
 else:

--- a/idaes/apps/caprese/examples/cstr_model.py
+++ b/idaes/apps/caprese/examples/cstr_model.py
@@ -34,6 +34,7 @@ from idaes.core.util.tests.test_initialization import (
 )
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.models.unit_models import CSTR, Mixer, MomentumMixingType
+from idaes.core.solvers import get_solver
 from idaes.apps.caprese import nmpc
 from idaes.apps.caprese.nmpc import *
 
@@ -42,8 +43,10 @@ __author__ = "Robert Parker"
 
 # See if ipopt is available and set up solver
 if SolverFactory("ipopt").available():
-    solver = SolverFactory("ipopt")
-    solver.options = {"tol": 1e-6, "mu_init": 1e-8, "bound_push": 1e-8}
+    solver = get_solver(
+        solver="ipopt", 
+        options={"tol": 1e-6, "mu_init": 1e-8, "bound_push": 1e-8},
+    )
 else:
     solver = None
 

--- a/idaes/apps/caprese/examples/cstr_nmpc.py
+++ b/idaes/apps/caprese/examples/cstr_nmpc.py
@@ -20,6 +20,7 @@ from pyomo.environ import SolverFactory
 from pyomo.dae.initialization import solve_consistent_initial_conditions
 import idaes.logger as idaeslog
 from idaes.apps.caprese.examples.cstr_model import make_model
+from idaes.core.solvers import get_solver
 import pandas as pd
 import matplotlib.pyplot as plt
 
@@ -28,13 +29,15 @@ __author__ = "Robert Parker"
 
 # See if ipopt is available and set up solver
 if SolverFactory("ipopt").available():
-    solver = SolverFactory("ipopt")
-    solver.options = {
-        "tol": 1e-6,
-        "bound_push": 1e-8,
-        "halt_on_ampl_error": "yes",
-        "linear_solver": "ma57",
-    }
+    solver = get_solver(
+        solver="ipopt",
+        options={
+            "tol": 1e-6,
+            "bound_push": 1e-8,
+            "halt_on_ampl_error": "yes",
+            "linear_solver": "ma57",
+        }
+    )
 else:
     solver = None
 

--- a/idaes/apps/caprese/examples/cstr_nmpc.py
+++ b/idaes/apps/caprese/examples/cstr_nmpc.py
@@ -36,7 +36,7 @@ if SolverFactory("ipopt").available():
             "bound_push": 1e-8,
             "halt_on_ampl_error": "yes",
             "linear_solver": "ma57",
-        }
+        },
     )
 else:
     solver = None

--- a/idaes/apps/caprese/examples/cstr_reduced.py
+++ b/idaes/apps/caprese/examples/cstr_reduced.py
@@ -23,6 +23,7 @@ from idaes.apps.caprese.categorize import (
     VariableCategory,
     ConstraintCategory,
 )
+from idaes.core.solvers import get_solver
 
 VC = VariableCategory
 CC = ConstraintCategory
@@ -47,13 +48,15 @@ __author__ = "Robert Parker"
 
 # See if ipopt is available and set up solver
 if pyo.SolverFactory("ipopt").available():
-    solver = pyo.SolverFactory("ipopt")
-    solver.options = {
-        "tol": 1e-6,
-        "bound_push": 1e-8,
-        "halt_on_ampl_error": "yes",
-        "linear_solver": "ma57",
-    }
+    solver = get_solver(
+        solver="ipopt",
+        options={
+            "tol": 1e-6,
+            "bound_push": 1e-8,
+            "halt_on_ampl_error": "yes",
+            "linear_solver": "ma57",
+        },
+    )
 else:
     solver = None
 

--- a/idaes/apps/caprese/tests/test_controller.py
+++ b/idaes/apps/caprese/tests/test_controller.py
@@ -39,10 +39,11 @@ from idaes.apps.caprese.common.config import (
     ControlPenaltyType,
 )
 from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.solvers import get_solver
 
 solver_available = pyo.SolverFactory("ipopt").available()
 if solver_available:
-    solver = pyo.SolverFactory("ipopt")
+    solver = get_solver(solver="ipopt")
 else:
     solver = None
 

--- a/idaes/apps/caprese/tests/test_dynamic_block.py
+++ b/idaes/apps/caprese/tests/test_dynamic_block.py
@@ -52,6 +52,7 @@ from idaes.apps.caprese.common.config import (
     VariableCategory,
     InputOption,
 )
+from idaes.core.solvers import get_solver
 
 VC = VariableCategory
 from idaes.apps.caprese.nmpc_var import (
@@ -71,7 +72,7 @@ __author__ = "Robert Parker"
 
 solver_available = pyo.SolverFactory("ipopt").available()
 if solver_available:
-    solver = pyo.SolverFactory("ipopt")
+    solver = get_solver(solver="ipopt")
 else:
     solver = None
 

--- a/idaes/apps/caprese/tests/test_util.py
+++ b/idaes/apps/caprese/tests/test_util.py
@@ -28,6 +28,7 @@ from idaes.core.util.model_statistics import (
 from idaes.apps.caprese.util import *
 from idaes.apps.caprese.common.config import NoiseBoundOption
 from idaes.apps.caprese.examples.cstr_model import make_model
+from idaes.core.solvers import get_solver
 import idaes.logger as idaeslog
 
 import random
@@ -38,13 +39,15 @@ __author__ = "Robert Parker"
 # See if ipopt is available and set up solver
 solver_available = SolverFactory("ipopt").available()
 if solver_available:
-    solver = SolverFactory("ipopt")
-    solver.options = {
-        "tol": 1e-6,
-        "mu_init": 1e-8,
-        "bound_push": 1e-8,
-        "halt_on_ampl_error": "yes",
-    }
+    solver = get_solver(
+        solver="ipopt",
+        options={
+            "tol": 1e-6,
+            "mu_init": 1e-8,
+            "bound_push": 1e-8,
+            "halt_on_ampl_error": "yes",
+        },
+    )
 else:
     solver = None
 

--- a/idaes/apps/caprese/util.py
+++ b/idaes/apps/caprese/util.py
@@ -36,6 +36,7 @@ from idaes.core.util.dyn_utils import (
     get_fixed_dict,
     deactivate_constraints_unindexed_by,
 )
+from idaes.core.solvers import get_solver
 from idaes.apps.caprese.common.config import NoiseBoundOption
 import idaes.logger as idaeslog
 
@@ -103,7 +104,7 @@ def initialize_by_element_in_range(
         solver : Solver option used to solve portions of the square model
         outlvl : idaes.logger output level
     """
-    solver = kwargs.pop("solver", SolverFactory("ipopt"))
+    solver = kwargs.pop("solver", get_solver(solver="ipopt"))
     outlvl = kwargs.pop("outlvl", idaeslog.NOTSET)
     init_log = idaeslog.getInitLogger("nmpc", outlvl)
     solver_log = idaeslog.getSolveLogger("nmpc", outlvl)

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -251,6 +251,16 @@ def _new_idaes_config_block():
         ),
     )
 
+    cfg["ipopt"]["options"].declare(
+        "max_iter",
+        pyomo.common.config.ConfigValue(
+            domain=int,
+            default=200,
+            description="Ipopt max_iter option",
+            doc="Ipopt max_iter option",
+        ),
+    )
+
     cfg.declare(
         "ipopt_l1",
         pyomo.common.config.ConfigBlock(
@@ -286,6 +296,16 @@ def _new_idaes_config_block():
             default=1e-6,
             description="Ipopt_l1 tol option",
             doc="Ipopt_l1 tol option",
+        ),
+    )
+
+    cfg["ipopt_l1"]["options"].declare(
+        "max_iter",
+        pyomo.common.config.ConfigValue(
+            domain=int,
+            default=200,
+            description="Ipopt_l1 max_iter option",
+            doc="Ipopt_l1 max_iter option",
         ),
     )
 

--- a/idaes/models_extra/gas_distribution/unit_models/tests/test_compressor.py
+++ b/idaes/models_extra/gas_distribution/unit_models/tests/test_compressor.py
@@ -31,6 +31,7 @@ from idaes.models_extra.gas_distribution.properties.natural_gas import (
 from idaes.models_extra.gas_distribution.unit_models.compressor import (
     IsothermalCompressor,
 )
+from idaes.core.solvers import get_solver
 
 """
 Test for the simple compressor.
@@ -182,7 +183,7 @@ class TestCompressorValues(unittest.TestCase):
             for key, val in target_values.items()
         )
 
-        ipopt = pyo.SolverFactory("ipopt")
+        ipopt = get_solver("ipopt")
         param_sweeper = ParamSweeper(
             n_scen,
             input_values,

--- a/idaes/models_extra/gas_distribution/unit_models/tests/test_pipeline.py
+++ b/idaes/models_extra/gas_distribution/unit_models/tests/test_pipeline.py
@@ -46,6 +46,7 @@ from idaes.apps.nmpc.dynamic_data import (
     load_inputs_into_model,
     interval_data_from_time_series,
 )
+from idaes.core.solvers import get_solver
 
 """
 Test for the simple pipeline model
@@ -162,7 +163,7 @@ class TestSolvePipelineSquare(unittest.TestCase):
 
         t0 = m.fs.time.first()
 
-        ipopt = pyo.SolverFactory("ipopt")
+        ipopt = get_solver("ipopt")
 
         res = ipopt.solve(m, tee=True)
         pyo.assert_optimal_termination(res)
@@ -254,7 +255,7 @@ class TestSolvePipelineSquare(unittest.TestCase):
                 to_fix=input_values,
                 output_values=target_values,
             )
-            ipopt = pyo.SolverFactory("ipopt")
+            ipopt = get_solver("ipopt")
             with param_sweeper:
                 # Note that doing this in a context manager means that
                 # on error, values are reset. This is inconvenient
@@ -348,7 +349,7 @@ class TestSolveDynamicPipeline(unittest.TestCase):
         Inlet pressure and outlet flow rate will be fixed.
         """
         nxfe = 4
-        ipopt = pyo.SolverFactory("ipopt")
+        ipopt = get_solver("ipopt")
 
         m_steady = self.make_steady_model(nfe=nxfe)
         self.fix_model_inlets(m_steady)
@@ -523,7 +524,7 @@ class TestSolveDynamicPipeline(unittest.TestCase):
         and 5e5 kg/hr.
         """
         nxfe = 4
-        ipopt = pyo.SolverFactory("ipopt")
+        ipopt = get_solver("ipopt")
 
         # Steady state data
         m_steady = self.make_steady_model(nfe=nxfe)

--- a/idaes/models_extra/gas_distribution/unit_models/tests/test_pipeline_compressor.py
+++ b/idaes/models_extra/gas_distribution/unit_models/tests/test_pipeline_compressor.py
@@ -39,7 +39,7 @@ from idaes.apps.nmpc.dynamic_data import (
     load_inputs_into_model,
     interval_data_from_time_series,
 )
-
+from idaes.core.solvers import get_solver
 
 @pytest.mark.component
 class TestSolveDynamicPipelineCompressor(unittest.TestCase):
@@ -119,7 +119,7 @@ class TestSolveDynamicPipelineCompressor(unittest.TestCase):
         Inlet pressure and outlet flow rate will be fixed.
         """
         nxfe = 4
-        ipopt = pyo.SolverFactory("ipopt")
+        ipopt = get_solver("ipopt")
 
         m_steady = self.make_steady_model(nfe=nxfe)
         self.fix_model_inlets(m_steady, inlet_pressure=50.0 * pyo.units.bar)

--- a/idaes/models_extra/gas_distribution/unit_models/tests/test_pipeline_compressor.py
+++ b/idaes/models_extra/gas_distribution/unit_models/tests/test_pipeline_compressor.py
@@ -41,6 +41,7 @@ from idaes.apps.nmpc.dynamic_data import (
 )
 from idaes.core.solvers import get_solver
 
+
 @pytest.mark.component
 class TestSolveDynamicPipelineCompressor(unittest.TestCase):
     def make_steady_model(

--- a/idaes/models_extra/power_generation/properties/sofc/sofc_keras_surrogate.py
+++ b/idaes/models_extra/power_generation/properties/sofc/sofc_keras_surrogate.py
@@ -18,6 +18,7 @@ from pyomo.environ import SolverFactory, Var, units as pyunits
 from idaes.core import declare_process_block_class, UnitModelBlockData
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.solvers import get_solver
 
 from idaes.core.surrogate.keras_surrogate import KerasSurrogate
 from idaes.core.surrogate.surrogate_block import SurrogateBlock
@@ -155,7 +156,7 @@ class SofcSurrogateData(UnitModelBlockData):
 
         init_log = idaeslog.getInitLogger(self.name, outlvl, tag="unit")
         solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="unit")
-        opt = SolverFactory(solver)
+        opt = get_solver(solver=solver)
         opt.options = optarg
 
         init_log.info_low("Starting initialization...")

--- a/idaes/models_extra/power_generation/unit_models/cpu.py
+++ b/idaes/models_extra/power_generation/unit_models/cpu.py
@@ -52,6 +52,7 @@ import pyomo.environ as pyo
 from pyomo.environ import Var, units as pyunits
 from pyomo.network import Port
 import idaes.logger as idaeslog
+from idaes.core.solvers import get_solver
 
 __author__ = "Differentiate Team (N. Susarla, A. Noring, M. Zamarripa)"
 __version__ = "1.1.0"
@@ -514,10 +515,10 @@ class CarbonProcessingUnitData(UnitModelBlockData):
         CO2 pure pyomo block initialization routine
 
         Keyword Arguments:
-            outlvl : sets output level of initialisation routine
+            outlvl : sets output level of initialization routine
 
             optarg : solver options dictionary object (default={'tol': 1e-6})
-            solver : str indicating whcih solver to use during
+            solver : str indicating which solver to use during
                      initialization (default = 'ipopt')
 
         Returns:
@@ -526,8 +527,7 @@ class CarbonProcessingUnitData(UnitModelBlockData):
         iscale.calculate_scaling_factors(blk)
         init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
-        opt = pyo.SolverFactory(solver)
-        opt.options = optarg
+        opt = get_solver(solver="ipopt", options=optarg)
 
         init_log.info_low("Starting initialization...")
 

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_contact_resistor.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_contact_resistor.py
@@ -21,8 +21,9 @@ from idaes.core import FlowsheetBlock
 from idaes.core.util.model_statistics import degrees_of_freedom
 import idaes.models_extra.power_generation.unit_models.soc_submodels as soc
 import idaes.models_extra.power_generation.unit_models.soc_submodels.testing as soc_testing
+from idaes.core.solvers import get_solver
 
-solver = pyo.SolverFactory("ipopt")
+solver = get_solver("ipopt")
 
 
 @pytest.fixture

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_herring_replication.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_herring_replication.py
@@ -75,6 +75,7 @@ from idaes.models.properties import iapws95
 from idaes.models.properties.general_helmholtz import helmholtz_data_dir as hdir
 import idaes.core.util.scaling as iscale
 from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.solvers import get_solver
 
 from idaes.models.properties.modular_properties import (
     GenericParameterBlock,
@@ -455,7 +456,7 @@ def kazempoor_braun_replication(model):
     cell = m.fs.cell
     case = 5
 
-    solver = pyo.SolverFactory("ipopt")
+    solver = get_solver("ipopt")
 
     N_voltage = 11
     N_case = 5

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_herring_replication_interconnect.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_herring_replication_interconnect.py
@@ -75,6 +75,7 @@ from idaes.models.properties import iapws95
 from idaes.models.properties.general_helmholtz import helmholtz_data_dir as hdir
 import idaes.core.util.scaling as iscale
 from idaes.core.util.model_statistics import degrees_of_freedom
+from idaes.core.solvers import get_solver
 
 from idaes.models.properties.modular_properties.base.generic_property import (
     GenericParameterBlock,
@@ -473,7 +474,7 @@ def kazempoor_braun_replication(model):
     cell = m.fs.cell
     case = 5
 
-    solver = pyo.SolverFactory("ipopt")
+    solver = get_solver("ipopt")
 
     N_voltage = 11
     N_case = 5

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_herring_replication_thin.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_herring_replication_thin.py
@@ -94,6 +94,7 @@ from idaes.models_extra.power_generation.unit_models.soc_submodels.common import
 
 from idaes.models.unit_models.heat_exchanger import HeatExchangerFlowPattern
 from idaes.models.properties.general_helmholtz import helmholtz_available
+from idaes.core.solvers import get_solver
 
 data_cache = os.sep.join([this_file_dir(), "data_cache"])
 
@@ -472,7 +473,7 @@ def kazempoor_braun_replication(model):
     cell = m.fs.cell
     case = 5
 
-    solver = pyo.SolverFactory("ipopt")
+    solver = get_solver("ipopt")
 
     N_voltage = 11
     N_case = 5

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_solid_oxide_cell.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_solid_oxide_cell.py
@@ -18,11 +18,12 @@ import numpy as np
 
 import pyomo.environ as pyo
 from idaes.core import FlowsheetBlock
+from idaes.core.solvers import get_solver
 from idaes.models.unit_models.heat_exchanger import HeatExchangerFlowPattern
 import idaes.models_extra.power_generation.unit_models.soc_submodels as soc
 import idaes.models_extra.power_generation.unit_models.soc_submodels.testing as soc_testing
 
-solver = pyo.SolverFactory("ipopt")
+solver = get_solver("ipopt")
 
 
 def build_tester(cell, nt, nz):

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_triple_phase_boundary.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/tests/test_triple_phase_boundary.py
@@ -24,8 +24,9 @@ from idaes.core.util.exceptions import ConfigurationError
 import idaes.models_extra.power_generation.unit_models.soc_submodels as soc
 import idaes.models_extra.power_generation.unit_models.soc_submodels.common as common
 import idaes.models_extra.power_generation.unit_models.soc_submodels.testing as soc_testing
+from idaes.core.solvers import get_solver
 
-solver = pyo.SolverFactory("ipopt")
+solver = get_solver("ipopt")
 
 
 def common_components(nt, nz, ncomp, nreact):

--- a/idaes/models_extra/power_generation/unit_models/soec_design.py
+++ b/idaes/models_extra/power_generation/unit_models/soec_design.py
@@ -55,7 +55,7 @@ class SoecDesignData(UnitModelBlockData):
             doc=(
                 "Property package for the oxygen side, using "
                 "idaes.models_extra.power_generation.properties.natural_gas_PR is "
-                "strongly recomended, either Peng-Robinson or Ideal is okay"
+                "strongly recommended, either Peng-Robinson or Ideal is okay"
             ),
         ),
     )
@@ -67,7 +67,7 @@ class SoecDesignData(UnitModelBlockData):
             doc=(
                 "Property package for the hydrogen side, using "
                 "idaes.models_extra.power_generation.properties.natural_gas_PR is "
-                "strongly recomended, either Peng-Robinson or Ideal is okay"
+                "strongly recommended, either Peng-Robinson or Ideal is okay"
             ),
         ),
     )
@@ -92,7 +92,7 @@ class SoecDesignData(UnitModelBlockData):
         ConfigValue(
             default=EosType.PR,
             domain=In(EosType),
-            description="Physical properies for electrolysis reactions",
+            description="Physical properties for electrolysis reactions",
             doc=(
                 "Reaction properties equation of state in: "
                 "{EosType.PR, EosType.IDEAL}."
@@ -156,10 +156,10 @@ class SoecDesignData(UnitModelBlockData):
 
     def _add_unit_models(self):
         """Add the unit models that make up the composite model. The main
-        things happening are 1) Electrolysis Reaction, 2) O2 Seperation, 3) O2
+        things happening are 1) Electrolysis Reaction, 2) O2 Separation, 3) O2
         mixes with sweep gas, and 4) sweep gas heat transfer.  There are
-        translator blocks to switch between property pacakage depending on the
-        existance of components in various streams.
+        translator blocks to switch between property package depending on the
+        existence of components in various streams.
         """
         self.h2_inlet_translator = um.Translator(
             doc="Translate hydrogen side properties to electrolysis properties",
@@ -169,26 +169,26 @@ class SoecDesignData(UnitModelBlockData):
             outlet_state_defined=False,
         )
         self.electrolysis_reactor = um.StoichiometricReactor(
-            doc="Electrolysis reator",
+            doc="Electrolysis reactor",
             property_package=self.electrolysis_prop_params,
             reaction_package=self.electrolysis_rxn_params,
             has_pressure_change=False,
             has_heat_transfer=True,
         )
-        self.o2_seperator = um.Separator(
+        self.o2_separator = um.Separator(
             property_package=self.electrolysis_prop_params,
             split_basis=um.SplittingType.componentFlow,
             outlet_list=["h2_strm", "o2_strm"],
         )
         self.h2_outlet_translator = um.Translator(
-            doc="Translate electrolysis properties to hydrogen properies",
+            doc="Translate electrolysis properties to hydrogen properties",
             inlet_property_package=self.electrolysis_prop_params,
             outlet_property_package=self.config.hydrogen_side_property_package,
             outlet_property_package_args=self.config.hydrogen_side_property_package_args,
             outlet_state_defined=False,
         )
         self.o2_translator = um.Translator(
-            doc="Translate electrolysis properties to oxygen properies",
+            doc="Translate electrolysis properties to oxygen properties",
             inlet_property_package=self.electrolysis_prop_params,
             outlet_property_package=self.config.oxygen_side_property_package,
             outlet_property_package_args=self.config.oxygen_side_property_package_args,
@@ -213,18 +213,18 @@ class SoecDesignData(UnitModelBlockData):
             destination=self.electrolysis_reactor.inlet,
         )
         self.strm2 = Arc(
-            doc="Electrolysis reactor to oxygen seperation",
+            doc="Electrolysis reactor to oxygen separation",
             source=self.electrolysis_reactor.outlet,
-            destination=self.o2_seperator.inlet,
+            destination=self.o2_separator.inlet,
         )
         self.strm3 = Arc(
-            doc="Oxygen seperation to hydrogen side outlet translator",
-            source=self.o2_seperator.h2_strm,
+            doc="Oxygen separation to hydrogen side outlet translator",
+            source=self.o2_separator.h2_strm,
             destination=self.h2_outlet_translator.inlet,
         )
         self.strm4 = Arc(
-            doc="Oxygen from electrolysis to translator to sweep properies",
-            source=self.o2_seperator.o2_strm,
+            doc="Oxygen from electrolysis to translator to sweep properties",
+            source=self.o2_separator.o2_strm,
             destination=self.o2_translator.inlet,
         )
         self.strm5 = Arc(
@@ -248,7 +248,7 @@ class SoecDesignData(UnitModelBlockData):
             self.flowsheet().time,
             initialize=0,
             units=pyo.units.ampere,
-            doc="SOEC module electric currrent",
+            doc="SOEC module electric current",
         )
         self.water_utilization = pyo.Var(
             self.flowsheet().time,
@@ -265,7 +265,7 @@ class SoecDesignData(UnitModelBlockData):
             self.flowsheet().time,
             units=pyo.units.W,
             initialize=0,
-            doc="Heat transfered to the module",
+            doc="Heat transferred to the module",
         )
         self.hydrogen_side_outlet_temperature = pyo.Reference(
             self.electrolysis_reactor.control_volume.properties_out[:].temperature
@@ -320,10 +320,10 @@ class SoecDesignData(UnitModelBlockData):
         def current_eqn(b, t):
             return b.current[t] == b.current_expr[t]
 
-        # Fix the O2 seperator split fractions to just remove O2 from fuel side
-        self.o2_seperator.split_fraction[:, "o2_strm", "O2"].fix(1)
-        self.o2_seperator.split_fraction[:, "o2_strm", "H2O"].fix(0)
-        self.o2_seperator.split_fraction[:, "o2_strm", "H2"].fix(0)
+        # Fix the O2 separator split fractions to just remove O2 from fuel side
+        self.o2_separator.split_fraction[:, "o2_strm", "O2"].fix(1)
+        self.o2_separator.split_fraction[:, "o2_strm", "H2O"].fix(0)
+        self.o2_separator.split_fraction[:, "o2_strm", "H2"].fix(0)
 
         @self.o2_mixer.Constraint(self.flowsheet().time)
         def pressure_eqn(b, t):
@@ -338,7 +338,7 @@ class SoecDesignData(UnitModelBlockData):
         @self.Expression(self.flowsheet().time)
         def delta_enth(b, t):
             return (
-                b.o2_seperator.h2_strm_state[t].get_enthalpy_flow_terms("Vap")
+                b.o2_separator.h2_strm_state[t].get_enthalpy_flow_terms("Vap")
                 + b.sweep_heater.control_volume.properties_out[
                     t
                 ].get_enthalpy_flow_terms("Vap")
@@ -370,7 +370,7 @@ class SoecDesignData(UnitModelBlockData):
             return b.properties_out[t].pressure == b.properties_in[t].pressure
 
     def _add_o2_translator_constraints(self):
-        """Add constraints to traslate from electrolysis properties to sweep
+        """Add constraints to translate from electrolysis properties to sweep
         properties.  The stream being translated contains only O2.
         """
         t0 = self.flowsheet().time.first()
@@ -394,7 +394,7 @@ class SoecDesignData(UnitModelBlockData):
         # for this due to the sum = 1 constraint
         self.o2_translator.properties_out[:].mole_frac_comp["O2"] = 1e-19
 
-        # Add constraints for the other componets
+        # Add constraints for the other components
         comps = set(self.h2_inlet_translator.properties_in[t0].mole_frac_comp.keys())
 
         @self.h2_inlet_translator.Constraint(self.flowsheet().time, comps)
@@ -411,7 +411,7 @@ class SoecDesignData(UnitModelBlockData):
         This stream contains only H2 and H2O.
         """
         t0 = self.flowsheet().time.first()
-        # Add constraints for the other componets
+        # Add constraints for the other components
         comps = set(self.h2_outlet_translator.properties_out[t0].mole_frac_comp.keys())
         comps.remove("H2")  # Need to remove one component due to sum = 1 constraint
 
@@ -541,7 +541,7 @@ class SoecDesignData(UnitModelBlockData):
         iscale.set_scaling_factor(
             unt.control_volume.properties_out[0.0].enth_mol_phase["Vap"], 1e-4
         )
-        unt = self.o2_seperator
+        unt = self.o2_separator
         iscale.set_scaling_factor(unt.h2_strm_state[0.0].enth_mol_phase["Vap"], 1e-4)
         unt = self.o2_mixer
         iscale.set_scaling_factor(unt.o2_strm_state[0.0].enth_mol_phase["Vap"], 1e-4)
@@ -681,7 +681,7 @@ class SoecDesignData(UnitModelBlockData):
             outlvl=outlvl, solver=solver, optarg=optarg
         )
         propagate_state(self.strm2)
-        self.o2_seperator.initialize(outlvl=outlvl, solver=solver, optarg=optarg)
+        self.o2_separator.initialize(outlvl=outlvl, solver=solver, optarg=optarg)
         propagate_state(self.strm3)
         self.h2_outlet_translator.initialize(
             outlvl=outlvl, solver=solver, optarg=optarg

--- a/idaes/models_extra/power_generation/unit_models/tests/test_soec_design.py
+++ b/idaes/models_extra/power_generation/unit_models/tests/test_soec_design.py
@@ -23,6 +23,7 @@ from idaes.models_extra.power_generation.unit_models.soec_design import (
     SoecDesign,
     EosType,
 )
+from idaes.core.solvers import get_solver
 import pytest
 
 
@@ -76,7 +77,7 @@ def flowsheet(eos=EosType.PR):
 @pytest.mark.component
 def test_soec_design_ideal():
     m = flowsheet(eos=EosType.IDEAL)
-    solver = pyo.SolverFactory("ipopt")
+    solver = get_solver(solver="ipopt")
     res = solver.solve(m)
     # Make sure it converged
     assert pyo.check_optimal_termination(res)
@@ -84,14 +85,14 @@ def test_soec_design_ideal():
     assert pytest.approx(0.703) == pyo.value(
         m.fs.soec.hydrogen_side_outlet.mole_frac_comp[0, "H2"]
     )
-    # should be at the thermoneutral volatage and I know about what that is
+    # should be at the thermoneutral voltage and I know about what that is
     assert pytest.approx(1.287, abs=0.02) == pyo.value(m.fs.soec.cell_potential[0])
 
 
 @pytest.mark.component
 def test_soec_design_pr():
     m = flowsheet(eos=EosType.IDEAL)
-    solver = pyo.SolverFactory("ipopt")
+    solver = get_solver(solver="ipopt")
     res = solver.solve(m)
     # Make sure it converged
     assert pyo.check_optimal_termination(res)
@@ -99,5 +100,5 @@ def test_soec_design_pr():
     assert pytest.approx(0.703) == pyo.value(
         m.fs.soec.hydrogen_side_outlet.mole_frac_comp[0, "H2"]
     )
-    # should be at the thermoneutral volatage and I know about what that is
+    # should be at the thermoneutral voltage and I know about what that is
     assert pytest.approx(1.287, abs=0.02) == pyo.value(m.fs.soec.cell_potential[0])


### PR DESCRIPTION
## Fixes #1099 

This sets the ipopt default config to have a max_iter of 200.  This can be overridden by explicitly setting max_iter if you are using get_solver() or have the IDAES solver config system turned on. I do not think this breaks any tests in the main repo, but it could break an example.  If you set the iteration limit too low pretty much all tests fail, so I know this is working, but I don't really know if 200 is too high.  At some point we should take a harder look at fragile tests and possibly tune this in the process.

The purpose of this is to let people now if they set something up that requires a suspiciously large number of iterations and to limit the amount of time a failing test can take.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
