### PR TITLE
Pass Codecov token to allow coverage uploads for non-PR workflows

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -147,6 +147,11 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+          # NOTE: secrets are not available for pull_request workflows
+          # However, as of 2024-02-10, Codecov is still allowing tokenless upload from PRs
+          # but does require token for other workflows e.g. merge to `main`
+          # see https://github.com/codecov/codecov-action/issues/1274#issuecomment-1934437359
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build-docs:
     name: Build Sphinx docs


### PR DESCRIPTION
## Fixes

Codecov upload failures for non-PR workflows after token policy changes in codecov-action@v4

## Summary/Motivation:

Recent (?) changes to Codecov upload policy:

- Token is still _not required_ for workflows triggered by forks (i.e. `pull_request`)
  - This is good, because providing a token securely through `secrets` is not available to `pull_request`-triggered workflow runs
- Token is now _required_ for other types of workflows (e.g. merging to `main`)

For more details, see https://github.com/codecov/codecov-action/issues/1274#issuecomment-1934437359

## Changes proposed in this PR:
- Add `CODECOV_TOKEN` repository secret
- Pass Codecov token as secret
  - This will be empty/null for PRs (which currently should still work as per the policies above)
  - This will be populated for non-PR workflow runs, which is when Codecov now requires tokens

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
