### PR TITLE
Test model diagnostics using multiple AMPL SCIP versions

### DIFF
--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -8,10 +8,6 @@ inputs:
     description: 'Command to use to install `install-target`'
     required: false
     default: pip --no-cache-dir install --progress-bar off
-  ampl-scip-version:
-    description: Version of AMPL Scip solver to install
-    required: false
-    default: '20240121'
 runs:
   using: "composite"
   steps:
@@ -45,10 +41,4 @@ runs:
       run: |
         echo '::group::Output of "idaes get-extensions" command'
         idaes get-extensions --extra petsc --verbose
-        echo '::endgroup::'
-    - name: Install SCIP from AMPL
-      shell: bash -l {0}
-      run: |
-        echo '::group::Output of "pip install ampl_module_scip" command'
-        ${{ inputs.install-command }} --index-url https://pypi.ampl.com ampl_module_scip==${{ inputs.ampl-scip-version }}
         echo '::endgroup::'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -119,7 +119,7 @@ jobs:
           echo PYTEST_ADDOPTS="$PYTEST_ADDOPTS --cov --cov-report=xml" >> "$GITHUB_ENV"
       - name: Run pytest (not integration)
         run: |
-          pytest -m "not integration"
+          pytest -k test_model_diagnostics
       - name: Upload coverage report as GHA workflow artifact
         if: matrix.cov-report
         uses: actions/upload-artifact@v4

--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -467,6 +467,7 @@ class _pip:
                 cmd,
                 *args,
             ],
+            check=True,
             **kwargs,
         )
 


### PR DESCRIPTION
## Summary/Motivation:

-  Testing with multiple AMPL SCIP versions helps us having (greater) confidence that the tests affected by #1353 are written in a way that is robust to known changes between different SCIP versions
- Whether we want or need to have this test harness permanently is still being discussed
- In the meantime, we can just treat this as a "one-time jig" to validate different solutions to make the tests affected by #1353 more robust
- In other words, once the tests pass on this PR, we could just keep the fix and get rid of the other changes

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
