### PR TITLE
Add SCIP solver for testing

### DIFF
--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -42,3 +42,9 @@ runs:
         echo '::group::Output of "idaes get-extensions" command'
         idaes get-extensions --extra petsc --verbose
         echo '::endgroup::'
+    - name: Install SCIP from AMPL
+      shell: bash -l {0}
+      run: |
+        echo '::group::Output of "pip install ampl_module_scip" command'
+        ${{ inputs.install-command }} --index-url https://pypi.ampl.com ampl_module_scip
+        echo '::endgroup::'

--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -21,8 +21,13 @@ This module contains utility functions for use in testing IDAES models.
 __author__ = "Andrew Lee"
 
 
+import os
+from typing import Callable, Union
+
 from pyomo.environ import Constraint, Set, units, Var
 from pyomo.common.config import ConfigBlock
+from pyomo.common import Executable
+from pyomo.common.dependencies import attempt_import
 
 from idaes.core import (
     declare_process_block_class,
@@ -409,3 +414,31 @@ class ReactionBlockData(ReactionBlockDataBase):
             return MaterialFlowBasis.mass
         else:
             return MaterialFlowBasis.other
+
+
+def _enable_scip_solver_for_testing(
+    name: str = "scip",
+) -> Union[Callable[[], None], None]:
+    ampl_module_scip, is_available = attempt_import("ampl_module_scip")
+    if not is_available:
+        _log.warning(
+            "ampl_module_scip must be installed to enable SCIP solver for testing"
+        )
+        return None
+
+    new_path_entry = ampl_module_scip.bin_dir
+    # TODO prepending new_path_entry to PATH means that the "testing" SCIP will "shadow"
+    # existing executable directories already on PATH
+    # this behavior would match the (implied) semantics of this function, i.e.
+    # "enable SCIP solver used for testing (at the expense of other non-testing SCIP executables)"
+    os.environ["PATH"] = os.pathsep.join([new_path_entry, os.environ["PATH"]])
+    Executable.rehash()
+
+    def undo_changes():
+        try:
+            os.environ["PATH"].remove(new_path_entry)
+            Executable.rehash()
+        except ValueError:
+            pass
+
+    return undo_changes

--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -434,11 +434,16 @@ def _enable_scip_solver_for_testing(
     os.environ["PATH"] = os.pathsep.join([new_path_entry, os.environ["PATH"]])
     Executable.rehash()
 
-    def undo_changes():
-        try:
-            os.environ["PATH"].remove(new_path_entry)
-            Executable.rehash()
-        except ValueError:
-            pass
+    def remove_from_path():
+        path_as_list = os.environ["PATH"].split(os.pathsep)
 
-    return undo_changes
+        try:
+            path_as_list.remove(new_path_entry)
+        except ValueError:
+            # not in PATH
+            pass
+        else:
+            os.environ["PATH"] = os.pathsep.join(path_as_list)
+            Executable.rehash()
+
+    return remove_from_path

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -1809,21 +1809,21 @@ class TestDegeneracyHunter:
         dh._prepare_candidates_milp()
         dh._solve_candidates_milp()
 
-        assert value(dh.candidates_milp.nu[0]) == pytest.approx(-1e-05, rel=1e-5)
-        assert value(dh.candidates_milp.nu[1]) == pytest.approx(1e-05, rel=1e-5)
+        assert value(dh.candidates_milp.nu[0]) == pytest.approx(1e-05, rel=1e-5)
+        assert value(dh.candidates_milp.nu[1]) == pytest.approx(-1e-05, rel=1e-5)
 
         assert value(dh.candidates_milp.y_pos[0]) == pytest.approx(0, abs=1e-5)
-        assert value(dh.candidates_milp.y_pos[1]) == pytest.approx(1, rel=1e-5)
+        assert value(dh.candidates_milp.y_pos[1]) == pytest.approx(0, rel=1e-5)
 
-        assert value(dh.candidates_milp.y_neg[0]) == pytest.approx(-0, abs=1e-5)
-        assert value(dh.candidates_milp.y_neg[1]) == pytest.approx(-0, abs=1e-5)
+        assert value(dh.candidates_milp.y_neg[0]) == pytest.approx(0, abs=1e-5)
+        assert value(dh.candidates_milp.y_neg[1]) == pytest.approx(1, abs=1e-5)
 
         assert value(dh.candidates_milp.abs_nu[0]) == pytest.approx(1e-05, rel=1e-5)
         assert value(dh.candidates_milp.abs_nu[1]) == pytest.approx(1e-05, rel=1e-5)
 
         assert dh.degenerate_set == {
-            model.con2: -1e-05,
-            model.con5: 1e-05,
+            model.con2: value(dh.candidates_milp.nu[0]),
+            model.con5: value(dh.candidates_milp.nu[1]),
         }
 
     @pytest.mark.unit

--- a/idaes/core/util/tests/test_scip_for_testing.py
+++ b/idaes/core/util/tests/test_scip_for_testing.py
@@ -1,0 +1,39 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2023 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+import os
+
+import pytest
+from pyomo.environ import SolverFactory
+
+from idaes.core.util.testing import _enable_scip_solver_for_testing
+
+
+ampl_module_scip = pytest.importorskip(
+    "ampl_module_scip", reason="'ampl_module_scip' not available"
+)
+
+
+@pytest.mark.unit
+def test_path_manipulation():
+    path_before_enabling = str(os.environ["PATH"])
+
+    func_to_revert_changes = _enable_scip_solver_for_testing()
+    path_after_enabling = str(os.environ["PATH"])
+    sf = SolverFactory("scip")
+    assert len(path_after_enabling) > len(path_before_enabling)
+    assert str(ampl_module_scip.bin_dir) in str(sf.executable())
+    assert sf.available()
+
+    func_to_revert_changes()
+    path_after_reverting = str(os.environ["PATH"])
+    assert path_after_reverting == path_before_enabling

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ kwargs = dict(
     # Put abstract (non-versioned) deps here.
     # Concrete dependencies go in requirements[-dev].txt
     install_requires=[
-        "pyomo>=6.6.2",
+        "pyomo @ git+https://github.com/IDAES/Pyomo@6.7.0.idaes.2023.11.6",
         "pint",  # required to use Pyomo units
         "networkx",  # required to use Pyomo network
         "numpy",


### PR DESCRIPTION
## Resolves #1281

## Changes proposed in this PR:
- Add non-public util function to enable SCIP solver (using `ampl_module_scip`)
- Add `scip_solver` pytest fixture for model diagnostics tests
  - If a test uses the `scip_solver` fixture (i.e. requires SCIP to run), it will be automatically skipped without the need of adding individual `pytest.mark.skipif()` markers if SCIP is not available
- Add step in GHA installation action to install `ampl_module_scip` from https://pypi.ampl.com

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
