### PR TITLE
Set constraint on IPython version for Python 3.8 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ kwargs = dict(
         "tinydb",
         "xlrd",  # for DMF read of old .xls Excel files
         "openpyxl",  # for DMF read of new .xls Excel files
-        # lbianchi-lbl: see https://github.com/IDAES/idaes-pse/issues/661
+        'ipython <= 8.12; python_version == "3.8"',
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Fixes

Installation failures due to the most recent version of IPython not supporting Python 3.8

![image](https://user-images.githubusercontent.com/48035537/235196774-83c1dd32-c0ec-477c-ac32-8cf3a3c4367f.png)


## Changes proposed in this PR:
- Add constraint to `ipython` requirement for Python 3.8


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
