### PR TITLE
Enable unnecessary-lambda Pylint check

### DIFF
--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -13,7 +13,6 @@ disable=no-self-argument,
     fixme,
     raise-missing-from,
     logging-fstring-interpolation,  # not sure why pylint doesn't like f-strings
-    unnecessary-lambda,
     attribute-defined-outside-init,
     arguments-differ,
     abstract-method,

--- a/idaes/core/util/tables.py
+++ b/idaes/core/util/tables.py
@@ -284,6 +284,9 @@ def stream_table_dataframe_to_string(stream_table, **kwargs):
     # Set some default values for keyword arguments
     na_rep = kwargs.pop("na_rep", "-")
     justify = kwargs.pop("justify", "center")
+    # the lambda here could be replaced by "{:#.5g}".format,
+    # but arguably that's not as clearly identifiable as a function/callable
+    # pylint: disable-next=unnecessary-lambda
     float_format = kwargs.pop("float_format", lambda x: "{:#.5g}".format(x))
 
     # Print stream table


### PR DESCRIPTION
## Summary/Motivation:

- `unnecessary-lambda` is a built-in Pylint check, that _might_ help addressing some of the issues with `lambda`s described in #1240 
- However, this only looks as cases where `my_func = lambda x, y: my_other_func(x, y)`, i.e where one could just simply set `my_func = my_other_func`
- More to the point, it does nothing to detect and prevent other uses of `lambda` that cause most of the issues in #1240 (specifically, by definition, the closure scope gotchas only arise when the `lambda` has fewer arguments that the function being used)

## Changes proposed in this PR:
- Enable `unnecessary-lambda` Pylint check

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
