### PR TITLE
Resolve Pylint rendering failures

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -178,7 +178,13 @@ jobs:
         if: failure()
         run: |
           base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blame/$GITHUB_SHA"
-          echo -e "## Pylint report\n" >> "$GITHUB_STEP_SUMMARY"
+
+          echo '
+          ## Pylint failures
+
+          For more information, refer to the [Pylint section](https://github.com/IDAES/idaes-pse/wiki/IDAES-Check-Suite#pylint) of the [IDAES check suite Wiki page](https://github.com/IDAES/idaes-pse/wiki/IDAES-Check-Suite).
+
+          ' >> "$GITHUB_STEP_SUMMARY"
           python .pylint/render_report.py --base-url="$base_url" --markdown-output-path="$GITHUB_STEP_SUMMARY" --pylint-data-path="$pylint_output_path"
       - name: Show PYLINT-TODO comments left in the codebase
         if: always()

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -178,7 +178,8 @@ jobs:
         if: failure()
         run: |
           base_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blame/$GITHUB_SHA"
-          python .pylint/render_report.py --base-url="$base_url" "$pylint_output_path"
+          echo -e "## Pylint report\n" >> "$GITHUB_STEP_SUMMARY"
+          python .pylint/render_report.py --base-url="$base_url" --markdown-output-path="$GITHUB_STEP_SUMMARY" --pylint-data-path="$pylint_output_path"
       - name: Show PYLINT-TODO comments left in the codebase
         if: always()
         run: |

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -147,7 +147,7 @@ jobs:
           retention-days: 7
 
   pylint:
-    name: pylint (errors only)
+    name: Pylint
     runs-on: ubuntu-latest
     needs: [code-formatting]
     env:

--- a/.pylint/render_report.py
+++ b/.pylint/render_report.py
@@ -40,7 +40,6 @@ class PylintRecord:
             line=line,
             path_url=path_url,
             line_url=line_url,
-            line=int(d.pop("line")),
             column=int(d.pop("column")),
             symbol=d.pop("symbol"),
             message=d.pop("message"),

--- a/.pylint/render_report.py
+++ b/.pylint/render_report.py
@@ -35,6 +35,9 @@ class PylintRecord:
         path_url = f"{base_url}/{path}"
         line_url = f"{path_url}#L{line}"
         return cls(
+            type=d.pop("type"),
+            module=d.pop("module"),
+            obj=d.pop("obj"),
             message_id=d.pop("message-id"),
             path=path,
             line=line,

--- a/.pylint/render_report.py
+++ b/.pylint/render_report.py
@@ -103,9 +103,7 @@ class Options:
     @classmethod
     def from_cli_args(cls, args: Optional[Iterable[str]] = None) -> "Options":
         parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "--pylint-data-path", default="./pylint.json"
-        )
+        parser.add_argument("--pylint-data-path", default="./pylint.json")
         parser.add_argument(
             "--base-url",
             default="https://github.com/IDAES/idaes-pse/tree/main",
@@ -119,7 +117,9 @@ class Options:
         return cls(
             pylint_data_path=Path(parsed.pylint_data_path),
             base_url=str(parsed.base_url),
-            markdown_output_path=Path(parsed.markdown_output_path) if parsed.markdown_output_path else None
+            markdown_output_path=Path(parsed.markdown_output_path)
+            if parsed.markdown_output_path
+            else None,
         )
 
 

--- a/.pylint/render_report.py
+++ b/.pylint/render_report.py
@@ -40,7 +40,10 @@ class PylintRecord:
             line=line,
             path_url=path_url,
             line_url=line_url,
-            **d,
+            line=int(d.pop("line")),
+            column=int(d.pop("column")),
+            symbol=d.pop("symbol"),
+            message=d.pop("message"),
         )
 
 

--- a/idaes/__init__.py
+++ b/idaes/__init__.py
@@ -27,6 +27,16 @@ from . import config
 from .ver import __version__  # noqa
 
 
+def _annoy_pylint(dangerous_default={}):
+    i = None
+    try:
+        a = i[b]
+    except:
+        do_something()
+        pass
+    return c
+
+
 def _handle_optional_compat_activation(
     env_var: str = "IDAES_ACTIVATE_V1_COMPAT",
 ):

--- a/idaes/__init__.py
+++ b/idaes/__init__.py
@@ -27,16 +27,6 @@ from . import config
 from .ver import __version__  # noqa
 
 
-def _annoy_pylint(dangerous_default={}):
-    i = None
-    try:
-        a = i[b]
-    except:
-        do_something()
-        pass
-    return c
-
-
 def _handle_optional_compat_activation(
     env_var: str = "IDAES_ACTIVATE_V1_COMPAT",
 ):


### PR DESCRIPTION
## Resolves: #1134

## Summary/Motivation:

- The cause of the failure seems to be an unexpected item in the dictionary containing the per-error information (which is provided by Pylint and therefore out of our control)
- The solution is to "pick and choose" what data to take from this dictionary instead of unpacking the entire rest of the `dict`

## Changes proposed in this PR:

- Change how Pylint-provided data is passed to our own custom reporting classes used to render the errors


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
