### PR TITLE
Model statistics scaling

### DIFF
--- a/idaes/core/util/model_statistics.py
+++ b/idaes/core/util/model_statistics.py
@@ -709,7 +709,7 @@ def variables_near_bounds_generator(
             continue
 
         if relative:
-            sf = get_scaling_factor(v)
+            sf = get_scaling_factor(v, default=1)
         else:
             sf = 1
 


### PR DESCRIPTION
## Summary/Motivation:
To find variables near their lower/upper bounds, judge relative proximity to bounds based on scaling factors rather than creating a surrogate scaling factor from the lower/upper bounds themselves.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
