### PR TITLE
Python 3.12 fix for idaes command

### DIFF
--- a/idaes/commands/__init__.py
+++ b/idaes/commands/__init__.py
@@ -20,10 +20,11 @@ import time
 _command_import_start_time = time.time()
 
 import pkgutil
+import click
 from idaes.commands.base import command_base as cb
 
 # import all the commands
-for loader, dotted_module_name, is_pkg in pkgutil.walk_packages(__path__):
+for finder, dotted_module_name, is_pkg in pkgutil.walk_packages(__path__):
     module_name_parts = dotted_module_name.split(".")
     module_name = module_name_parts[-1]
     is_test_module = module_name.startswith("test_")
@@ -32,6 +33,11 @@ for loader, dotted_module_name, is_pkg in pkgutil.walk_packages(__path__):
     elif is_test_module:
         pass
     else:
-        loader.find_module(module_name).load_module(module_name)
+        try:
+            finder.find_spec(module_name).loader.load_module(module_name)
+        except ModuleNotFoundError:
+            click.echo(
+                f"Could not import commands from {module_name}. Perhaps a dependency is missing."
+            )
 
 _command_import_total_time = time.time() - _command_import_start_time


### PR DESCRIPTION
## Fixes

Python 3.12 compatibility issue with the idaes command.


## Changes proposed in this PR:
- Fix minor issue due to pkgutil API change
- Catch exception if a command module fails to import a dependency

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
