### PR TITLE
[WIP] Unpack idaes-local tar file in get-extensions command

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -621,7 +621,7 @@ def create_dir(d):
     if os.path.exists(d):
         return
     else:
-        os.mkdir(d)
+        os.makedirs(d)
 
 
 def get_data_directory():


### PR DESCRIPTION
## Fixes
Part of https://github.com/IDAES/idaes-ext/issues/261

## Summary/Motivation:
Make CyIpopt as easy to use as possible.

## Changes proposed in this PR:
- After unpacking `idaes-solvers-<os>.tar.gz` into `.idaes/bin`, unpack `idaes-local-<os>.tar.gz` (which is included in idaes-solvers) into `.idaes`

Opening as a WIP as there are some unresolved details:
- Current implementation assumes that the parent directory of the "install-to directory" is writable (and the correct place to unpack idaes-local). I'm not sure what the best way to specify this directory is.
- Implementation could probably be streamlined if we distributed `idaes-local-<os>.tar.gz` on the downloads page of idaes-ext (instead of inside the idaes-solvers tar file)
- We currently distribute idaes-local for MacOS as `idaes-local-darwin-arm64.tar.gz`, which is inconsistent with all the other tar files distributed for MacOS (which are `*-darwin-aarch64.tar.gz`). I would recommend changing this in idaes-ext

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
