### PR TITLE
Fixes error pointed out by Jinliang in SOC interpolation function

### DIFF
--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/common.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/common.py
@@ -182,11 +182,11 @@ def _interpolate_2D(
         phi_bound_1: expression for the value of the quantity to be interpolated
             at the 1 bound
         derivative: If True estimate derivative
-        method: interpolation method currently only CDS is supported
 
     Returns:
         expression for phi at face
     """
+    # TODO add tests to ensure this function works as designed
     icu = ic - 1
     icd = ic
     if ic == ifaces.first():
@@ -203,7 +203,7 @@ def _interpolate_2D(
     if not derivative:
         cf = faces.at(ic)
         lambf = (cd - cf) / (cd - cu)
-        return (1 - lambf) * phi_func(icu) + lambf * phi_func(icd)
+        return (1 - lambf) * phi_func(icd) + lambf * phi_func(icu)
     else:
         # Since we are doing linear interpolation derivative is the slope
         # between node centers even if they are not evenly spaced


### PR DESCRIPTION
## Fixes
Switches evaluation indexes in interpolation function used in SOC submodels

## Summary/Motivation:
The original interpolation function had a typo, this PR fixes it. However, I don't believe it should affect anything we've published, because the incorrect formula gives the correct answer when a uniform discretization is used.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
