### PR TITLE
Activing pylint C and I flags in GHA

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -173,7 +173,7 @@ jobs:
           echo "::group::Display pylint version"
           pip show pylint astroid
           echo "::endgroup::"
-          pylint --rcfile=./.pylint/pylintrc --disable=C,R,I --output-format=idaes_reporters.MultiReporter "$pylint_target_dir"
+          pylint --rcfile=./.pylint/pylintrc --disable=R --output-format=idaes_reporters.MultiReporter "$pylint_target_dir"
       - name: Generate pylint report on failure
         if: failure()
         run: |


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
I forgot to activate the C(onvention) and I(nformation) flags in our GHA run.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
