### PR TITLE
Raise exception in modular properties if IdealBubbleDew used with more than 2 phases

### DIFF
--- a/docs/explanations/components/property_package/general/bubble_dew.rst
+++ b/docs/explanations/components/property_package/general/bubble_dew.rst
@@ -7,7 +7,7 @@ Bubble and Dew Point Methods
 Ideal Assumptions (``IdealBubbleDew``)
 --------------------------------------
 
-In the case where ideal behavior can be assumed, i.e. ideal gas assumption and Raoult's Law holds, the bubble and dew points can be calculated directly from the saturation pressure using the following equations.
+In the case where ideal behavior can be assumed, i.e., ideal gas assumption and Raoult's Law holds, the bubble and dew points can be calculated directly from the saturation pressure using the following equations. Note that these equations assume that only two phases are present, and thus this approach is not easily extended to cases where additional phases are present (a ConfigurationError will be raised if this is detected). For systems with more than two phases, the LogBubbleDew approach should be used instead.
 
 Ideal Bubble Pressure
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference_guides/core/util/index.rst
+++ b/docs/reference_guides/core/util/index.rst
@@ -6,6 +6,7 @@
 
     dyn_utils
     initialization
+    math
     misc
     model_diagnostics
     model_serializer

--- a/docs/reference_guides/core/util/math.rst
+++ b/docs/reference_guides/core/util/math.rst
@@ -1,0 +1,13 @@
+Mathematical Utility Methods
+============================
+
+.. contents:: Contents
+    :depth: 2
+
+There are a number of useful mathematical operations that either exhibit singularities or non-smooth behavior that can cause issues when used in equation-oriented models. This library contains smooth formulations for some of these operations which can be used to approximate these operations in models.
+
+Users should note that these formulations involve smoothing parameters which should be tuned for their particular system. Larger values generally result in smoother behavior but greater error.
+
+.. automodule:: idaes.core.util.math
+  :members:
+

--- a/idaes/models/properties/modular_properties/phase_equil/bubble_dew.py
+++ b/idaes/models/properties/modular_properties/phase_equil/bubble_dew.py
@@ -26,6 +26,7 @@ from idaes.models.properties.modular_properties.base.utility import (
     get_component_object as cobj,
 )
 import idaes.core.util.scaling as iscale
+from idaes.core.util.exceptions import ConfigurationError
 
 # _valid_VL_component_list return variables that are not need in all cases
 # pylint: disable=W0612
@@ -42,6 +43,7 @@ class IdealBubbleDew:
     # calculate concentrations at the bubble and dew points
     @staticmethod
     def temperature_bubble(b):
+        _non_vle_phase_check(b)
         try:
 
             def rule_bubble_temp(b, p1, p2):
@@ -161,6 +163,7 @@ class IdealBubbleDew:
     # Dew temperature methods
     @staticmethod
     def temperature_dew(b):
+        _non_vle_phase_check(b)
         try:
 
             def rule_dew_temp(b, p1, p2):
@@ -282,6 +285,7 @@ class IdealBubbleDew:
     # Bubble pressure methods
     @staticmethod
     def pressure_bubble(b):
+        _non_vle_phase_check(b)
         try:
 
             def rule_bubble_press(b, p1, p2):
@@ -386,6 +390,7 @@ class IdealBubbleDew:
     # Dew pressure methods
     @staticmethod
     def pressure_dew(b):
+        _non_vle_phase_check(b)
         try:
 
             def rule_dew_press(b, p1, p2):
@@ -887,3 +892,11 @@ def _valid_VL_component_list(blk, pp):
                 v_only_comps.append(j)
 
     return l_phase, v_phase, vl_comps, henry_comps, l_only_comps, v_only_comps
+
+
+def _non_vle_phase_check(blk):
+    if len(blk.phase_list) > 2:
+        raise ConfigurationError(
+            "Ideal assumption for calculating bubble and/or dew points is only valid "
+            "for systems with two phases. Please use LogBubbleDew approach instead."
+        )

--- a/idaes/models/properties/modular_properties/phase_equil/tests/test_bubble_dew.py
+++ b/idaes/models/properties/modular_properties/phase_equil/tests/test_bubble_dew.py
@@ -29,6 +29,7 @@ from idaes.models.properties.modular_properties.base.generic_property import (
     GenericParameterData,
 )
 from idaes.models.properties.modular_properties.base.tests.dummy_eos import DummyEoS
+from idaes.core.util.exceptions import ConfigurationError
 
 
 # Dummy class to use for Psat calls
@@ -142,6 +143,43 @@ class TestBubbleTempIdeal(object):
                         frame.props[1].eq_mole_frac_tbub[pp[0], pp[1], k].body
                     ) == pytest.approx(0, abs=1e-8)
 
+    @pytest.mark.unit
+    def test_inert_phases(self):
+        m = ConcreteModel()
+
+        # Dummy params block
+        m.params = DummyParameterBlock(
+            components={
+                "H2O": {"pressure_sat_comp": pressure_sat_comp},
+                "EtOH": {"pressure_sat_comp": pressure_sat_comp},
+            },
+            phases={
+                "Liq": {"equation_of_state": DummyEoS},
+                "Vap": {"equation_of_state": DummyEoS},
+                "Sold": {"equation_of_state": DummyEoS},
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units={
+                "time": pyunits.s,
+                "length": pyunits.m,
+                "mass": pyunits.kg,
+                "amount": pyunits.mol,
+                "temperature": pyunits.K,
+            },
+        )
+        m.params._pe_pairs = Set(initialize=[("Vap", "Liq")])
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        with pytest.raises(
+            ConfigurationError,
+            match="Ideal assumption for calculating bubble and/or dew points is only valid "
+            "for systems with two phases. Please use LogBubbleDew approach instead.",
+        ):
+            IdealBubbleDew.temperature_bubble(m.props[1])
+
 
 class TestDewTempIdeal(object):
     @pytest.mark.unit
@@ -191,6 +229,43 @@ class TestDewTempIdeal(object):
                         frame.props[1].eq_mole_frac_tdew[pp[0], pp[1], k].body
                     ) == pytest.approx(0, abs=1e-8)
 
+    @pytest.mark.unit
+    def test_inert_phases(self):
+        m = ConcreteModel()
+
+        # Dummy params block
+        m.params = DummyParameterBlock(
+            components={
+                "H2O": {"pressure_sat_comp": pressure_sat_comp},
+                "EtOH": {"pressure_sat_comp": pressure_sat_comp},
+            },
+            phases={
+                "Liq": {"equation_of_state": DummyEoS},
+                "Vap": {"equation_of_state": DummyEoS},
+                "Sold": {"equation_of_state": DummyEoS},
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units={
+                "time": pyunits.s,
+                "length": pyunits.m,
+                "mass": pyunits.kg,
+                "amount": pyunits.mol,
+                "temperature": pyunits.K,
+            },
+        )
+        m.params._pe_pairs = Set(initialize=[("Vap", "Liq")])
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        with pytest.raises(
+            ConfigurationError,
+            match="Ideal assumption for calculating bubble and/or dew points is only valid "
+            "for systems with two phases. Please use LogBubbleDew approach instead.",
+        ):
+            IdealBubbleDew.temperature_bubble(m.props[1])
+
 
 class TestBubblePresIdeal(object):
     @pytest.mark.unit
@@ -238,6 +313,43 @@ class TestBubblePresIdeal(object):
                     assert value(
                         frame.props[1].eq_mole_frac_pbub[pp[0], pp[1], k].body
                     ) == pytest.approx(0, abs=1e-8)
+
+    @pytest.mark.unit
+    def test_inert_phases(self):
+        m = ConcreteModel()
+
+        # Dummy params block
+        m.params = DummyParameterBlock(
+            components={
+                "H2O": {"pressure_sat_comp": pressure_sat_comp},
+                "EtOH": {"pressure_sat_comp": pressure_sat_comp},
+            },
+            phases={
+                "Liq": {"equation_of_state": DummyEoS},
+                "Vap": {"equation_of_state": DummyEoS},
+                "Sold": {"equation_of_state": DummyEoS},
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units={
+                "time": pyunits.s,
+                "length": pyunits.m,
+                "mass": pyunits.kg,
+                "amount": pyunits.mol,
+                "temperature": pyunits.K,
+            },
+        )
+        m.params._pe_pairs = Set(initialize=[("Vap", "Liq")])
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        with pytest.raises(
+            ConfigurationError,
+            match="Ideal assumption for calculating bubble and/or dew points is only valid "
+            "for systems with two phases. Please use LogBubbleDew approach instead.",
+        ):
+            IdealBubbleDew.temperature_bubble(m.props[1])
 
 
 class TestDewPressureIdeal(object):
@@ -287,3 +399,40 @@ class TestDewPressureIdeal(object):
                     assert value(
                         frame.props[1].eq_mole_frac_pdew[pp[0], pp[1], k].body
                     ) == pytest.approx(0, abs=1e-8)
+
+    @pytest.mark.unit
+    def test_inert_phases(self):
+        m = ConcreteModel()
+
+        # Dummy params block
+        m.params = DummyParameterBlock(
+            components={
+                "H2O": {"pressure_sat_comp": pressure_sat_comp},
+                "EtOH": {"pressure_sat_comp": pressure_sat_comp},
+            },
+            phases={
+                "Liq": {"equation_of_state": DummyEoS},
+                "Vap": {"equation_of_state": DummyEoS},
+                "Sold": {"equation_of_state": DummyEoS},
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units={
+                "time": pyunits.s,
+                "length": pyunits.m,
+                "mass": pyunits.kg,
+                "amount": pyunits.mol,
+                "temperature": pyunits.K,
+            },
+        )
+        m.params._pe_pairs = Set(initialize=[("Vap", "Liq")])
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        with pytest.raises(
+            ConfigurationError,
+            match="Ideal assumption for calculating bubble and/or dew points is only valid "
+            "for systems with two phases. Please use LogBubbleDew approach instead.",
+        ):
+            IdealBubbleDew.temperature_bubble(m.props[1])


### PR DESCRIPTION
## Fixes #1176, #1212


## Summary/Motivation:
From issue #1212, using the `IdealBubbleDew` approach in a system with more than just vapor and liquid phases results in unexpected (and incorrect) behavior. For these cases, `LogBubbleDew` should be used instead.

Also, this PR adds the missing docs for `idaes.core.util.math`.

## Changes proposed in this PR:
- Raises a `ConfigurationError` if a user tries to use `IdealBubbleDew` with more than 2 phases (we check that there is a vapor and liquid phase elsewhere).
- Add comment to docs informing users of this limitation and instructing them to use `LogBubbleDew` instead.
- Add missing docs page for mathematical utility functions using automodule.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
