### PR TITLE
Tweaks to convergence tester

### DIFF
--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -3177,6 +3177,47 @@ class IpoptConvergenceAnalysis:
         if any(len(v) != 0 for v in diffs.values()):
             raise AssertionError("Convergence analysis does not match baseline")
 
+    def report_convergence_summary(self, stream=None):
+        """
+        Reports a brief summary of the model convergence run.
+
+        Args:
+            stream: Optional output stream to print results to.
+
+        Returns:
+            None
+
+        """
+        if stream is None:
+            stream = sys.stdout
+
+        successes = 0
+        failures = 0
+        runs_w_restoration = 0
+        runs_w_regulariztion = 0
+        runs_w_num_iss = 0
+
+        for k, v in self.results.items():
+            # Check for differences
+            if v["success"]:
+                successes += 1
+            else:
+                failures += 1
+
+            if v["results"]["iters_in_restoration"] > 0:
+                runs_w_restoration += 1
+            if v["results"]["iters_w_regularization"] > 0:
+                runs_w_regulariztion += 1
+            if v["results"]["numerical_issues"] > 0:
+                runs_w_num_iss += 1
+
+        stream.write(
+            f"Successes: {successes}, Failures {failures} ({100*successes/(successes+failures)}%)\n"
+        )
+        stream.write(f"Runs with Restoration: {runs_w_restoration}\n")
+        stream.write(f"Runs with Regularization: {runs_w_regulariztion}\n")
+        stream.write(f"Runs with Numerical Issues: {runs_w_num_iss}\n")
+
     def to_dict(self):
         """
         Serialize specification and current results to dict form

--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -3197,7 +3197,7 @@ class IpoptConvergenceAnalysis:
         runs_w_regulariztion = 0
         runs_w_num_iss = 0
 
-        for k, v in self.results.items():
+        for v in self.results.values():
             # Check for differences
             if v["success"]:
                 successes += 1

--- a/idaes/core/util/parameter_sweep.py
+++ b/idaes/core/util/parameter_sweep.py
@@ -495,7 +495,7 @@ class ParameterSweepBase:
             results = self.build_outputs(model, run_stats)
         else:
             # Catch any Exception for recourse
-            results, success = self.handle_error(model)
+            results = self.handle_error(model)
 
         _log.info(f"Sample {sample_id} finished.")
 

--- a/idaes/core/util/parameter_sweep.py
+++ b/idaes/core/util/parameter_sweep.py
@@ -697,8 +697,8 @@ class ParameterSweepBase:
             Output of handle_solver_error callback
         """
         if self.config.handle_solver_error is None:
-            # No recourse specified, so success=False and results=None
-            return None, False
+            # No recourse specified, so results=None
+            return None
         else:
             args = self.config.handle_solver_error_arguments
             if args is None:

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -2375,6 +2375,51 @@ class TestIpoptConvergenceAnalysis:
 
         return ca
 
+    @pytest.mark.unit
+    def test_report_convergence_summary(self):
+        stream = StringIO()
+
+        ca = IpoptConvergenceAnalysis(
+            model=ConcreteModel(),
+        )
+
+        ca._psweep._results = {
+            0: {
+                "success": True,
+                "results": {
+                    "iters_in_restoration": 1,
+                    "iters_w_regularization": 0,
+                    "numerical_issues": 10,
+                },
+            },
+            1: {
+                "success": True,
+                "results": {
+                    "iters_in_restoration": 0,
+                    "iters_w_regularization": 5,
+                    "numerical_issues": 5,
+                },
+            },
+            2: {
+                "success": False,
+                "results": {
+                    "iters_in_restoration": 0,
+                    "iters_w_regularization": 0,
+                    "numerical_issues": 0,
+                },
+            },
+        }
+
+        ca.report_convergence_summary(stream)
+
+        expected = """Successes: 2, Failures 1 (66.66666666666667%)
+Runs with Restoration: 1
+Runs with Regularization: 1
+Runs with Numerical Issues: 2
+"""
+
+        assert stream.getvalue() == expected
+
     @pytest.mark.component
     def test_to_dict(self, ca_with_results):
         outdict = ca_with_results.to_dict()

--- a/idaes/core/util/tests/test_parameter_sweep.py
+++ b/idaes/core/util/tests/test_parameter_sweep.py
@@ -957,7 +957,7 @@ class TestParameterSweepBase:
 
         results = psweep.handle_error(model)
 
-        assert results == (None, False)
+        assert results == None
 
     @pytest.mark.unit
     def test_handle_error(self):
@@ -1121,7 +1121,7 @@ class TestParameterSweepBase:
                 raise Exception("Test exception")
 
         def recourse(model):
-            return "foo", "bar"
+            return "foo"
 
         spec2 = ParameterSweepSpecification()
         spec2.set_sampling_method(UniformSampling)
@@ -1138,7 +1138,7 @@ class TestParameterSweepBase:
         results, success, error = psweep.execute_single_sample(1)
 
         assert results == "foo"
-        assert success == "bar"
+        assert not success
         assert error == "Test exception"
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
In adding some more robustness tests using the new convergence analysis tools, a bug was found as well as the need for a summary report of the convergence analysis.

## Changes proposed in this PR:
- Fixes bug in ParameterSweep
- Adds a report method to IpoptConvergenceAnalysis

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
