### PR TITLE
Solid-Liquid Separator Base Model

### DIFF
--- a/docs/reference_guides/model_libraries/generic/unit_models/index.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/index.rst
@@ -2,7 +2,7 @@ Unit Models
 ===========
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     compressor
     cstr
@@ -30,3 +30,5 @@ Unit Models
     translator
     turbine
     valve
+    
+    solid_liquid/index

--- a/docs/reference_guides/model_libraries/generic/unit_models/index.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/index.rst
@@ -2,7 +2,7 @@ Unit Models
 ===========
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     compressor
     cstr

--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/index.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/index.rst
@@ -1,7 +1,7 @@
 Solid-Liquid Unit Models
 ========================
 
-This library contains models specific for solid-liquid processing operations (although some of them may also be applicable in other circumstances). Models in this library assume streams consist of separate solid and liquid phases (with separate property packages) and thus all stream are represented by separate solid and liquid ports. Separation of solids and liquids is generally assume to result in a concentrated solid-liquid stream and a clarified liquid stream.
+This library contains models specific for solid-liquid processing operations (although some of them may also be applicable in other circumstances). Models in this library assume streams consist of separate solid and liquid phases (with separate property packages) and thus all streams are represented by separate solid and liquid ports. Separation of solids and liquids is generally assumed to result in a concentrated solid-liquid stream and a clarified liquid stream.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/index.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/index.rst
@@ -1,0 +1,9 @@
+Solid-Liquid Unit Models
+========================
+
+This library contains models specific for solid-liquid processing operations (although some of them may also be applicable in other circumstances). Models in this library assume streams consist of separate solid and liquid phases (with separate property packages) and thus all stream are represented by separate solid and liquid ports. Separation of solids and liquids is generally assume to result in a concentrated solid-liquid stream and a clarified liquid stream.
+
+.. toctree::
+    :maxdepth: 1
+
+    sl_separator

--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/index.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/index.rst
@@ -7,3 +7,4 @@ This library contains models specific for solid-liquid processing operations (al
     :maxdepth: 1
 
     sl_separator
+    thickener0d

--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator.rst
@@ -1,0 +1,52 @@
+Generic Solid-Liquid Separator
+===============================
+
+The ``SLSeparator`` unit model is a general purpose model for representing the separation of mixed streams containing solids and liquids, such as filtration and thickening. The model assumes that the mixed stream is separated into a concentrated solid-liquid stream and a stream of clarified liquid.
+
+Degrees of Freedom
+------------------
+
+The ``SLSeparator`` model has 1 degree of freedom, which is generally the liquid recovery fraction. Note that due to the assumption that all solids report to the concentrated outlet, the solid inlet and outlet Ports link to the same variables (and thus cannot be fixed independently).
+
+Model Structure
+---------------
+
+The model consists of two parts. The solid phase is represented by a single StateBlock as all solids in the inlet are assumed to report to the concentrated outlet. The liquid phase is represented by a standard :ref:`Separator <reference_guides/model_libraries/generic/unit_models/separator:Separator>` block which splits the incoming liquid between the concentrated and clarified outlets.
+
+The ``SLSeparator`` unit model has a total of 5 ports:
+
+* ``solid_inlet`` representing the solids in the incoming stream,
+* ``liquid_inlet`` representing the liquid in the incoming stream,
+* ``solid_outlet`` representing the solids in the concentrated stream,
+* ``retained_liquid_outlet`` representing the liquid in the concentrated stream, and,
+* ``recovered_liquid_outlet`` representing the liquid in the clarified stream.
+
+Additional Constraints
+----------------------
+
+The ``SLSeparator`` model adds no additional constraints beyond those written by the :ref:`Separator <reference_guides/model_libraries/generic/unit_models/separator:Separator>` and StateBlocks.
+
+Variables
+---------
+
+The ``SLSeparator`` adds one Reference to a variable in the :ref:`Separator <reference_guides/model_libraries/generic/unit_models/separator:Separator>`.
+
+============ ================ ================================================================================================
+Variable     Name             Notes
+============ ================ ================================================================================================
+:math:`R_t`  liquid_recovery  Fraction of liquid which reports to the clarified stream, reference to ``split.split_fraction``
+============ ================ ================================================================================================
+
+.. module:: idaes.models.unit_models.solid_liquid.sl_separator
+
+SLSeparator Class
+-----------------
+
+.. autoclass:: SLSeparator
+  :members:
+
+SLSeparatorData Class
+---------------------
+
+.. autoclass:: SLSeparatorData
+  :members:

--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator.rst
@@ -1,5 +1,5 @@
 Generic Solid-Liquid Separator
-===============================
+==============================
 
 The ``SLSeparator`` unit model is a general purpose model for representing the separation of mixed streams containing solids and liquids, such as filtration and thickening. The model assumes that the mixed stream is separated into a concentrated solid-liquid stream and a stream of clarified liquid.
 

--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/thickener0d.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/thickener0d.rst
@@ -19,7 +19,7 @@ In the current implementation of the model, :math:`Y_{pinch}` and :math:`u_{pinc
 Degrees of Freedom
 ------------------
 
-The ``Thickener0D`` model has 5 degrees of freedom, which is are generally chosen from:
+The ``Thickener0D`` model has 5 degrees of freedom, which are generally chosen from:
 
 * the liquid recovery fraction or underflow liquid-to-solid ratio,
 * the liquid-to-solid ratio and settling velocity at the pinch (critical) point,

--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/thickener0d.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/thickener0d.rst
@@ -1,0 +1,70 @@
+Thickener (0D)
+==============
+
+The ``Thickener0D`` unit model is an extension of the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Generic Solid-Liquid Separator>` model which adds constraints to estimate the area and height of a vessel required ot achive the desired separation of solid and liquid based on experimental measurements of the settling velocity. This model is based on corrleations described in:
+
+[1] Couldson & Richardson's Chemical Engineering, Volume 2 Particle Technology & Separation Processes (4th Ed.), Butterworth-Heinemann (2001)
+
+Degrees of Freedom
+------------------
+
+The ``Thickener0D`` model has 5 degrees of freedom, which is are generally chosen from:
+
+* the liquid recovery fraction or underflow liquid-to-solid ratio,
+* the liquid-to-solid ratio and settling velocity at the pinch (critical) point,
+* the cross-sectional area of the thickener,
+* the depth of the clarification zone,
+* the depth of the sedimetnation zone or the required settling time (experimental).
+
+Model Structure
+---------------
+
+The ``Thickener0D`` model has the same strucutre as the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Model Structure>`.
+
+Additional Constraints
+----------------------
+
+The ``Thickener0D`` model adds the following additional constraints beyond those written by the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Additional Constraints>`.
+
+The cross-sectional area of the thickener is calculated using:
+
+.. math:: A = \frac{S_t}{\rho_{liq, t}} \times \frac{(Y_{pinch, t}-Y_{under, t})}{u_{pinch, t}}
+
+where :math:`A` is the cross-section area ofthe thickener, :math:`S_t` is the mass flowrate of solids entering the thickener, :math:`\rho_{liq}` is hte mass density of the liquid phase, :math:`Y_{pinch}` and :math:`Y_{under}` are the mass-based liquid-to-solid ratios atthe pinch point and underflow respectively and :math:`u_{pinch}` is the sedimentaion velocity of the suspension at the pinch point (Eqn 5.54, pg. 198 in [1]).
+
+The liquid-solid ratio at the underflow can be calculated using:
+
+.. math:: Y_{under, t} = \frac{L_{under, t}}{S_t}
+
+where :math:`L_{under}` is hte liquid mass flowrate at the underflow.
+
+The total height of the thickener is calculated using:
+
+.. math:: H = \frac{S_t \tau_{t}}{A\rho_{sol, t}} \times (1+\frac{\rho_{sol}}{\rho_{liq}} \times Y_{avg}) + H_{clarified}
+
+where :math:`H` is the total height of the thickener, :math:`H_{clarified}` is the height of the clarification zone, :math:`\tau` is the empirically measured settling time required to achieve the desired underflow conditions and :math:`Y_avg` is the average liquid-solid ratio in the thickener (assumed to be linear) (Eqn 5.55, pg. 198 in [1]).
+
+Variables
+---------
+
+The ``Thickener0D`` adds the following variables in addition to those in the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Variables>`.
+
+============ ================ ================================================================================================
+Variable     Name             Notes
+============ ================ ================================================================================================
+:math:`R_t`  liquid_recovery  Fraction of liquid which reports to the clarified stream, reference to ``split.split_fraction``
+============ ================ ================================================================================================
+
+.. module:: idaes.models.unit_models.solid_liquid.thickener
+
+SLSeparator Class
+-----------------
+
+.. autoclass:: Thickener0D
+  :members:
+
+SLSeparatorData Class
+---------------------
+
+.. autoclass:: Thickener0DData
+  :members:

--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/thickener0d.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/thickener0d.rst
@@ -1,9 +1,20 @@
 Thickener (0D)
 ==============
 
-The ``Thickener0D`` unit model is an extension of the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Generic Solid-Liquid Separator>` model which adds constraints to estimate the area and height of a vessel required ot achive the desired separation of solid and liquid based on experimental measurements of the settling velocity. This model is based on corrleations described in:
+The ``Thickener0D`` unit model is an extension of the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Generic Solid-Liquid Separator>` model which adds constraints to estimate the area and height of a vessel required to achieve the desired separation of solid and liquid based on experimental measurements of the settling velocity. This model is based on correlations described in:
 
-[1] Couldson & Richardson's Chemical Engineering, Volume 2 Particle Technology & Separation Processes (4th Ed.), Butterworth-Heinemann (2001)
+[1] Coulson & Richardson's Chemical Engineering, Volume 2 Particle Technology & Separation Processes (4th Ed.), Butterworth-Heinemann (2001)
+
+Sizing Thickeners and Pinch Point
+---------------------------------
+
+The approach for sizing the thickener vessel used in this model relies on identifying a pinch point in the thickener which is the limiting condition for the settling velocity of the suspension as described in [1]. The pinch point is described by the condition:
+
+.. math:: max \left( \frac{(Y - Y_{under})}{u(Y)} \right)
+
+where :math:`Y` is the mass based liquid-to-solid ratio, :math:`u(Y)` is the settling velocity of the suspension as a function of :math:`Y` and :math:`Y_{under}` is the liquid-solid ratio at the thickener underflow. Correlations exist which can predict :math:`u(Y)` however in many cases it is necessary to measure this experimentally. Additionally, whilst there are techniques for embedding the maximization operation within an equation-oriented model, these approaches tend to be highly non-linear and require the user to provide good values for scaling parameters and thus have not been implemented yet.
+
+In the current implementation of the model, :math:`Y_{pinch}` and :math:`u_{pinch}` are created as user-defined input variables which should generally be fixed at appropriate values. Users may choose to add a correlation for :math:`u(Y)` if they choose.
 
 Degrees of Freedom
 ------------------
@@ -14,12 +25,12 @@ The ``Thickener0D`` model has 5 degrees of freedom, which is are generally chose
 * the liquid-to-solid ratio and settling velocity at the pinch (critical) point,
 * the cross-sectional area of the thickener,
 * the depth of the clarification zone,
-* the depth of the sedimetnation zone or the required settling time (experimental).
+* the depth of the sedimentation zone or the required settling time (experimental).
 
 Model Structure
 ---------------
 
-The ``Thickener0D`` model has the same strucutre as the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Model Structure>`.
+The ``Thickener0D`` model has the same structure as the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Model Structure>`.
 
 Additional Constraints
 ----------------------
@@ -30,17 +41,17 @@ The cross-sectional area of the thickener is calculated using:
 
 .. math:: A = \frac{S_t}{\rho_{liq, t}} \times \frac{(Y_{pinch, t}-Y_{under, t})}{u_{pinch, t}}
 
-where :math:`A` is the cross-section area ofthe thickener, :math:`S_t` is the mass flowrate of solids entering the thickener, :math:`\rho_{liq}` is hte mass density of the liquid phase, :math:`Y_{pinch}` and :math:`Y_{under}` are the mass-based liquid-to-solid ratios atthe pinch point and underflow respectively and :math:`u_{pinch}` is the sedimentaion velocity of the suspension at the pinch point (Eqn 5.54, pg. 198 in [1]).
+where :math:`A` is the cross-section area of the thickener, :math:`S_t` is the mass flowrate of solids entering the thickener, :math:`\rho_{liq}` is the mass density of the liquid phase, :math:`Y_{pinch}` and :math:`Y_{under}` are the mass-based liquid-to-solid ratios at the pinch point and underflow respectively and :math:`u_{pinch}` is the sedimentation velocity of the suspension at the pinch point (Eqn 5.54, pg. 198 in [1]).
 
 The liquid-solid ratio at the underflow can be calculated using:
 
 .. math:: Y_{under, t} = \frac{L_{under, t}}{S_t}
 
-where :math:`L_{under}` is hte liquid mass flowrate at the underflow.
+where :math:`L_{under}` is the liquid mass flowrate at the underflow.
 
 The total height of the thickener is calculated using:
 
-.. math:: H = \frac{S_t \tau_{t}}{A\rho_{sol, t}} \times (1+\frac{\rho_{sol}}{\rho_{liq}} \times Y_{avg}) + H_{clarified}
+.. math:: H = \frac{S_t \tau_{t}}{A\rho_{sol, t}} \times \left( 1+\frac{\rho_{sol}}{\rho_{liq}} \times Y_{avg} \right) + H_{clarified}
 
 where :math:`H` is the total height of the thickener, :math:`H_{clarified}` is the height of the clarification zone, :math:`\tau` is the empirically measured settling time required to achieve the desired underflow conditions and :math:`Y_avg` is the average liquid-solid ratio in the thickener (assumed to be linear) (Eqn 5.55, pg. 198 in [1]).
 
@@ -49,11 +60,17 @@ Variables
 
 The ``Thickener0D`` adds the following variables in addition to those in the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Variables>`.
 
-============ ================ ================================================================================================
-Variable     Name             Notes
-============ ================ ================================================================================================
-:math:`R_t`  liquid_recovery  Fraction of liquid which reports to the clarified stream, reference to ``split.split_fraction``
-============ ================ ================================================================================================
+===================== ======================== ====== =====================================================================
+Variable              Name                     Index  Notes
+===================== ======================== ====== =====================================================================
+:math:`A`             area                     None   Cross-sectional area of thickener
+:math:`H`             height                   None   Total height of thickener
+:math:`H_{clarified}` height_clarified         None   Height of clarification zone in thickener (height above feed point)
+:math:`u_{pinch}`     settling_velocity_pinch  time   Settling velocity of suspension at pinch point
+:math:`Y_{pinch}`     liquid_solid_pinch       time   Liquid-solid ratio at pinch point
+:math:`Y_{under}`     liquid_solid_underflow   time   Liquid-solid ratio at underflow
+:math:`\tau`          settling_time            time   Settling time in thickener
+===================== ======================== ====== =====================================================================
 
 .. module:: idaes.models.unit_models.solid_liquid.thickener
 

--- a/idaes/models/unit_models/flash.py
+++ b/idaes/models/unit_models/flash.py
@@ -140,7 +140,7 @@ not used for when ideal_separation == True.
 **default** - EnergySplittingType.equal_temperature.
 **Valid values:** {
 **EnergySplittingType.equal_temperature** - outlet temperatures equal inlet
-**EnergySplittingType.equal_molar_enthalpy** - oulet molar enthalpies equal
+**EnergySplittingType.equal_molar_enthalpy** - outlet molar enthalpies equal
 inlet,
 **EnergySplittingType.enthalpy_split** - apply split fractions to enthalpy
 flows.}""",

--- a/idaes/models/unit_models/mscontactor.py
+++ b/idaes/models/unit_models/mscontactor.py
@@ -15,6 +15,8 @@ IDAES model for a generic multiple-stream contactor unit.
 """
 from functools import partial
 
+from pandas import DataFrame
+
 # Import Pyomo libraries
 from pyomo.environ import Block, Constraint, RangeSet, Reals, Set, units, Var
 from pyomo.common.config import ConfigDict, ConfigValue, Bool, In
@@ -42,6 +44,7 @@ from idaes.core.initialization.initializer_base import StoreState
 from idaes.core.solvers import get_solver
 from idaes.core.util.model_serializer import to_json, from_json
 import idaes.logger as idaeslog
+from idaes.core.util.units_of_measurement import report_quantity
 
 __author__ = "Andrew Lee"
 
@@ -902,7 +905,46 @@ class MSContactorData(UnitModelBlockData):
         )
 
     def _get_performance_contents(self, time_point=0):
-        raise NotImplementedError()
+        assert False
+        return {"vars": {"Liquid Recovery": self.liquid_recovery[time_point]}}
+
+    def _get_stream_table_contents(self, time_point=0):
+        stream_attributes = {}
+        stream_attributes["Units"] = {}
+
+        sblocks = {}
+        for stream, pconfig in self.config.streams.keys():
+            sblock = getattr(self, stream)
+            flow_dir = pconfig.flow_direction
+
+            if pconfig.has_feed:
+                inlet_state = getattr(self, stream + "_inlet_state")
+                sblocks[stream + " Inlet"] = inlet_state
+
+            if flow_dir == FlowDirection.forward:
+                outlet = self.elements.last()
+            elif flow_dir == FlowDirection.backward:
+                outlet = self.elements.first()
+            else:
+                raise BurntToast("If/else overrun when constructing stream table")
+
+            sblocks[stream + " Outlet"] = sblock[outlet]
+
+        for n, v in sblocks.items():
+            dvars = v[time_point].define_display_vars()
+
+            stream_attributes[n] = {}
+
+            for k in dvars:
+                for i in dvars[k].keys():
+                    stream_key = k if i is None else f"{k} {i}"
+
+                    quant = report_quantity(dvars[k][i])
+
+                    stream_attributes[n][stream_key] = quant.m
+                    stream_attributes["Units"][stream_key] = quant.u
+
+        return DataFrame.from_dict(stream_attributes, orient="columns")
 
 
 def _get_state_blocks(blk, t, s, stream):

--- a/idaes/models/unit_models/mscontactor.py
+++ b/idaes/models/unit_models/mscontactor.py
@@ -905,21 +905,22 @@ class MSContactorData(UnitModelBlockData):
         )
 
     def _get_performance_contents(self, time_point=0):
-        assert False
-        return {"vars": {"Liquid Recovery": self.liquid_recovery[time_point]}}
+        # Due to the flexibility of the MSContactor and the number of possible terms
+        # that could be included here, we will leave this up to the user to define.
+        return {}
 
     def _get_stream_table_contents(self, time_point=0):
         stream_attributes = {}
         stream_attributes["Units"] = {}
 
         sblocks = {}
-        for stream, pconfig in self.config.streams.keys():
+        for stream, pconfig in self.config.streams.items():
             sblock = getattr(self, stream)
             flow_dir = pconfig.flow_direction
 
             if pconfig.has_feed:
                 inlet_state = getattr(self, stream + "_inlet_state")
-                sblocks[stream + " Inlet"] = inlet_state
+                sblocks[stream + " Inlet"] = inlet_state[time_point]
 
             if flow_dir == FlowDirection.forward:
                 outlet = self.elements.last()
@@ -928,10 +929,10 @@ class MSContactorData(UnitModelBlockData):
             else:
                 raise BurntToast("If/else overrun when constructing stream table")
 
-            sblocks[stream + " Outlet"] = sblock[outlet]
+            sblocks[stream + " Outlet"] = sblock[time_point, outlet]
 
         for n, v in sblocks.items():
-            dvars = v[time_point].define_display_vars()
+            dvars = v.define_display_vars()
 
             stream_attributes[n] = {}
 

--- a/idaes/models/unit_models/solid_liquid/__init__.py
+++ b/idaes/models/unit_models/solid_liquid/__init__.py
@@ -11,3 +11,4 @@
 # for full copyright and license information.
 #################################################################################
 from .sl_separator import SLSeparator
+from .thickener import Thickener0D

--- a/idaes/models/unit_models/solid_liquid/__init__.py
+++ b/idaes/models/unit_models/solid_liquid/__init__.py
@@ -1,0 +1,13 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2023 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+from .sl_separator import SLSeparator

--- a/idaes/models/unit_models/solid_liquid/sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/sl_separator.py
@@ -15,7 +15,7 @@ Base model for solid-liquid separations.
 
 This model is intended to form the basis for solid-liquid separations where a mixed
 stream enters the unit and is separated into a concentrated solid-liquid stream and
-a stream of pure liquid (e.g. filers, thickeners, etc.)
+a stream of pure liquid (e.g. filters, thickeners, etc.)
 
 This model assumes separate property packages and ports for the solid and liquid
 streams and thus two inlet Ports (solid and liquid) and three outlet Ports (solids,

--- a/idaes/models/unit_models/solid_liquid/sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/sl_separator.py
@@ -23,14 +23,15 @@ This model assumes:
 streams.
 * two inlet Ports (solid and liquid)
 * three outlet Ports (solids, liquid with solids, separated liquids).
+
 """
 # Import Python libraries
 import logging
 from pandas import DataFrame
 
 # Import Pyomo libraries
-from pyomo.environ import Constraint, Reference
-from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
+from pyomo.environ import Reference
+from pyomo.common.config import ConfigBlock, ConfigValue, In
 from pyomo.network import Port
 
 # Import IDAES cores

--- a/idaes/models/unit_models/solid_liquid/sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/sl_separator.py
@@ -1,0 +1,301 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2023 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+"""
+Base model for solid-liquid separations.
+
+This model is intended to form the basis for solid-liquid separations where a mixed
+stream enters the unit and is separated into a concentrated solid-liquid stream and
+a stream of pure liquid (e.g. filers, thickeners, etc.)
+
+This model assumes:
+
+* separate property packages and ports for the solid and liquid
+streams.
+* two inlet Ports (solid and liquid)
+* three outlet Ports (solids, liquid with solids, separated liquids).
+"""
+# Import Python libraries
+import logging
+from pandas import DataFrame
+
+# Import Pyomo libraries
+from pyomo.environ import Constraint, Reference
+from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
+from pyomo.network import Port
+
+# Import IDAES cores
+from idaes.core import (
+    declare_process_block_class,
+    MaterialBalanceType,
+    MomentumBalanceType,
+    UnitModelBlockData,
+    useDefault,
+)
+from idaes.models.unit_models.separator import (
+    Separator,
+    SplittingType,
+    EnergySplittingType,
+)
+from idaes.core.initialization import BlockTriangularizationInitializer
+from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.units_of_measurement import report_quantity
+
+
+__author__ = "Andrew Lee"
+
+
+# Set up logger
+logger = logging.getLogger("idaes.unit_model")
+
+
+@declare_process_block_class("SLSeparator")
+class SLSeparatorData(UnitModelBlockData):
+    """
+    Standard Solid-Liquid Separator Unit Model Class
+    """
+
+    CONFIG = ConfigBlock()
+    CONFIG.declare(
+        "dynamic",
+        ConfigValue(
+            domain=In([False]),
+            default=False,
+            description="Dynamic model flag - must be False",
+            doc="""Indicates whether this model will be dynamic or not,
+**default** = False. Flash units do not support dynamic behavior.""",
+        ),
+    )
+    CONFIG.declare(
+        "has_holdup",
+        ConfigValue(
+            default=False,
+            domain=In([False]),
+            description="Holdup construction flag - must be False",
+            doc="""Indicates whether holdup terms should be constructed or not.
+**default** - False. Flash units do not have defined volume, thus
+this must be False.""",
+        ),
+    )
+    CONFIG.declare(
+        "material_balance_type",
+        ConfigValue(
+            default=MaterialBalanceType.useDefault,
+            domain=In(MaterialBalanceType),
+            description="Material balance construction flag",
+            doc="""Indicates what type of mass balance should be constructed,
+**default** - MaterialBalanceType.useDefault.
+**Valid values:** {
+**MaterialBalanceType.useDefault - refer to property package for default
+balance type
+**MaterialBalanceType.none** - exclude material balances,
+**MaterialBalanceType.componentPhase** - use phase component balances,
+**MaterialBalanceType.componentTotal** - use total component balances,
+**MaterialBalanceType.elementTotal** - use total element balances,
+**MaterialBalanceType.total** - use total material balance.}""",
+        ),
+    )
+    CONFIG.declare(
+        "momentum_balance_type",
+        ConfigValue(
+            default=MomentumBalanceType.pressureTotal,
+            domain=In(MomentumBalanceType),
+            description="Momentum balance construction flag",
+            doc="""Indicates what type of momentum balance should be constructed,
+**default** - MomentumBalanceType.pressureTotal.
+**Valid values:** {
+**MomentumBalanceType.none** - exclude momentum balances,
+**MomentumBalanceType.pressureTotal** - single pressure balance for material,
+**MomentumBalanceType.pressurePhase** - pressure balances for each phase,
+**MomentumBalanceType.momentumTotal** - single momentum balance for material,
+**MomentumBalanceType.momentumPhase** - momentum balances for each phase.}""",
+        ),
+    )
+    CONFIG.declare(
+        "energy_split_basis",
+        ConfigValue(
+            default=EnergySplittingType.equal_temperature,
+            domain=EnergySplittingType,
+            description="Type of constraint to write for energy splitting",
+            doc="""Argument indicating basis to use for splitting energy this is
+not used for when ideal_separation == True.
+**default** - EnergySplittingType.equal_temperature.
+**Valid values:** {
+**EnergySplittingType.equal_temperature** - outlet temperatures equal inlet
+**EnergySplittingType.equal_molar_enthalpy** - outlet molar enthalpies equal
+inlet,
+**EnergySplittingType.enthalpy_split** - apply split fractions to enthalpy
+flows.}""",
+        ),
+    )
+    CONFIG.declare(
+        "solid_property_package",
+        ConfigValue(
+            default=useDefault,
+            domain=is_physical_parameter_block,
+            description="Property package to use for solid phase",
+            doc="""Property parameter object used to define solid phase property
+calculations,
+**default** - useDefault.
+**Valid values:** {
+**useDefault** - use default package from parent model or flowsheet,
+**PropertyParameterObject** - a PropertyParameterBlock object.}""",
+        ),
+    )
+    CONFIG.declare(
+        "solid_property_package_args",
+        ConfigBlock(
+            implicit=True,
+            description="Arguments to use for constructing solid phase property packages",
+            doc="""A ConfigBlock with arguments to be passed to a solid phase property
+block(s) and used when constructing these,
+**default** - None.
+**Valid values:** {
+see property package for documentation.}""",
+        ),
+    )
+    CONFIG.declare(
+        "liquid_property_package",
+        ConfigValue(
+            default=useDefault,
+            domain=is_physical_parameter_block,
+            description="Property package to use for liquid phase",
+            doc="""Property parameter object used to define liquid phase property
+    calculations,
+    **default** - useDefault.
+    **Valid values:** {
+    **useDefault** - use default package from parent model or flowsheet,
+    **PropertyParameterObject** - a PropertyParameterBlock object.}""",
+        ),
+    )
+    CONFIG.declare(
+        "liquid_property_package_args",
+        ConfigBlock(
+            implicit=True,
+            description="Arguments to use for constructing liquid phase property packages",
+            doc="""A ConfigBlock with arguments to be passed to a liquid phase property
+    block(s) and used when constructing these,
+    **default** - None.
+    **Valid values:** {
+    see property package for documentation.}""",
+        ),
+    )
+
+    default_initializer = BlockTriangularizationInitializer
+
+    def build(self):
+        """
+        Begin building model (pre-DAE transformation).
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
+        # Call UnitModel.build to setup dynamics
+        super().build()
+
+        # Build Solid Phase - inlet=outlet so only need a StateBlock
+        # Setup StateBlock argument dict
+        tmp_dict = dict(**self.config.solid_property_package_args)
+        tmp_dict["has_phase_equilibrium"] = False
+        tmp_dict["defined_state"] = True
+
+        self.solid_state = self.config.solid_property_package.build_state_block(
+            self.flowsheet().time, doc="Solid properties in separator", **tmp_dict
+        )
+
+        # Add Solids Ports
+        self.add_port(
+            name="solid_inlet", block=self.solid_state, doc="Solid inlet to separator"
+        )
+        self.add_port(
+            name="solid_outlet",
+            block=self.solid_state,
+            doc="Solid outlet from separator",
+        )
+
+        # Add Liquid Inlet
+        # Setup StateBlock argument dict
+        tmp_dict = dict(**self.config.liquid_property_package_args)
+        tmp_dict["has_phase_equilibrium"] = False
+        tmp_dict["defined_state"] = True
+
+        self.liquid_inlet_state = self.config.liquid_property_package.build_state_block(
+            self.flowsheet().time,
+            doc="Liquid properties at inlet to separator",
+            **tmp_dict,
+        )
+
+        self.split = Separator(
+            property_package=self.config.liquid_property_package,
+            property_package_args=self.config.liquid_property_package_args,
+            outlet_list=["recovered", "retained"],
+            split_basis=SplittingType.totalFlow,
+            ideal_separation=False,
+            mixed_state_block=self.liquid_inlet_state,
+            has_phase_equilibrium=False,
+            material_balance_type=self.config.material_balance_type,
+            momentum_balance_type=self.config.momentum_balance_type,
+            energy_split_basis=self.config.energy_split_basis,
+        )
+
+        # Add liquid ports
+        self.add_port(
+            name="liquid_inlet",
+            block=self.liquid_inlet_state,
+            doc="Liquid inlet to separator",
+        )
+        self.recovered_liquid_outlet = Port(extends=self.split.recovered)
+        self.retained_liquid_outlet = Port(extends=self.split.retained)
+
+        # Add liquid recovery
+        self.liquid_recovery = Reference(self.split.split_fraction[:, "recovered"])
+
+    def initialize(self, **kwargs):
+        raise NotImplementedError(
+            "The SLSeparator unit model does not support the old initialization API. "
+            "Please use the new API (InitializerObjects) instead."
+        )
+
+    def _get_performance_contents(self, time_point=0):
+
+        return {"vars": {"Liquid Recovery": self.liquid_recovery[time_point]}}
+
+    def _get_stream_table_contents(self, time_point=0):
+        stream_attributes = {}
+        stream_attributes["Units"] = {}
+
+        sblocks = {
+            "Solid Inlet": self.solid_state,
+            "Liquid Inlet": self.liquid_inlet_state,
+            "Solid Outlet": self.solid_state,
+            "Liquid in Solids Outlet": self.split.retained_state,
+            "Recovered Liquid Outlet": self.split.recovered_state,
+        }
+
+        for n, v in sblocks.items():
+            dvars = v[time_point].define_display_vars()
+
+            stream_attributes[n] = {}
+
+            for k in dvars:
+                for i in dvars[k].keys():
+                    stream_key = k if i is None else f"{k} {i}"
+
+                    quant = report_quantity(dvars[k][i])
+
+                    stream_attributes[n][stream_key] = quant.m
+                    stream_attributes["Units"][stream_key] = quant.u
+
+        return DataFrame.from_dict(stream_attributes, orient="columns")

--- a/idaes/models/unit_models/solid_liquid/sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/sl_separator.py
@@ -17,12 +17,9 @@ This model is intended to form the basis for solid-liquid separations where a mi
 stream enters the unit and is separated into a concentrated solid-liquid stream and
 a stream of pure liquid (e.g. filers, thickeners, etc.)
 
-This model assumes:
-
-* separate property packages and ports for the solid and liquid
-streams.
-* two inlet Ports (solid and liquid)
-* three outlet Ports (solids, liquid with solids, separated liquids).
+This model assumes separate property packages and ports for the solid and liquid
+streams and thus two inlet Ports (solid and liquid) and three outlet Ports (solids,
+liquid with solids, separated liquids).
 
 """
 # Import Python libraries

--- a/idaes/models/unit_models/solid_liquid/tests/test_sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/tests/test_sl_separator.py
@@ -416,7 +416,7 @@ class TestSLSeparatorBasic:
         }
 
     @pytest.mark.ui
-    @pytest.mark.unit
+    @pytest.mark.component
     def test_get_stream_table_contents(self, model):
         stable = model.fs.unit._get_stream_table_contents()
 

--- a/idaes/models/unit_models/solid_liquid/tests/test_sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/tests/test_sl_separator.py
@@ -19,7 +19,7 @@ import pytest
 
 from pyomo.environ import check_optimal_termination, ConcreteModel, units, value, Var
 from pyomo.network import Port
-from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
+from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import (
     FlowsheetBlock,
@@ -154,10 +154,6 @@ class TestSLSeparatorBasic:
 
         assert isinstance(model.fs.unit.split, SeparatorData)
         assert isinstance(model.fs.unit.liquid_recovery, Var)
-
-        print(number_variables(model))
-        print(number_total_constraints(model))
-        print(number_unused_variables(model))
 
         assert number_variables(model) == 34
         assert number_total_constraints(model) == 17

--- a/idaes/models/unit_models/solid_liquid/tests/test_sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/tests/test_sl_separator.py
@@ -1,0 +1,492 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2023 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+"""
+Tests for solid-liquid separator unit model.
+Authors: Andrew Lee
+"""
+
+import pytest
+
+from pyomo.environ import check_optimal_termination, ConcreteModel, units, value, Var
+from pyomo.network import Port
+from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
+
+from idaes.core import (
+    FlowsheetBlock,
+    MaterialBalanceType,
+    EnergyBalanceType,
+    MomentumBalanceType,
+)
+from idaes.models.unit_models.solid_liquid import SLSeparator
+from idaes.models.unit_models.separator import (
+    Separator,
+    SeparatorData,
+    SplittingType,
+    EnergySplittingType,
+)
+from idaes.core.util.model_statistics import (
+    degrees_of_freedom,
+    number_variables,
+    number_total_constraints,
+    number_unused_variables,
+)
+from idaes.models.properties.examples.saponification_thermo import (
+    SaponificationParameterBlock,
+)
+from idaes.core.solvers import get_solver
+from idaes.core.initialization import (
+    BlockTriangularizationInitializer,
+    InitializationStatus,
+)
+from idaes.core.util import DiagnosticsToolbox
+
+# -----------------------------------------------------------------------------
+# Get default solver for testing
+solver = get_solver()
+
+
+# -----------------------------------------------------------------------------
+class TestSLSeparatorBasic:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+
+        m.fs.properties = SaponificationParameterBlock()
+
+        m.fs.unit = SLSeparator(
+            solid_property_package=m.fs.properties,
+            liquid_property_package=m.fs.properties,
+        )
+
+        m.fs.unit.solid_inlet.flow_vol.fix(10)
+        m.fs.unit.solid_inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
+        m.fs.unit.solid_inlet.conc_mol_comp[0, "NaOH"].fix(100.0)
+        m.fs.unit.solid_inlet.conc_mol_comp[0, "EthylAcetate"].fix(100.0)
+        m.fs.unit.solid_inlet.conc_mol_comp[0, "SodiumAcetate"].fix(1e-6)
+        m.fs.unit.solid_inlet.conc_mol_comp[0, "Ethanol"].fix(1e-6)
+        m.fs.unit.solid_inlet.temperature.fix(303.15)
+        m.fs.unit.solid_inlet.pressure.fix(101325.0)
+
+        m.fs.unit.liquid_inlet.flow_vol.fix(20)
+        m.fs.unit.liquid_inlet.conc_mol_comp[0, "H2O"].fix(55388.0)
+        m.fs.unit.liquid_inlet.conc_mol_comp[0, "NaOH"].fix(1e-6)
+        m.fs.unit.liquid_inlet.conc_mol_comp[0, "EthylAcetate"].fix(1e-6)
+        m.fs.unit.liquid_inlet.conc_mol_comp[0, "SodiumAcetate"].fix(50.0)
+        m.fs.unit.liquid_inlet.conc_mol_comp[0, "Ethanol"].fix(50.0)
+        m.fs.unit.liquid_inlet.temperature.fix(320)
+        m.fs.unit.liquid_inlet.pressure.fix(2e5)
+
+        m.fs.unit.liquid_recovery.fix(0.7)
+
+        return m
+
+    @pytest.mark.unit
+    def test_config(self, model):
+        # Check unit config arguments
+        assert len(model.fs.unit.config) == 9
+
+        assert not model.fs.unit.config.dynamic
+        assert not model.fs.unit.config.has_holdup
+        assert (
+            model.fs.unit.config.material_balance_type == MaterialBalanceType.useDefault
+        )
+        assert (
+            model.fs.unit.config.energy_split_basis
+            == EnergySplittingType.equal_temperature
+        )
+        assert (
+            model.fs.unit.config.momentum_balance_type
+            == MomentumBalanceType.pressureTotal
+        )
+
+        assert model.fs.unit.config.solid_property_package is model.fs.properties
+        assert model.fs.unit.config.liquid_property_package is model.fs.properties
+
+        assert model.fs.unit.default_initializer is BlockTriangularizationInitializer
+
+    @pytest.mark.build
+    @pytest.mark.unit
+    def test_build(self, model):
+
+        assert isinstance(model.fs.unit.solid_inlet, Port)
+        assert len(model.fs.unit.solid_inlet.vars) == 4
+        assert hasattr(model.fs.unit.solid_inlet, "flow_vol")
+        assert hasattr(model.fs.unit.solid_inlet, "conc_mol_comp")
+        assert hasattr(model.fs.unit.solid_inlet, "temperature")
+        assert hasattr(model.fs.unit.solid_inlet, "pressure")
+
+        assert isinstance(model.fs.unit.solid_outlet, Port)
+        assert len(model.fs.unit.solid_outlet.vars) == 4
+        assert hasattr(model.fs.unit.solid_outlet, "flow_vol")
+        assert hasattr(model.fs.unit.solid_outlet, "conc_mol_comp")
+        assert hasattr(model.fs.unit.solid_outlet, "temperature")
+        assert hasattr(model.fs.unit.solid_outlet, "pressure")
+
+        assert isinstance(model.fs.unit.liquid_inlet, Port)
+        assert len(model.fs.unit.liquid_inlet.vars) == 4
+        assert hasattr(model.fs.unit.liquid_inlet, "flow_vol")
+        assert hasattr(model.fs.unit.liquid_inlet, "conc_mol_comp")
+        assert hasattr(model.fs.unit.liquid_inlet, "temperature")
+        assert hasattr(model.fs.unit.liquid_inlet, "pressure")
+
+        assert isinstance(model.fs.unit.retained_liquid_outlet, Port)
+        assert len(model.fs.unit.retained_liquid_outlet.vars) == 4
+        assert hasattr(model.fs.unit.retained_liquid_outlet, "flow_vol")
+        assert hasattr(model.fs.unit.retained_liquid_outlet, "conc_mol_comp")
+        assert hasattr(model.fs.unit.retained_liquid_outlet, "temperature")
+        assert hasattr(model.fs.unit.retained_liquid_outlet, "pressure")
+
+        assert isinstance(model.fs.unit.recovered_liquid_outlet, Port)
+        assert len(model.fs.unit.recovered_liquid_outlet.vars) == 4
+        assert hasattr(model.fs.unit.recovered_liquid_outlet, "flow_vol")
+        assert hasattr(model.fs.unit.recovered_liquid_outlet, "conc_mol_comp")
+        assert hasattr(model.fs.unit.recovered_liquid_outlet, "temperature")
+        assert hasattr(model.fs.unit.recovered_liquid_outlet, "pressure")
+
+        assert isinstance(model.fs.unit.split, SeparatorData)
+        assert isinstance(model.fs.unit.liquid_recovery, Var)
+
+        print(number_variables(model))
+        print(number_total_constraints(model))
+        print(number_unused_variables(model))
+
+        assert number_variables(model) == 34
+        assert number_total_constraints(model) == 17
+        # These are the solid properties, as they do not appear in constraints
+        assert number_unused_variables(model) == 8
+
+    @pytest.mark.component
+    def test_units(self, model):
+        assert_units_consistent(model)
+
+    @pytest.mark.unit
+    def test_dof(self, model):
+        assert degrees_of_freedom(model) == 0
+
+    @pytest.mark.component
+    def test_structural_issues(self, model):
+        dt = DiagnosticsToolbox(model)
+        dt.assert_no_structural_warnings()
+
+    @pytest.mark.component
+    def test_block_triangularization(self, model):
+        initializer = BlockTriangularizationInitializer(constraint_tolerance=2e-5)
+        initializer.initialize(model.fs.unit)
+
+        assert initializer.summary[model.fs.unit]["status"] == InitializationStatus.Ok
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, model):
+        results = solver.solve(model, tee=True)
+
+        # Check for optimal solution
+        assert check_optimal_termination(results)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_numerical_issues(self, model):
+        dt = DiagnosticsToolbox(model)
+        dt.assert_no_numerical_warnings()
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, model):
+        # Solid outlet
+        assert pytest.approx(101325.0, rel=1e-8) == value(
+            model.fs.unit.solid_outlet.pressure[0]
+        )
+        assert pytest.approx(303.15, rel=1e-8) == value(
+            model.fs.unit.solid_outlet.temperature[0]
+        )
+        assert pytest.approx(100, rel=1e-8) == value(
+            model.fs.unit.solid_outlet.conc_mol_comp[0, "NaOH"]
+        )
+        assert pytest.approx(100, rel=1e-8) == value(
+            model.fs.unit.solid_outlet.conc_mol_comp[0, "EthylAcetate"]
+        )
+        assert pytest.approx(1e-6, rel=1e-8) == value(
+            model.fs.unit.solid_outlet.conc_mol_comp[0, "Ethanol"]
+        )
+        assert pytest.approx(1e-6, rel=1e-8) == value(
+            model.fs.unit.solid_outlet.conc_mol_comp[0, "SodiumAcetate"]
+        )
+        assert pytest.approx(10, rel=1e-8) == value(
+            model.fs.unit.solid_outlet.flow_vol[0]
+        )
+
+        # Retained liquid
+        assert pytest.approx(2e5, rel=1e-8) == value(
+            model.fs.unit.retained_liquid_outlet.pressure[0]
+        )
+        assert pytest.approx(320, rel=1e-8) == value(
+            model.fs.unit.retained_liquid_outlet.temperature[0]
+        )
+        assert pytest.approx(1e-6, rel=1e-8) == value(
+            model.fs.unit.retained_liquid_outlet.conc_mol_comp[0, "NaOH"]
+        )
+        assert pytest.approx(1e-6, rel=1e-8) == value(
+            model.fs.unit.retained_liquid_outlet.conc_mol_comp[0, "EthylAcetate"]
+        )
+        assert pytest.approx(50, rel=1e-8) == value(
+            model.fs.unit.retained_liquid_outlet.conc_mol_comp[0, "Ethanol"]
+        )
+        assert pytest.approx(50, rel=1e-8) == value(
+            model.fs.unit.retained_liquid_outlet.conc_mol_comp[0, "SodiumAcetate"]
+        )
+        assert pytest.approx(20 * 0.3, rel=1e-8) == value(
+            model.fs.unit.retained_liquid_outlet.flow_vol[0]
+        )
+
+        # Recovered liquid
+        assert pytest.approx(2e5, rel=1e-8) == value(
+            model.fs.unit.recovered_liquid_outlet.pressure[0]
+        )
+        assert pytest.approx(320, rel=1e-8) == value(
+            model.fs.unit.recovered_liquid_outlet.temperature[0]
+        )
+        assert pytest.approx(1e-6, rel=1e-8) == value(
+            model.fs.unit.recovered_liquid_outlet.conc_mol_comp[0, "NaOH"]
+        )
+        assert pytest.approx(1e-6, rel=1e-8) == value(
+            model.fs.unit.recovered_liquid_outlet.conc_mol_comp[0, "EthylAcetate"]
+        )
+        assert pytest.approx(50, rel=1e-8) == value(
+            model.fs.unit.recovered_liquid_outlet.conc_mol_comp[0, "Ethanol"]
+        )
+        assert pytest.approx(50, rel=1e-8) == value(
+            model.fs.unit.recovered_liquid_outlet.conc_mol_comp[0, "SodiumAcetate"]
+        )
+        assert pytest.approx(20 * 0.7, rel=1e-8) == value(
+            model.fs.unit.recovered_liquid_outlet.flow_vol[0]
+        )
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solid_conservation(self, model):
+        assert (
+            abs(
+                value(
+                    model.fs.unit.solid_inlet.flow_vol[0]
+                    - model.fs.unit.solid_outlet.flow_vol[0]
+                )
+            )
+            <= 1e-6
+        )
+        assert (
+            abs(
+                value(
+                    model.fs.unit.solid_inlet.flow_vol[0]
+                    * sum(
+                        model.fs.unit.solid_inlet.conc_mol_comp[0, j]
+                        for j in model.fs.properties.component_list
+                    )
+                    - model.fs.unit.solid_outlet.flow_vol[0]
+                    * sum(
+                        model.fs.unit.solid_outlet.conc_mol_comp[0, j]
+                        for j in model.fs.properties.component_list
+                    )
+                )
+            )
+            <= 1e-6
+        )
+
+        assert (
+            abs(
+                value(
+                    (
+                        model.fs.unit.solid_inlet.flow_vol[0]
+                        * model.fs.properties.dens_mol
+                        * model.fs.properties.cp_mol
+                        * (
+                            model.fs.unit.solid_inlet.temperature[0]
+                            - model.fs.properties.temperature_ref
+                        )
+                    )
+                    - (
+                        model.fs.unit.solid_outlet.flow_vol[0]
+                        * model.fs.properties.dens_mol
+                        * model.fs.properties.cp_mol
+                        * (
+                            model.fs.unit.solid_outlet.temperature[0]
+                            - model.fs.properties.temperature_ref
+                        )
+                    )
+                )
+            )
+            <= 1e-3
+        )
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_liquid_conservation(self, model):
+        assert (
+            abs(
+                value(
+                    model.fs.unit.liquid_inlet.flow_vol[0]
+                    - model.fs.unit.retained_liquid_outlet.flow_vol[0]
+                    - model.fs.unit.recovered_liquid_outlet.flow_vol[0]
+                )
+            )
+            <= 1e-6
+        )
+        assert (
+            abs(
+                value(
+                    model.fs.unit.liquid_inlet.flow_vol[0]
+                    * sum(
+                        model.fs.unit.liquid_inlet.conc_mol_comp[0, j]
+                        for j in model.fs.properties.component_list
+                    )
+                    - model.fs.unit.retained_liquid_outlet.flow_vol[0]
+                    * sum(
+                        model.fs.unit.retained_liquid_outlet.conc_mol_comp[0, j]
+                        for j in model.fs.properties.component_list
+                    )
+                    - model.fs.unit.recovered_liquid_outlet.flow_vol[0]
+                    * sum(
+                        model.fs.unit.recovered_liquid_outlet.conc_mol_comp[0, j]
+                        for j in model.fs.properties.component_list
+                    )
+                )
+            )
+            <= 1e-6
+        )
+
+        assert (
+            abs(
+                value(
+                    (
+                        model.fs.unit.liquid_inlet.flow_vol[0]
+                        * model.fs.properties.dens_mol
+                        * model.fs.properties.cp_mol
+                        * (
+                            model.fs.unit.liquid_inlet.temperature[0]
+                            - model.fs.properties.temperature_ref
+                        )
+                    )
+                    - (
+                        model.fs.unit.retained_liquid_outlet.flow_vol[0]
+                        * model.fs.properties.dens_mol
+                        * model.fs.properties.cp_mol
+                        * (
+                            model.fs.unit.retained_liquid_outlet.temperature[0]
+                            - model.fs.properties.temperature_ref
+                        )
+                    )
+                    - (
+                        model.fs.unit.recovered_liquid_outlet.flow_vol[0]
+                        * model.fs.properties.dens_mol
+                        * model.fs.properties.cp_mol
+                        * (
+                            model.fs.unit.recovered_liquid_outlet.temperature[0]
+                            - model.fs.properties.temperature_ref
+                        )
+                    )
+                )
+            )
+            <= 1e-3
+        )
+
+    @pytest.mark.ui
+    @pytest.mark.unit
+    def test_get_performance_contents(self, model):
+        perf_dict = model.fs.unit._get_performance_contents()
+
+        assert perf_dict == {
+            "vars": {
+                "Liquid Recovery": model.fs.unit.liquid_recovery[0],
+            }
+        }
+
+    @pytest.mark.ui
+    @pytest.mark.unit
+    def test_get_stream_table_contents(self, model):
+        stable = model.fs.unit._get_stream_table_contents()
+
+        expected = {
+            "Units": {
+                "Volumetric Flowrate": getattr(units.pint_registry, "m**3/second"),
+                "Molar Concentration H2O": getattr(units.pint_registry, "mole/m**3"),
+                "Molar Concentration NaOH": getattr(units.pint_registry, "mole/m**3"),
+                "Molar Concentration EthylAcetate": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Molar Concentration SodiumAcetate": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Molar Concentration Ethanol": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Temperature": getattr(units.pint_registry, "K"),
+                "Pressure": getattr(units.pint_registry, "Pa"),
+            },
+            "Solid Inlet": {
+                "Volumetric Flowrate": pytest.approx(10, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(1e-6, abs=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(1e-6, rel=1e-4),
+                "Temperature": pytest.approx(303.15, rel=1e-4),
+                "Pressure": pytest.approx(101325, rel=1e-4),
+            },
+            "Liquid Inlet": {
+                "Volumetric Flowrate": pytest.approx(20, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
+                "Temperature": pytest.approx(320, rel=1e-4),
+                "Pressure": pytest.approx(2e5, rel=1e-4),
+            },
+            "Solid Outlet": {
+                "Volumetric Flowrate": pytest.approx(10, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(1e-6, rel=1e-4),
+                "Temperature": pytest.approx(303.15, rel=1e-4),
+                "Pressure": pytest.approx(101325, rel=1e-4),
+            },
+            "Liquid in Solids Outlet": {
+                "Volumetric Flowrate": pytest.approx(20 * 0.3, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
+                "Temperature": pytest.approx(320, rel=1e-4),
+                "Pressure": pytest.approx(2e5, rel=1e-4),
+            },
+            "Recovered Liquid Outlet": {
+                "Volumetric Flowrate": pytest.approx(20 * 0.7, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
+                "Temperature": pytest.approx(320, rel=1e-4),
+                "Pressure": pytest.approx(2e5, rel=1e-4),
+            },
+        }
+
+        assert stable.to_dict() == expected

--- a/idaes/models/unit_models/solid_liquid/tests/test_thickener.py
+++ b/idaes/models/unit_models/solid_liquid/tests/test_thickener.py
@@ -11,7 +11,7 @@
 # for full copyright and license information.
 #################################################################################
 """
-Tests for solid-liquid separator unit model.
+Tests for thickener unit model.
 Authors: Andrew Lee
 """
 
@@ -26,7 +26,7 @@ from idaes.core import (
     MaterialBalanceType,
     MomentumBalanceType,
 )
-from idaes.models.unit_models.solid_liquid import SLSeparator
+from idaes.models.unit_models.solid_liquid import Thickener0D
 from idaes.models.unit_models.separator import (
     Separator,
     SeparatorData,
@@ -54,7 +54,7 @@ solver = get_solver()
 
 
 # -----------------------------------------------------------------------------
-class TestSLSeparatorBasic:
+class TestThickener0DBasic:
     @pytest.fixture(scope="class")
     def model(self):
         m = ConcreteModel()
@@ -62,7 +62,7 @@ class TestSLSeparatorBasic:
 
         m.fs.properties = SaponificationParameterBlock()
 
-        m.fs.unit = SLSeparator(
+        m.fs.unit = Thickener0D(
             solid_property_package=m.fs.properties,
             liquid_property_package=m.fs.properties,
         )

--- a/idaes/models/unit_models/solid_liquid/thickener.py
+++ b/idaes/models/unit_models/solid_liquid/thickener.py
@@ -21,8 +21,7 @@ area and vessel height to the liquid recovery fraction.
 import logging
 
 # Import Pyomo libraries
-from pyomo.environ import Constraint, Var, units
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+from pyomo.environ import Var, units
 
 # Import IDAES cores
 from idaes.core import (

--- a/idaes/models/unit_models/solid_liquid/thickener.py
+++ b/idaes/models/unit_models/solid_liquid/thickener.py
@@ -106,7 +106,7 @@ class Thickener0DData(SLSeparatorData):
         )
 
         self.settling_time = Var(
-            self.flowsheet().time(),
+            self.flowsheet().time,
             initialize=1,
             units=s_metadata.get_derived_units("time"),
             doc="Settling time of suspension",
@@ -116,7 +116,7 @@ class Thickener0DData(SLSeparatorData):
             self.flowsheet().time, doc="Constraint to calculate L/S ratio at underflow"
         )
         def underflow_sl_constraint(b, t):
-            return b.liquid_frac_underflow[t] * b.solid_state[
+            return b.liquid_solid_underflow[t] * b.solid_state[
                 t
             ].flow_mass == units.convert(
                 b.split.retained_state[t].flow_mass,
@@ -127,10 +127,10 @@ class Thickener0DData(SLSeparatorData):
             self.flowsheet().time, doc="Constraint to estimate cross-sectional area"
         )
         def cross_sectional_area_constraint(b, t):
-            return b.area * b.liquid_inlet_state[t].dens_mass * b.velocity_pinch[
+            return b.area * b.liquid_inlet_state[
                 t
-            ] == b.solid_state[t].flow_mass * (
-                b.liquid_frac_pinch[t] - b.liquid_frac_underflow[t]
+            ].dens_mass * b.settling_velocity_pinch[t] == b.solid_state[t].flow_mass * (
+                b.liquid_solid_pinch[t] - b.liquid_solid_underflow[t]
             )
 
         @self.Constraint(
@@ -161,11 +161,11 @@ class Thickener0DData(SLSeparatorData):
         return {
             "vars": {
                 "Area": self.area,
-                # TODO: Height
+                "Height": self.height,
                 "Liquid Recovery": self.liquid_recovery[time_point],
                 "Underflow L/S": self.liquid_solid_underflow[time_point],
                 "Pinch L/S": self.liquid_solid_pinch[time_point],
-                "Critical Settling Velocity": self.settling_velocity_pich[time_point],
-                # TODO: Settling time
+                "Critical Settling Velocity": self.settling_velocity_pinch[time_point],
+                "Settling Time": self.settling_time[time_point],
             }
         }

--- a/idaes/models/unit_models/solid_liquid/thickener.py
+++ b/idaes/models/unit_models/solid_liquid/thickener.py
@@ -1,0 +1,171 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2023 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+"""
+Thickener unit model.
+
+This model extends the SLSeparator unit model by adding constraints that relate
+area and vessel height to the liquid recovery fraction.
+
+"""
+# Import Python libraries
+import logging
+
+# Import Pyomo libraries
+from pyomo.environ import Constraint, Var, units
+from pyomo.common.config import ConfigBlock, ConfigValue, In
+
+# Import IDAES cores
+from idaes.core import (
+    declare_process_block_class,
+)
+from idaes.models.unit_models.solid_liquid.sl_separator import (
+    SLSeparatorData,
+)
+
+
+__author__ = "Andrew Lee"
+
+
+# Set up logger
+logger = logging.getLogger("idaes.unit_model")
+
+
+@declare_process_block_class("Thickener0D")
+class Thickener0DData(SLSeparatorData):
+    """
+    Thickener0D Unit Model Class
+    """
+
+    CONFIG = SLSeparatorData.CONFIG()
+    # TODO: Method to calculate pinch settling velocity
+
+    def build(self):
+        """
+        Begin building model (pre-DAE transformation).
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
+        # Call super().build to setup dynamics
+        super().build()
+
+        # Add additional variables and constraints
+        s_metadata = self.solid_state.params.get_metadata()
+        # TODO: Add support for molar basis
+
+        self.area = Var(
+            initialize=1,
+            units=s_metadata.get_derived_units("area"),
+            doc="Cross sectional area of thickener",
+        )
+
+        self.height = Var(
+            initialize=1,
+            units=s_metadata.get_derived_units("length"),
+            doc="Total depth of thickener",
+        )
+
+        self.height_clarification = Var(
+            initialize=1,
+            units=s_metadata.get_derived_units("length"),
+            doc="Depth of clarification zone",
+        )
+
+        self.settling_velocity_pinch = Var(
+            self.flowsheet().time,
+            initialize=1,
+            units=s_metadata.get_derived_units("velocity"),
+            doc="Settling velocity of suspension at pinch point",
+        )
+
+        self.liquid_solid_pinch = Var(
+            self.flowsheet().time,
+            initialize=0.2,
+            units=units.dimensionless,
+            doc="Liquid-solid ratio (mass basis) at pinch point",
+        )
+
+        self.liquid_solid_underflow = Var(
+            self.flowsheet().time,
+            initialize=0.2,
+            units=units.dimensionless,
+            doc="Liquid-solid ratio (mass basis) at underflow",
+        )
+
+        self.settling_time = Var(
+            self.flowsheet().time(),
+            initialize=1,
+            units=s_metadata.get_derived_units("time"),
+            doc="Settling time of suspension",
+        )
+
+        @self.Constraint(
+            self.flowsheet().time, doc="Constraint to calculate L/S ratio at underflow"
+        )
+        def underflow_sl_constraint(b, t):
+            return b.liquid_frac_underflow[t] * b.solid_state[
+                t
+            ].flow_mass == units.convert(
+                b.split.retained_state[t].flow_mass,
+                to_units=s_metadata.get_derived_units("flow_mass"),
+            )
+
+        @self.Constraint(
+            self.flowsheet().time, doc="Constraint to estimate cross-sectional area"
+        )
+        def cross_sectional_area_constraint(b, t):
+            return b.area * b.liquid_inlet_state[t].dens_mass * b.velocity_pinch[
+                t
+            ] == b.solid_state[t].flow_mass * (
+                b.liquid_frac_pinch[t] - b.liquid_frac_underflow[t]
+            )
+
+        @self.Constraint(
+            self.flowsheet().time, doc="Constraint to estimate height of thickener"
+        )
+        def height_constraint(b, t):
+            return (b.height - b.height_clarification) * b.area * b.solid_state[
+                t
+            ].dens_mass == units.convert(
+                b.settling_time[t]
+                * (
+                    b.solid_state[t].flow_mass
+                    + units.convert(
+                        b.solid_state[t].dens_mass / b.liquid_inlet_state[t].dens_mass,
+                        to_units=units.dimensionless,
+                    )
+                    * (
+                        b.liquid_inlet_state[t].flow_mass
+                        + b.split.retained_state[t].flow_mass
+                    )
+                    / 2
+                ),
+                to_units=s_metadata.get_derived_units("mass"),
+            )
+
+    def _get_performance_contents(self, time_point=0):
+
+        return {
+            "vars": {
+                "Area": self.area,
+                # TODO: Height
+                "Liquid Recovery": self.liquid_recovery[time_point],
+                "Underflow L/S": self.liquid_solid_underflow[time_point],
+                "Pinch L/S": self.liquid_solid_pinch[time_point],
+                "Critical Settling Velocity": self.settling_velocity_pich[time_point],
+                # TODO: Settling time
+            }
+        }

--- a/idaes/models/unit_models/tests/test_mscontactor.py
+++ b/idaes/models/unit_models/tests/test_mscontactor.py
@@ -2632,6 +2632,79 @@ class TestMSContactorInitializer:
         assert not model.fs.contactor.s2_inlet.temperature[0].fixed
         assert not model.fs.contactor.s2_inlet.pressure[0].fixed
 
+    @pytest.mark.ui
+    @pytest.mark.unit
+    def test_get_performance_contents(self, model):
+        perf_dict = model.fs.contactor._get_performance_contents()
+
+        assert perf_dict == {}
+
+    @pytest.mark.ui
+    @pytest.mark.unit
+    def test_get_stream_table_contents(self, model):
+        stable = model.fs.contactor._get_stream_table_contents()
+
+        expected = {
+            "Units": {
+                "Volumetric Flowrate": getattr(units.pint_registry, "m**3/second"),
+                "Molar Concentration H2O": getattr(units.pint_registry, "mole/m**3"),
+                "Molar Concentration NaOH": getattr(units.pint_registry, "mole/m**3"),
+                "Molar Concentration EthylAcetate": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Molar Concentration SodiumAcetate": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Molar Concentration Ethanol": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Temperature": getattr(units.pint_registry, "K"),
+                "Pressure": getattr(units.pint_registry, "Pa"),
+            },
+            "s1 Inlet": {
+                "Volumetric Flowrate": pytest.approx(0.001, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(0, abs=1e-6),
+                "Molar Concentration Ethanol": pytest.approx(0, abs=1e-6),
+                "Temperature": pytest.approx(303.15, rel=1e-4),
+                "Pressure": pytest.approx(101325, rel=1e-4),
+            },
+            "s1 Outlet": {
+                "Volumetric Flowrate": pytest.approx(1, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(100, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(100, rel=1e-4),
+                "Temperature": pytest.approx(298.15, rel=1e-4),
+                "Pressure": pytest.approx(101325, rel=1e-4),
+            },
+            "s2 Inlet": {
+                "Volumetric Flowrate": pytest.approx(0.002, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(50, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(50, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
+                "Temperature": pytest.approx(323.15, rel=1e-4),
+                "Pressure": pytest.approx(2e5, rel=1e-4),
+            },
+            "s2 Outlet": {
+                "Volumetric Flowrate": pytest.approx(1, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(100, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(100, rel=1e-4),
+                "Temperature": pytest.approx(298.15, rel=1e-4),
+                "Pressure": pytest.approx(101325, rel=1e-4),
+            },
+        }
+
+        assert stable.to_dict() == expected
+
 
 class TestLiCODiafiltration:
     """
@@ -3055,81 +3128,3 @@ class TestLiCODiafiltration:
         )
         assert R_Li == pytest.approx(0.9451, rel=1e-4)
         assert R_Co == pytest.approx(0.6378, rel=1e-4)
-
-    @pytest.mark.ui
-    @pytest.mark.unit
-    def test_get_stream_table_contents(self, model):
-        stable = model.fs.unit._get_stream_table_contents()
-
-        print(stable)
-
-        expected = {
-            "Units": {
-                "Volumetric Flowrate": getattr(units.pint_registry, "m**3/second"),
-                "Molar Concentration H2O": getattr(units.pint_registry, "mole/m**3"),
-                "Molar Concentration NaOH": getattr(units.pint_registry, "mole/m**3"),
-                "Molar Concentration EthylAcetate": getattr(
-                    units.pint_registry, "mole/m**3"
-                ),
-                "Molar Concentration SodiumAcetate": getattr(
-                    units.pint_registry, "mole/m**3"
-                ),
-                "Molar Concentration Ethanol": getattr(
-                    units.pint_registry, "mole/m**3"
-                ),
-                "Temperature": getattr(units.pint_registry, "K"),
-                "Pressure": getattr(units.pint_registry, "Pa"),
-            },
-            "Solid Inlet": {
-                "Volumetric Flowrate": pytest.approx(10, rel=1e-4),
-                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
-                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
-                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
-                "Molar Concentration SodiumAcetate": pytest.approx(1e-6, abs=1e-4),
-                "Molar Concentration Ethanol": pytest.approx(1e-6, rel=1e-4),
-                "Temperature": pytest.approx(303.15, rel=1e-4),
-                "Pressure": pytest.approx(101325, rel=1e-4),
-            },
-            "Liquid Inlet": {
-                "Volumetric Flowrate": pytest.approx(20, rel=1e-4),
-                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
-                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
-                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
-                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
-                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
-                "Temperature": pytest.approx(320, rel=1e-4),
-                "Pressure": pytest.approx(2e5, rel=1e-4),
-            },
-            "Solid Outlet": {
-                "Volumetric Flowrate": pytest.approx(10, rel=1e-4),
-                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
-                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
-                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
-                "Molar Concentration SodiumAcetate": pytest.approx(1e-6, rel=1e-4),
-                "Molar Concentration Ethanol": pytest.approx(1e-6, rel=1e-4),
-                "Temperature": pytest.approx(303.15, rel=1e-4),
-                "Pressure": pytest.approx(101325, rel=1e-4),
-            },
-            "Liquid in Solids Outlet": {
-                "Volumetric Flowrate": pytest.approx(20 * 0.3, rel=1e-4),
-                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
-                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
-                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
-                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
-                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
-                "Temperature": pytest.approx(320, rel=1e-4),
-                "Pressure": pytest.approx(2e5, rel=1e-4),
-            },
-            "Recovered Liquid Outlet": {
-                "Volumetric Flowrate": pytest.approx(20 * 0.7, rel=1e-4),
-                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
-                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
-                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
-                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
-                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
-                "Temperature": pytest.approx(320, rel=1e-4),
-                "Pressure": pytest.approx(2e5, rel=1e-4),
-            },
-        }
-
-        assert stable.to_dict() == expected

--- a/idaes/models/unit_models/tests/test_mscontactor.py
+++ b/idaes/models/unit_models/tests/test_mscontactor.py
@@ -3055,3 +3055,81 @@ class TestLiCODiafiltration:
         )
         assert R_Li == pytest.approx(0.9451, rel=1e-4)
         assert R_Co == pytest.approx(0.6378, rel=1e-4)
+
+    @pytest.mark.ui
+    @pytest.mark.unit
+    def test_get_stream_table_contents(self, model):
+        stable = model.fs.unit._get_stream_table_contents()
+
+        print(stable)
+
+        expected = {
+            "Units": {
+                "Volumetric Flowrate": getattr(units.pint_registry, "m**3/second"),
+                "Molar Concentration H2O": getattr(units.pint_registry, "mole/m**3"),
+                "Molar Concentration NaOH": getattr(units.pint_registry, "mole/m**3"),
+                "Molar Concentration EthylAcetate": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Molar Concentration SodiumAcetate": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Molar Concentration Ethanol": getattr(
+                    units.pint_registry, "mole/m**3"
+                ),
+                "Temperature": getattr(units.pint_registry, "K"),
+                "Pressure": getattr(units.pint_registry, "Pa"),
+            },
+            "Solid Inlet": {
+                "Volumetric Flowrate": pytest.approx(10, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(1e-6, abs=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(1e-6, rel=1e-4),
+                "Temperature": pytest.approx(303.15, rel=1e-4),
+                "Pressure": pytest.approx(101325, rel=1e-4),
+            },
+            "Liquid Inlet": {
+                "Volumetric Flowrate": pytest.approx(20, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
+                "Temperature": pytest.approx(320, rel=1e-4),
+                "Pressure": pytest.approx(2e5, rel=1e-4),
+            },
+            "Solid Outlet": {
+                "Volumetric Flowrate": pytest.approx(10, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(100, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(100, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(1e-6, rel=1e-4),
+                "Temperature": pytest.approx(303.15, rel=1e-4),
+                "Pressure": pytest.approx(101325, rel=1e-4),
+            },
+            "Liquid in Solids Outlet": {
+                "Volumetric Flowrate": pytest.approx(20 * 0.3, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
+                "Temperature": pytest.approx(320, rel=1e-4),
+                "Pressure": pytest.approx(2e5, rel=1e-4),
+            },
+            "Recovered Liquid Outlet": {
+                "Volumetric Flowrate": pytest.approx(20 * 0.7, rel=1e-4),
+                "Molar Concentration H2O": pytest.approx(5.5388e4, rel=1e-4),
+                "Molar Concentration NaOH": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration EthylAcetate": pytest.approx(1e-6, rel=1e-4),
+                "Molar Concentration SodiumAcetate": pytest.approx(50, rel=1e-4),
+                "Molar Concentration Ethanol": pytest.approx(50, rel=1e-4),
+                "Temperature": pytest.approx(320, rel=1e-4),
+                "Pressure": pytest.approx(2e5, rel=1e-4),
+            },
+        }
+
+        assert stable.to_dict() == expected


### PR DESCRIPTION
## Fixes #1218 amongst other things


## Summary/Motivation:
This PR adds a new unit model base class for separating solids and liquids such as filters and thickeners. The unit has two inlets (solid and liquid) and three outlets (solids, retained_liquid (with solids) and recovered liquid).

Docs to come, along with a derived model for thickeners.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
