### PR TITLE
Remove workaround for tests affected by #1317

### DIFF
--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -1798,10 +1798,6 @@ class TestDegeneracyHunter:
             model.con5: 1e-05,
         }
 
-    @pytest.mark.xfail(
-        reason="Known failure. See IDAES/idaes-pse#1317 for details",
-        strict=True,
-    )
     @pytest.mark.solver
     @pytest.mark.component
     def test_solve_candidates_milp(self, model, scip_solver):


### PR DESCRIPTION
## Fixes


## Summary/Motivation:

As of yesterday, CI checks on `main` have started failing again because `test_solve_candidates_milp` (which has been marked as XFAIL by #1319) started passing again:

![image](https://github.com/IDAES/idaes-pse/assets/48035537/acfabe58-07e3-4332-8b5d-263deb8ea286)

## Changes proposed in this PR:

- Remove XFAIL marker added in #1319

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
