### PR TITLE
global search and replace pyomo.core.expr.current -> pyomo.core.expr (ref pyomo PR #2910)

### DIFF
--- a/idaes/apps/uncertainty_propagation/sens.py
+++ b/idaes/apps/uncertainty_propagation/sens.py
@@ -33,7 +33,7 @@ from pyomo.environ import (
     check_optimal_termination,
 )
 from pyomo.common.sorting import sorted_robust
-from pyomo.core.expr.current import ExpressionReplacementVisitor
+from pyomo.core.expr import ExpressionReplacementVisitor
 
 from pyomo.common.modeling import unique_component_name
 from pyomo.opt import SolverFactory, SolverStatus

--- a/idaes/core/util/model_statistics.py
+++ b/idaes/core/util/model_statistics.py
@@ -22,7 +22,7 @@ import sys
 
 from pyomo.environ import Block, Constraint, Expression, Objective, Var, value
 from pyomo.dae import DerivativeVar
-from pyomo.core.expr.current import identify_variables
+from pyomo.core.expr import identify_variables
 from pyomo.common.collections import ComponentSet
 
 

--- a/idaes/models_extra/gas_distribution/properties/natural_gas.py
+++ b/idaes/models_extra/gas_distribution/properties/natural_gas.py
@@ -27,7 +27,7 @@ from pyomo.core.base.var import Var
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.expression import Expression
 from pyomo.core.base.param import Param
-from pyomo.core.expr.current import sqrt
+from pyomo.core.expr import sqrt
 
 # Import IDAES cores
 from idaes.core import (

--- a/idaes/models_extra/gas_distribution/unit_models/pipeline.py
+++ b/idaes/models_extra/gas_distribution/unit_models/pipeline.py
@@ -31,7 +31,7 @@ from pyomo.core.base.param import Param
 from pyomo.core.base.units_container import units as pyunits
 from pyomo.core.base.reference import Reference
 from pyomo.dae.diffvar import DerivativeVar
-from pyomo.core.expr.current import log10
+from pyomo.core.expr import log10
 from pyomo.core.expr.numvalue import value as pyo_value
 
 from idaes.core import (

--- a/idaes/models_extra/power_generation/unit_models/steamheater.py
+++ b/idaes/models_extra/power_generation/unit_models/steamheater.py
@@ -26,7 +26,7 @@ and roof superheater, model main equations:
 # Import Pyomo libraries
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 from pyomo.environ import value, Var, Param, asin, cos, Reference
-from pyomo.core.expr.current import Expr_if
+from pyomo.core.expr import Expr_if
 from pyomo.dae import DerivativeVar
 
 # Import IDAES cores

--- a/idaes/models_extra/power_generation/unit_models/waterwall_section.py
+++ b/idaes/models_extra/power_generation/unit_models/waterwall_section.py
@@ -37,7 +37,7 @@ from pyomo.environ import (
 )
 from pyomo.dae import DerivativeVar
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
-from pyomo.core.expr.current import Expr_if
+from pyomo.core.expr import Expr_if
 
 # Import IDAES cores
 from idaes.core import (

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ kwargs = dict(
     # Put abstract (non-versioned) deps here.
     # Concrete dependencies go in requirements[-dev].txt
     install_requires=[
-        "pyomo>=6.6.1",
+        "pyomo @ https://github.com/IDAES/pyomo/archive/6.6.2.idaes.2023.07.28.zip",
         "pint",  # required to use Pyomo units
         "networkx",  # required to use Pyomo network
         "numpy",


### PR DESCRIPTION
## Fixes
search and replace pyomo.core.expr.current -> pyomo.core.expr

## Summary/Motivation:
".current" has been deprecated (see pyomo PR #2910) 

## Changes proposed in this PR:
- replace deprecated imports 
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
