### PR TITLE
Creating issue in initialaiztion tester that left Sets attached ot model

### DIFF
--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -83,16 +83,17 @@ def initialization_tester(m, dof=0, unit=None, **init_kwargs):
     unit.__dummy_var = Var()
     unit.__dummy_equality = Constraint(expr=unit.__dummy_var == 5)
     unit.__dummy_inequality = Constraint(expr=unit.__dummy_var <= 10)
+    unit.__dummy_set = Set(initialize=[1])
 
     def deq_idx(b, i):
         return unit.__dummy_var == 5
 
-    unit.__dummy_equality_idx = Constraint([1], rule=deq_idx)
+    unit.__dummy_equality_idx = Constraint(unit.__dummy_set, rule=deq_idx)
 
     def dieq_idx(b, i):
         return unit.__dummy_var <= 10
 
-    unit.__dummy_inequality_idx = Constraint([1], rule=dieq_idx)
+    unit.__dummy_inequality_idx = Constraint(unit.__dummy_set, rule=dieq_idx)
 
     unit.__dummy_equality.deactivate()
     unit.__dummy_inequality.deactivate()
@@ -128,6 +129,7 @@ def initialization_tester(m, dof=0, unit=None, **init_kwargs):
     unit.del_component(unit.__dummy_inequality_idx)
     unit.del_component(unit.__dummy_equality_idx)
     unit.del_component(unit.__dummy_var)
+    unit.del_component(unit.__dummy_set)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Fixes #1141


## Summary/Motivation:
The `initialization_tester` function implicitly created some indexing `Set` which were not cleaned up after execution and prevented the function from being run twice on the same model.

## Changes proposed in this PR:
- Explicitly create indexing `Set` in `initialization_tester` and remove when finished.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
