### PR TITLE
Address Pyomo 6.6 compatibility issues

### DIFF
--- a/idaes/core/surrogate/tests/test_pysmo_surrogate.py
+++ b/idaes/core/surrogate/tests/test_pysmo_surrogate.py
@@ -2186,8 +2186,8 @@ class TestPysmoSurrogate:
         assert list(pysmo_surr_poly._trained._data) == ["z1"]
         # Assert that correcte xpression string was returned
         assert pysmo_surr_poly._trained._data["z1"].expression_str == (
-            "-75.26111111111476 -8.815277777775934*IndexedParam[x1] + 18.81527777777826*IndexedParam[x2]"
-            " -2.2556956302821618e-13*(IndexedParam[x2]*IndexedParam[x1])"
+            "-75.26111111111476 - 8.815277777775934*IndexedParam[x1] + 18.81527777777826*IndexedParam[x2]"
+            " - 2.2556956302821618e-13*(IndexedParam[x2]*IndexedParam[x1])"
         )
         # Assert that correct model is returned with generate_expression()
         assert str(
@@ -2232,11 +2232,11 @@ class TestPysmoSurrogate:
         # Assert that correct expression strings were returned for both surrogates
         assert pysmo_surr_poly._trained._data["z1"].expression_str == (
             "-14.290243902439855 + 6.4274390243899795*IndexedParam[x1] + 3.572560975609962*IndexedParam[x2] "
-            "+ 1.9753643165643098e-13*log(IndexedParam[x1]) -4.4048098502003086e-14*sin(IndexedParam[x2])"
+            "+ 1.9753643165643098e-13*log(IndexedParam[x1]) - 4.4048098502003086e-14*sin(IndexedParam[x2])"
         )
         assert pysmo_surr_poly._trained._data["z2"].expression_str == (
-            "5.704971042443143 + 2.4262427606248815*IndexedParam[x1] -0.42624276060821653*IndexedParam[x2] "
-            "-5.968545102597034e-11*log(IndexedParam[x1]) + 6.481176706429892e-12*sin(IndexedParam[x2])"
+            "5.704971042443143 + 2.4262427606248815*IndexedParam[x1] - 0.42624276060821653*IndexedParam[x2] "
+            "- 5.968545102597034e-11*log(IndexedParam[x1]) + 6.481176706429892e-12*sin(IndexedParam[x2])"
         )
         # Assert that correct model is returned with generate_expression()
         assert str(
@@ -2318,11 +2318,11 @@ class TestPysmoSurrogate:
         assert list(pysmo_surr_poly._trained._data) == ["z1", "z2"]
         # Assert that correct expression strings were returned for both surrogates
         assert pysmo_surr_poly._trained._data["z1"].expression_str == (
-            "-110.15000000001504 -17.53750000000189*IndexedParam[x1] + 27.537500000006148*IndexedParam[x2] "
-            "-5.3967136315336006e-11*(IndexedParam[x1]/IndexedParam[x2])"
+            "-110.15000000001504 - 17.53750000000189*IndexedParam[x1] + 27.537500000006148*IndexedParam[x2] "
+            "- 5.3967136315336006e-11*(IndexedParam[x1]/IndexedParam[x2])"
         )
         assert pysmo_surr_poly._trained._data["z2"].expression_str == (
-            "-12.523574144487087 -2.1308935361219556*IndexedParam[x1] + 4.1308935361216435*IndexedParam[x2]"
+            "-12.523574144487087 - 2.1308935361219556*IndexedParam[x1] + 4.1308935361216435*IndexedParam[x2]"
             " + 3.6347869158959156e-12*(IndexedParam[x1]/IndexedParam[x2])"
         )
         # Assert that correct model is returned with generate_expression()
@@ -2432,18 +2432,18 @@ class TestPysmoSurrogate:
         assert list(pysmo_surr_rbf._trained._data) == ["z1", "z2"]
         # Assert that correct expression strings were returned for both surrogates
         assert pysmo_surr_rbf._trained._data["z1"].expression_str == (
-            "10 + 40*(-69.10791015625*exp(- (0.05*(((IndexedParam[x1] -1)/4)**2 + ((IndexedParam[x2] -5)/4)**2)**0.5)**2) "
-            "-319807.1317138672*exp(- (0.05*(((IndexedParam[x1] -1)/4 -0.25)**2 + ((IndexedParam[x2] -5)/4 -0.25)**2)**0.5)**2) "
-            "+ 959336.2551269531*exp(- (0.05*(((IndexedParam[x1] -1)/4 -0.5)**2 + ((IndexedParam[x2] -5)/4 -0.5)**2)**0.5)**2) "
-            "-959973.7440185547*exp(- (0.05*(((IndexedParam[x1] -1)/4 -0.75)**2 + ((IndexedParam[x2] -5)/4 -0.75)**2)**0.5)**2) "
-            "+ 320514.66677856445*exp(- (0.05*(((IndexedParam[x1] -1)/4 -1.0)**2 + ((IndexedParam[x2] -5)/4 -1.0)**2)**0.5)**2))"
+            "10 + 40*(-69.10791015625*exp(- (0.05*(((IndexedParam[x1] - 1)/4)**2 + ((IndexedParam[x2] - 5)/4)**2)**0.5)**2) "
+            "- 319807.1317138672*exp(- (0.05*(((IndexedParam[x1] - 1)/4 - 0.25)**2 + ((IndexedParam[x2] - 5)/4 - 0.25)**2)**0.5)**2) "
+            "+ 959336.2551269531*exp(- (0.05*(((IndexedParam[x1] - 1)/4 - 0.5)**2 + ((IndexedParam[x2] - 5)/4 - 0.5)**2)**0.5)**2) "
+            "- 959973.7440185547*exp(- (0.05*(((IndexedParam[x1] - 1)/4 - 0.75)**2 + ((IndexedParam[x2] - 5)/4 - 0.75)**2)**0.5)**2) "
+            "+ 320514.66677856445*exp(- (0.05*(((IndexedParam[x1] - 1)/4 - 1.0)**2 + ((IndexedParam[x2] - 5)/4 - 1.0)**2)**0.5)**2))"
         )
         assert pysmo_surr_rbf._trained._data["z2"].expression_str == (
-            "6 + 8*(-69.10791015625*exp(- (0.05*(((IndexedParam[x1] -1)/4)**2 + ((IndexedParam[x2] -5)/4)**2)**0.5)**2) "
-            "-319807.1317138672*exp(- (0.05*(((IndexedParam[x1] -1)/4 -0.25)**2 + ((IndexedParam[x2] -5)/4 -0.25)**2)**0.5)**2) "
-            "+ 959336.2551269531*exp(- (0.05*(((IndexedParam[x1] -1)/4 -0.5)**2 + ((IndexedParam[x2] -5)/4 -0.5)**2)**0.5)**2) "
-            "-959973.7440185547*exp(- (0.05*(((IndexedParam[x1] -1)/4 -0.75)**2 + ((IndexedParam[x2] -5)/4 -0.75)**2)**0.5)**2) "
-            "+ 320514.66677856445*exp(- (0.05*(((IndexedParam[x1] -1)/4 -1.0)**2 + ((IndexedParam[x2] -5)/4 -1.0)**2)**0.5)**2))"
+            "6 + 8*(-69.10791015625*exp(- (0.05*(((IndexedParam[x1] - 1)/4)**2 + ((IndexedParam[x2] - 5)/4)**2)**0.5)**2) "
+            "- 319807.1317138672*exp(- (0.05*(((IndexedParam[x1] - 1)/4 - 0.25)**2 + ((IndexedParam[x2] - 5)/4 - 0.25)**2)**0.5)**2) "
+            "+ 959336.2551269531*exp(- (0.05*(((IndexedParam[x1] - 1)/4 - 0.5)**2 + ((IndexedParam[x2] - 5)/4 - 0.5)**2)**0.5)**2) "
+            "- 959973.7440185547*exp(- (0.05*(((IndexedParam[x1] - 1)/4 - 0.75)**2 + ((IndexedParam[x2] - 5)/4 - 0.75)**2)**0.5)**2) "
+            "+ 320514.66677856445*exp(- (0.05*(((IndexedParam[x1] - 1)/4 - 1.0)**2 + ((IndexedParam[x2] - 5)/4 - 1.0)**2)**0.5)**2))"
         )
         # Assert that correct model is returned with generate_expression()
         assert str(

--- a/idaes/models/properties/general_helmholtz/tests/test_parameter_util.py
+++ b/idaes/models/properties/general_helmholtz/tests/test_parameter_util.py
@@ -241,8 +241,8 @@ def test_r1234ze():
         },
         2: {
             "T": 200,
-            "p": 0.0,
-            "rho": 0.0,
+            "p": 0,
+            "rho": 1e-12,  # Need a small number here to avoid 0/0
         },
         3: {
             "T": 350,

--- a/idaes/models/properties/modular_properties/eos/tests/test_ideal.py
+++ b/idaes/models/properties/modular_properties/eos/tests/test_ideal.py
@@ -332,7 +332,7 @@ def test_energy_internal_mol_phase_comp_with_h_form(m):
         # For liquid phase, delta(n) should be 4 (2*He + 2*O2)
         assert (
             str(Ideal.energy_internal_mol_phase_comp(m.props[1], "Liq", j))
-            == "42.0 -4.0*("
+            == "42.0 - 4.0*("
             + str(Ideal.gas_constant(m.props[1]))
             + ")*params.temperature_ref"
         )

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ kwargs = dict(
         "numpy",
         "omlt==1.1",  # fix the version for now as package evolves
         "pandas",
-        "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.5.23.zip",
+        "pyomo @ https://github.com/IDAES/pyomo/archive/6.6.0.zip",
         "sympy",  # pyomo differentiation
         "pint",  # pyomo units
         "networkx",  # pyomo network

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ kwargs = dict(
         "numpy",
         "omlt==1.1",  # fix the version for now as package evolves
         "pandas",
-        "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.03.28.zip",
+        "pyomo @ https://github.com/IDAES/pyomo/archive/6.5.1.idaes.2023.5.23.zip",
         "sympy",  # pyomo differentiation
         "pint",  # pyomo units
         "networkx",  # pyomo network


### PR DESCRIPTION
## Fixes None

This is waiting on https://github.com/Pyomo/pyomo/pull/2816

## Summary/Motivation:
This PR addresses compatibility issues in a few tests due to changes in Pyomo 6.6. These changes only affect tests and not actual functionality.

## Changes proposed in this PR:
- Update expected expressions that changed in Pyomo 6.6
- Fix an issue with 0/0 caused by the new expression system

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
