### PR TITLE
Setting pandas!=2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ kwargs = dict(
         "numpy",
         # pandas constraint added on 2023-08-30 b/c bug in v2.1
         # see IDAES/idaes-pse#1253
-        "pandas!=2.1",
+        "pandas!=2.1.0",
         "scipy",
         "sympy",  # idaes.core.util.expr_doc
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -131,9 +131,9 @@ kwargs = dict(
         "pint",  # required to use Pyomo units
         "networkx",  # required to use Pyomo network
         "numpy",
-        # pandas constraint added on 2023-08-30 b/c Pysmo test failures with 2.1
+        # pandas constraint added on 2023-08-30 b/c bug in v2.1
         # see IDAES/idaes-pse#1253
-        "pandas<2.1",
+        "pandas!=2.1",
         "scipy",
         "sympy",  # idaes.core.util.expr_doc
         "matplotlib",


### PR DESCRIPTION
## Fixes #1253


## Summary/Motivation:
Pandas introduced a bug in v2.1.0 that is causing Pysmo tests to fail. It looks like this bug will be fixed in the upcoming v2.1.1 pandas release.

## Changes proposed in this PR:
- Setting `"pandas!=2.1.0"` in `setup.py` to avoid using the buggy version of pandas and to allow us to switch the the corrected version once it is released.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
