### PR TITLE
Extract Codecov upload steps in CI workflow to dedicated dependent job

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -135,24 +135,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["linux", "win64"]
-        include:
-          - os: linux
-            codecov-os: linux
-          - os: win64
-            codecov-os: windows
+        report-variant: ["linux", "win64"]
     steps:
       # the checkout step is needed to have access to codecov.yml
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-report-${{ matrix.os }}
+          name: coverage-report-${{ matrix.report-variant }}
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: true
-          os: ${{ matrix.codecov-os }}
 
   build-docs:
     name: Build Sphinx docs

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -120,11 +120,39 @@ jobs:
       - name: Run pytest (not integration)
         run: |
           pytest -m "not integration"
-      - name: Upload coverage report to Codecov
+      - name: Upload coverage report as GHA workflow artifact
         if: matrix.cov-report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ matrix.os }}
+          path: coverage.xml
+          if-no-files-found: error
+
+  upload-coverage:
+    name: Upload coverage report (Codecov)
+    needs: [pytest]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["linux", "win64"]
+        include:
+          - os: linux
+            codecov-os: linux
+          - os: win64
+            codecov-os: windows
+    steps:
+      # the checkout step is needed to have access to codecov.yml
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-report-${{ matrix.os }}
+      - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
+          verbose: true
+          os: ${{ matrix.codecov-os }}
 
   build-docs:
     name: Build Sphinx docs


### PR DESCRIPTION
## Summary/Motivation:

- Codecov upload failures are frustrating, as they currently require re-running the entire test suite that generates the report (20-40+ minutes)
- The proper fix is to use a Codecov upload token, saved as a repository secret
  - However, this require a major restructuring of the CI workflow because `pull_request` triggers cannot access `secrets`, requiring the creation of a new, non-`pull_request` workflow
  - Synchronizing triggers  and passing data between different workflows is considerably more complicated compared to doing the same between different jobs in the same workflow
- As an intermediate fix, we can separate the Codecov upload so that it runs in a separate job within the `pull_request`-triggered workflow, so that when it fails, it can be re-run separately (which should only take a few seconds)

## Changes proposed in this PR:

- In `pytest` job: replace step uploading report to Codecov with `actions/upload-artifact`
- Create new `upload-coverage` job dependent on `pytest` that just

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
