### PR TITLE
bug fix for issue #1364: catch AttributeError in set_scaling_from_default

### DIFF
--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -1179,9 +1179,15 @@ def set_scaling_from_default(
                 return
 
         parent = component.parent_block()
-        dsf = parent.get_default_scaling(
-            component.parent_component().local_name, index=component.index()
-        )
+        try:
+            dsf = parent.get_default_scaling(
+                component.parent_component().local_name, index=component.index()
+            )
+        except AttributeError:
+            dsf = None
+            _log.warning(
+                f"{component.name} block missing 'get_default_scaling()' method, no scaling factor assigned."
+            )
 
         if dsf is not None:
             set_scaling_factor(component, dsf, overwrite=overwrite)


### PR DESCRIPTION
## Fixes
#1364 Incompatibility between set_scaling_from_default() and generic reaction parameter data

## Summary/Motivation:
Currently set_scaling_from_default assumes all blocks have a `get_default_scaling()` method, but this is not guaranteed.

## Changes proposed in this PR:
- Add try/except around call to `get_default_scaling()`
- Log warning

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
