### PR TITLE
Add workaround for MEA PHE test failures

### DIFF
--- a/idaes/models_extra/column_models/plate_heat_exchanger.py
+++ b/idaes/models_extra/column_models/plate_heat_exchanger.py
@@ -46,6 +46,7 @@ from pyomo.environ import (
 )
 from pyomo.common.config import ConfigValue, In, Integer
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
+from pyomo.common.deprecation import deprecated
 
 # Import IDAES cores
 from idaes.core import declare_process_block_class
@@ -61,6 +62,13 @@ __author__ = "Paul Akula, Andrew Lee"
 _log = idaeslog.getLogger(__name__)
 
 
+@deprecated(
+    "The Plate Heat Exchanger (PHE) model is known to be affected by "
+    "issues causing it to fail to solve on certain platforms starting with Pyomo v6.7.0. "
+    "This might cause the model to be removed in an upcoming IDAES release if these failures are not resolved. "
+    "For more information, see IDAES/idaes-pse#1294",
+    version="2.3.0",
+)
 @declare_process_block_class("PlateHeatExchanger")
 class PlateHeatExchangerData(HeatExchangerNTUData):
     """Plate Heat Exchanger(PHE) Unit Model."""

--- a/idaes/models_extra/column_models/tests/test_plate_heat_exchanger.py
+++ b/idaes/models_extra/column_models/tests/test_plate_heat_exchanger.py
@@ -67,7 +67,7 @@ def test_config():
 
 workaround_for_1294 = pytest.mark.xfail(
     reason="These tests fail with Pyomo 6.7.0. See IDAES/idaes-pse#1294 for details",
-    strict=True,  # will cause failure if test start passing again so that the marker can be removed
+    strict=False,  # the failures only occur for certain platforms, e.g. Windows on GHA
 )
 
 

--- a/idaes/models_extra/column_models/tests/test_plate_heat_exchanger.py
+++ b/idaes/models_extra/column_models/tests/test_plate_heat_exchanger.py
@@ -65,6 +65,12 @@ def test_config():
     assert len(m.fs.unit.config) == 9
 
 
+workaround_for_1294 = pytest.mark.xfail(
+    reason="These tests fail with Pyomo 6.7.0. See IDAES/idaes-pse#1294 for details",
+    strict=True,  # will cause failure if test start passing again so that the marker can be removed
+)
+
+
 # -----------------------------------------------------------------------------
 class TestPHE(object):
     @pytest.fixture(scope="class")
@@ -166,6 +172,7 @@ class TestPHE(object):
             phe, duty=(245000, pyunits.W), optarg={"bound_push": 1e-8, "mu_init": 1e-8}
         )
 
+    @workaround_for_1294
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -175,6 +182,7 @@ class TestPHE(object):
         # Check for optimal solution
         assert check_optimal_termination(results)
 
+    @workaround_for_1294
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
@@ -214,6 +222,7 @@ class TestPHE(object):
             phe.fs.unit.cold_side_outlet.temperature[0]
         )
 
+    @workaround_for_1294
     @pytest.mark.solver
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component


### PR DESCRIPTION
## Summary/Motivation:

- Add workaround for test failures described in #1294

## Changes proposed in this PR:
- Add `xfail` marker for tests affected by #1294

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
