### PR TITLE
Add encoding to read helmholtz references

### DIFF
--- a/idaes/models/properties/general_helmholtz/components/parameters/__init__.py
+++ b/idaes/models/properties/general_helmholtz/components/parameters/__init__.py
@@ -84,7 +84,7 @@ def auto_register():
             viscosity_ref = None
             surface_tension_ref = None
             if rematch:
-                with open(os.path.join(pth, fname), "r") as fptr:
+                with open(os.path.join(pth, fname), "r", encoding="utf-8") as fptr:
                     dct = json.load(fptr)
                 try:
                     eos_ref = dct["eos"]["reference"]


### PR DESCRIPTION
## Fixes #1189

## Summary/Motivation:

It seems that it is posible for have text files open with unexpected encodings, which can cause trouble reading JSON.  This sets the encoding of the Helmholtz parameter files to UTF-8 when reading literature reference information, so that it can be parsed without issue regardless of the default encoding. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
