### PR TITLE
Adding checks for issues with phase equilibrium in Helmholtz EoS

### DIFF
--- a/docs/reference_guides/model_libraries/generic/property_models/helmholtz.rst
+++ b/docs/reference_guides/model_libraries/generic/property_models/helmholtz.rst
@@ -63,6 +63,12 @@ two-phase presentation.  The mixed-phase presentation can be used with most
 standard unit models that do not provide phase separation.  If phase separation
 is required, either use the two-phase presentation or create a custom model.
 
+.. warning::
+    The "has_phase_equilibrium" argument is ignored when constructing Helmholtz
+    property packages using mixed phase presentation. However, setting this to
+    `True` may cause errors in unit models as it is not possible to construct
+    phase equilibrium transfer terms with only one phase present.
+
 The ``PhaseType.LG`` option appears to the IDAES framework to be two phases "Vap"
 and "Liq".  This option requires one of two unit model options to be set.  You
 can use the total material balance option for unit models, to specify that only

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -226,6 +226,13 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                     )
 
         if has_phase_equilibrium:
+            # First, check that phase equilibrium makes sense
+            if len(self.config.property_package.phase_list) < 2:
+                raise ConfigurationError(
+                    "Property package has only one phase; control volume cannot include phase "
+                    "equilibrium terms. Some property packages support phase equilibrium "
+                    "implicitly in which case additional terms are not necessary."
+                )
             # Check that state blocks are set to calculate equilibrium
             for t in self.flowsheet().time:
                 if not self.properties_out[t].config.has_phase_equilibrium:

--- a/idaes/core/base/control_volume1d.py
+++ b/idaes/core/base/control_volume1d.py
@@ -436,6 +436,13 @@ argument).""",
                         )
 
         if has_phase_equilibrium:
+            # First, check that phase equilibrium makes sense
+            if len(self.config.property_package.phase_list) < 2:
+                raise ConfigurationError(
+                    "Property package has only one phase; control volume cannot include phase "
+                    "equilibrium terms. Some property packages support phase equilibrium "
+                    "implicitly in which case additional terms are not necessary."
+                )
             # Check that state blocks are set to calculate equilibrium
             for t in self.flowsheet().time:
                 for x in self.length_domain:

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -613,6 +613,32 @@ def test_add_material_balances_rxn_mass():
     assert_units_equivalent(m.fs.cv.phase_equilibrium_generation, pp_units)
 
 
+@pytest.mark.unit
+def test_add_material_balances_single_phase_w_equilibrium():
+    from idaes.models.properties import iapws95
+
+    m = ConcreteModel()
+    m.fs = Flowsheet(dynamic=False)
+    m.fs.pp = iapws95.Iapws95ParameterBlock(
+        phase_presentation=iapws95.PhaseType.MIX, state_vars=iapws95.StateVars.PH
+    )
+
+    m.fs.cv = ControlVolume0DBlock(property_package=m.fs.pp)
+
+    m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
+
+    with pytest.raises(
+        ConfigurationError,
+        match="Property package has only one phase; control volume cannot include phase "
+        "equilibrium terms. Some property packages support phase equilibrium "
+        "implicitly in which case additional terms are not necessary.",
+    ):
+        m.fs.cv.add_material_balances(
+            balance_type=MaterialBalanceType.useDefault,
+            has_phase_equilibrium=True,
+        )
+
+
 # -----------------------------------------------------------------------------
 # Test add_phase_component_balances
 @pytest.mark.unit

--- a/idaes/core/base/tests/test_control_volume_1d.py
+++ b/idaes/core/base/tests/test_control_volume_1d.py
@@ -1244,6 +1244,38 @@ def test_add_material_balances_rxn_mass():
     assert_units_equivalent(m.fs.cv.phase_equilibrium_generation, pp_units)
 
 
+@pytest.mark.unit
+def test_add_material_balances_single_phase_w_equilibrium():
+    from idaes.models.properties import iapws95
+
+    m = ConcreteModel()
+    m.fs = Flowsheet(dynamic=False)
+    m.fs.pp = iapws95.Iapws95ParameterBlock(
+        phase_presentation=iapws95.PhaseType.MIX, state_vars=iapws95.StateVars.PH
+    )
+
+    m.fs.cv = ControlVolume1DBlock(
+        property_package=m.fs.pp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
+
+    m.fs.cv.add_geometry()
+    m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
+
+    with pytest.raises(
+        ConfigurationError,
+        match="Property package has only one phase; control volume cannot include phase "
+        "equilibrium terms. Some property packages support phase equilibrium "
+        "implicitly in which case additional terms are not necessary.",
+    ):
+        m.fs.cv.add_material_balances(
+            balance_type=MaterialBalanceType.useDefault,
+            has_phase_equilibrium=True,
+        )
+
+
 # -----------------------------------------------------------------------------
 # Test add_phase_component_balances
 @pytest.mark.unit

--- a/idaes/core/base/unit_model.py
+++ b/idaes/core/base/unit_model.py
@@ -490,7 +490,7 @@ Must be True if dynamic = True,
         except AttributeError:
             raise ConfigurationError(
                 f"Unit model {self.name} does not have the standard Port "
-                f"names (inet and outlet). Please contact the unit model "
+                f"names (inlet and outlet). Please contact the unit model "
                 f"developer to develop a unit specific stream table."
             )
 

--- a/idaes/models/properties/general_helmholtz/helmholtz_state.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_state.py
@@ -250,6 +250,17 @@ class HelmholtzStateBlockData(StateBlockData):
         params = self.config.parameters
         cmp = params.pure_component
         phase_set = params.config.phase_presentation
+
+        # Check for inconsistent phase presentation and phase equilibrium
+        if phase_set == PhaseType.MIX and self.config.has_phase_equilibrium:
+            _log.warning(
+                "Helmholtz EoS packages using Mixed phase representation ignore the "
+                "'has_phase_equilibrium' configuration argument. However, setting "
+                "this to True can result in errors when constructing material balances "
+                "due to only having a single phase (thus phase transfer terms cannot "
+                "be constructed)."
+            )
+
         # Add flow variable
         if self.amount_basis == AmountBasis.MOLE:
             self.flow_mol = pyo.Var(

--- a/idaes/models/properties/tests/test_harness.py
+++ b/idaes/models/properties/tests/test_harness.py
@@ -332,13 +332,20 @@ class PropertyTestHarness(object):
 
     @pytest.mark.component
     def test_CV_integration(self, frame):
+        # Phase equilibrium does not make sense for single phase systems, so check
+        # and only set to True if more than one phase present.
+        if len(frame.fs.params.phase_list) > 1:
+            has_pe = True
+        else:
+            has_pe = False
+
         frame.fs.cv = ControlVolume0DBlock(property_package=frame.fs.params)
 
         frame.fs.cv.add_geometry()
 
-        frame.fs.cv.add_state_blocks(has_phase_equilibrium=True)
+        frame.fs.cv.add_state_blocks(has_phase_equilibrium=has_pe)
 
-        frame.fs.cv.add_material_balances(has_phase_equilibrium=True)
+        frame.fs.cv.add_material_balances(has_phase_equilibrium=has_pe)
 
         frame.fs.cv.add_energy_balances()
 


### PR DESCRIPTION
## Fixes none


## Summary/Motivation:
An external user recently reported an issue constructing models when using the Helmholtz EoS packages with `has_phase_equilibrium=True`. This is because it is not possible to construct interphase material transfer terms when there is only one phase present. This PR adds checks to catch this issue and return useful error messages to the user.

## Changes proposed in this PR:
- Add checks in control volume code (0D and 1D) to raise a `ConfigurationError` if `has_phase_equilibrium=True` and only one phase is declared by the property package.
- Update property test harness to only set `has_phase_equilibrium=True` if property package has more than one phase.
- Log a warning in the Helmholtz EoS code if a user sets `has_phase_equilibrium=True` in a package using mixed phase representation.
- Add a warning in the Helmholtz EoS docs about phase equilibrium in mixed phase representation.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
