### PR TITLE
Correct argument type for ParamSweeper construction in pipeline tests

### DIFF
--- a/idaes/models_extra/gas_distribution/unit_models/tests/test_compressor.py
+++ b/idaes/models_extra/gas_distribution/unit_models/tests/test_compressor.py
@@ -188,7 +188,7 @@ class TestCompressorValues(unittest.TestCase):
             n_scen,
             input_values,
             output_values=target_values,
-            to_fix=input_values,
+            to_fix=list(input_values.keys()),
         )
         with param_sweeper:
             self.assertEqual(degrees_of_freedom(m), 0)

--- a/idaes/models_extra/gas_distribution/unit_models/tests/test_pipeline.py
+++ b/idaes/models_extra/gas_distribution/unit_models/tests/test_pipeline.py
@@ -252,7 +252,7 @@ class TestSolvePipelineSquare(unittest.TestCase):
             param_sweeper = ParamSweeper(
                 n_scen,
                 input_values,
-                to_fix=input_values,
+                to_fix=list(input_values.keys()),
                 output_values=target_values,
             )
             ipopt = get_solver("ipopt")


### PR DESCRIPTION
## Fixes
Failures with https://github.com/Pyomo/pyomo/pull/2834

## Summary/Motivation:
I was passing `ComponentMap`s as the `to_fix` argument in `ParamSweeper`, despite it being clearly documented that this should be a list.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
