### PR TITLE
Update parameter sweep tool to support indexed vars

### DIFF
--- a/idaes/core/util/parameter_sweep.py
+++ b/idaes/core/util/parameter_sweep.py
@@ -625,13 +625,24 @@ class ParameterSweepBase:
                     )
                 comp.set_value(v)
             elif ctype is Var:
-                if not comp.is_fixed():
-                    raise ValueError(
-                        f"Convergence testing found an input of type Var that "
-                        f"was not fixed ({comp.name}). Please make sure all "
-                        f"sampled inputs are either mutable params or fixed vars."
-                    )
-                comp.set_value(float(v))
+                try:
+                    if not comp.is_fixed():
+                        raise ValueError(
+                            f"Convergence testing found an input of type Var that "
+                            f"was not fixed ({comp.name}). Please make sure all "
+                            f"sampled inputs are either mutable params or fixed vars."
+                        )
+                    comp.set_value(float(v))
+                except AttributeError:
+                    # Component might be indexed, try iterating and setting value
+                    for i, c in comp.items():
+                        if not c.is_fixed():
+                            raise ValueError(
+                                f"Convergence testing found an input of type IndexedVar that "
+                                f"was not fixed ({comp.name}, index {i}). Please make sure all "
+                                f"sampled inputs are either mutable params or fixed vars."
+                            )
+                        c.set_value(float(v))
             else:
                 raise ValueError(
                     f"Failed to find a valid input component (must be "

--- a/idaes/core/util/tests/test_parameter_sweep.py
+++ b/idaes/core/util/tests/test_parameter_sweep.py
@@ -837,6 +837,40 @@ class TestParameterSweepBase:
             psweep.set_input_values(model, 0)
 
     @pytest.mark.unit
+    def test_set_input_indexed_var(self):
+        def bm():
+            m = ConcreteModel()
+            m.v1 = Var([1, 2])
+            return m
+
+        spec2 = ParameterSweepSpecification()
+        spec2.set_sampling_method(UniformSampling)
+        spec2.add_sampled_input("v1", 0, 10)
+        spec2.set_sample_size([2])
+
+        psweep = ParameterSweepBase(
+            build_model=bm,
+            input_specification=spec2,
+        )
+
+        model = psweep.get_initialized_model()
+
+        with pytest.raises(
+            ValueError,
+            match="Convergence testing found an input of type IndexedVar that "
+            "was not fixed \(v1, index 1\). Please make sure all "
+            "sampled inputs are either mutable params or fixed vars.",
+        ):
+            psweep.set_input_values(model, 0)
+
+        model.v1.fix(20)
+
+        psweep.set_input_values(model, 0)
+
+        assert value(model.v1[1]) == 0
+        assert value(model.v1[2]) == 0
+
+    @pytest.mark.unit
     def test_set_input_invalid_ctype(self):
         def bm():
             m = ConcreteModel()

--- a/idaes/models/unit_models/tests/test_heat_exchanger.py
+++ b/idaes/models/unit_models/tests/test_heat_exchanger.py
@@ -28,7 +28,6 @@ from pyomo.environ import (
     units as pyunits,
 )
 from pyomo.common.config import ConfigBlock
-from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
 
 from idaes.core import (
     FlowsheetBlock,

--- a/idaes/models/unit_models/tests/test_heat_exchanger_1D.py
+++ b/idaes/models/unit_models/tests/test_heat_exchanger_1D.py
@@ -24,7 +24,6 @@ from pyomo.environ import (
     units as pyunits,
 )
 from pyomo.common.config import ConfigBlock
-from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
 import pyomo.common.unittest as unittest
 
 import idaes
@@ -55,7 +54,6 @@ from idaes.models.properties.examples.saponification_thermo import (
 
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
 from idaes.core.util.model_statistics import (
-    degrees_of_freedom,
     number_variables,
     number_total_constraints,
     number_unused_variables,


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
This PR allows users of the parameter sweep tool to specify a value for an IndexedVar as a whole, rather than individual elements. All elements will be set to the same value.

## Changes proposed in this PR:
- Support for indexed variables in parameter sweep tool
- Clean up a few unused imports in other test files

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
