### PR TITLE
Make `DegeneracyHunter` tests more robust wrt different solutions

### DIFF
--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -8,10 +8,10 @@ inputs:
     description: 'Command to use to install `install-target`'
     required: false
     default: pip --no-cache-dir install --progress-bar off
-  ampl-scip-version:
-    description: Version of AMPL Scip solver to install
+  ampl-scip-pip-target:
+    description: pip install target (dist name and optionally version constraint) of AMPL SCIP solver to install
     required: false
-    default: '20240121'
+    default: ampl-module-scip
 runs:
   using: "composite"
   steps:
@@ -46,9 +46,10 @@ runs:
         echo '::group::Output of "idaes get-extensions" command'
         idaes get-extensions --extra petsc --verbose
         echo '::endgroup::'
-    - name: Install SCIP from AMPL
+    - name: Install AMPL SCIP (${{ inputs.ampl-scip-pip-target }})
+      if: inputs.ampl-scip-pip-target
       shell: bash -l {0}
       run: |
         echo '::group::Output of "pip install ampl_module_scip" command'
-        ${{ inputs.install-command }} --index-url https://pypi.ampl.com ampl_module_scip==${{ inputs.ampl-scip-version }}
+        ${{ inputs.install-command }} --index-url https://pypi.ampl.com ${{ inputs.ampl-scip-pip-target }}
         echo '::endgroup::'

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -1974,22 +1974,31 @@ class TestDegeneracyHunter:
         dh._prepare_candidates_milp()
         dh._solve_candidates_milp()
 
-        assert value(dh.candidates_milp.nu[0]) == pytest.approx(1e-05, rel=1e-5)
-        assert value(dh.candidates_milp.nu[1]) == pytest.approx(-1e-05, rel=1e-5)
-
-        assert value(dh.candidates_milp.y_pos[0]) == pytest.approx(0, abs=1e-5)
-        assert value(dh.candidates_milp.y_pos[1]) == pytest.approx(0, rel=1e-5)
-
-        assert value(dh.candidates_milp.y_neg[0]) == pytest.approx(0, abs=1e-5)
-        assert value(dh.candidates_milp.y_neg[1]) == pytest.approx(1, abs=1e-5)
-
-        assert value(dh.candidates_milp.abs_nu[0]) == pytest.approx(1e-05, rel=1e-5)
-        assert value(dh.candidates_milp.abs_nu[1]) == pytest.approx(1e-05, rel=1e-5)
-
         assert dh.degenerate_set == {
             model.con2: value(dh.candidates_milp.nu[0]),
             model.con5: value(dh.candidates_milp.nu[1]),
         }
+
+        assert abs(value(dh.candidates_milp.nu[0])) == pytest.approx(1e-05, rel=1e-5)
+        assert abs(value(dh.candidates_milp.nu[1])) == pytest.approx(1e-05, rel=1e-5)
+
+        # One must be positive and one must be negative, so produce will be negative
+        assert value(
+            dh.candidates_milp.nu[0] * dh.candidates_milp.nu[1]
+        ) == pytest.approx(-1e-10, rel=1e-5)
+
+        assert (
+            value(
+                dh.candidates_milp.y_pos[0]
+                + dh.candidates_milp.y_pos[1]
+                + dh.candidates_milp.y_neg[0]
+                + dh.candidates_milp.y_neg[1]
+            )
+            >= 1
+        )
+
+        assert value(dh.candidates_milp.abs_nu[0]) == pytest.approx(1e-05, rel=1e-5)
+        assert value(dh.candidates_milp.abs_nu[1]) == pytest.approx(1e-05, rel=1e-5)
 
     @pytest.mark.unit
     def test_prepare_ids_milp(self, model):


### PR DESCRIPTION
## Summary/Motivation

Make `DegeneracyHunter` tests more robust wrt different solutions, which were previously causing issues due to differences between AMPL SCIP versions.

## Changes proposed in this PR

- Apply @andrewlee94's changes from edb038b without the rest of the testing infrastructure from #1359 
- Revert the temporary fix in #1354 by setting a default input value where the `ampl-module-scip` version is not specified exactly

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
