### PR TITLE
Update imports of `native_types` and `pyomo_constant_types` in scaling module

### DIFF
--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -47,7 +47,7 @@ from pyomo.dae import DerivativeVar
 from pyomo.dae.flatten import slice_component_along_sets
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.core import expr as EXPR
-from pyomo.core.expr.numvalue import native_types, pyomo_constant_types
+from pyomo.common.numeric_types import native_types, pyomo_constant_types
 from pyomo.core.base.units_container import _PyomoUnit
 
 import idaes.logger as idaeslog

--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -47,7 +47,7 @@ from pyomo.dae import DerivativeVar
 from pyomo.dae.flatten import slice_component_along_sets
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.core import expr as EXPR
-from pyomo.common.numeric_types import native_types, pyomo_constant_types
+from pyomo.common.numeric_types import native_types
 from pyomo.core.base.units_container import _PyomoUnit
 
 import idaes.logger as idaeslog

--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -1509,7 +1509,7 @@ class NominalValueExtractionVisitor(EXPR.StreamBasedExpressionVisitor):
         # first check if the node is a leaf
         nodetype = type(node)
 
-        if nodetype in native_types or nodetype in pyomo_constant_types:
+        if nodetype in native_types:
             return [node]
 
         node_func = self.node_type_method_map.get(nodetype, None)


### PR DESCRIPTION
These should be imported from `pyomo.common.numeric_types`. Also, `pyomo_constant_types` was deprecated last week (although I don't do anything about that). This PR is necessary to prevent import errors with pyomo/main, as `pyomo_constant_types` no longer exists in `pyomo.core.expr.numvalue`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
