### PR TITLE
Simplify error check for ipopt_with_diagnostics test

### DIFF
--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -694,4 +694,4 @@ def test_ipopt_solve_halt_on_error(capsys):
         pass
 
     captured = capsys.readouterr()
-    assert "Error evaluating constraint c: can't evaluate log(-5)." in captured.out
+    assert "c: can't evaluate log(-5)." in captured.out


### PR DESCRIPTION
## Fixes test failure introduced in PR #1143 


## Summary/Motivation:
#1143 seems to have introduced a test failure on Python 3.11 where the check for an expected error message fails (possible due to line breaks).

## Changes proposed in this PR:
- Shorten expected string being tested for.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
