### PR TITLE
Fixing model statistics to work for indexed blocks

### DIFF
--- a/idaes/core/util/model_statistics.py
+++ b/idaes/core/util/model_statistics.py
@@ -27,6 +27,24 @@ from pyomo.common.collections import ComponentSet
 
 
 # -------------------------------------------------------------------------
+# Generator to handle cases where the input is an indexed Block
+# Indexed blocks do not have component_data_objects, so we need to iterate
+# over the indexed block first.
+def _iter_indexed_block_data_objects(block, ctype, active, descend_into):
+    if block.is_indexed():
+        for bd in block.values():
+            for c in bd.component_data_objects(
+                ctype=ctype, active=active, descend_into=descend_into
+            ):
+                yield c
+    else:
+        for c in block.component_data_objects(
+            ctype=ctype, active=active, descend_into=descend_into
+        ):
+            yield c
+
+
+# -------------------------------------------------------------------------
 # Block methods
 def total_blocks_set(block):
     """
@@ -40,7 +58,9 @@ def total_blocks_set(block):
         itself)
     """
     total_blocks_set = ComponentSet(
-        block.component_data_objects(ctype=Block, active=None, descend_into=True)
+        _iter_indexed_block_data_objects(
+            block, ctype=Block, active=None, descend_into=True
+        )
     )
     total_blocks_set.add(block)
     return total_blocks_set
@@ -60,8 +80,8 @@ def number_total_blocks(block):
     return (
         sum(
             1
-            for _ in block.component_data_objects(
-                ctype=Block, active=None, descend_into=True
+            for _ in _iter_indexed_block_data_objects(
+                block, ctype=Block, active=None, descend_into=True
             )
         )
         + 1
@@ -83,8 +103,8 @@ def activated_blocks_set(block):
     block_set = ComponentSet()
     if block.active:
         block_set.add(block)
-        for b in block.component_data_objects(
-            ctype=Block, active=True, descend_into=True
+        for b in _iter_indexed_block_data_objects(
+            block, ctype=Block, active=True, descend_into=True
         ):
             block_set.add(b)
     return block_set
@@ -105,8 +125,8 @@ def number_activated_blocks(block):
         b = 1
         b += sum(
             1
-            for _ in block.component_data_objects(
-                ctype=Block, active=True, descend_into=True
+            for _ in _iter_indexed_block_data_objects(
+                block, ctype=Block, active=True, descend_into=True
             )
         )
     return b
@@ -315,7 +335,9 @@ def activated_equalities_generator(block):
         A generator which returns all activated equality Constraint components
         block
     """
-    for c in block.component_data_objects(Constraint, active=True, descend_into=True):
+    for c in _iter_indexed_block_data_objects(
+        block, Constraint, active=True, descend_into=True
+    ):
         if (
             c.upper is not None
             and c.lower is not None
@@ -457,7 +479,9 @@ def activated_inequalities_generator(block):
         A generator which returns all activated inequality Constraint
         components block
     """
-    for c in block.component_data_objects(Constraint, active=True, descend_into=True):
+    for c in _iter_indexed_block_data_objects(
+        block, Constraint, active=True, descend_into=True
+    ):
         if c.upper is None or c.lower is None:
             yield c
 
@@ -552,7 +576,9 @@ def variables_set(block):
         A ComponentSet including all Var components in block
     """
     return ComponentSet(
-        block.component_data_objects(ctype=Var, active=True, descend_into=True)
+        _iter_indexed_block_data_objects(
+            block, ctype=Var, active=True, descend_into=True
+        )
     )
 
 
@@ -579,7 +605,9 @@ def fixed_variables_generator(block):
     Returns:
         A generator which returns all fixed Var components block
     """
-    for v in block.component_data_objects(ctype=Var, active=True, descend_into=True):
+    for v in _iter_indexed_block_data_objects(
+        block, ctype=Var, active=True, descend_into=True
+    ):
         if v.fixed:
             yield v
 
@@ -620,7 +648,9 @@ def unfixed_variables_generator(block):
     Returns:
         A generator which returns all unfixed Var components block
     """
-    for v in block.component_data_objects(ctype=Var, active=True, descend_into=True):
+    for v in _iter_indexed_block_data_objects(
+        block, ctype=Var, active=True, descend_into=True
+    ):
         if not v.fixed:
             yield v
 
@@ -669,7 +699,9 @@ def variables_near_bounds_generator(
         A generator which returns all Var components block that are close to a
         bound
     """
-    for v in block.component_data_objects(ctype=Var, active=True, descend_into=True):
+    for v in _iter_indexed_block_data_objects(
+        block, ctype=Var, active=True, descend_into=True
+    ):
         # To avoid errors, check that v has a value
         if v.value is None:
             continue
@@ -749,8 +781,8 @@ def variables_in_activated_constraints_set(block):
         activated Constraints in block
     """
     var_set = ComponentSet()
-    for c in block.component_data_objects(
-        ctype=Constraint, active=True, descend_into=True
+    for c in _iter_indexed_block_data_objects(
+        block, ctype=Constraint, active=True, descend_into=True
     ):
         for v in identify_variables(c.body):
             var_set.add(v)
@@ -788,7 +820,9 @@ def variables_not_in_activated_constraints_set(block):
 
     active_vars = variables_in_activated_constraints_set(block)
 
-    for v in block.component_data_objects(ctype=Var, active=True, descend_into=True):
+    for v in _iter_indexed_block_data_objects(
+        block, ctype=Var, active=True, descend_into=True
+    ):
         if v not in active_vars:
             var_set.add(v)
     return var_set
@@ -1094,8 +1128,8 @@ def derivative_variables_set(block):
         block
     """
     return ComponentSet(
-        block.component_data_objects(
-            ctype=DerivativeVar, active=True, descend_into=True
+        _iter_indexed_block_data_objects(
+            block, ctype=DerivativeVar, active=True, descend_into=True
         )
     )
 
@@ -1263,7 +1297,9 @@ def expressions_set(block):
         block
     """
     return ComponentSet(
-        block.component_data_objects(ctype=Expression, active=True, descend_into=True)
+        _iter_indexed_block_data_objects(
+            block, ctype=Expression, active=True, descend_into=True
+        )
     )
 
 
@@ -1319,8 +1355,8 @@ def large_residuals_set(block, tol=1e-5, return_residual_values=False):
     large_residuals_set = ComponentSet()
     if return_residual_values:
         residual_values = dict()
-    for c in block.component_data_objects(
-        ctype=Constraint, active=True, descend_into=True
+    for c in _iter_indexed_block_data_objects(
+        block, ctype=Constraint, active=True, descend_into=True
     ):
         try:
             r = 0.0  # residual
@@ -1376,8 +1412,8 @@ def number_large_residuals(block, tol=1e-5):
         appear in block
     """
     lr = 0
-    for c in block.component_data_objects(
-        ctype=Constraint, active=True, descend_into=True
+    for c in _iter_indexed_block_data_objects(
+        block, ctype=Constraint, active=True, descend_into=True
     ):
         if c.active and value(c.lower - c.body()) > tol:
             lr += 1
@@ -1519,10 +1555,14 @@ def activated_block_component_generator(block, ctype):
         activated Blocks in block
     """
     # Yield local components first
-    for c in block.component_data_objects(ctype=ctype, active=None, descend_into=False):
+    for c in _iter_indexed_block_data_objects(
+        block, ctype=ctype, active=None, descend_into=False
+    ):
         yield c
 
     # Then yield components in active sub-blocks
-    for b in block.component_data_objects(ctype=Block, active=True, descend_into=True):
+    for b in _iter_indexed_block_data_objects(
+        block, ctype=Block, active=True, descend_into=True
+    ):
         for c in b.component_data_objects(ctype=ctype, active=None, descend_into=False):
             yield c

--- a/idaes/core/util/tests/test_model_statistics.py
+++ b/idaes/core/util/tests/test_model_statistics.py
@@ -30,6 +30,38 @@ from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.common.collections import ComponentSet
 
 from idaes.core.util.model_statistics import *
+from idaes.core.util.model_statistics import _iter_indexed_block_data_objects
+
+
+@pytest.mark.unit
+def test_iter_indexed_block_data_objects_scalar_block():
+    m = ConcreteModel()
+
+    m.s = Set(initialize=["a", "b"])
+    m.b = Block()
+
+    m.b.v = Var(m.s, initialize=1, bounds=(0, 10))
+
+    chk_lst = list(_iter_indexed_block_data_objects(m.b, Var, True, True))
+    assert len(chk_lst) == 2
+    for v in chk_lst:
+        assert v.name in ["b.v[a]", "b.v[b]"]
+
+
+@pytest.mark.unit
+def test_iter_indexed_block_data_objects_indexed_block():
+    m = ConcreteModel()
+
+    m.s = Set(initialize=["a", "b"])
+    m.b = Block(m.s)
+
+    m.b["a"].v = Var(m.s, initialize=1, bounds=(0, 10))
+    m.b["b"].v = Var(m.s, initialize=1, bounds=(0, 10))
+
+    chk_lst = list(_iter_indexed_block_data_objects(m.b, Var, True, True))
+    assert len(chk_lst) == 4
+    for v in chk_lst:
+        assert v.name in ["b[a].v[a]", "b[a].v[b]", "b[b].v[a]", "b[b].v[b]"]
 
 
 # Author: Andrew Lee
@@ -92,31 +124,37 @@ def m():
 @pytest.mark.unit
 def test_total_blocks_set(m):
     assert len(total_blocks_set(m)) == 5
+    assert len(total_blocks_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_total_blocks(m):
     assert number_total_blocks(m) == 5
+    assert number_total_blocks(m.b2) == 1
 
 
 @pytest.mark.unit
 def test_activated_blocks_set(m):
     assert len(activated_blocks_set(m)) == 3
+    assert len(activated_blocks_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_activated_blocks(m):
     assert number_activated_blocks(m) == 3
+    assert number_activated_blocks(m.b2) == 1
 
 
 @pytest.mark.unit
 def test_deactivated_blocks_set(m):
     assert len(deactivated_blocks_set(m)) == 2
+    assert len(deactivated_blocks_set(m.b2)) == 0
 
 
 @pytest.mark.unit
 def test_number_deactivated_blocks(m):
     assert number_deactivated_blocks(m) == 2
+    assert number_deactivated_blocks(m.b2) == 0
 
 
 # -------------------------------------------------------------------------
@@ -124,31 +162,37 @@ def test_number_deactivated_blocks(m):
 @pytest.mark.unit
 def test_total_constraints_set(m):
     assert len(total_constraints_set(m)) == 14
+    assert len(total_constraints_set(m.b2)) == 4
 
 
 @pytest.mark.unit
 def test_number_total_constraints(m):
     assert number_total_constraints(m) == 14
+    assert number_total_constraints(m.b2) == 4
 
 
 @pytest.mark.unit
 def test_activated_constraints_set(m):
     assert len(activated_constraints_set(m)) == 12
+    assert len(activated_constraints_set(m.b2)) == 2
 
 
 @pytest.mark.unit
 def test_number_activated_constraints(m):
     assert number_activated_constraints(m) == 12
+    assert number_activated_constraints(m.b2) == 2
 
 
 @pytest.mark.unit
 def test_deactivated_constraints_set(m):
     assert len(deactivated_constraints_set(m)) == 2
+    assert len(deactivated_constraints_set(m.b2)) == 2
 
 
 @pytest.mark.unit
 def test_number_deactivated_constraints(m):
     assert number_deactivated_constraints(m) == 2
+    assert number_deactivated_constraints(m.b2) == 2
 
 
 # -------------------------------------------------------------------------
@@ -156,31 +200,37 @@ def test_number_deactivated_constraints(m):
 @pytest.mark.unit
 def test_total_equalities_set(m):
     assert len(total_equalities_set(m)) == 12
+    assert len(total_equalities_set(m.b2)) == 2
 
 
 @pytest.mark.unit
 def test_number_total_equalities(m):
     assert number_total_equalities(m) == 12
+    assert number_total_equalities(m.b2) == 2
 
 
 @pytest.mark.unit
 def test_activated_equalities_set(m):
     assert len(activated_equalities_set(m)) == 11
+    assert len(activated_equalities_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_activated_equalities(m):
     assert number_activated_equalities(m) == 11
+    assert number_activated_equalities(m.b2) == 1
 
 
 @pytest.mark.unit
 def test_deactivated_equalities_set(m):
     assert len(deactivated_equalities_set(m)) == 1
+    assert len(deactivated_equalities_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_deactivated_equalities(m):
     assert number_deactivated_equalities(m) == 1
+    assert number_deactivated_equalities(m.b2) == 1
 
 
 # -------------------------------------------------------------------------
@@ -188,65 +238,77 @@ def test_number_deactivated_equalities(m):
 @pytest.mark.unit
 def test_total_inequalities_set(m):
     assert len(total_inequalities_set(m)) == 2
+    assert len(total_inequalities_set(m.b2)) == 2
 
 
 @pytest.mark.unit
 def test_number_total_inequalities(m):
     assert number_total_inequalities(m) == 2
+    assert number_total_inequalities(m.b2) == 2
 
 
 @pytest.mark.unit
 def test_activated_inequalities_set(m):
     assert len(activated_inequalities_set(m)) == 1
+    assert len(activated_inequalities_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_activated_inequalities(m):
     assert number_activated_inequalities(m) == 1
+    assert number_activated_inequalities(m.b2) == 1
 
 
 @pytest.mark.unit
 def test_deactivated_inequalities_set(m):
     assert len(deactivated_inequalities_set(m)) == 1
+    assert len(deactivated_inequalities_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_deactivated_inequalities(m):
     assert number_deactivated_inequalities(m) == 1
+    assert number_deactivated_inequalities(m.b2) == 1
 
 
 # -------------------------------------------------------------------------
 # Basic Variable Methods
 # Always use ComponentSets for Vars to avoid duplication of References
-# i.e. number methods should alwys use the ComponentSet, not a generator
+# i.e. number methods should always use the ComponentSet, not a generator
 @pytest.mark.unit
 def test_variables_set(m):
     assert len(variables_set(m)) == 28
+    assert len(variables_set(m.b2)) == 6
 
 
 @pytest.mark.unit
 def test_number_variables(m):
     assert number_variables(m) == 28
+    assert number_variables(m.b2) == 6
 
 
 @pytest.mark.unit
 def test_fixed_variables_set(m):
     assert len(fixed_variables_set(m)) == 2
+    assert len(fixed_variables_set(m.b2)) == 2
 
 
 @pytest.mark.unit
 def test_number_fixed_variables(m):
     assert number_fixed_variables(m) == 2
+    assert number_fixed_variables(m.b2) == 2
 
 
 @pytest.mark.unit
 def test_unfixed_variables_set(m):
     assert len(unfixed_variables_set(m)) == 26
+    assert len(unfixed_variables_set(m.b2)) == 4
 
 
 @pytest.mark.unit
 def test_number_unfixed_variables(m):
     assert number_unfixed_variables(m) == 26
+    assert number_unfixed_variables(m.b2) == 4
 
 
 @pytest.mark.unit
@@ -325,6 +387,7 @@ def test_variables_near_bounds_set(m):
 @pytest.mark.unit
 def test_number_variables_near_bounds(m):
     assert number_variables_near_bounds(m) == 6
+    assert number_variables_near_bounds(m.b2) == 6
 
 
 # -------------------------------------------------------------------------
@@ -332,41 +395,49 @@ def test_number_variables_near_bounds(m):
 @pytest.mark.unit
 def test_variables_in_activated_constraints_set(m):
     assert len(variables_in_activated_constraints_set(m)) == 22
+    assert len(variables_in_activated_constraints_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_variables_in_activated_constraints(m):
     assert number_variables_in_activated_constraints(m) == 22
+    assert number_variables_in_activated_constraints(m.b2) == 1
 
 
 @pytest.mark.unit
 def test_variables_not_in_activated_constraints_set(m):
     assert len(variables_not_in_activated_constraints_set(m)) == 6
+    assert len(variables_not_in_activated_constraints_set(m.b2)) == 5
 
 
 @pytest.mark.unit
 def test_number_variables_not_in_activated_constraints(m):
     assert number_variables_not_in_activated_constraints(m) == 6
+    assert number_variables_not_in_activated_constraints(m.b2) == 5
 
 
 @pytest.mark.unit
 def test_variables_in_activated_equalities_set(m):
     assert len(variables_in_activated_equalities_set(m)) == 22
+    assert len(variables_in_activated_equalities_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_variables_in_activated_equalities(m):
     assert number_variables_in_activated_equalities(m) == 22
+    assert number_variables_in_activated_equalities(m.b2) == 1
 
 
 @pytest.mark.unit
 def test_variables_in_activated_inequalities_set(m):
     assert len(variables_in_activated_inequalities_set(m)) == 1
+    assert len(variables_in_activated_inequalities_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_variables_in_activated_inequalities(m):
     assert number_variables_in_activated_inequalities(m) == 1
+    assert number_variables_in_activated_inequalities(m.b2) == 1
 
 
 @pytest.mark.unit
@@ -374,6 +445,7 @@ def test_variables_only_in_inequalities(m):
     m.v3 = Var(initialize=1)
     m.c3 = Constraint(expr=m.v3 >= 1)
     assert len(variables_only_in_inequalities(m)) == 1
+    assert len(variables_only_in_inequalities(m.b2)) == 0
 
 
 @pytest.mark.unit
@@ -381,6 +453,7 @@ def test_number_variables_only_in_inequalities(m):
     m.v3 = Var(initialize=1)
     m.c3 = Constraint(expr=m.v3 >= 1)
     assert number_variables_only_in_inequalities(m) == 1
+    assert number_variables_only_in_inequalities(m.b2) == 0
 
 
 # -------------------------------------------------------------------------
@@ -388,11 +461,13 @@ def test_number_variables_only_in_inequalities(m):
 @pytest.mark.unit
 def test_fixed_variables_in_activated_equalities_set(m):
     assert len(fixed_variables_in_activated_equalities_set(m)) == 1
+    assert len(fixed_variables_in_activated_equalities_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_fixed_variables_in_activated_equalities(m):
     assert number_fixed_variables_in_activated_equalities(m) == 1
+    assert number_fixed_variables_in_activated_equalities(m.b2) == 1
 
 
 @pytest.mark.unit
@@ -401,6 +476,7 @@ def test_fixed_variables_only_in_inequalities(m):
     m.v3.fix(1)
     m.c3 = Constraint(expr=m.v3 >= 1)
     assert len(fixed_variables_only_in_inequalities(m)) == 1
+    assert len(fixed_variables_only_in_inequalities(m.b2)) == 0
 
 
 @pytest.mark.unit
@@ -409,6 +485,7 @@ def test_number_fixed_variables_only_in_inequalities(m):
     m.v3.fix(1)
     m.c3 = Constraint(expr=m.v3 >= 1)
     assert number_fixed_variables_only_in_inequalities(m) == 1
+    assert number_fixed_variables_only_in_inequalities(m.b2) == 0
 
 
 # -------------------------------------------------------------------------
@@ -416,21 +493,25 @@ def test_number_fixed_variables_only_in_inequalities(m):
 @pytest.mark.unit
 def test_unused_variables_set(m):
     assert len(unused_variables_set(m)) == 6
+    assert len(unused_variables_set(m.b2)) == 5
 
 
 @pytest.mark.unit
 def test_number_unused_variables(m):
     assert number_unused_variables(m) == 6
+    assert number_unused_variables(m.b2) == 5
 
 
 @pytest.mark.unit
 def test_fixed_unused_variables_set(m):
     assert len(fixed_unused_variables_set(m)) == 1
+    assert len(fixed_unused_variables_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_fixed_unused_variables(m):
     assert number_fixed_unused_variables(m) == 1
+    assert number_fixed_unused_variables(m.b2) == 1
 
 
 @pytest.mark.unit
@@ -472,11 +553,13 @@ def test_number_derivative_variables():
 @pytest.mark.unit
 def test_total_objectives_set(m):
     assert len(total_objectives_set(m)) == 2
+    assert len(total_objectives_set(m.b2)) == 2
 
 
 @pytest.mark.unit
 def test_number_total_objectives(m):
     assert number_total_objectives(m) == 2
+    assert number_total_objectives(m.b2) == 2
 
 
 @pytest.mark.unit
@@ -487,16 +570,19 @@ def test_activated_objectives_set(m):
 @pytest.mark.unit
 def test_number_activated_objectives(m):
     assert number_activated_objectives(m) == 1
+    assert number_activated_objectives(m.b2) == 1
 
 
 @pytest.mark.unit
 def test_deactivated_objectives_set(m):
     assert len(deactivated_objectives_set(m)) == 1
+    assert len(deactivated_objectives_set(m.b2)) == 1
 
 
 @pytest.mark.unit
 def test_number_deactivated_objectives(m):
     assert number_deactivated_objectives(m) == 1
+    assert number_deactivated_objectives(m.b2) == 1
 
 
 # -------------------------------------------------------------------------
@@ -504,11 +590,13 @@ def test_number_deactivated_objectives(m):
 @pytest.mark.unit
 def test_expressions_set(m):
     assert len(expressions_set(m)) == 3
+    assert len(expressions_set(m.b2)) == 2
 
 
 @pytest.mark.unit
 def test_number_expressions(m):
     assert number_expressions(m) == 3
+    assert number_expressions(m.b2) == 2
 
 
 # -------------------------------------------------------------------------
@@ -516,6 +604,7 @@ def test_number_expressions(m):
 @pytest.mark.unit
 def test_degrees_of_freedom(m):
     assert degrees_of_freedom(m) == 10
+    assert degrees_of_freedom(m.b2) == -1
 
 
 @pytest.mark.unit
@@ -537,19 +626,31 @@ def test_number_large_residuals(m):
 @pytest.mark.unit
 def test_active_variables_in_deactivated_blocks_set(m):
     assert len(active_variables_in_deactivated_blocks_set(m)) == 0
+    assert (
+        len(active_variables_in_deactivated_blocks_set(m.b2)) == 1
+    )  # TODO: Not sure why?
 
     m.c = Constraint(expr=m.b1.v1 >= 2)
 
     assert len(active_variables_in_deactivated_blocks_set(m)) == 1
+    assert (
+        len(active_variables_in_deactivated_blocks_set(m.b2)) == 1
+    )  # TODO: Not sure why?
 
 
 @pytest.mark.unit
 def test_number_active_variables_in_deactivated_blocks(m):
     assert number_active_variables_in_deactivated_blocks(m) == 0
+    assert (
+        number_active_variables_in_deactivated_blocks(m.b2) == 1
+    )  # TODO: Not sure why?
 
     m.c = Constraint(expr=m.b1.v1 >= 2)
 
     assert number_active_variables_in_deactivated_blocks(m) == 1
+    assert (
+        number_active_variables_in_deactivated_blocks(m.b2) == 1
+    )  # TODO: Not sure why?
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
The current model statistics functions do not work when provided with an `IndexedBlock` as these do not have a `component_data_objects` method. This PR updates these methods to catch cases where the block is indexed and to first iterate over the `BlockData` objects.

## Changes proposed in this PR:
- Add new private generator method that checks for indexed blocks and iterates over BlockData objects if required.
- Update tests to cover indexed blocks.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
