### PR TITLE
Adding deprecation warning for has_phase_equilibrium but only 1 phase

### DIFF
--- a/idaes/core/base/control_volume1d.py
+++ b/idaes/core/base/control_volume1d.py
@@ -37,6 +37,7 @@ from pyomo.environ import (
 )
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.common.config import ConfigValue, In
+from pyomo.common.deprecation import deprecation_warning
 
 # Import IDAES cores
 from idaes.core import (
@@ -438,22 +439,30 @@ argument).""",
         if has_phase_equilibrium:
             # First, check that phase equilibrium makes sense
             if len(self.config.property_package.phase_list) < 2:
-                raise ConfigurationError(
+                msg = (
                     "Property package has only one phase; control volume cannot include phase "
                     "equilibrium terms. Some property packages support phase equilibrium "
-                    "implicitly in which case additional terms are not necessary."
+                    "implicitly in which case additional terms are not necessary. "
+                    "You should set has_phase_equilibrium=False."
                 )
-            # Check that state blocks are set to calculate equilibrium
-            for t in self.flowsheet().time:
-                for x in self.length_domain:
-                    if not self.properties[t, x].config.has_phase_equilibrium:
-                        raise ConfigurationError(
-                            "{} material balance was set to include phase "
-                            "equilibrium, however the associated "
-                            "StateBlock was not set to include equilibrium "
-                            "constraints (has_phase_equilibrium=False). Please"
-                            " correct your configuration arguments.".format(self.name)
-                        )
+                deprecation_warning(
+                    msg=msg, logger=_log, version="2.0.0", remove_in="3.0.0"
+                )
+                has_phase_equilibrium = False
+            else:
+                # Check that state blocks are set to calculate equilibrium
+                for t in self.flowsheet().time:
+                    for x in self.length_domain:
+                        if not self.properties[t, x].config.has_phase_equilibrium:
+                            raise ConfigurationError(
+                                "{} material balance was set to include phase "
+                                "equilibrium, however the associated "
+                                "StateBlock was not set to include equilibrium "
+                                "constraints (has_phase_equilibrium=False). Please"
+                                " correct your configuration arguments.".format(
+                                    self.name
+                                )
+                            )
 
         # Get units from property package
         units = self.config.property_package.get_metadata().get_derived_units

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -614,7 +614,7 @@ def test_add_material_balances_rxn_mass():
 
 
 @pytest.mark.unit
-def test_add_material_balances_single_phase_w_equilibrium():
+def test_add_material_balances_single_phase_w_equilibrium(caplog):
     from idaes.models.properties import iapws95
 
     m = ConcreteModel()
@@ -627,16 +627,20 @@ def test_add_material_balances_single_phase_w_equilibrium():
 
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
 
-    with pytest.raises(
-        ConfigurationError,
-        match="Property package has only one phase; control volume cannot include phase "
-        "equilibrium terms. Some property packages support phase equilibrium "
-        "implicitly in which case additional terms are not necessary.",
-    ):
-        m.fs.cv.add_material_balances(
-            balance_type=MaterialBalanceType.useDefault,
-            has_phase_equilibrium=True,
-        )
+    m.fs.cv.add_material_balances(
+        balance_type=MaterialBalanceType.useDefault,
+        has_phase_equilibrium=True,
+    )
+    msg = (
+        "DEPRECATED: Property package has only one phase; control volume cannot "
+        "include phase equilibrium terms. Some property packages support phase "
+        "equilibrium implicitly in which case additional terms are not "
+        "necessary. You should set has_phase_equilibrium=False.  (deprecated in "
+        "2.0.0, will be removed in (or after) 3.0.0)"
+    )
+    assert msg.replace(" ", "") in caplog.records[0].message.replace("\n", "").replace(
+        " ", ""
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/core/base/tests/test_control_volume_1d.py
+++ b/idaes/core/base/tests/test_control_volume_1d.py
@@ -1245,7 +1245,7 @@ def test_add_material_balances_rxn_mass():
 
 
 @pytest.mark.unit
-def test_add_material_balances_single_phase_w_equilibrium():
+def test_add_material_balances_single_phase_w_equilibrium(caplog):
     from idaes.models.properties import iapws95
 
     m = ConcreteModel()
@@ -1264,16 +1264,21 @@ def test_add_material_balances_single_phase_w_equilibrium():
     m.fs.cv.add_geometry()
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
 
-    with pytest.raises(
-        ConfigurationError,
-        match="Property package has only one phase; control volume cannot include phase "
-        "equilibrium terms. Some property packages support phase equilibrium "
-        "implicitly in which case additional terms are not necessary.",
-    ):
-        m.fs.cv.add_material_balances(
-            balance_type=MaterialBalanceType.useDefault,
-            has_phase_equilibrium=True,
-        )
+    m.fs.cv.add_material_balances(
+        balance_type=MaterialBalanceType.useDefault,
+        has_phase_equilibrium=True,
+    )
+
+    msg = (
+        "DEPRECATED: Property package has only one phase; control volume cannot "
+        "include phase equilibrium terms. Some property packages support phase "
+        "equilibrium implicitly in which case additional terms are not "
+        "necessary. You should set has_phase_equilibrium=False.  (deprecated in "
+        "2.0.0, will be removed in (or after) 3.0.0)"
+    )
+    assert msg.replace(" ", "") in caplog.records[0].message.replace("\n", "").replace(
+        " ", ""
+    )
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Required for #1225


## Summary/Motivation:
This PR adds a deprecation warning for backward compatibility for cases where a control volume is set to include phase equilibrium terms but the associated property package only has a single phase.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
