### PR TITLE
Restore ability to run pytest on individual files or directories

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -119,7 +119,7 @@ jobs:
           echo PYTEST_ADDOPTS="$PYTEST_ADDOPTS --cov --cov-report=xml" >> "$GITHUB_ENV"
       - name: Run pytest (not integration)
         run: |
-          pytest -m "not integration"
+          pytest --pyargs idaes -m "not integration"
       - name: Upload coverage report as GHA workflow artifact
         if: matrix.cov-report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           install-target: -r requirements-dev.txt
       - name: Run pytest (integration)
-        run: pytest -m integration
+        run: pytest --pyargs idaes -m integration
 
   examples:
     name: Run examples (py${{ matrix.python-version }}/${{ matrix.os }})

--- a/idaes/conftest.py
+++ b/idaes/conftest.py
@@ -41,6 +41,16 @@ import pytest
 ####
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--performance",
+        action="store_true",
+        dest="performance",
+        default=False,
+        help="enable performance decorated tests",
+    )
+
+
 MARKERS = {
     "build": "test of model build methods",
     "cubic_root": "test requires the compiled cubic root finder",
@@ -56,9 +66,21 @@ MARKERS = {
 
 
 def pytest_configure(config: pytest.Config):
-
     for name, description in MARKERS.items():
         config.addinivalue_line("markers", f"{name}: {description}")
+
+    if not config.option.performance:
+        if len(config.option.markexpr) > 0:
+            setattr(
+                config.option,
+                "markexpr",
+                f"{config.option.markexpr} and not performance",
+            )
+        else:
+            setattr(config.option, "markexpr", "not performance")
+    else:
+        setattr(config.option, "markexpr", "performance")
+
 
 
 REQUIRED_MARKERS = {"unit", "component", "integration", "performance"}
@@ -134,29 +156,6 @@ def _validate_required_markers(item, required_markers=None, expected_count=1):
         )
         pytest.fail(msg)
 
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--performance",
-        action="store_true",
-        dest="performance",
-        default=False,
-        help="enable performance decorated tests",
-    )
-
-
-def pytest_configure(config):
-    if not config.option.performance:
-        if len(config.option.markexpr) > 0:
-            setattr(
-                config.option,
-                "markexpr",
-                f"{config.option.markexpr} and not performance",
-            )
-        else:
-            setattr(config.option, "markexpr", "not performance")
-    else:
-        setattr(config.option, "markexpr", "performance")
 
 
 ModuleName = str

--- a/idaes/conftest.py
+++ b/idaes/conftest.py
@@ -82,7 +82,6 @@ def pytest_configure(config: pytest.Config):
         setattr(config.option, "markexpr", "performance")
 
 
-
 REQUIRED_MARKERS = {"unit", "component", "integration", "performance"}
 ALL_PLATFORMS = {"darwin", "linux", "win32"}
 
@@ -155,7 +154,6 @@ def _validate_required_markers(item, required_markers=None, expected_count=1):
             f"found: {required_markers_on_item or required_count}"
         )
         pytest.fail(msg)
-
 
 
 ModuleName = str

--- a/idaes/conftest.py
+++ b/idaes/conftest.py
@@ -41,6 +41,26 @@ import pytest
 ####
 
 
+MARKERS = {
+    "build": "test of model build methods",
+    "cubic_root": "test requires the compiled cubic root finder",
+    "iapws": "test requires the compiled IAPWS95 property package",
+    "initialization": "test of initialization methods. These generally require a solver as well",
+    "solver": "test requires a solver",
+    "ui": "tests of an aspect of the ui",
+    "unit": "quick tests that do not require a solver, must run in <2s",
+    "component": "quick tests that may require a solver",
+    "integration": "long duration tests",
+    "performance": "tests for the IDAES performance testing suite",
+}
+
+
+def pytest_configure(config: pytest.Config):
+
+    for name, description in MARKERS.items():
+        config.addinivalue_line("markers", f"{name}: {description}")
+
+
 REQUIRED_MARKERS = {"unit", "component", "integration", "performance"}
 ALL_PLATFORMS = {"darwin", "linux", "win32"}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-addopts = --pyargs idaes
-          --durations=100
+addopts = --durations=100
+          --durations-min=2
           -W ignore
 log_file = pytest.log
 log_file_date_format = %Y-%m-%dT%H:%M:%S

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,14 +6,3 @@ log_file = pytest.log
 log_file_date_format = %Y-%m-%dT%H:%M:%S
 log_file_format = %(asctime)s %(levelname)-7s <%(filename)s:%(lineno)d> %(message)s
 log_file_level = INFO
-markers =
-    build: test of model build methods
-    cubic_root : test requires the compiled cubic root finder
-    iapws: test requires the compiled IAPWS95 property package
-    initialization: test of initialization methods. These generally require a solver as well
-    solver: test requires a solver
-    ui: tests of an aspect of the ui
-    unit: quick tests that do not require a solver, must run in <2s
-    component: quick tests that may require a solver
-    integration: long duration tests
-    performance: tests for the IDAES performance testing suite

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 addopts = --durations=100
           --durations-min=2
-          -W ignore
 log_file = pytest.log
 log_file_date_format = %Y-%m-%dT%H:%M:%S
 log_file_format = %(asctime)s %(levelname)-7s <%(filename)s:%(lineno)d> %(message)s


### PR DESCRIPTION
## Fixes #1200

## Changes proposed in this PR:
- Remove `--pyargs idaes` from `pytest.ini`
- Move markers definition from `pytest.ini` to `idaes/conftest.py` so that tests can be run without warnings without requiring `pytest.ini`, which is not available in non-editable installations without ad-hoc download

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
