### PR TITLE
Improve methods for fixing inlet conditions in new API

### DIFF
--- a/idaes/core/base/unit_model.py
+++ b/idaes/core/base/unit_model.py
@@ -637,7 +637,7 @@ Must be True if dynamic = True,
     def fix_initialization_states(self):
         """
         Attempts to fix inlet states by iterating over all Ports and looking for "inlet"
-        in the name
+        in the name.
 
         More complex models may need to overload this with a model-specific method.
 

--- a/idaes/models/properties/examples/tests/test_saponification_thermo.py
+++ b/idaes/models/properties/examples/tests/test_saponification_thermo.py
@@ -24,8 +24,11 @@ from idaes.models.properties.examples.saponification_thermo import (
     SaponificationParameterBlock,
     SaponificationStateBlock,
 )
-
 from idaes.core.solvers import get_solver
+from idaes.core.initialization import (
+    BlockTriangularizationInitializer,
+    InitializationStatus,
+)
 
 
 # -----------------------------------------------------------------------------
@@ -295,3 +298,18 @@ class TestStateBlock(object):
     @pytest.mark.component
     def check_units(self, model):
         assert_units_consistent(model)
+
+
+@pytest.mark.component
+def test_initializer():
+    model = ConcreteModel()
+    model.params = SaponificationParameterBlock()
+
+    model.props = model.params.build_state_block([1])
+
+    assert model.props.default_initializer is BlockTriangularizationInitializer
+
+    initializer = model.props.default_initializer()
+    initializer.initialize(model.props)
+
+    assert initializer.summary[model.props]["status"] == InitializationStatus.Ok

--- a/idaes/models/unit_models/feed_flash.py
+++ b/idaes/models/unit_models/feed_flash.py
@@ -30,6 +30,7 @@ from idaes.core import (
 )
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.tables import create_stream_table_dataframe
+from idaes.core.util.initialization import fix_state_vars
 
 __author__ = "Andrew Lee"
 
@@ -204,3 +205,12 @@ see property package for documentation.}""",
         return create_stream_table_dataframe(
             {"Outlet": self.outlet}, time_point=time_point
         )
+
+    def fix_initialization_states(self):
+        """
+        Fix feed state variables
+
+        Returns:
+            None
+        """
+        fix_state_vars(self.control_volume.properties_in)

--- a/idaes/models/unit_models/mixer.py
+++ b/idaes/models/unit_models/mixer.py
@@ -920,6 +920,33 @@ objects linked to all inlet states and the mixed state,
         self.minimum_pressure_constraint.deactivate()
         self.pressure_equality_constraints.activate()
 
+    def fix_initialization_states(self):
+        """
+        Iterate over inlet ports and fix all variables.
+
+        For Mixers with pressure equality, we will assume that pressure has been
+        correctly specified and not fix pressures.
+
+        Returns:
+            None
+        """
+        inlet_list = self.create_inlet_list()
+        print(inlet_list)
+        for p in inlet_list:
+            p_obj = getattr(self, p)
+            # Iterate over vars
+            for v in p_obj.iter_vars():
+                print(v.name)
+                if (
+                    self.config.momentum_mixing_type == MomentumMixingType.equality
+                    or self.config.momentum_mixing_type
+                    == MomentumMixingType.minimize_and_equality
+                ) and v.local_name == "pressure":
+                    # Don';'t fix pressure in cases where pressure equality is specified
+                    continue
+                else:
+                    v.fix()
+
     def initialize_build(
         blk, outlvl=idaeslog.NOTSET, optarg=None, solver=None, hold_state=False
     ):

--- a/idaes/models/unit_models/skeleton_model.py
+++ b/idaes/models/unit_models/skeleton_model.py
@@ -133,6 +133,21 @@ class SkeletonUnitModelData(ProcessBlockData):
         for k in member_dict.keys():
             p.add(member_dict[k], name=k)
 
+    def fix_initialization_states(self):
+        """
+        Attempts to fix inlet states by iterating over all Ports and looking for "inlet"
+        in the name.
+
+        Users may need to fix inlets manually if they use names which do not include "inlet".
+
+        Returns:
+            None
+        """
+        for p in self.component_objects(Port, descend_into=False):
+            if "inlet" in p.name:
+                # Assume name is correct and fix all variables inside
+                p.fix()
+
     # TODO : Work out how to make this work with new UnitModel initialization
     def initialize(
         self, outlvl=idaeslog.NOTSET, solver=None, optarg=None, initial_guess=None

--- a/idaes/models/unit_models/tests/test_cstr.py
+++ b/idaes/models/unit_models/tests/test_cstr.py
@@ -282,23 +282,23 @@ class TestInitializers:
             has_pressure_change=True,
         )
 
-        m.fs.unit.inlet.flow_vol.fix(1.0e-03)
-        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.inlet.flow_vol[0].set_value(1.0e-03)
+        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
-        m.fs.unit.inlet.temperature.fix(303.15)
-        m.fs.unit.inlet.pressure.fix(101325.0)
+        m.fs.unit.inlet.temperature[0].set_value(303.15)
+        m.fs.unit.inlet.pressure[0].set_value(101325.0)
 
-        m.fs.unit.volume.fix(1.5e-03)
-        m.fs.unit.heat_duty.fix(0)
-        m.fs.unit.deltaP.fix(0)
+        m.fs.unit.volume[0].fix(1.5e-03)
+        m.fs.unit.heat_duty[0].fix(0)
+        m.fs.unit.deltaP[0].fix(0)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = SingleControlVolumeUnitInitializer()
         initializer.initialize(model.fs.unit)
@@ -328,7 +328,17 @@ class TestInitializers:
             101325, rel=1e-5
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -357,3 +367,13 @@ class TestInitializers:
         assert value(model.fs.unit.outlet.pressure[0]) == pytest.approx(
             101325, rel=1e-5
         )
+
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_equilibrium_reactor.py
+++ b/idaes/models/unit_models/tests/test_equilibrium_reactor.py
@@ -281,22 +281,22 @@ class TestInitializers:
             has_pressure_change=True,
         )
 
-        m.fs.unit.inlet.flow_vol.fix(1.0e-03)
-        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.inlet.flow_vol[0].set_value(1.0e-03)
+        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
-        m.fs.unit.inlet.temperature.fix(303.15)
-        m.fs.unit.inlet.pressure.fix(101325.0)
+        m.fs.unit.inlet.temperature[0].set_value(303.15)
+        m.fs.unit.inlet.pressure[0].set_value(101325.0)
 
         m.fs.unit.heat_duty.fix(0)
         m.fs.unit.deltaP.fix(0)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = SingleControlVolumeUnitInitializer()
         initializer.initialize(model.fs.unit)
@@ -326,7 +326,17 @@ class TestInitializers:
             101325, rel=1e-6
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -355,3 +365,13 @@ class TestInitializers:
         assert value(model.fs.unit.outlet.pressure[0]) == pytest.approx(
             101325, rel=1e-6
         )
+
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_feed.py
+++ b/idaes/models/unit_models/tests/test_feed.py
@@ -315,13 +315,13 @@ class TestInitializers:
 
         m.fs.unit = Feed(property_package=m.fs.properties)
 
-        m.fs.unit.flow_mol.fix(100)
-        m.fs.unit.enth_mol.fix(24000)
-        m.fs.unit.pressure.fix(101325)
+        m.fs.unit.flow_mol[0].set_value(100)
+        m.fs.unit.enth_mol[0].set_value(24000)
+        m.fs.unit.pressure[0].set_value(101325)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_default_initializer(self, model):
         initializer = FeedInitializer()
         initializer.initialize(model.fs.unit)
@@ -341,7 +341,11 @@ class TestInitializers:
             model.fs.unit.properties[0].phase_frac["Liq"]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.flow_mol[0].fixed
+        assert not model.fs.unit.enth_mol[0].fixed
+        assert not model.fs.unit.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -360,3 +364,7 @@ class TestInitializers:
         assert pytest.approx(0.5953, abs=1e-4) == value(
             model.fs.unit.properties[0].phase_frac["Liq"]
         )
+
+        assert not model.fs.unit.flow_mol[0].fixed
+        assert not model.fs.unit.enth_mol[0].fixed
+        assert not model.fs.unit.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_feed_flash.py
+++ b/idaes/models/unit_models/tests/test_feed_flash.py
@@ -376,15 +376,15 @@ class TestInitializersBT:
 
         m.fs.unit = FeedFlash(property_package=m.fs.properties)
 
-        m.fs.unit.flow_mol.fix(1)
-        m.fs.unit.temperature.fix(368)
-        m.fs.unit.pressure.fix(101325)
-        m.fs.unit.mole_frac_comp[0, "benzene"].fix(0.5)
-        m.fs.unit.mole_frac_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.flow_mol[0].set_value(1)
+        m.fs.unit.temperature[0].set_value(368)
+        m.fs.unit.pressure[0].set_value(101325)
+        m.fs.unit.mole_frac_comp[0, "benzene"].set_value(0.5)
+        m.fs.unit.mole_frac_comp[0, "toluene"].set_value(0.5)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = SingleControlVolumeUnitInitializer()
         initializer.initialize(model.fs.unit)
@@ -402,7 +402,13 @@ class TestInitializersBT:
             model.fs.unit.control_volume.properties_out[0].flow_mol_phase["Vap"]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.flow_mol[0].fixed
+        assert not model.fs.unit.temperature[0].fixed
+        assert not model.fs.unit.pressure[0].fixed
+        assert not model.fs.unit.mole_frac_comp[0, "benzene"].fixed
+        assert not model.fs.unit.mole_frac_comp[0, "toluene"].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -419,3 +425,9 @@ class TestInitializersBT:
         assert pytest.approx(0.396, abs=1e-3) == value(
             model.fs.unit.control_volume.properties_out[0].flow_mol_phase["Vap"]
         )
+
+        assert not model.fs.unit.flow_mol[0].fixed
+        assert not model.fs.unit.temperature[0].fixed
+        assert not model.fs.unit.pressure[0].fixed
+        assert not model.fs.unit.mole_frac_comp[0, "benzene"].fixed
+        assert not model.fs.unit.mole_frac_comp[0, "toluene"].fixed

--- a/idaes/models/unit_models/tests/test_flash.py
+++ b/idaes/models/unit_models/tests/test_flash.py
@@ -592,18 +592,18 @@ class TestInitializersCubicBTX:
 
         m.fs.unit = Flash(property_package=m.fs.properties)
 
-        m.fs.unit.inlet.flow_mol.fix(1)
-        m.fs.unit.inlet.temperature.fix(368)
-        m.fs.unit.inlet.pressure.fix(101325)
-        m.fs.unit.inlet.mole_frac_comp[0, "benzene"].fix(0.5)
-        m.fs.unit.inlet.mole_frac_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.inlet.flow_mol[0].set_value(1)
+        m.fs.unit.inlet.temperature[0].set_value(368)
+        m.fs.unit.inlet.pressure[0].set_value(101325)
+        m.fs.unit.inlet.mole_frac_comp[0, "benzene"].set_value(0.5)
+        m.fs.unit.inlet.mole_frac_comp[0, "toluene"].set_value(0.5)
 
         m.fs.unit.heat_duty.fix(0)
         m.fs.unit.deltaP.fix(0)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = SingleControlVolumeUnitInitializer()
         initializer.initialize(model.fs.unit)
@@ -636,7 +636,13 @@ class TestInitializersCubicBTX:
             model.fs.unit.vap_outlet.mole_frac_comp[0, "toluene"]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "benzene"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "toluene"].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -668,3 +674,9 @@ class TestInitializersCubicBTX:
         assert pytest.approx(0.366, abs=1e-3) == value(
             model.fs.unit.vap_outlet.mole_frac_comp[0, "toluene"]
         )
+
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "benzene"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "toluene"].fixed

--- a/idaes/models/unit_models/tests/test_gibbs.py
+++ b/idaes/models/unit_models/tests/test_gibbs.py
@@ -461,24 +461,24 @@ class TestInitializers:
             has_pressure_change=True,
         )
 
-        m.fs.unit.inlet.flow_mol[0].fix(230.0)
-        m.fs.unit.inlet.mole_frac_comp[0, "H2"].fix(0.0435)
-        m.fs.unit.inlet.mole_frac_comp[0, "N2"].fix(0.6522)
-        m.fs.unit.inlet.mole_frac_comp[0, "O2"].fix(0.1739)
-        m.fs.unit.inlet.mole_frac_comp[0, "CO2"].fix(1e-5)
-        m.fs.unit.inlet.mole_frac_comp[0, "CH4"].fix(0.1304)
-        m.fs.unit.inlet.mole_frac_comp[0, "CO"].fix(1e-5)
-        m.fs.unit.inlet.mole_frac_comp[0, "H2O"].fix(1e-5)
-        m.fs.unit.inlet.mole_frac_comp[0, "NH3"].fix(1e-5)
-        m.fs.unit.inlet.temperature[0].fix(1500.0)
-        m.fs.unit.inlet.pressure[0].fix(101325.0)
+        m.fs.unit.inlet.flow_mol[0].set_value(230.0)
+        m.fs.unit.inlet.mole_frac_comp[0, "H2"].set_value(0.0435)
+        m.fs.unit.inlet.mole_frac_comp[0, "N2"].set_value(0.6522)
+        m.fs.unit.inlet.mole_frac_comp[0, "O2"].set_value(0.1739)
+        m.fs.unit.inlet.mole_frac_comp[0, "CO2"].set_value(1e-5)
+        m.fs.unit.inlet.mole_frac_comp[0, "CH4"].set_value(0.1304)
+        m.fs.unit.inlet.mole_frac_comp[0, "CO"].set_value(1e-5)
+        m.fs.unit.inlet.mole_frac_comp[0, "H2O"].set_value(1e-5)
+        m.fs.unit.inlet.mole_frac_comp[0, "NH3"].set_value(1e-5)
+        m.fs.unit.inlet.temperature[0].set_value(1500.0)
+        m.fs.unit.inlet.pressure[0].set_value(101325.0)
 
         m.fs.unit.outlet.temperature[0].fix(2844.38)
         m.fs.unit.deltaP.fix(0)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = SingleControlVolumeUnitInitializer()
         initializer.initialize(
@@ -531,7 +531,19 @@ class TestInitializers:
             model.fs.unit.outlet.pressure[0]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "H2"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "N2"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "O2"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "CO2"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "CH4"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "CO"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "NH3"].fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(
@@ -583,3 +595,15 @@ class TestInitializers:
         assert pytest.approx(101325.0, abs=1e-2) == value(
             model.fs.unit.outlet.pressure[0]
         )
+
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "H2"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "N2"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "O2"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "CO2"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "CH4"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "CO"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.mole_frac_comp[0, "NH3"].fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_heat_exchanger.py
+++ b/idaes/models/unit_models/tests/test_heat_exchanger.py
@@ -2122,20 +2122,20 @@ class TestInitializersIAPWS:
             flow_pattern=HeatExchangerFlowPattern.countercurrent,
         )
 
-        m.fs.unit.hot_side_inlet.flow_mol[0].fix(100)
-        m.fs.unit.hot_side_inlet.enth_mol[0].fix(6000)
-        m.fs.unit.hot_side_inlet.pressure[0].fix(101325)
+        m.fs.unit.hot_side_inlet.flow_mol[0].set_value(100)
+        m.fs.unit.hot_side_inlet.enth_mol[0].set_value(6000)
+        m.fs.unit.hot_side_inlet.pressure[0].set_value(101325)
 
-        m.fs.unit.cold_side_inlet.flow_mol[0].fix(100)
-        m.fs.unit.cold_side_inlet.enth_mol[0].fix(5000)
-        m.fs.unit.cold_side_inlet.pressure[0].fix(101325)
+        m.fs.unit.cold_side_inlet.flow_mol[0].set_value(100)
+        m.fs.unit.cold_side_inlet.enth_mol[0].set_value(5000)
+        m.fs.unit.cold_side_inlet.pressure[0].set_value(101325)
 
         m.fs.unit.area.fix(1000)
         m.fs.unit.overall_heat_transfer_coefficient.fix(100)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_hx0d_initializer(self, model):
         initializer = HX0DInitializer()
         initializer.initialize(model.fs.unit)
@@ -2163,7 +2163,15 @@ class TestInitializersIAPWS:
             model.fs.unit.cold_side_outlet.pressure[0]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.hot_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.enth_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.pressure[0].fixed
+
+        assert not model.fs.unit.cold_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.enth_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -2190,3 +2198,11 @@ class TestInitializersIAPWS:
         assert pytest.approx(101325, abs=1e2) == value(
             model.fs.unit.cold_side_outlet.pressure[0]
         )
+
+        assert not model.fs.unit.hot_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.enth_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.pressure[0].fixed
+
+        assert not model.fs.unit.cold_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.enth_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_heat_exchanger_1D.py
+++ b/idaes/models/unit_models/tests/test_heat_exchanger_1D.py
@@ -2835,21 +2835,21 @@ class TestInitializersModularCoCurrent:
         m.fs.unit.area.fix(0.5)
         m.fs.unit.heat_transfer_coefficient.fix(500)
 
-        m.fs.unit.hot_side_inlet.flow_mol[0].fix(5)  # mol/s
-        m.fs.unit.hot_side_inlet.temperature[0].fix(365)  # K
-        m.fs.unit.hot_side_inlet.pressure[0].fix(101325)  # Pa
-        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "benzene"].fix(0.5)
-        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.hot_side_inlet.flow_mol[0].set_value(5)  # mol/s
+        m.fs.unit.hot_side_inlet.temperature[0].set_value(365)  # K
+        m.fs.unit.hot_side_inlet.pressure[0].set_value(101325)  # Pa
+        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "benzene"].set_value(0.5)
+        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "toluene"].set_value(0.5)
 
-        m.fs.unit.cold_side_inlet.flow_mol[0].fix(1)  # mol/s
-        m.fs.unit.cold_side_inlet.temperature[0].fix(540)  # degR
-        m.fs.unit.cold_side_inlet.pressure[0].fix(101.325)  # kPa
-        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "benzene"].fix(0.5)
-        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "toluene"].fix(0.5)
+        m.fs.unit.cold_side_inlet.flow_mol[0].set_value(1)  # mol/s
+        m.fs.unit.cold_side_inlet.temperature[0].set_value(540)  # degR
+        m.fs.unit.cold_side_inlet.pressure[0].set_value(101.325)  # kPa
+        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "benzene"].set_value(0.5)
+        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "toluene"].set_value(0.5)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hx1d_initializer(self, model):
         initializer = HX1DInitializer()
         initializer.initialize(model.fs.unit)
@@ -2876,5 +2876,17 @@ class TestInitializersModularCoCurrent:
         assert pytest.approx(101.325, rel=1e-5) == value(
             model.fs.unit.cold_side_outlet.pressure[0]
         )
+
+        assert not model.fs.unit.hot_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.temperature[0].fixed
+        assert not model.fs.unit.hot_side_inlet.pressure[0].fixed
+        assert not model.fs.unit.hot_side_inlet.mole_frac_comp[0, "benzene"].fixed
+        assert not model.fs.unit.hot_side_inlet.mole_frac_comp[0, "toluene"].fixed
+
+        assert not model.fs.unit.cold_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.temperature[0].fixed
+        assert not model.fs.unit.cold_side_inlet.pressure[0].fixed
+        assert not model.fs.unit.cold_side_inlet.mole_frac_comp[0, "benzene"].fixed
+        assert not model.fs.unit.cold_side_inlet.mole_frac_comp[0, "toluene"].fixed
 
     # TODO: BT Initializer struggles with this case for some reason

--- a/idaes/models/unit_models/tests/test_heat_exchanger_lc.py
+++ b/idaes/models/unit_models/tests/test_heat_exchanger_lc.py
@@ -437,23 +437,23 @@ class TestInitializers:
             dynamic_heat_balance=False,
         )
 
-        m.fs.unit.hot_side_inlet.flow_vol[0].fix(1e-3)
-        m.fs.unit.hot_side_inlet.temperature[0].fix(320)
-        m.fs.unit.hot_side_inlet.pressure[0].fix(101325)
-        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.hot_side_inlet.flow_vol[0].set_value(1e-3)
+        m.fs.unit.hot_side_inlet.temperature[0].set_value(320)
+        m.fs.unit.hot_side_inlet.pressure[0].set_value(101325)
+        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.hot_side_inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
-        m.fs.unit.cold_side_inlet.flow_vol[0].fix(1e-3)
-        m.fs.unit.cold_side_inlet.temperature[0].fix(300)
-        m.fs.unit.cold_side_inlet.pressure[0].fix(101325)
-        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.cold_side_inlet.flow_vol[0].set_value(1e-3)
+        m.fs.unit.cold_side_inlet.temperature[0].set_value(300)
+        m.fs.unit.cold_side_inlet.pressure[0].set_value(101325)
+        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.cold_side_inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
         m.fs.unit.area.fix(1000)
 
@@ -466,7 +466,7 @@ class TestInitializers:
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_hx_initializer(self, model):
         initializer = HX0DInitializer()
         initializer.initialize(model.fs.unit)
@@ -525,5 +525,23 @@ class TestInitializers:
         assert pytest.approx(101325, abs=1e2) == value(
             model.fs.unit.cold_side_outlet.pressure[0]
         )
+
+        assert not model.fs.unit.hot_side_inlet.flow_vol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.temperature[0].fixed
+        assert not model.fs.unit.hot_side_inlet.pressure[0].fixed
+        assert not model.fs.unit.hot_side_inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.hot_side_inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.hot_side_inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.hot_side_inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.hot_side_inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.cold_side_inlet.flow_vol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.temperature[0].fixed
+        assert not model.fs.unit.cold_side_inlet.pressure[0].fixed
+        assert not model.fs.unit.cold_side_inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.cold_side_inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.cold_side_inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.cold_side_inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.cold_side_inlet.conc_mol_comp[0, "Ethanol"].fixed
 
     # TODO: BT initializer runs into a Max Iter failure on Windows

--- a/idaes/models/unit_models/tests/test_heater.py
+++ b/idaes/models/unit_models/tests/test_heater.py
@@ -750,20 +750,20 @@ class TestInitializersSapon:
 
         m.fs.unit = Heater(property_package=m.fs.properties)
 
-        m.fs.unit.inlet.flow_vol[0].fix(1e-3)
-        m.fs.unit.inlet.temperature[0].fix(320)
-        m.fs.unit.inlet.pressure[0].fix(101325)
-        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.inlet.flow_vol[0].set_value(1e-3)
+        m.fs.unit.inlet.temperature[0].set_value(320)
+        m.fs.unit.inlet.pressure[0].set_value(101325)
+        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
         m.fs.unit.heat_duty.fix(1000)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = SingleControlVolumeUnitInitializer()
         initializer.initialize(model.fs.unit)
@@ -780,7 +780,16 @@ class TestInitializersSapon:
         )
         assert pytest.approx(101325, abs=1e2) == value(model.fs.unit.outlet.pressure[0])
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -796,3 +805,12 @@ class TestInitializersSapon:
             model.fs.unit.outlet.temperature[0]
         )
         assert pytest.approx(101325, abs=1e2) == value(model.fs.unit.outlet.pressure[0])
+
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed

--- a/idaes/models/unit_models/tests/test_hx_ntu.py
+++ b/idaes/models/unit_models/tests/test_hx_ntu.py
@@ -537,20 +537,20 @@ class TestInitializers(object):
         )
 
         # Hot fluid
-        m.fs.unit.hot_side_inlet.flow_mol[0].fix(60.54879)
-        m.fs.unit.hot_side_inlet.temperature[0].fix(392.23)
-        m.fs.unit.hot_side_inlet.pressure[0].fix(202650)
-        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "CO2"].fix(0.0158)
-        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "H2O"].fix(0.8747)
-        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "MEA"].fix(0.1095)
+        m.fs.unit.hot_side_inlet.flow_mol[0].set_value(60.54879)
+        m.fs.unit.hot_side_inlet.temperature[0].set_value(392.23)
+        m.fs.unit.hot_side_inlet.pressure[0].set_value(202650)
+        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "CO2"].set_value(0.0158)
+        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "H2O"].set_value(0.8747)
+        m.fs.unit.hot_side_inlet.mole_frac_comp[0, "MEA"].set_value(0.1095)
 
         # Cold fluid
-        m.fs.unit.cold_side_inlet.flow_mol[0].fix(63.01910)
-        m.fs.unit.cold_side_inlet.temperature[0].fix(326.36)
-        m.fs.unit.cold_side_inlet.pressure[0].fix(202650)
-        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "CO2"].fix(0.0414)
-        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "H2O"].fix(0.8509)
-        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "MEA"].fix(0.1077)
+        m.fs.unit.cold_side_inlet.flow_mol[0].set_value(63.01910)
+        m.fs.unit.cold_side_inlet.temperature[0].set_value(326.36)
+        m.fs.unit.cold_side_inlet.pressure[0].set_value(202650)
+        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "CO2"].set_value(0.0414)
+        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "H2O"].set_value(0.8509)
+        m.fs.unit.cold_side_inlet.mole_frac_comp[0, "MEA"].set_value(0.1077)
 
         # Unit design variables
         m.fs.unit.area.fix(100)
@@ -562,7 +562,7 @@ class TestInitializers(object):
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_hx_ntu_initializer(self, model):
         # Need to estimate outlet state values based on heat duty
         initializer = HXNTUInitializer(always_estimate_states=True)
@@ -627,7 +627,21 @@ class TestInitializers(object):
             model.fs.unit.heat_duty[0]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.hot_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.temperature[0].fixed
+        assert not model.fs.unit.hot_side_inlet.pressure[0].fixed
+        assert not model.fs.unit.hot_side_inlet.mole_frac_comp[0, "CO2"].fixed
+        assert not model.fs.unit.hot_side_inlet.mole_frac_comp[0, "H2O"].fixed
+        assert not model.fs.unit.hot_side_inlet.mole_frac_comp[0, "MEA"].fixed
+
+        assert not model.fs.unit.cold_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.temperature[0].fixed
+        assert not model.fs.unit.cold_side_inlet.pressure[0].fixed
+        assert not model.fs.unit.cold_side_inlet.mole_frac_comp[0, "CO2"].fixed
+        assert not model.fs.unit.cold_side_inlet.mole_frac_comp[0, "H2O"].fixed
+        assert not model.fs.unit.cold_side_inlet.mole_frac_comp[0, "MEA"].fixed
+
+    @pytest.mark.component
     def test_block_triangularization_initializer(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -690,3 +704,17 @@ class TestInitializers(object):
         assert pytest.approx(0.7 * Cmin * (392.23 - 326.36), rel=1e-5) == value(
             model.fs.unit.heat_duty[0]
         )
+
+        assert not model.fs.unit.hot_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.temperature[0].fixed
+        assert not model.fs.unit.hot_side_inlet.pressure[0].fixed
+        assert not model.fs.unit.hot_side_inlet.mole_frac_comp[0, "CO2"].fixed
+        assert not model.fs.unit.hot_side_inlet.mole_frac_comp[0, "H2O"].fixed
+        assert not model.fs.unit.hot_side_inlet.mole_frac_comp[0, "MEA"].fixed
+
+        assert not model.fs.unit.cold_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.temperature[0].fixed
+        assert not model.fs.unit.cold_side_inlet.pressure[0].fixed
+        assert not model.fs.unit.cold_side_inlet.mole_frac_comp[0, "CO2"].fixed
+        assert not model.fs.unit.cold_side_inlet.mole_frac_comp[0, "H2O"].fixed
+        assert not model.fs.unit.cold_side_inlet.mole_frac_comp[0, "MEA"].fixed

--- a/idaes/models/unit_models/tests/test_mixer.py
+++ b/idaes/models/unit_models/tests/test_mixer.py
@@ -1489,27 +1489,27 @@ class TestInitializersSapon:
 
         m.fs.unit = Mixer(property_package=m.fs.properties)
 
-        m.fs.unit.inlet_1.flow_vol[0].fix(1e-3)
-        m.fs.unit.inlet_1.temperature[0].fix(320)
-        m.fs.unit.inlet_1.pressure[0].fix(101325)
-        m.fs.unit.inlet_1.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.inlet_1.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.inlet_1.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.inlet_1.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.inlet_1.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.inlet_1.flow_vol[0].set_value(1e-3)
+        m.fs.unit.inlet_1.temperature[0].set_value(320)
+        m.fs.unit.inlet_1.pressure[0].set_value(101325)
+        m.fs.unit.inlet_1.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.inlet_1.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.inlet_1.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.inlet_1.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.inlet_1.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
-        m.fs.unit.inlet_2.flow_vol[0].fix(1e-3)
-        m.fs.unit.inlet_2.temperature[0].fix(300)
-        m.fs.unit.inlet_2.pressure[0].fix(101325)
-        m.fs.unit.inlet_2.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.inlet_2.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.inlet_2.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.inlet_2.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.inlet_2.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.inlet_2.flow_vol[0].set_value(1e-3)
+        m.fs.unit.inlet_2.temperature[0].set_value(300)
+        m.fs.unit.inlet_2.pressure[0].set_value(101325)
+        m.fs.unit.inlet_2.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.inlet_2.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.inlet_2.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.inlet_2.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.inlet_2.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_mixer_init(self, model):
         initializer = MixerInitializer()
         initializer.initialize(model.fs.unit)
@@ -1540,7 +1540,7 @@ class TestInitializersSapon:
 
         assert pytest.approx(101325, abs=1e2) == value(model.fs.unit.outlet.pressure[0])
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -1586,17 +1586,17 @@ class TestInitializersIAPWSEquality:
             momentum_mixing_type=MomentumMixingType.equality,
         )
 
-        m.fs.unit.inlet_1.flow_mol[0].fix(100)
-        m.fs.unit.inlet_1.enth_mol[0].fix(5500)
+        m.fs.unit.inlet_1.flow_mol[0].set_value(100)
+        m.fs.unit.inlet_1.enth_mol[0].set_value(5500)
         m.fs.unit.inlet_1.pressure[0].fix(101325)
 
-        m.fs.unit.inlet_2.flow_mol[0].fix(100)
-        m.fs.unit.inlet_2.enth_mol[0].fix(5000)
-        m.fs.unit.inlet_2.pressure[0].value = 1e5
+        m.fs.unit.inlet_2.flow_mol[0].set_value(100)
+        m.fs.unit.inlet_2.enth_mol[0].set_value(5000)
+        m.fs.unit.inlet_2.pressure[0].set_value(1e5)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_mixer_init(self, model):
         initializer = MixerInitializer()
         initializer.initialize(model.fs.unit)
@@ -1607,7 +1607,15 @@ class TestInitializersIAPWSEquality:
         assert pytest.approx(5250, abs=1e0) == value(model.fs.unit.outlet.enth_mol[0])
         assert pytest.approx(101325, abs=1e2) == value(model.fs.unit.outlet.pressure[0])
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet_1.flow_mol[0].fixed
+        assert not model.fs.unit.inlet_1.enth_mol[0].fixed
+        assert model.fs.unit.inlet_1.pressure[0].fixed
+
+        assert not model.fs.unit.inlet_2.flow_mol[0].fixed
+        assert not model.fs.unit.inlet_2.enth_mol[0].fixed
+        assert not model.fs.unit.inlet_2.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -1617,3 +1625,11 @@ class TestInitializersIAPWSEquality:
         assert pytest.approx(200, abs=1e-5) == value(model.fs.unit.outlet.flow_mol[0])
         assert pytest.approx(5250, abs=1e0) == value(model.fs.unit.outlet.enth_mol[0])
         assert pytest.approx(101325, abs=1e2) == value(model.fs.unit.outlet.pressure[0])
+
+        assert not model.fs.unit.inlet_1.flow_mol[0].fixed
+        assert not model.fs.unit.inlet_1.enth_mol[0].fixed
+        assert model.fs.unit.inlet_1.pressure[0].fixed
+
+        assert not model.fs.unit.inlet_2.flow_mol[0].fixed
+        assert not model.fs.unit.inlet_2.enth_mol[0].fixed
+        assert not model.fs.unit.inlet_2.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_mscontactor.py
+++ b/idaes/models/unit_models/tests/test_mscontactor.py
@@ -2322,23 +2322,23 @@ class TestMSContactorInitializer:
             },
         )
 
-        m.fs.contactor.s1_inlet.flow_vol.fix(1.0e-03)
-        m.fs.contactor.s1_inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.contactor.s1_inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.contactor.s1_inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.contactor.s1_inlet.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.contactor.s1_inlet.conc_mol_comp[0, "Ethanol"].fix(0.0)
-        m.fs.contactor.s1_inlet.temperature.fix(303.15)
-        m.fs.contactor.s1_inlet.pressure.fix(101325.0)
+        m.fs.contactor.s1_inlet.flow_vol.set_value(1.0e-03)
+        m.fs.contactor.s1_inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.contactor.s1_inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.contactor.s1_inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.contactor.s1_inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.contactor.s1_inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
+        m.fs.contactor.s1_inlet.temperature.set_value(303.15)
+        m.fs.contactor.s1_inlet.pressure.set_value(101325.0)
 
-        m.fs.contactor.s2_inlet.flow_vol.fix(2.0e-03)
-        m.fs.contactor.s2_inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.contactor.s2_inlet.conc_mol_comp[0, "NaOH"].fix(50.0)
-        m.fs.contactor.s2_inlet.conc_mol_comp[0, "EthylAcetate"].fix(50.0)
-        m.fs.contactor.s2_inlet.conc_mol_comp[0, "SodiumAcetate"].fix(50.0)
-        m.fs.contactor.s2_inlet.conc_mol_comp[0, "Ethanol"].fix(50.0)
-        m.fs.contactor.s2_inlet.temperature.fix(323.15)
-        m.fs.contactor.s2_inlet.pressure.fix(2e5)
+        m.fs.contactor.s2_inlet.flow_vol.set_value(2.0e-03)
+        m.fs.contactor.s2_inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.contactor.s2_inlet.conc_mol_comp[0, "NaOH"].set_value(50.0)
+        m.fs.contactor.s2_inlet.conc_mol_comp[0, "EthylAcetate"].set_value(50.0)
+        m.fs.contactor.s2_inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(50.0)
+        m.fs.contactor.s2_inlet.conc_mol_comp[0, "Ethanol"].set_value(50.0)
+        m.fs.contactor.s2_inlet.temperature.set_value(323.15)
+        m.fs.contactor.s2_inlet.pressure.set_value(2e5)
 
         m.fs.contactor.material_transfer_term.fix(0)
         m.fs.contactor.energy_transfer_term.fix(0)
@@ -2409,6 +2409,24 @@ class TestMSContactorInitializer:
             assert value(model.fs.contactor.s2[0, x].pressure) == pytest.approx(
                 2e5, rel=1e-6
             )
+
+        assert not model.fs.contactor.s1_inlet.flow_vol.fixed
+        assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "Ethanol"].fixed
+        assert not model.fs.contactor.s1_inlet.temperature.fixed
+        assert not model.fs.contactor.s1_inlet.pressure.fixed
+
+        assert not model.fs.contactor.s2_inlet.flow_vol.fixed
+        assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "Ethanol"].fixed
+        assert not model.fs.contactor.s2_inlet.temperature.fixed
+        assert not model.fs.contactor.s2_inlet.pressure.fixed
 
 
 class TestLiCODiafiltration:

--- a/idaes/models/unit_models/tests/test_mscontactor.py
+++ b/idaes/models/unit_models/tests/test_mscontactor.py
@@ -2322,23 +2322,23 @@ class TestMSContactorInitializer:
             },
         )
 
-        m.fs.contactor.s1_inlet.flow_vol.set_value(1.0e-03)
+        m.fs.contactor.s1_inlet.flow_vol[0].set_value(1.0e-03)
         m.fs.contactor.s1_inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
         m.fs.contactor.s1_inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
         m.fs.contactor.s1_inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
         m.fs.contactor.s1_inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
         m.fs.contactor.s1_inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
-        m.fs.contactor.s1_inlet.temperature.set_value(303.15)
-        m.fs.contactor.s1_inlet.pressure.set_value(101325.0)
+        m.fs.contactor.s1_inlet.temperature[0].set_value(303.15)
+        m.fs.contactor.s1_inlet.pressure[0].set_value(101325.0)
 
-        m.fs.contactor.s2_inlet.flow_vol.set_value(2.0e-03)
+        m.fs.contactor.s2_inlet.flow_vol[0].set_value(2.0e-03)
         m.fs.contactor.s2_inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
         m.fs.contactor.s2_inlet.conc_mol_comp[0, "NaOH"].set_value(50.0)
         m.fs.contactor.s2_inlet.conc_mol_comp[0, "EthylAcetate"].set_value(50.0)
         m.fs.contactor.s2_inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(50.0)
         m.fs.contactor.s2_inlet.conc_mol_comp[0, "Ethanol"].set_value(50.0)
-        m.fs.contactor.s2_inlet.temperature.set_value(323.15)
-        m.fs.contactor.s2_inlet.pressure.set_value(2e5)
+        m.fs.contactor.s2_inlet.temperature[0].set_value(323.15)
+        m.fs.contactor.s2_inlet.pressure[0].set_value(2e5)
 
         m.fs.contactor.material_transfer_term.fix(0)
         m.fs.contactor.energy_transfer_term.fix(0)
@@ -2410,23 +2410,23 @@ class TestMSContactorInitializer:
                 2e5, rel=1e-6
             )
 
-        assert not model.fs.contactor.s1_inlet.flow_vol.fixed
+        assert not model.fs.contactor.s1_inlet.flow_vol[0].fixed
         assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "H2O"].fixed
         assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "NaOH"].fixed
         assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "EthylAcetate"].fixed
         assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
         assert not model.fs.contactor.s1_inlet.conc_mol_comp[0, "Ethanol"].fixed
-        assert not model.fs.contactor.s1_inlet.temperature.fixed
-        assert not model.fs.contactor.s1_inlet.pressure.fixed
+        assert not model.fs.contactor.s1_inlet.temperature[0].fixed
+        assert not model.fs.contactor.s1_inlet.pressure[0].fixed
 
-        assert not model.fs.contactor.s2_inlet.flow_vol.fixed
+        assert not model.fs.contactor.s2_inlet.flow_vol[0].fixed
         assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "H2O"].fixed
         assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "NaOH"].fixed
         assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "EthylAcetate"].fixed
         assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
         assert not model.fs.contactor.s2_inlet.conc_mol_comp[0, "Ethanol"].fixed
-        assert not model.fs.contactor.s2_inlet.temperature.fixed
-        assert not model.fs.contactor.s2_inlet.pressure.fixed
+        assert not model.fs.contactor.s2_inlet.temperature[0].fixed
+        assert not model.fs.contactor.s2_inlet.pressure[0].fixed
 
 
 class TestLiCODiafiltration:

--- a/idaes/models/unit_models/tests/test_pfr.py
+++ b/idaes/models/unit_models/tests/test_pfr.py
@@ -295,15 +295,15 @@ class TestInitializers:
             has_pressure_change=True,
         )
 
-        m.fs.unit.inlet.flow_vol.set_value(1.0)
+        m.fs.unit.inlet.flow_vol[0].set_value(1.0)
         m.fs.unit.inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
         m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
         m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
         m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
         m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
-        m.fs.unit.inlet.temperature.set_value(303.15)
-        m.fs.unit.inlet.pressure.set_value(101325.0)
+        m.fs.unit.inlet.temperature[0].set_value(303.15)
+        m.fs.unit.inlet.pressure[0].set_value(101325.0)
 
         m.fs.unit.length.fix(0.5)
         m.fs.unit.area.fix(0.1)
@@ -331,15 +331,15 @@ class TestInitializers:
             model.fs.unit.outlet.conc_mol_comp[0, "EthylAcetate"]
         )
 
-        assert not model.fs.unit.inlet.flow_vol.fixed
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
 
-        assert not model.fs.unit.inlet.temperature.fixed
-        assert not model.fs.unit.inlet.pressure.fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
 
     @pytest.mark.component
     def test_block_triangularization(self, model):
@@ -361,12 +361,12 @@ class TestInitializers:
             model.fs.unit.outlet.conc_mol_comp[0, "EthylAcetate"]
         )
 
-        assert not model.fs.unit.inlet.flow_vol.fixed
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
 
-        assert not model.fs.unit.inlet.temperature.fixed
-        assert not model.fs.unit.inlet.pressure.fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_pfr.py
+++ b/idaes/models/unit_models/tests/test_pfr.py
@@ -295,15 +295,15 @@ class TestInitializers:
             has_pressure_change=True,
         )
 
-        m.fs.unit.inlet.flow_vol.fix(1.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.inlet.flow_vol.set_value(1.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
-        m.fs.unit.inlet.temperature.fix(303.15)
-        m.fs.unit.inlet.pressure.fix(101325.0)
+        m.fs.unit.inlet.temperature.set_value(303.15)
+        m.fs.unit.inlet.pressure.set_value(101325.0)
 
         m.fs.unit.length.fix(0.5)
         m.fs.unit.area.fix(0.1)
@@ -313,7 +313,7 @@ class TestInitializers:
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = SingleControlVolumeUnitInitializer()
         initializer.initialize(model.fs.unit)
@@ -331,7 +331,17 @@ class TestInitializers:
             model.fs.unit.outlet.conc_mol_comp[0, "EthylAcetate"]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_vol.fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.inlet.temperature.fixed
+        assert not model.fs.unit.inlet.pressure.fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=1e-5)
 
@@ -350,3 +360,13 @@ class TestInitializers:
         assert pytest.approx(62.29202, rel=1e-5) == value(
             model.fs.unit.outlet.conc_mol_comp[0, "EthylAcetate"]
         )
+
+        assert not model.fs.unit.inlet.flow_vol.fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.inlet.temperature.fixed
+        assert not model.fs.unit.inlet.pressure.fixed

--- a/idaes/models/unit_models/tests/test_pressure_changer.py
+++ b/idaes/models/unit_models/tests/test_pressure_changer.py
@@ -999,16 +999,16 @@ class TestInitializersTurbine1:
         )
 
         # set inputs
-        m.fs.unit.inlet.flow_mol[0].fix(1000)  # mol/s
+        m.fs.unit.inlet.flow_mol[0].set_value(1000)  # mol/s
         Tin = 500  # K
         Pin = 1000000  # Pa
         hin = value(iapws95.htpx(Tin * units.K, Pin * units.Pa))
-        m.fs.unit.inlet.enth_mol[0].fix(hin)
-        m.fs.unit.inlet.pressure[0].fix(Pin)
+        m.fs.unit.inlet.enth_mol[0].set_value(hin)
+        m.fs.unit.inlet.pressure[0].set_value(Pin)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_isentropic(self, model):
         initializer = IsentropicPressureChangerInitializer()
         initializer.initialize(model.fs.unit)
@@ -1020,7 +1020,11 @@ class TestInitializersTurbine1:
         )
         assert value(model.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.enth_mol[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         # Need to use reverse_numeric differentiation due to ExternalFunctions
         initializer = BlockTriangularizationInitializer(
@@ -1037,3 +1041,7 @@ class TestInitializersTurbine1:
             0.9, rel=1e-3
         )
         assert value(model.fs.unit.deltaP[0]) == pytest.approx(-3e5, rel=1e-3)
+
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.enth_mol[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_product.py
+++ b/idaes/models/unit_models/tests/test_product.py
@@ -397,13 +397,13 @@ class TestInitializers:
 
         m.fs.unit = Product(property_package=m.fs.properties)
 
-        m.fs.unit.flow_mol[0].fix(100)
-        m.fs.unit.enth_mol[0].fix(5000)
-        m.fs.unit.pressure[0].fix(101325)
+        m.fs.unit.flow_mol[0].set_value(100)
+        m.fs.unit.enth_mol[0].set_value(5000)
+        m.fs.unit.pressure[0].set_value(101325)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_product_initializer(self, model):
         initializer = ProductInitializer()
         initializer.initialize(model.fs.unit)
@@ -412,7 +412,11 @@ class TestInitializers:
 
         # No results to check
 
-    @pytest.mark.integration
+        assert not model.fs.unit.flow_mol[0].fixed
+        assert not model.fs.unit.enth_mol[0].fixed
+        assert not model.fs.unit.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
@@ -420,3 +424,7 @@ class TestInitializers:
         assert initializer.summary[model.fs.unit]["status"] == InitializationStatus.Ok
 
         # No results to check
+
+        assert not model.fs.unit.flow_mol[0].fixed
+        assert not model.fs.unit.enth_mol[0].fixed
+        assert not model.fs.unit.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_rstoic.py
+++ b/idaes/models/unit_models/tests/test_rstoic.py
@@ -282,15 +282,15 @@ class TestInitializersSapon:
             has_pressure_change=True,
         )
 
-        m.fs.unit.inlet.flow_vol.fix(1)
-        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fix(0.0)
-        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fix(0.0)
+        m.fs.unit.inlet.flow_vol.set_value(1)
+        m.fs.unit.inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
+        m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
-        m.fs.unit.inlet.temperature.fix(303.15)
-        m.fs.unit.inlet.pressure.fix(101325.0)
+        m.fs.unit.inlet.temperature.set_value(303.15)
+        m.fs.unit.inlet.pressure.set_value(101325.0)
 
         m.fs.unit.rate_reaction_extent[0, "R1"].fix(90)
         m.fs.unit.heat_duty.fix(0)
@@ -298,7 +298,7 @@ class TestInitializersSapon:
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = SingleControlVolumeUnitInitializer()
         initializer.initialize(model.fs.unit)
@@ -315,7 +315,17 @@ class TestInitializersSapon:
             model.fs.unit.outlet.conc_mol_comp[0, "Ethanol"]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_vol.fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.inlet.temperature.fixed
+        assert not model.fs.unit.inlet.pressure.fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         # Need to limit tolerance on 1x1 solver otherwise it exceeds the iteration limit
         initializer = BlockTriangularizationInitializer(
@@ -334,3 +344,13 @@ class TestInitializersSapon:
         assert pytest.approx(90, abs=1e-2) == value(
             model.fs.unit.outlet.conc_mol_comp[0, "Ethanol"]
         )
+
+        assert not model.fs.unit.inlet.flow_vol.fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
+        assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
+
+        assert not model.fs.unit.inlet.temperature.fixed
+        assert not model.fs.unit.inlet.pressure.fixed

--- a/idaes/models/unit_models/tests/test_rstoic.py
+++ b/idaes/models/unit_models/tests/test_rstoic.py
@@ -282,15 +282,15 @@ class TestInitializersSapon:
             has_pressure_change=True,
         )
 
-        m.fs.unit.inlet.flow_vol.set_value(1)
+        m.fs.unit.inlet.flow_vol[0].set_value(1)
         m.fs.unit.inlet.conc_mol_comp[0, "H2O"].set_value(55388.0)
         m.fs.unit.inlet.conc_mol_comp[0, "NaOH"].set_value(100.0)
         m.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].set_value(100.0)
         m.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].set_value(0.0)
         m.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].set_value(0.0)
 
-        m.fs.unit.inlet.temperature.set_value(303.15)
-        m.fs.unit.inlet.pressure.set_value(101325.0)
+        m.fs.unit.inlet.temperature[0].set_value(303.15)
+        m.fs.unit.inlet.pressure[0].set_value(101325.0)
 
         m.fs.unit.rate_reaction_extent[0, "R1"].fix(90)
         m.fs.unit.heat_duty.fix(0)
@@ -315,15 +315,15 @@ class TestInitializersSapon:
             model.fs.unit.outlet.conc_mol_comp[0, "Ethanol"]
         )
 
-        assert not model.fs.unit.inlet.flow_vol.fixed
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
 
-        assert not model.fs.unit.inlet.temperature.fixed
-        assert not model.fs.unit.inlet.pressure.fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
 
     @pytest.mark.component
     def test_block_triangularization(self, model):
@@ -345,12 +345,12 @@ class TestInitializersSapon:
             model.fs.unit.outlet.conc_mol_comp[0, "Ethanol"]
         )
 
-        assert not model.fs.unit.inlet.flow_vol.fixed
+        assert not model.fs.unit.inlet.flow_vol[0].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "H2O"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "NaOH"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "EthylAcetate"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "SodiumAcetate"].fixed
         assert not model.fs.unit.inlet.conc_mol_comp[0, "Ethanol"].fixed
 
-        assert not model.fs.unit.inlet.temperature.fixed
-        assert not model.fs.unit.inlet.pressure.fixed
+        assert not model.fs.unit.inlet.temperature[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_separator.py
+++ b/idaes/models/unit_models/tests/test_separator.py
@@ -3555,16 +3555,16 @@ class TestInitializersIAPWS:
             has_phase_equilibrium=False,
         )
 
-        m.fs.unit.inlet.flow_mol[0].fix(100)
-        m.fs.unit.inlet.enth_mol[0].fix(5000)
-        m.fs.unit.inlet.pressure[0].fix(101325)
+        m.fs.unit.inlet.flow_mol[0].set_value(100)
+        m.fs.unit.inlet.enth_mol[0].set_value(5000)
+        m.fs.unit.inlet.pressure[0].set_value(101325)
 
         m.fs.unit.split_fraction[0, "outlet_1", "H2O"].fix(0.4)
         m.fs.unit.split_fraction[0, "outlet_2", "H2O"].fix(0.5)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_separator_initializer(self, model):
         initializer = SeparatorInitializer()
         initializer.initialize(model.fs.unit)
@@ -3589,7 +3589,11 @@ class TestInitializersIAPWS:
             model.fs.unit.outlet_3.pressure[0]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.enth_mol[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(
             calculate_variable_options={
@@ -3620,3 +3624,7 @@ class TestInitializersIAPWS:
         assert pytest.approx(101325, abs=1e2) == value(
             model.fs.unit.outlet_3.pressure[0]
         )
+
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.enth_mol[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_shell_and_tube_1D.py
+++ b/idaes/models/unit_models/tests/test_shell_and_tube_1D.py
@@ -2018,17 +2018,17 @@ class TestInitializersIAPWSCounterCurrent:
         m.fs.unit.hot_side_heat_transfer_coefficient.fix(2000)
         m.fs.unit.cold_side_heat_transfer_coefficient.fix(51000)
 
-        m.fs.unit.hot_side_inlet.flow_mol[0].fix(5)
-        m.fs.unit.hot_side_inlet.enth_mol[0].fix(50000)
-        m.fs.unit.hot_side_inlet.pressure[0].fix(101325)
+        m.fs.unit.hot_side_inlet.flow_mol[0].set_value(5)
+        m.fs.unit.hot_side_inlet.enth_mol[0].set_value(50000)
+        m.fs.unit.hot_side_inlet.pressure[0].set_value(101325)
 
-        m.fs.unit.cold_side_inlet.flow_mol[0].fix(5)
-        m.fs.unit.cold_side_inlet.enth_mol[0].fix(7000)
-        m.fs.unit.cold_side_inlet.pressure[0].fix(101325)
+        m.fs.unit.cold_side_inlet.flow_mol[0].set_value(5)
+        m.fs.unit.cold_side_inlet.enth_mol[0].set_value(7000)
+        m.fs.unit.cold_side_inlet.pressure[0].set_value(101325)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_general_hierarchical(self, model):
         initializer = ShellAndTubeInitializer(always_estimate_states=True)
         initializer.initialize(model.fs.unit)
@@ -2056,7 +2056,15 @@ class TestInitializersIAPWSCounterCurrent:
             model.fs.unit.cold_side_outlet.pressure[0]
         )
 
-    @pytest.mark.integration
+        assert not model.fs.unit.hot_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.enth_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.pressure[0].fixed
+
+        assert not model.fs.unit.cold_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.enth_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit, exclude_unused_vars=True)
@@ -2083,3 +2091,11 @@ class TestInitializersIAPWSCounterCurrent:
         assert pytest.approx(101325, rel=1e-5) == value(
             model.fs.unit.cold_side_outlet.pressure[0]
         )
+
+        assert not model.fs.unit.hot_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.enth_mol[0].fixed
+        assert not model.fs.unit.hot_side_inlet.pressure[0].fixed
+
+        assert not model.fs.unit.cold_side_inlet.flow_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.enth_mol[0].fixed
+        assert not model.fs.unit.cold_side_inlet.pressure[0].fixed

--- a/idaes/models/unit_models/tests/test_skeleton_unit_model.py
+++ b/idaes/models/unit_models/tests/test_skeleton_unit_model.py
@@ -188,7 +188,7 @@ class TestSkeletonDefault(object):
         )
 
 
-@pytest.mark.integration
+@pytest.mark.component
 def test_default_initializer():
     m = ConcreteModel()
     m.fs = FlowsheetBlock(dynamic=False)
@@ -239,10 +239,10 @@ def test_default_initializer():
     m.fs.skeleton.add_ports(name="inlet", member_dict=inlet_dict)
     m.fs.skeleton.add_ports(name="outlet", member_dict=outlet_dict)
 
-    m.fs.skeleton.inlet.flow_mol_comp[0, "c1"].fix(2)
-    m.fs.skeleton.inlet.flow_mol_comp[0, "c2"].fix(2)
-    m.fs.skeleton.inlet.temperature.fix(325)
-    m.fs.skeleton.inlet.pressure.fix(200)
+    m.fs.skeleton.inlet.flow_mol_comp[0, "c1"].set_value(2)
+    m.fs.skeleton.inlet.flow_mol_comp[0, "c2"].set_value(2)
+    m.fs.skeleton.inlet.temperature[0].set_value(325)
+    m.fs.skeleton.inlet.pressure[0].set_value(200)
 
     initializer = m.fs.skeleton.default_initializer()
     initializer.initialize(m.fs.skeleton)
@@ -255,6 +255,11 @@ def test_default_initializer():
     )
     assert value(m.fs.skeleton.outlet.temperature[0]) == pytest.approx(335, abs=1e-3)
     assert value(m.fs.skeleton.outlet.pressure[0]) == pytest.approx(190, abs=1e-3)
+
+    assert not m.fs.skeleton.inlet.flow_mol_comp[0, "c1"].fixed
+    assert not m.fs.skeleton.inlet.flow_mol_comp[0, "c2"].fixed
+    assert not m.fs.skeleton.inlet.temperature[0].fixed
+    assert not m.fs.skeleton.inlet.pressure[0].fixed
 
 
 class TestSkeletonCustom(object):

--- a/idaes/models/unit_models/tests/test_statejunction.py
+++ b/idaes/models/unit_models/tests/test_statejunction.py
@@ -297,22 +297,30 @@ class TestInitializers:
 
         m.fs.unit = StateJunction(property_package=m.fs.properties)
 
-        m.fs.unit.inlet.flow_mol[0].fix(100)
-        m.fs.unit.inlet.enth_mol[0].fix(4000)
-        m.fs.unit.inlet.pressure[0].fix(101325)
+        m.fs.unit.inlet.flow_mol[0].set_value(100)
+        m.fs.unit.inlet.enth_mol[0].set_value(4000)
+        m.fs.unit.inlet.pressure[0].set_value(101325)
 
         return m
 
-    @pytest.mark.integration
+    @pytest.mark.component
     def test_default_initializer(self, model):
         initializer = StateJunctionInitializer()
         initializer.initialize(model.fs.unit)
 
         assert initializer.summary[model.fs.unit]["status"] == InitializationStatus.Ok
 
-    @pytest.mark.integration
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.enth_mol[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed
+
+    @pytest.mark.component
     def test_block_triangularization(self, model):
         initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
         initializer.initialize(model.fs.unit)
 
         assert initializer.summary[model.fs.unit]["status"] == InitializationStatus.Ok
+
+        assert not model.fs.unit.inlet.flow_mol[0].fixed
+        assert not model.fs.unit.inlet.enth_mol[0].fixed
+        assert not model.fs.unit.inlet.pressure[0].fixed


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
This PR refines the methods used to fix inlet conditions during initialization with the new API. The default method is updated to iterate overall `Port` and fix the variables in any `Port` with "inlet" in the name. Custom methods have been added for some non-standard models that were lacking these.

Testing was also improved for the new API to state most test cases with the inlet variables unfixed to make sure they are correctly fixed and unfixed during initialization.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
