### PR TITLE
Add optional dependency target for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ idaes get-extensions
 The IDAES examples can be installed by running:
 
 ```bash
-jupyter notebook examples/notebook_index.ipynb
+pip install "idaes-pse[examples]"
 ```
 
 For more information, refer to the [IDAES/examples](https://github.com/IDAES/examples) repository, as well as the online static version of the examples available at <https://idaes-examples.readthedocs.org>.

--- a/README.md
+++ b/README.md
@@ -50,21 +50,19 @@ You can check the version installed with the command:
 idaes --version
 ```
 
-Now install the examples and the pre-build extensions (binary solvers):
+Now install the pre-build extensions (binary solvers):
 
 ```bash
-idaes get-examples
 idaes get-extensions
 ```
 
-This will install the examples into an `examples` subdirectory which can be opened using a [Jypter](https://jupyter.org) Notebook:
+The IDAES examples can be installed by running:
 
 ```bash
 jupyter notebook examples/notebook_index.ipynb
 ```
-From there you can explore the examples and tutorials.
 
-For more information on how to use Jupyter Lab, use the built-in *Help* menu and the extensive documentation on the [Jupyter website](https://jupyter.org).
+For more information, refer to the [IDAES/examples](https://github.com/IDAES/examples) repository, as well as the online static version of the examples available at <https://idaes-examples.readthedocs.org>.
 
 Finally, refer to the [complete idaes-pse documentation](https://idaes-pse.readthedocs.io/en/stable) for detailed [installation instructions](https://idaes-pse.readthedocs.io/en/stable/tutorials/getting_started/index.html), examples, guides, and reference.
 

--- a/docs/how_to_guides/opt_dependencies.rst
+++ b/docs/how_to_guides/opt_dependencies.rst
@@ -27,7 +27,7 @@ Available optional dependencies targets
 
 As of IDAES 2.1, the following ``extras_require`` targets are available:
 
-* ``examples``: for the :ref:`IDAES Examples <https://idaes-examples.readthedocs.org>`
+* ``examples``: for the `IDAES Examples <https://idaes-examples.readthedocs.org>`
 * ``ui``: for the :ref:`IDAES Flowsheet Visualizer <IFV>`
 * ``dmf``: for the :ref:`Data Management Framework <dmf-overview>`
 * ``grid``: for the :ref:`IDAES Grid integration <idaes-grid>`

--- a/docs/how_to_guides/opt_dependencies.rst
+++ b/docs/how_to_guides/opt_dependencies.rst
@@ -27,6 +27,7 @@ Available optional dependencies targets
 
 As of IDAES 2.1, the following ``extras_require`` targets are available:
 
+* ``examples``: for the :ref:`IDAES Examples <https://idaes-examples.readthedocs.org>`
 * ``ui``: for the :ref:`IDAES Flowsheet Visualizer <IFV>`
 * ``dmf``: for the :ref:`Data Management Framework <dmf-overview>`
 * ``grid``: for the :ref:`IDAES Grid integration <idaes-grid>`

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,9 @@ class ExtraDependencies:
         "addheader",
         "pyyaml",
     ]
+    examples = [
+        "idaes-examples",
+    ]
 
     def __init__(self):
         self._data = dict(type(self).__dict__)


### PR DESCRIPTION
## Summary/Motivation

- Allows the examples to be installed alongside the other optional dependencies, e.g.:

  ```sh
  pip install "idaes-pse[ui,dmf,grid,examples]"
  ```

## Changes proposed in this PR:

- Add `examples` to available `extras_require` targets
- Update README and Sphinx docs accordingly

## TODO

- [ ] Decide whether this is necessary, or potentially adding more confusion than it's worth, etc
- [ ] Decide if and how this should be tested in CI (e.g. could the "Run examples" job use this for installation?)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
