### PR TITLE
Resolve failures in examples CI job by adding XFAIL pattern for new sco2 ALAMO surrogate examples

### DIFF
--- a/.github/actions/run-examples/examples_for_idaes_ci.py
+++ b/.github/actions/run-examples/examples_for_idaes_ci.py
@@ -28,7 +28,7 @@ def _matches_pattern(item: pytest.Item, pattern: str) -> bool:
 
 def pytest_configure(config: pytest.Config):
     tensorflow_py311_win = pytest.mark.xfail(
-        condition=(sys.platform.startswith("win") and sys.version_info > (3, 11)),
+        condition=sys.version_info > (3, 11),
         run=True,
         strict=False,
         reason="tensorflow ImportError on 3.11+ on Windows (cannot import name 'formatargspec' from 'inspect')",

--- a/.github/actions/run-examples/examples_for_idaes_ci.py
+++ b/.github/actions/run-examples/examples_for_idaes_ci.py
@@ -27,22 +27,18 @@ def _matches_pattern(item: pytest.Item, pattern: str) -> bool:
 
 
 def pytest_configure(config: pytest.Config):
+    tensorflow_py311_win = pytest.mark.xfail(
+        condition=(sys.platform.startswith("win") and sys.version_info > (3, 11)),
+        run=True,
+        strict=False,
+        reason="tensorflow ImportError on 3.11+ on Windows (cannot import name 'formatargspec' from 'inspect')",
+    )
     config.stash[matchmarker] = {
         "*/held/*": pytest.mark.xfail(run=False, reason="notebook has 'held' status"),
         "*/archive/*": pytest.mark.skip(reason="notebook is archived"),
         # TODO: Need to fix this once the Python 3.11 issue is resolved in tensorflow
-        "*/surrogates/best_practices_optimization*": pytest.mark.xfail(
-            condition=sys.version_info > (3, 11),
-            run=True,
-            strict=False,
-            reason="tensorflow ImportError on 3.11",
-        ),
-        "*/surrogates/omlt/keras_flowsheet_optimization*": pytest.mark.xfail(
-            condition=sys.version_info > (3, 11),
-            run=True,
-            strict=False,
-            reason="tensorflow ImportError on 3.11",
-        ),
+        "*/surrogates/best_practices_optimization*": tensorflow_py311_win,
+        "*/surrogates/omlt/keras_flowsheet_optimization*": tensorflow_py311_win,
         "*/surrogates/sco2/alamo/*": pytest.mark.xfail(
             run=False,
             reason="notebooks require ALAMO to run",

--- a/.github/actions/run-examples/examples_for_idaes_ci.py
+++ b/.github/actions/run-examples/examples_for_idaes_ci.py
@@ -43,6 +43,8 @@ def pytest_configure(config: pytest.Config):
             run=False,
             reason="notebooks require ALAMO to run",
         ),
+        "*/surrogates/sco2/omlt/keras_training*": tensorflow_py311_win,
+        "*/surrogates/sco2/omlt/flowsheet_optimization*": tensorflow_py311_win,
     }
     config.stash[marked] = []
 

--- a/.github/actions/run-examples/examples_for_idaes_ci.py
+++ b/.github/actions/run-examples/examples_for_idaes_ci.py
@@ -43,6 +43,10 @@ def pytest_configure(config: pytest.Config):
             strict=False,
             reason="tensorflow ImportError on 3.11",
         ),
+        "*/surrogates/sco2/alamo/*": pytest.mark.xfail(
+            run=False,
+            reason="notebooks require ALAMO to run",
+        ),
     }
     config.stash[marked] = []
 


### PR DESCRIPTION
## Fixes

CI failures due to notebooks being added by IDAES/examples#69.

## Changes proposed in this PR:
- Add XFAIL pattern for new sco2 ALAMO surrogate examples

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
