### PR TITLE
Add constraint to exclude TensorFlow 2.16.1 and above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ class ExtraDependencies:
     ]
     omlt = [
         "omlt==1.1",  # fix the version for now as package evolves
-        'tensorflow; python_version < "3.12"',
+        'tensorflow < 2.16.1 ; python_version < "3.12"',
     ]
     grid = [
         "gridx-prescient>=2.2.1",  # idaes.tests.prescient


### PR DESCRIPTION
## Summary/Motivation:

Workaround for the new version of TensorFlow that's causing #1369 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
