### PR TITLE
Fixing errors due to bound checking in nl writer

### DIFF
--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -467,7 +467,7 @@ class TestDiagnosticsToolbox:
         m.b.v2 = Var(units=units.m)
         m.b.v3 = Var(bounds=(0, 5))
         m.b.v4 = Var()
-        m.b.v5 = Var(bounds=(0, 1))
+        m.b.v5 = Var(bounds=(0, 5))
         m.b.v6 = Var()
         m.b.v7 = Var(
             units=units.m, bounds=(0, 1)
@@ -550,7 +550,6 @@ The following variable(s) are fixed to zero:
 The following variable(s) have values at or outside their bounds (tol=0.0E+00):
 
     b.v3 (free): value=0.0 bounds=(0, 5)
-    b.v5 (fixed): value=2 bounds=(0, 1)
 
 ====================================================================================
 """
@@ -619,7 +618,6 @@ The following variable(s) have extreme values (<1.0E-04 or > 1.0E+04):
 The following variable(s) have values close to their bounds (abs=1.0E-04, rel=1.0E-04):
 
     b.v3: value=0.0 bounds=(0, 5)
-    b.v5: value=2 bounds=(0, 1)
     b.v7: value=1.0000939326524314e-07 bounds=(0, 1)
 
 ====================================================================================
@@ -1009,7 +1007,7 @@ values (<1.0E-04 or>1.0E+04):
 
         assert len(warnings) == 2
         assert "WARNING: 1 Constraint with large residuals (>1.0E-05)" in warnings
-        assert "WARNING: 2 Variables at or outside bounds (tol=0.0E+00)" in warnings
+        assert "WARNING: 1 Variable at or outside bounds (tol=0.0E+00)" in warnings
 
         assert len(next_steps) == 2
         assert "display_constraints_with_large_residuals()" in next_steps
@@ -1070,10 +1068,9 @@ values (<1.0E-04 or>1.0E+04):
         dt = DiagnosticsToolbox(model=model.b)
 
         cautions = dt._collect_numerical_cautions()
-
         assert len(cautions) == 5
         assert (
-            "Caution: 3 Variables with value close to their bounds (abs=1.0E-04, rel=1.0E-04)"
+            "Caution: 2 Variables with value close to their bounds (abs=1.0E-04, rel=1.0E-04)"
             in cautions
         )
         assert "Caution: 2 Variables with value close to zero (tol=1.0E-08)" in cautions
@@ -1133,7 +1130,6 @@ values (<1.0E-04 or>1.0E+04):
 
         # Fix numerical issues
         m.b.v3.setlb(-5)
-        m.b.v5.setub(10)
 
         solver = get_solver()
         solver.solve(m)
@@ -1198,12 +1194,12 @@ Model Statistics
 2 WARNINGS
 
     WARNING: 1 Constraint with large residuals (>1.0E-05)
-    WARNING: 2 Variables at or outside bounds (tol=0.0E+00)
+    WARNING: 1 Variable at or outside bounds (tol=0.0E+00)
 
 ------------------------------------------------------------------------------------
 5 Cautions
 
-    Caution: 3 Variables with value close to their bounds (abs=1.0E-04, rel=1.0E-04)
+    Caution: 2 Variables with value close to their bounds (abs=1.0E-04, rel=1.0E-04)
     Caution: 2 Variables with value close to zero (tol=1.0E-08)
     Caution: 1 Variable with extreme value (<1.0E-04 or >1.0E+04)
     Caution: 1 Variable with None value

--- a/idaes/core/util/tests/test_utility_minimization.py
+++ b/idaes/core/util/tests/test_utility_minimization.py
@@ -127,7 +127,7 @@ class TestStateBlock(object):
             "state_definition": FTPx,
             "state_bounds": {
                 "flow_mol": (0, 100, 1000, pyunits.mol / pyunits.s),
-                "temperature": (273.15, 300, 450, pyunits.K),
+                "temperature": (100, 300, 450, pyunits.K),
                 "pressure": (5e4, 1e5, 1e6, pyunits.Pa),
             },
             "pressure_ref": (1e5, pyunits.Pa),

--- a/idaes/models/properties/modular_properties/examples/tests/test_BT_PR.py
+++ b/idaes/models/properties/modular_properties/examples/tests/test_BT_PR.py
@@ -80,7 +80,7 @@ class TestBTExample(object):
         m.fs.obj = Objective(expr=(m.fs.state[1].temperature - 510) ** 2)
         m.fs.state[1].temperature.setub(600)
 
-        for logP in range(8, 13, 1):
+        for logP in [9.5, 10, 10.5, 11, 11.5, 12]:
             m.fs.obj.deactivate()
 
             m.fs.state[1].flow_mol.fix(100)
@@ -115,11 +115,11 @@ class TestBTExample(object):
             assert check_optimal_termination(results)
 
             while m.fs.state[1].pressure.value <= 1e6:
-                m.fs.state[1].pressure.value = m.fs.state[1].pressure.value + 1e5
 
                 results = solver.solve(m)
                 assert check_optimal_termination(results)
-                print(T, m.fs.state[1].pressure.value)
+
+                m.fs.state[1].pressure.value = m.fs.state[1].pressure.value + 1e5
 
     @pytest.mark.component
     def test_T350_P1_x5(self, m):

--- a/idaes/models/unit_models/tests/test_equilibrium_reactor.py
+++ b/idaes/models/unit_models/tests/test_equilibrium_reactor.py
@@ -253,13 +253,6 @@ class TestSaponification(object):
             }
         }
 
-    @pytest.mark.component
-    def test_initialization_error(self, sapon):
-        sapon.fs.unit.outlet.pressure[0].fix(1)
-
-        with pytest.raises(InitializationError):
-            sapon.fs.unit.initialize()
-
 
 class TestInitializers:
     @pytest.fixture

--- a/idaes/models/unit_models/tests/test_hx_ntu.py
+++ b/idaes/models/unit_models/tests/test_hx_ntu.py
@@ -505,16 +505,6 @@ class TestHXNTU(object):
             <= 1e-6
         )
 
-    @pytest.mark.component
-    def test_initialization_error(self, model):
-        model.fs.unit.hot_side_outlet.pressure[0].fix(1)
-
-        with pytest.raises(InitializationError):
-            model.fs.unit.initialize()
-
-        # Revert DoF change to avoid contaminating subsequent tests
-        model.fs.unit.hot_side_outlet.pressure[0].unfix()
-
 
 class TestInitializers(object):
     @pytest.fixture(scope="class")


### PR DESCRIPTION
## Related to #1292


## Summary/Motivation:
Pyomo 6.7.0 added checks for fixed variables which violate bounds which caused a number of our tests to fail (about half were deliberate violations in the diagnostics tools for testing, but the rest were real).

## Changes proposed in this PR:
- Updated tests to remove bound violations
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
