### PR TITLE
Update approach for documenting Config Blocks

### DIFF
--- a/idaes/core/base/process_block.py
+++ b/idaes/core/base/process_block.py
@@ -23,7 +23,7 @@ import sys
 import logging
 import inspect
 
-from pyomo.common.config import ConfigBlock
+from pyomo.common.config import ConfigBlock, String_ConfigFormatter
 from pyomo.environ import Block
 from pyomo.common.pyomo_typing import get_overloads_for
 
@@ -197,7 +197,7 @@ def declare_process_block_class(name, block_class=ProcessBlock, doc=""):
         # create a new class called name from block_class
         try:
             cb_doc = cls.CONFIG.generate_documentation(
-                format=pyomo.common.config.String_ConfigFormatter(
+                format=String_ConfigFormatter(
                     block_start="",
                     block_end="",
                     item_start="%s\n",

--- a/idaes/core/base/process_block.py
+++ b/idaes/core/base/process_block.py
@@ -197,12 +197,14 @@ def declare_process_block_class(name, block_class=ProcessBlock, doc=""):
         # create a new class called name from block_class
         try:
             cb_doc = cls.CONFIG.generate_documentation(
-                block_start="",
-                block_end="",
-                item_start="%s\n",
+                format=pyomo.common.config.String_ConfigFormatter(
+                    block_start="",
+                    block_end="",
+                    item_start="%s\n",
+                    item_body="%s",
+                    item_end="\n",
+                ),
                 indent_spacing=4,
-                item_body="%s",
-                item_end="\n",
                 width=66,
             )
             cb_doc += "\n"

--- a/idaes/core/initialization/initializer_base.py
+++ b/idaes/core/initialization/initializer_base.py
@@ -23,7 +23,7 @@ from pyomo.environ import (
     Var,
 )
 from pyomo.core.base.var import _VarData
-from pyomo.common.config import ConfigBlock, ConfigValue, add_docstring_list
+from pyomo.common.config import ConfigBlock, ConfigValue, String_ConfigFormatter
 
 from idaes.core.util.model_serializer import to_json, from_json, StoreSpec, _only_fixed
 from idaes.core.util.exceptions import InitializationError
@@ -100,8 +100,6 @@ class InitializerBase:
         ),
     )
 
-    __doc__ = add_docstring_list(__doc__, CONFIG)
-
     def __init__(self, **kwargs):
         self.config = self.CONFIG(kwargs)
 
@@ -110,7 +108,17 @@ class InitializerBase:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        cls.__doc__ = add_docstring_list(cls.__doc__ if cls.__doc__ else "", cls.CONFIG)
+        cls.__doc__ = cls.__doc__ + cls.CONFIG.generate_documentation(
+            format=String_ConfigFormatter(
+                block_start="",
+                block_end="",
+                item_start="%s\n",
+                item_body="%s",
+                item_end="\n",
+            ),
+            indent_spacing=4,
+            width=66,
+        )
 
     def get_logger(self, model):
         """Get logger for model by name"""

--- a/idaes/core/initialization/initializer_base.py
+++ b/idaes/core/initialization/initializer_base.py
@@ -492,6 +492,7 @@ class ModularInitializerBase(InitializerBase):
 
     This extends the base Initializer class to include attributes and methods for
     defining initializer objects for sub-models.
+
     """
 
     CONFIG = InitializerBase.CONFIG()

--- a/idaes/core/plugins/variable_replace.py
+++ b/idaes/core/plugins/variable_replace.py
@@ -17,7 +17,11 @@
 from pyomo.core.base.transformation import TransformationFactory
 from pyomo.core.plugins.transform.hierarchy import NonIsomorphicTransformation
 from pyomo.core.expr import current as EXPR
-from pyomo.common.config import ConfigBlock, ConfigValue, add_docstring_list
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    document_kwargs_from_configdict,
+)
 from pyomo.core.base.var import _GeneralVarData, Var
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.expression import Expression
@@ -34,6 +38,7 @@ def _is_var(v):
 @TransformationFactory.register(
     "replace_variables", doc="Replace variables with other variables."
 )
+@document_kwargs_from_configdict("CONFIG")
 class ReplaceVariables(NonIsomorphicTransformation):
     """Replace variables in a model or block with other variables.
 
@@ -53,8 +58,6 @@ class ReplaceVariables(NonIsomorphicTransformation):
             "transformation is not reversible.",
         ),
     )
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
     @staticmethod
     def replace(instance, substitute):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.30.28.zip"
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.03.28.zip"
 ]
 
 # For included DMF data

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def rglob(path, glob):
 
 
 DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.0.zip"
+    "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.30.28.zip"
 ]
 
 # For included DMF data

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ def rglob(path, glob):
     return list(map(str, p.rglob(glob)))
 
 
-DEPENDENCIES_FOR_PRERELEASE_VERSION = [
-    "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.03.28.zip"
-]
+DEPENDENCIES_FOR_PRERELEASE_VERSION = []
 
 # For included DMF data
 DMF_DATA_ROOT = "data"
@@ -78,7 +76,7 @@ kwargs = dict(
         "numpy",
         "omlt==1.1",  # fix the version for now as package evolves
         "pandas",
-        "pyomo ~= 6.5",
+        "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.03.28.zip",
         "sympy",  # pyomo differentiation
         "pint",  # pyomo units
         "networkx",  # pyomo network


### PR DESCRIPTION
## Fixes None.


## Summary/Motivation:
With Pyomo v6.5.0, some of the methods we use to document the Config Blocks in our models have been deprecated. This PR updates the relevant lines of code to use newer methods.

## Changes proposed in this PR:
- Update`process_block.py` to better format Config block and suppress deprecation warnings.
- Update how Config blocks are included in Initializers.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
