### PR TITLE
Adding voltage units to `property_meta` file

### DIFF
--- a/idaes/core/base/property_meta.py
+++ b/idaes/core/base/property_meta.py
@@ -346,6 +346,10 @@ class UnitSet(object):
     def POWER(self):
         return self._mass * self._length**2 * self._time**-3
 
+    @property
+    def VOLTAGE(self):
+        return self._mass * self._length**2 * self._time**-3 * self._current**-1
+
     # Heat Related
     @property
     def HEAT_CAPACITY_MASS(self):

--- a/idaes/core/base/tests/test_property_meta.py
+++ b/idaes/core/base/tests/test_property_meta.py
@@ -196,6 +196,7 @@ derived_quantities = {
         units.kg * units.m**2 * units.s**-2 * units.K**-1 * units.mol**-1
     ),
     "power": (units.kg * units.m**2 * units.s**-3),
+    "voltage": (units.kg * units.m**2 * units.s**-3 * units.ampere**-1),
     "pressure": (units.kg * units.m**-1 * units.s**-2),
     "heat_capacity_mass": (units.m**2 * units.s**-2 * units.K**-1),
     "heat_capacity_mole": (


### PR DESCRIPTION
## Fixes
Add voltage units to `property_meta` file

## Summary/Motivation:
Add voltage units to `property_meta` file to directly call `"voltage"` when using `get_derived_units` or similar utility

## Changes proposed in this PR:
- Add voltage units to `property_meta` file

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
