### PR TITLE
Add version constraint to exclude pandas 2.1 as a workaround for Pysmo test failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ kwargs = dict(
         "pint",  # required to use Pyomo units
         "networkx",  # required to use Pyomo network
         "numpy",
-        "pandas<2.1",
+        "pandas==2.1",
         "scipy",
         "sympy",  # idaes.core.util.expr_doc
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,8 @@ kwargs = dict(
         "pint",  # required to use Pyomo units
         "networkx",  # required to use Pyomo network
         "numpy",
+        # pandas constraint added on 2023-08-30 b/c Pysmo test failures with 2.1
+        # see IDAES/idaes-pse#1253
         "pandas<2.1",
         "scipy",
         "sympy",  # idaes.core.util.expr_doc

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ kwargs = dict(
         "pint",  # required to use Pyomo units
         "networkx",  # required to use Pyomo network
         "numpy",
-        "pandas==2.1",
+        "pandas<2.1",
         "scipy",
         "sympy",  # idaes.core.util.expr_doc
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ kwargs = dict(
         "pint",  # required to use Pyomo units
         "networkx",  # required to use Pyomo network
         "numpy",
-        "pandas",
+        "pandas<2.1",
         "scipy",
         "sympy",  # idaes.core.util.expr_doc
         "matplotlib",


### PR DESCRIPTION
## Resolves (temporarily) #1253


## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
