### PR TITLE
Update Prescient requirement to 2.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ kwargs = dict(
         "nbformat",
         "numpy",
         "omlt==1.1",  # fix the version for now as package evolves
-        "pandas < 2",
+        "pandas",
         "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.03.28.zip",
         "sympy",  # pyomo differentiation
         "pint",  # pyomo units

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ kwargs = dict(
         "optional": [
             "sympy",  # idaes.core.util.expr_doc
             "tensorflow",  # idaes.core.surrogate.keras_surrogate
-            "gridx-prescient>=2.2.1",  # idaes.tests.prescient
+            "gridx-prescient>=2.2.2",  # idaes.tests.prescient
             # A Lee 11-Jan-22: no precompiled version of CoolProp available for Pyhton 3.9
             "coolprop; python_version < '3.9'",  # idaes.generic_models.properties.general.coolprop
         ],


### PR DESCRIPTION
## Fixes


## Summary/Motivation:


## Changes proposed in this PR:
- Update Prescient to today's (2023 Apr 3) release
- Remove pandas < 2 requirement

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
