### PR TITLE
Support calcuation of critical properties of mixtures in Modular Properties

### DIFF
--- a/docs/explanations/components/property_package/general/eos/cubic.rst
+++ b/docs/explanations/components/property_package/general/eos/cubic.rst
@@ -67,6 +67,7 @@ Cubic equations of state require the following parameters to be defined:
 
 1. `omega` (Pitzer acentricity factor) needs to be defined for each component (in the `parameter_data` for each component).
 2. `kappa` (binary interaction parameters) needs to be defined for each component pair in the system. This parameter needs to be defined in the general `parameter_data` argument for the overall property package (as it can be used in multiple phases).
+3. Component critical properties (`compresss_fact_crit`, `dens_mol_crit`, `pressure_crit`, and `temperature_crit`) are often required as well.
 
 Calculation of Properties
 -------------------------
@@ -76,6 +77,26 @@ Many thermophysical properties are calculated using an ideal and residual term, 
 .. math:: p = p^0 + p^r
 
 The residual term is derived from the partial derivatives of the cubic equation of state, whilst the ideal term is determined using pure component properties for the ideal gas phase defined for each component.
+
+Critical Properties of Mixtures
+-------------------------------
+
+The critical properties of the mixture are calculated by solving the cubic equation of state at the critical point using the following constraints.
+
+.. math:: \Omega_A R^2 T_c^2 = a_{c,m}P_c
+.. math:: \Omega_BRT_c = b_{c,m}P_c
+.. math:: 0 = Z_c^3 - (1+B_c-uB_c)Z_c^2 + (A_c-uB_c-(u-w)B_c^2)Z_c - A_cB_c-wB_c^2-wB_c^3
+.. math:: P_c = Z_cRT_c\rho_{c}
+
+
+with the following expressions:
+
+.. math:: a_{c,j} = \frac{\Omega_AR^2T_{c,j}^2}{P_{c, j}}\alpha_j(T_c)
+.. math:: a_{c,m} = \sum_i{\sum_j{y_iy_j(a_{c,i}a_{c,j})^{1/2}(1-\kappa_{ij})}}
+.. math:: b_{c,m} = \sum_i{y_ib_i}
+.. math:: A_c = \frac{a_{c,m}P_c}{R^2T_c^2}
+.. math:: B_c = \frac{b_{c,m}P_c}{RT_c}
+
 
 Mass Density by Phase
 ---------------------
@@ -109,14 +130,14 @@ Component Molar Enthalpy by Phase
 
 Component molar enthalpies by phase are calculated using the pure component method provided by the users in the property package configuration arguments.
 
-Molar Isobaric Heat Capcity (:math:`C_p`)
+Molar Isobaric Heat Capacity (:math:`C_p`)
 -----------------------------------------
 
-The ideal molar isobaric heat capcity term is calculated from the weighted sum of the (ideal) component molar isobaric heat capacity:
+The ideal molar isobaric heat capacity term is calculated from the weighted sum of the (ideal) component molar isobaric heat capacity:
 
 .. math:: C_{p, ig}^0 = \sum_j y_j C_{p, ig, j}
 
-The residual molar isobaric heat capcity term is given by:
+The residual molar isobaric heat capacity term is given by:
 
 .. math:: C_p^r = R \left[ T \left(\frac{\partial Z}{\partial T}\right)_P + Z - 1 \right] +  \frac{ T \frac{d^2a_m}{dT^2}}{\sqrt{u^2 - 4w} \cdot b_m} \ln \left[ \frac{2Z + uB + \sqrt{u^2 - 4w} B}{2Z + uB - \sqrt{u^2 - 4w} B} \right]
 .. math:: + \left(a_m - T \frac{da_m}{dT}\right) \cdot \frac{B}{b_m} \cdot \frac{\left(\frac{\partial Z}{\partial T}\right)_P + \frac{Z}{T}}{Z^2 + Z uB + wB^2}

--- a/docs/explanations/components/property_package/general/eos/cubic.rst
+++ b/docs/explanations/components/property_package/general/eos/cubic.rst
@@ -131,7 +131,7 @@ Component Molar Enthalpy by Phase
 Component molar enthalpies by phase are calculated using the pure component method provided by the users in the property package configuration arguments.
 
 Molar Isobaric Heat Capacity (:math:`C_p`)
------------------------------------------
+------------------------------------------
 
 The ideal molar isobaric heat capacity term is calculated from the weighted sum of the (ideal) component molar isobaric heat capacity:
 

--- a/docs/explanations/components/property_package/general/eos/cubic.rst
+++ b/docs/explanations/components/property_package/general/eos/cubic.rst
@@ -67,7 +67,7 @@ Cubic equations of state require the following parameters to be defined:
 
 1. `omega` (Pitzer acentricity factor) needs to be defined for each component (in the `parameter_data` for each component).
 2. `kappa` (binary interaction parameters) needs to be defined for each component pair in the system. This parameter needs to be defined in the general `parameter_data` argument for the overall property package (as it can be used in multiple phases).
-3. Component critical properties (`compresss_fact_crit`, `dens_mol_crit`, `pressure_crit`, and `temperature_crit`) are often required as well.
+3. Component critical properties (`compress_fact_crit`, `dens_mol_crit`, `pressure_crit`, and `temperature_crit`) are often required as well.
 
 Calculation of Properties
 -------------------------

--- a/docs/explanations/components/property_package/general/eos/ideal.rst
+++ b/docs/explanations/components/property_package/general/eos/ideal.rst
@@ -9,6 +9,11 @@ Introduction
 
 Ideal behavior represents the simplest possible equation of state that ensures thermodynamic consistency between different properties.
 
+Critical Properties of Mixtures
+-------------------------------
+
+The Ideal Equation of State module does not support the calculation of mixture critical properties as the ideal equation of state cannot represent the critical point.
+
 Mass Density by Phase
 ---------------------
 

--- a/docs/explanations/components/property_package/general/phase_def.rst
+++ b/docs/explanations/components/property_package/general/phase_def.rst
@@ -34,7 +34,7 @@ Equations of state (or equivalent methods) describe the relationship between dif
 
 A wide range of equations of states are available in literature for different applications and levels of rigor, and the IDAES Generic Property Package Framework provides a number of prebuilt modules for users, which are listed below.
 
-Equation of state packages may allow for user options (e.g. choosing a specific type of cubic equation of state). The options are set using the `equation_of_state_options` argument, and the options available are described in the documentation of each equation of state module.
+Equation of state packages may allow for user options (e.g., choosing a specific type of cubic equation of state). The options are set using the `equation_of_state_options` argument, and the options available are described in the documentation of each equation of state module.
 
 Equation of State Libraries
 """""""""""""""""""""""""""
@@ -44,6 +44,20 @@ Equation of State Libraries
 
     eos/ideal
     eos/cubic
+    
+Critical Properties of Mixtures
+"""""""""""""""""""""""""""""""
+
+Calculation of the critical properties of mixtures depends on the equation of state being used. As the Modular Property Package framework allows users to specify different equations of state for each phase, the following logic is used to determine which equation of state to use for calculating critical properties.
+
+1. If a vapor-liquid equilibrium pair is defined in the `"phases_in_equilibrium"` configuration argument, then the liquid phase from this pair is used (IDAES generally assumed supercritical fluids are liquid like).
+2. If no vapor-liquid equilibrium pair is defined, then the first liquid phase define is used.
+3. If no liquid phases are defined then the vapor phase is used (it is assumed there will only be one vapor phase).
+4. If no vapor phase is defined, then a `PropertyPackageError` is returned as there is no suitable phase for calculating critical properties.
+
+Note that not all Equations of State are suitable for calculating critical properties as many cannot represent the critical conditions. The Ideal equation of State is one common example of an equation of state that DOES NOT support critical properties.
+
+During initialization, the critical properties of the mixture are approximated using the mole fraction weighted sum of the component critical properties (note that users must provide values for all component critical properties (i.e., `compress_fact_crit`, `dens_mol_crit`, `pressure_crit` and `temperature_crit`) for initialization if critical properties are to be calculated.
 
 Phase-Specific Parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,6 +67,6 @@ In some cases, a property package may include parameters which are specific to a
 Phases with Partial Component Lists
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In many applications a mixture will contain species that only appear in a single phase (either by nature or assumption). Common examples include crystalline solids and non-condensable gases. The IDAES Generic Property Package Framework provides support for these behaviors and allows users to specify phase-specific component lists (i.e. a list of components which appear in a given phase).
+In many applications a mixture will contain species that only appear in a single phase (either by nature or assumption). Common examples include crystalline solids and non-condensable gases. The IDAES Generic Property Package Framework provides support for these behaviors and allows users to specify phase-specific component lists (i.e., a list of components which appear in a given phase).
 
 This is done by providing a phase with a `component_list` argument, which provides a `list` of component names which appear in the phase. The framework automatically validates the `component_list` argument to ensure that it is a sub-set of the master component list for the property package, and will inform the user if an unrecognized component is included. If a phase is not provided with a `component_list` argument it is assumed that all components defined in the master component list may be present in the phase.

--- a/docs/explanations/components/property_package/general/phase_def.rst
+++ b/docs/explanations/components/property_package/general/phase_def.rst
@@ -50,14 +50,14 @@ Critical Properties of Mixtures
 
 Calculation of the critical properties of mixtures depends on the equation of state being used. As the Modular Property Package framework allows users to specify different equations of state for each phase, the following logic is used to determine which equation of state to use for calculating critical properties.
 
-1. If a vapor-liquid equilibrium pair is defined in the `"phases_in_equilibrium"` configuration argument, then the liquid phase from this pair is used (IDAES generally assumed supercritical fluids are liquid like).
-2. If no vapor-liquid equilibrium pair is defined, then the first liquid phase define is used.
+1. If a vapor-liquid equilibrium pair is defined in the `"phases_in_equilibrium"` configuration argument, then the liquid phase from this pair is used (IDAES generally assumed supercritical fluids are liquid-like).
+2. If no vapor-liquid equilibrium pair is defined, then the first liquid phase defined is used.
 3. If no liquid phases are defined then the vapor phase is used (it is assumed there will only be one vapor phase).
 4. If no vapor phase is defined, then a `PropertyPackageError` is returned as there is no suitable phase for calculating critical properties.
 
 Note that not all Equations of State are suitable for calculating critical properties as many cannot represent the critical conditions. The Ideal equation of State is one common example of an equation of state that DOES NOT support critical properties.
 
-During initialization, the critical properties of the mixture are approximated using the mole fraction weighted sum of the component critical properties (note that users must provide values for all component critical properties (i.e., `compress_fact_crit`, `dens_mol_crit`, `pressure_crit` and `temperature_crit`) for initialization if critical properties are to be calculated.
+During initialization, the critical properties of the mixture are approximated using the mole fraction weighted sum of the component critical properties (note that users must provide values for all component critical properties (i.e., `compress_fact_crit`, `dens_mol_crit`, `pressure_crit` and `temperature_crit`) for initialization if critical properties are to be calculated. Note that it is up to the user to ensure these values are consistent (if necessary).
 
 Phase-Specific Parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/explanations/components/property_package/general/phase_def.rst
+++ b/docs/explanations/components/property_package/general/phase_def.rst
@@ -50,7 +50,7 @@ Critical Properties of Mixtures
 
 Calculation of the critical properties of mixtures depends on the equation of state being used. As the Modular Property Package framework allows users to specify different equations of state for each phase, the following logic is used to determine which equation of state to use for calculating critical properties.
 
-1. If a vapor-liquid equilibrium pair is defined in the `"phases_in_equilibrium"` configuration argument, then the liquid phase from this pair is used (IDAES generally assumed supercritical fluids are liquid-like).
+1. If a vapor-liquid equilibrium pair is defined in the `"phases_in_equilibrium"` configuration argument, then the liquid phase from this pair is used (IDAES generally assumes supercritical fluids are liquid-like).
 2. If no vapor-liquid equilibrium pair is defined, then the first liquid phase defined is used.
 3. If no liquid phases are defined then the vapor phase is used (it is assumed there will only be one vapor phase).
 4. If no vapor phase is defined, then a `PropertyPackageError` is returned as there is no suitable phase for calculating critical properties.

--- a/idaes/core/base/components.py
+++ b/idaes/core/base/components.py
@@ -246,6 +246,7 @@ class ComponentData(ProcessBlockData):
 
         # Create Vars for common parameters
         var_dict = {
+            "compress_fact_crit": pyunits.dimensionless,
             "dens_mol_crit": base_units.DENSITY_MOLE,
             "omega": pyunits.dimensionless,
             "pressure_crit": base_units.PRESSURE,

--- a/idaes/core/base/property_meta.py
+++ b/idaes/core/base/property_meta.py
@@ -267,9 +267,7 @@ class UnitSet(object):
     # Backward compatibility name
     @property
     def MOLAR_VOLUME(self):
-        msg = (
-            f"The unit name MOLAR_VOLUME is being deprecated in " "favor of VOLUME_MOL."
-        )
+        msg = "The unit name MOLAR_VOLUME is being deprecated in favor of VOLUME_MOL."
         deprecation_warning(msg=msg, logger=_log, version="2.3.0", remove_in="3.0.0")
         return self.VOLUME_MOLE
 

--- a/idaes/core/base/property_meta.py
+++ b/idaes/core/base/property_meta.py
@@ -261,7 +261,7 @@ class UnitSet(object):
         return self._length**3 * self._mass**-1
 
     @property
-    def VOLUME_MOL(self):
+    def VOLUME_MOLE(self):
         return self._length**3 * self._amount**-1
 
     # Backward compatibility name
@@ -271,7 +271,7 @@ class UnitSet(object):
             f"The unit name MOLAR_VOLUME is being deprecated in " "favor of VOLUME_MOL."
         )
         deprecation_warning(msg=msg, logger=_log, version="2.3.0", remove_in="3.0.0")
-        return self.VOLUME_MOL
+        return self.VOLUME_MOLE
 
     # Flows
     @property

--- a/idaes/core/base/property_meta.py
+++ b/idaes/core/base/property_meta.py
@@ -257,8 +257,21 @@ class UnitSet(object):
         return self._length**3
 
     @property
-    def MOLAR_VOLUME(self):
+    def VOLUME_MASS(self):
+        return self._length**3 * self._mass**-1
+
+    @property
+    def VOLUME_MOL(self):
         return self._length**3 * self._amount**-1
+
+    # Backward compatibility name
+    @property
+    def MOLAR_VOLUME(self):
+        msg = (
+            f"The unit name MOLAR_VOLUME is being deprecated in " "favor of VOLUME_MOL."
+        )
+        deprecation_warning(msg=msg, logger=_log, version="2.3.0", remove_in="3.0.0")
+        return self.VOLUME_MOL
 
     # Flows
     @property

--- a/idaes/core/base/property_set.py
+++ b/idaes/core/base/property_set.py
@@ -627,6 +627,11 @@ class StandardPropertySet(PropertySetBase):
         doc="Compressiblity Factor",
         units=pyunits.dimensionless,
     )
+    compress_fact_crit = PropertyMetadata(
+        name="compress_fact_crit",
+        doc="Compressiblity Factor at Critical Point",
+        units=pyunits.dimensionless,
+    )
     conc_mass = PropertyMetadata(
         name="conc_mass",
         doc="Concentration on a Mass Basis",
@@ -890,12 +895,12 @@ class StandardPropertySet(PropertySetBase):
     vol_mol = PropertyMetadata(
         name="vol_mol",
         doc="Molar Volume",
-        units="MOLAR_VOLUME",
+        units="VOLUME_MOL",
     )
     vol_mol_crit = PropertyMetadata(
         name="vol_mol",
         doc="Molar Volume at Critical Point",
-        units="MOLAR_VOLUME",
+        units="VOLUME_MOL",
     )
     # Log terms
     log_act = PropertyMetadata(

--- a/idaes/core/base/property_set.py
+++ b/idaes/core/base/property_set.py
@@ -895,12 +895,12 @@ class StandardPropertySet(PropertySetBase):
     vol_mol = PropertyMetadata(
         name="vol_mol",
         doc="Molar Volume",
-        units="VOLUME_MOL",
+        units="VOLUME_MOLE",
     )
     vol_mol_crit = PropertyMetadata(
         name="vol_mol",
         doc="Molar Volume at Critical Point",
-        units="VOLUME_MOL",
+        units="VOLUME_MOLE",
     )
     # Log terms
     log_act = PropertyMetadata(

--- a/idaes/core/base/tests/test_components.py
+++ b/idaes/core/base/tests/test_components.py
@@ -185,6 +185,8 @@ class TestComponent:
         m.comp = Component(
             parameter_data={
                 "mw": 10,
+                "compress_fact_crit": 1,
+                "dens_mol_crit": 55,
                 "pressure_crit": 1e5,
                 "temperature_crit": 500,
             }
@@ -192,6 +194,12 @@ class TestComponent:
 
         assert isinstance(m.comp.mw, Param)
         assert m.comp.mw.value == 10
+
+        assert isinstance(m.comp.compress_fact_crit, Var)
+        assert m.comp.compress_fact_crit.value == 1
+
+        assert isinstance(m.comp.dens_mol_crit, Var)
+        assert m.comp.dens_mol_crit.value == 55
 
         assert isinstance(m.comp.pressure_crit, Var)
         assert m.comp.pressure_crit.value == 1e5

--- a/idaes/core/base/tests/test_property_meta.py
+++ b/idaes/core/base/tests/test_property_meta.py
@@ -175,6 +175,8 @@ def test_luminous_intensity(unit_set):
 derived_quantities = {
     "area": units.m**2,
     "volume": units.m**3,
+    "volume_mass": units.m**3 / units.kg,
+    "volume_mol": units.m**3 / units.mol,
     "flow_mass": units.kg * units.s**-1,
     "flow_mole": units.mol * units.s**-1,
     "flow_vol": units.m**3 * units.s**-1,

--- a/idaes/core/base/tests/test_property_meta.py
+++ b/idaes/core/base/tests/test_property_meta.py
@@ -176,7 +176,7 @@ derived_quantities = {
     "area": units.m**2,
     "volume": units.m**3,
     "volume_mass": units.m**3 / units.kg,
-    "volume_mol": units.m**3 / units.mol,
+    "volume_mole": units.m**3 / units.mol,
     "flow_mass": units.kg * units.s**-1,
     "flow_mole": units.mol * units.s**-1,
     "flow_vol": units.m**3 * units.s**-1,

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1296,7 +1296,7 @@ class ModularPropertiesInitializer(InitializerBase):
                     k.inherent_equilibrium_constraint.deactivate()
 
         # ---------------------------------------------------------------------
-        # If present, initialize bubble and dew point and critical property calculations
+        # If present, initialize bubble, dew, and critical point calculations
         for k in model.values():
             T_units = k.params.get_metadata().default_units.TEMPERATURE
 
@@ -1347,21 +1347,21 @@ class ModularPropertiesInitializer(InitializerBase):
             if hasattr(k, "_mole_frac_pdew"):
                 model._init_Pdew(k, T_units)
 
-            # Solve bubble, dew and critical point constraints
+            # Solve bubble, dew, and critical point constraints
             for c in k.component_objects(Constraint):
                 # Deactivate all constraints not associated with bubble and dew
                 # points or critical points
                 if c.local_name not in cons_list:
                     c.deactivate()
 
-        # If StateBlock has active constraints (i.e. has bubble and/or dew
+        # If StateBlock has active constraints (i.e. has bubble, dew, or critical
         # point calculations), solve the block to converge these
         for b in model.values():
             if number_activated_constraints(b) > 0:
                 if not degrees_of_freedom(b) == 0:
                     raise InitializationError(
                         f"{b.name} Unexpected degrees of freedom during "
-                        f"initialization at bubble and dew and critical point step: "
+                        f"initialization at bubble, dew, and critical point step: "
                         f"{degrees_of_freedom(b)}."
                     )
                 with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
@@ -1371,7 +1371,7 @@ class ModularPropertiesInitializer(InitializerBase):
                         solve_kwds={"tee": slc.tee},
                         calc_var_kwds=self.config.calculate_variable_options,
                     )
-        init_log.info("Bubble, dew and critical point initialization completed.")
+        init_log.info("Bubble, dew, and critical point initialization completed.")
 
         # ---------------------------------------------------------------------
         # Calculate _teq if required
@@ -1751,7 +1751,7 @@ class _GenericStateBlock(StateBlock):
         opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
-        # If present, initialize bubble and dew point, and critical property calculations
+        # If present, initialize bubble, dew , and critical point calculations
         for k in blk.values():
             T_units = k.params.get_metadata().default_units.TEMPERATURE
 
@@ -1798,14 +1798,14 @@ class _GenericStateBlock(StateBlock):
             if hasattr(k, "_mole_frac_pdew"):
                 blk._init_Pdew(k, T_units)
 
-            # Solve bubble, dew and critical point constraints
+            # Solve bubble, dew, and critical point constraints
             for c in k.component_objects(Constraint):
-                # Deactivate all constraints not associated with bubble and dew
-                # points or critical points
+                # Deactivate all constraints not associated with bubble, dew,
+                # or critical points
                 if c.local_name not in cons_list:
                     c.deactivate()
 
-        # If StateBlock has active constraints (i.e. has bubble and/or dew
+        # If StateBlock has active constraints (i.e. has bubble, dew, or critical
         # point calculations), solve the block to converge these
         n_cons = 0
         dof = 0
@@ -1816,12 +1816,12 @@ class _GenericStateBlock(StateBlock):
             if dof > 0:
                 raise InitializationError(
                     f"{blk.name} Unexpected degrees of freedom during "
-                    f"initialization at bubble, dew and critical point step: {dof}."
+                    f"initialization at bubble, dew, and critical point step: {dof}."
                 )
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
                 res = solve_indexed_blocks(opt, [blk], tee=slc.tee)
             init_log.info(
-                "Bubble, dew and critical point initialization: {}.".format(
+                "Bubble, dew, and critical point initialization: {}.".format(
                     idaeslog.condition(res)
                 )
             )

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -2975,7 +2975,7 @@ class GenericStateBlockData(StateBlockData):
             )
 
             p_config = self.params.get_phase(ref_phase).config
-            p_config.equation_of_state.build_critical_properties(self, ref_phase)
+            p_config.equation_of_state.build_critical_properties(self)
 
         except AttributeError:
             self.del_component(self.compress_fact_crit)

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -2975,7 +2975,7 @@ class GenericStateBlockData(StateBlockData):
             )
 
             p_config = self.params.get_phase(ref_phase).config
-            p_config.equation_of_state.build_critical_properties(self)
+            p_config.equation_of_state.build_critical_properties(self, ref_phase)
 
         except AttributeError:
             self.del_component(self.compress_fact_crit)

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -2961,7 +2961,7 @@ class GenericStateBlockData(StateBlockData):
 
             self.dens_mol_crit = Var(
                 doc="Critical molar density of mixture",
-                units=base_units.DENS_MOL,
+                units=base_units.DENSITY_MOLE,
             )
 
             self.pressure_crit = Var(

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -5157,27 +5157,25 @@ def _log_mole_frac_bubble_dew(b, name):
 def _initialize_critical_props(state_data):
     params = state_data.params
     # Use mole weighted sum of component critical properties
-    state_data.compress_fact_crit.set_value(
-        sum(
-            state_data.mole_frac_comp[j] * params.get_component(j).compress_fact_crit
-            for j in state_data.component_list
-        )
-    )
-    state_data.dens_mol_crit.set_value(
-        sum(
-            state_data.mole_frac_comp[j] * params.get_component(j).dens_mol_crit
-            for j in state_data.component_list
-        )
-    )
-    state_data.pressure_crit.set_value(
-        sum(
-            state_data.mole_frac_comp[j] * params.get_component(j).pressure_crit
-            for j in state_data.component_list
-        )
-    )
-    state_data.temperature_crit.set_value(
-        sum(
-            state_data.mole_frac_comp[j] * params.get_component(j).temperature_crit
-            for j in state_data.component_list
-        )
-    )
+    crit_props = [
+        "compress_fact_crit",
+        "dens_mol_crit",
+        "pressure_crit",
+        "temperature_crit",
+    ]
+
+    for prop in crit_props:
+        try:
+            getattr(state_data, prop).set_value(
+                sum(
+                    state_data.mole_frac_comp[j]
+                    * getattr(params.get_component(j), prop)
+                    for j in state_data.component_list
+                )
+            )
+        except AttributeError:
+            raise AttributeError(
+                f"Missing attribute found when initializing {prop}. "
+                f"Make sure you have provided values for {prop} in all Component "
+                "declarations."
+            )

--- a/idaes/models/properties/modular_properties/base/tests/test_generic_property.py
+++ b/idaes/models/properties/modular_properties/base/tests/test_generic_property.py
@@ -1461,3 +1461,150 @@ class TestGenericStateBlock(object):
 
         for p in frame.props[1].phase_list:
             assert value(frame.props[1].visc_d_phase[p]) == 4
+
+
+class TestCriticalProps:
+    @pytest.mark.unit
+    def test_get_critical_ref_phase_exception(self):
+        # No vapor or liquid phases
+        m = ConcreteModel()
+        m.params = DummyParameterBlock(
+            components={
+                "a": {},
+            },
+            phases={
+                "p1": {
+                    "equation_of_state": DummyEoS,
+                },
+                "p2": {
+                    "equation_of_state": DummyEoS,
+                },
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units=base_units,
+        )
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        with pytest.raises(
+            AttributeError,
+            match="No liquid or vapor phase found to use as reference phase "
+            "for calculating critical properties.",
+        ):
+            m.props[1]._get_critical_ref_phase()
+
+    @pytest.mark.unit
+    def test_get_critical_ref_phase_exception(self):
+        # No vapor or liquid phases
+        m = ConcreteModel()
+        m.params = DummyParameterBlock(
+            components={
+                "a": {},
+            },
+            phases={
+                "p1": {
+                    "equation_of_state": DummyEoS,
+                },
+                "p2": {
+                    "equation_of_state": DummyEoS,
+                },
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units=base_units,
+        )
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        with pytest.raises(
+            PropertyPackageError,
+            match="No liquid or vapor phase found to use as reference phase "
+            "for calculating critical properties.",
+        ):
+            m.props[1]._get_critical_ref_phase()
+
+    @pytest.mark.unit
+    def test_get_critical_ref_phase_VL(self):
+        # No vapor or liquid phases
+        m = ConcreteModel()
+        m.params = DummyParameterBlock(
+            components={
+                "a": {},
+            },
+            phases={
+                "p1": {
+                    "type": LiquidPhase,
+                    "equation_of_state": DummyEoS,
+                },
+                "p2": {
+                    "type": VaporPhase,
+                    "equation_of_state": DummyEoS,
+                },
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units=base_units,
+        )
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        assert m.props[1]._get_critical_ref_phase() == "p1"
+
+    @pytest.mark.unit
+    def test_get_critical_ref_phase_LL(self):
+        # No vapor or liquid phases
+        m = ConcreteModel()
+        m.params = DummyParameterBlock(
+            components={
+                "a": {},
+            },
+            phases={
+                "p1": {
+                    "type": LiquidPhase,
+                    "equation_of_state": DummyEoS,
+                },
+                "p2": {
+                    "type": LiquidPhase,
+                    "equation_of_state": DummyEoS,
+                },
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units=base_units,
+        )
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        assert m.props[1]._get_critical_ref_phase() == "p1"
+
+    @pytest.mark.unit
+    def test_get_critical_ref_phase_VX(self):
+        # No vapor or liquid phases
+        m = ConcreteModel()
+        m.params = DummyParameterBlock(
+            components={
+                "a": {},
+            },
+            phases={
+                "p1": {
+                    "type": VaporPhase,
+                    "equation_of_state": DummyEoS,
+                },
+                "p2": {
+                    "equation_of_state": DummyEoS,
+                },
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            base_units=base_units,
+        )
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        assert m.props[1]._get_critical_ref_phase() == "p1"

--- a/idaes/models/properties/modular_properties/base/tests/test_generic_property.py
+++ b/idaes/models/properties/modular_properties/base/tests/test_generic_property.py
@@ -1852,3 +1852,96 @@ class TestCriticalProps:
         assert value(m.props[1].dens_mol_crit) == 0.4 * 1 + 0.6 * 2 + 1e-8 * 3
         assert value(m.props[1].pressure_crit) == 0.4 * 1e5 + 0.6 * 2e5 + 1e-8 * 3e5
         assert value(m.props[1].temperature_crit) == 0.4 * 1e2 + 0.6 * 2e2 + 1e-8 * 3e2
+
+    @pytest.mark.unit
+    def test_initialize_critical_props_missing_value(self):
+        m = ConcreteModel()
+
+        class DummyEoS2(DummyEoS):
+            @staticmethod
+            def build_critical_properties(b, *args, **kwargs):
+                b._dummy_crit_executed = True
+
+        # Dummy params block
+        m.params = DummyParameterBlock(
+            components={
+                "a": {
+                    "parameter_data": {
+                        "dens_mol_crit": 1,  # Missing Z_crit
+                        "pressure_crit": 1e5,
+                        "temperature_crit": 100,
+                    }
+                },
+                "b": {
+                    "parameter_data": {
+                        "compress_fact_crit": 0.2,
+                        "dens_mol_crit": 2,
+                        "pressure_crit": 2e5,
+                        "temperature_crit": 200,
+                    }
+                },
+                "c": {
+                    "parameter_data": {
+                        "compress_fact_crit": 0.3,
+                        "dens_mol_crit": 3,
+                        "pressure_crit": 3e5,
+                        "temperature_crit": 300,
+                    }
+                },
+            },
+            phases={
+                "Vap": {
+                    "type": LiquidPhase,
+                    "equation_of_state": DummyEoS2,
+                },
+                "Liq": {
+                    "type": LiquidPhase,
+                    "equation_of_state": DummyEoS2,
+                },
+            },
+            base_units={
+                "time": pyunits.s,
+                "length": pyunits.m,
+                "mass": pyunits.kg,
+                "amount": pyunits.mol,
+                "temperature": pyunits.K,
+            },
+            state_definition=modules[__name__],
+            pressure_ref=100000.0,
+            temperature_ref=300,
+            parameter_data={
+                "PR_kappa": {
+                    ("a", "a"): 0.0,
+                    ("a", "b"): 0.0,
+                    ("a", "c"): 0.0,
+                    ("b", "a"): 0.0,
+                    ("b", "b"): 0.0,
+                    ("b", "c"): 0.0,
+                    ("c", "a"): 0.0,
+                    ("c", "b"): 0.0,
+                    ("c", "c"): 0.0,
+                },
+            },
+        )
+
+        m.props = m.params.build_state_block([1], defined_state=False)
+
+        # Add common variables
+        m.props[1].mole_frac_comp = Var(
+            m.params.component_list, initialize=0.5, bounds=(1e-12, 1)
+        )
+        m.props[1].mole_frac_comp["a"].fix(0.4)
+        m.props[1].mole_frac_comp["b"].fix(0.6)
+        m.props[1].mole_frac_comp["c"].fix(1e-8)
+
+        # Build critical props
+        m.props[1]._critical_props()
+
+        # Initialize critical props
+        with pytest.raises(
+            AttributeError,
+            match="Missing attribute found when initializing compress_fact_crit. "
+            "Make sure you have provided values for compress_fact_crit in all "
+            "Component declarations.",
+        ):
+            _initialize_critical_props(m.props[1])

--- a/idaes/models/properties/modular_properties/eos/ceos.py
+++ b/idaes/models/properties/modular_properties/eos/ceos.py
@@ -1012,6 +1012,15 @@ class Cubic(EoSBase):
             * m.dens_mol_crit
         )
 
+    @staticmethod
+    def list_critical_property_constraint_names():
+        return [
+            "dens_mol_crit_eq",
+            "compress_fact_crit_eq",
+            "A_crit",
+            "B_crit",
+        ]
+
 
 def _dZ_dT(blk, p):
     pobj = blk.params.get_phase(p)

--- a/idaes/models/properties/modular_properties/eos/eos_base.py
+++ b/idaes/models/properties/modular_properties/eos/eos_base.py
@@ -68,7 +68,11 @@ class EoSBase:
         Returns:
             list of constraint names
         """
-        raise NotImplementedError(_msg(b, "list_critical_property_constraint_names"))
+        raise NotImplementedError(
+            "Equation of State module has not implemented a method for "
+            "list_critical_property_constraint_names. Please contact the "
+            "EoS developer or use a different module."
+        )
 
     @staticmethod
     def get_vol_mol_pure(b, phase, comp, temperature):

--- a/idaes/models/properties/modular_properties/eos/eos_base.py
+++ b/idaes/models/properties/modular_properties/eos/eos_base.py
@@ -51,12 +51,8 @@ class EoSBase:
         raise NotImplementedError(_msg(b, "build_parameters"))
 
     @staticmethod
-    def build_critical_properties(b, p):
+    def build_critical_properties(b):
         raise NotImplementedError(_msg(b, "build_critical_properties"))
-
-    @staticmethod
-    def initialize_critical_properties(b, p):
-        raise NotImplementedError(_msg(b, "initialize_critical_properties"))
 
     @staticmethod
     def get_vol_mol_pure(b, phase, comp, temperature):

--- a/idaes/models/properties/modular_properties/eos/eos_base.py
+++ b/idaes/models/properties/modular_properties/eos/eos_base.py
@@ -52,7 +52,23 @@ class EoSBase:
 
     @staticmethod
     def build_critical_properties(b, ref_phase):
+        """
+        This method is used to define the constraints used to calculate mixture
+        critical properties.
+        """
         raise NotImplementedError(_msg(b, "build_critical_properties"))
+
+    @staticmethod
+    def list_critical_property_constraint_names():
+        """
+        If critical properties are supported, this method is required during
+        initialization to identify the constraints that are associated
+        with calculating the critical properties.
+
+        Returns:
+            list of constraint names
+        """
+        raise NotImplementedError(_msg(b, "list_critical_property_constraint_names"))
 
     @staticmethod
     def get_vol_mol_pure(b, phase, comp, temperature):

--- a/idaes/models/properties/modular_properties/eos/eos_base.py
+++ b/idaes/models/properties/modular_properties/eos/eos_base.py
@@ -51,6 +51,14 @@ class EoSBase:
         raise NotImplementedError(_msg(b, "build_parameters"))
 
     @staticmethod
+    def build_critical_properties(b, p):
+        raise NotImplementedError(_msg(b, "build_critical_properties"))
+
+    @staticmethod
+    def initialize_critical_properties(b, p):
+        raise NotImplementedError(_msg(b, "initialize_critical_properties"))
+
+    @staticmethod
     def get_vol_mol_pure(b, phase, comp, temperature):
         try:
             vol_mol = get_method(b, "vol_mol_" + phase + "_comp", comp)(

--- a/idaes/models/properties/modular_properties/eos/eos_base.py
+++ b/idaes/models/properties/modular_properties/eos/eos_base.py
@@ -51,7 +51,7 @@ class EoSBase:
         raise NotImplementedError(_msg(b, "build_parameters"))
 
     @staticmethod
-    def build_critical_properties(b):
+    def build_critical_properties(b, ref_phase):
         raise NotImplementedError(_msg(b, "build_critical_properties"))
 
     @staticmethod

--- a/idaes/models/properties/modular_properties/eos/ideal.py
+++ b/idaes/models/properties/modular_properties/eos/ideal.py
@@ -21,7 +21,7 @@ Currently only supports liquid and vapor phases
 # TODO: Look into protected access issues
 # pylint: disable=protected-access
 
-from pyomo.environ import Constraint, Expression, log, units
+from pyomo.environ import Expression, log
 
 from idaes.core import Apparent
 from idaes.core.util.exceptions import ConfigurationError, PropertyNotSupportedError
@@ -34,7 +34,6 @@ from idaes.models.properties.modular_properties.phase_equil.henry import (
     log_henry_pressure,
 )
 from .eos_base import EoSBase
-from idaes.core.util.constants import Constants as CONST
 
 
 # TODO: Add support for ideal solids
@@ -48,41 +47,6 @@ class Ideal(EoSBase):
     def common(b, pobj):
         # No common components required for ideal property calculations
         pass
-
-    @staticmethod
-    def build_critical_properties(b, ref_phase):
-        base_units = b.params.get_metadata().default_units
-
-        # Use Kay's method for critical pressure and temperature
-        def p_crit_rule(b):
-            return b.pressure_crit == sum(
-                b.mole_frac_comp[j] * b.params.get_component(j).pressure_crit
-                for j in b.component_list
-            )
-
-        b.pressure_crit_constraint = Constraint(rule=p_crit_rule)
-
-        def t_crit_rule(b):
-            return b.temperature_crit == sum(
-                b.mole_frac_comp[j] * b.params.get_component(j).temperature_crit
-                for j in b.component_list
-            )
-
-        b.temperature_crit_constraint = Constraint(rule=t_crit_rule)
-
-        # Fix critical compressibility factor to 1 - user can override if necessary
-        b.compress_fact_crit.fix(1)
-
-        def rho_crit_rule(b):
-            return b.pressure_crit == units.convert(
-                b.compress_fact_crit
-                * CONST.gas_constant
-                * b.temperature_crit
-                * b.dens_mol_crit,
-                to_units=base_units.PRESSURE,
-            )
-
-        b.dens_mol_crit_constraint = Constraint(rule=rho_crit_rule)
 
     @staticmethod
     def calculate_scaling_factors(b, pobj):

--- a/idaes/models/properties/modular_properties/eos/ideal.py
+++ b/idaes/models/properties/modular_properties/eos/ideal.py
@@ -50,7 +50,7 @@ class Ideal(EoSBase):
         pass
 
     @staticmethod
-    def build_critical_properties(b):
+    def build_critical_properties(b, ref_phase):
         base_units = b.params.get_metadata().default_units
 
         # Use Kay's method for critical pressure and temperature

--- a/idaes/models/properties/modular_properties/eos/tests/test_ideal.py
+++ b/idaes/models/properties/modular_properties/eos/tests/test_ideal.py
@@ -217,7 +217,6 @@ def test_cv_mol_phase_comp(m):
 
 @pytest.mark.unit
 def test_heat_capacity_ratio_phase(m):
-
     m.props[1].cp_mol_phase = Var(m.params.phase_list)
     m.props[1].cv_mol_phase = Var(m.params.phase_list)
 

--- a/idaes/models/properties/modular_properties/eos/tests/test_ideal.py
+++ b/idaes/models/properties/modular_properties/eos/tests/test_ideal.py
@@ -18,7 +18,7 @@ Author: Andrew Lee
 import pytest
 from sys import modules
 
-from pyomo.environ import ConcreteModel, Constraint, Var, units as pyunits, value
+from pyomo.environ import ConcreteModel, Var, units as pyunits, value
 from pyomo.util.check_units import assert_units_equivalent
 
 from idaes.core import (
@@ -685,74 +685,3 @@ def test_vol_mol_phase():
                 + 1 / 42.0 * m.props[1].mole_frac_phase_comp["Liq", "b"]
                 + 42.0 * m.props[1].mole_frac_phase_comp["Liq", "c"]
             )
-
-
-@pytest.mark.unit
-def test_critical_props():
-    m = ConcreteModel()
-
-    # Dummy params block
-    m.params = DummyParameterBlock(
-        components={
-            "a": {"parameter_data": {"pressure_crit": 1e5, "temperature_crit": 100}},
-            "b": {"parameter_data": {"pressure_crit": 2e5, "temperature_crit": 200}},
-            "c": {"parameter_data": {"pressure_crit": 3e5, "temperature_crit": 300}},
-        },
-        phases={
-            "Vap": {"type": VaporPhase, "equation_of_state": Ideal},
-            "Liq": {"type": LiquidPhase, "equation_of_state": Ideal},
-        },
-        base_units={
-            "time": pyunits.s,
-            "length": pyunits.m,
-            "mass": pyunits.kg,
-            "amount": pyunits.mol,
-            "temperature": pyunits.K,
-        },
-        state_definition=modules[__name__],
-        pressure_ref=100000.0,
-        temperature_ref=300,
-    )
-
-    m.props = m.params.state_block_class([1], defined_state=False, parameters=m.params)
-
-    # Add common variables
-    m.props[1].mole_frac_comp = Var(m.params.component_list, initialize=0.5)
-
-    m.props[1]._critical_props()
-
-    assert isinstance(m.props[1].compress_fact_crit, Var)
-    assert isinstance(m.props[1].dens_mol_crit, Var)
-    assert isinstance(m.props[1].pressure_crit, Var)
-    assert isinstance(m.props[1].temperature_crit, Var)
-
-    assert isinstance(m.props[1].pressure_crit_constraint, Constraint)
-    assert str(m.props[1].pressure_crit_constraint.expr) == str(
-        m.props[1].pressure_crit
-        == m.props[1].mole_frac_comp["a"] * m.params.a.pressure_crit
-        + m.props[1].mole_frac_comp["b"] * m.params.b.pressure_crit
-        + m.props[1].mole_frac_comp["c"] * m.params.c.pressure_crit
-    )
-
-    assert isinstance(m.props[1].temperature_crit_constraint, Constraint)
-    assert str(m.props[1].temperature_crit_constraint.expr) == str(
-        m.props[1].temperature_crit
-        == m.props[1].mole_frac_comp["a"] * m.params.a.temperature_crit
-        + m.props[1].mole_frac_comp["b"] * m.params.b.temperature_crit
-        + m.props[1].mole_frac_comp["c"] * m.params.c.temperature_crit
-    )
-
-    assert m.props[1].compress_fact_crit.fixed
-    assert value(m.props[1].compress_fact_crit) == 1
-
-    assert isinstance(m.props[1].dens_mol_crit_constraint, Constraint)
-    assert str(m.props[1].dens_mol_crit_constraint.expr) == str(
-        m.props[1].pressure_crit
-        == pyunits.convert(
-            m.props[1].compress_fact_crit
-            * const.gas_constant
-            * m.props[1].temperature_crit
-            * m.props[1].dens_mol_crit,
-            to_units=pyunits.kg / pyunits.m / pyunits.s**2,
-        )
-    )


### PR DESCRIPTION
## Replaces part of #977 


## Summary/Motivation:
This PR adds support for calculating the critical properties of mixtures in the Modular Properties framework, which is necessary to support the new Smooth VLE formulation. This is done by adding  a new method to EoS classes which contains instructions for how to calculate the mixture critical properties appropriate to the EoS.

When dealing with systems with multiple phases/EoS, only one EoS can be used thus it is necessary to determine which EoS to use. This PR applies the following steps:

1. Iterate over all phases and take the EoS associated with the first liquid phase encountered.
2. If no liquid phases are found, use the EoS associated with the vapor phase (assumes only 1 vapor phase).
3. If no liquid or vapor phases are found, raise an exception.

## Changes proposed in this PR:
- Add new unit definitions for specific volumes, and deprecate non-standard `MOLAR_VOLUME` unit.
- Add `compress_fact_crit` and `dens_mol_crit` to the standard property set.
- Add methods and metadata to core modular properties code to support critical properties as build-on-demand.
- Add placeholder `build_critical_properties` method to `EoSBase`.
- Add `build_critical_properties` method to `IdealEoS`. Cubic equivalent WIP.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
4. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
