### PR TITLE
Adding beta warning to Thickener model

### DIFF
--- a/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/thickener0d.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/solid_liquid/thickener0d.rst
@@ -1,6 +1,9 @@
 Thickener (0D)
 ==============
 
+.. warning::
+    The Thickener model is currently in beta status and will likely change in the next release as a more predictive version is developed.
+
 The ``Thickener0D`` unit model is an extension of the :ref:`SLSeparator <reference_guides/model_libraries/generic/unit_models/solid_liquid/sl_separator:Generic Solid-Liquid Separator>` model which adds constraints to estimate the area and height of a vessel required to achieve the desired separation of solid and liquid based on experimental measurements of the settling velocity. This model is based on correlations described in:
 
 [1] Coulson & Richardson's Chemical Engineering, Volume 2 Particle Technology & Separation Processes (4th Ed.), Butterworth-Heinemann (2001)

--- a/idaes/models/unit_models/solid_liquid/tests/test_thickener.py
+++ b/idaes/models/unit_models/solid_liquid/tests/test_thickener.py
@@ -155,6 +155,26 @@ class TestStateBlockData(StateBlockData):
 
 
 # -----------------------------------------------------------------------------
+@pytest.mark.unit
+def test_beta_logger(caplog):
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=False)
+
+    m.fs.properties = TestParameterBlock()
+
+    m.fs.unit = Thickener0D(
+        solid_property_package=m.fs.properties,
+        liquid_property_package=m.fs.properties,
+    )
+    expected = (
+        "The Thickener0D model is currently a beta capability and will "
+        "likely change in the next release as a more predictive version is "
+        "developed."
+    )
+
+    assert expected in caplog.text
+
+
 class TestThickener0DBasic:
     @pytest.fixture(scope="class")
     def model(self):

--- a/idaes/models/unit_models/solid_liquid/thickener.py
+++ b/idaes/models/unit_models/solid_liquid/thickener.py
@@ -58,6 +58,11 @@ class Thickener0DData(SLSeparatorData):
         Returns:
             None
         """
+        logger.warning(
+            "The Thickener0D model is currently a beta capability and will "
+            "likely change in the next release as a more predictive version is "
+            "developed."
+        )
         # Call super().build to setup dynamics
         super().build()
 


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
I have been working on an improved (more predictive) version of the thickener model and have a prototype ready which will not make this release. This PR adds a beta warning to the model to let users know it will change in the next release (this model is new for this release so there is no previous backward compatibility to worry about).

## Changes proposed in this PR:
- Add beta warning to logger and docs for thickener model.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
