### PR TITLE
Add XFAIL marker to bypass #1317 known failures

### DIFF
--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -1847,6 +1847,10 @@ class TestDegeneracyHunter:
             model.con5: -1,
         }
 
+    @pytest.mark.xfail(
+        reason="Known failure. See IDAES/idaes-pse#1317 for details",
+        strict=True,
+    )
     @pytest.mark.solver
     @pytest.mark.component
     def test_solve_ids_milp(self, model, scip_solver):

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -1798,6 +1798,10 @@ class TestDegeneracyHunter:
             model.con5: 1e-05,
         }
 
+    @pytest.mark.xfail(
+        reason="Known failure. See IDAES/idaes-pse#1317 for details",
+        strict=True,
+    )
     @pytest.mark.solver
     @pytest.mark.component
     def test_solve_candidates_milp(self, model, scip_solver):
@@ -1847,10 +1851,7 @@ class TestDegeneracyHunter:
             model.con5: -1,
         }
 
-    @pytest.mark.xfail(
-        reason="Known failure. See IDAES/idaes-pse#1317 for details",
-        strict=True,
-    )
+    # TODO does this test function have the exact same name as the one above?
     @pytest.mark.solver
     @pytest.mark.component
     def test_solve_ids_milp(self, model, scip_solver):


### PR DESCRIPTION
## Summary/Motivation:

This is a temporary workaround to avoid test failures described in #1317 to hold up CI for unrelated PRs.

## Changes proposed in this PR:
- Add `pytest.xfail` marker to test(s) causing failures

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
