### PR TITLE
Infeasibility diagnostic tool

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -36,6 +36,9 @@ equil = "equil"
 astroid = "astroid"
 # delt == delta
 delt = "delt"
+# Minimal Infeasible System
+mis = "mis"
+MIS = "MIS"
 # TEMPORARY - Remove after example update
 upadate = "upadate"
 

--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -298,7 +298,7 @@ CONFIG.declare(
     ConfigValue(
         default=1e-6,
         domain=float,
-        description="Feasiblity tolerance for idenifying infeasible constraint and bounds",
+        description="Feasibility tolerance for identifying infeasible constraint and bounds",
     ),
 )
 

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -81,7 +81,6 @@ from idaes.core.util.model_diagnostics import (
     _collect_model_statistics,
     check_parallel_jacobian,
     compute_ill_conditioning_certificate,
-    compute_infeasibility_explanation,
 )
 from idaes.core.util.parameter_sweep import (
     SequentialSweepRunner,
@@ -1091,7 +1090,7 @@ The following pairs of variables are nearly parallel:
 
         assert len(next_steps) == 3
         assert "display_constraints_with_large_residuals()" in next_steps
-        assert "compute_infeasibility_explanation(solver=)" in next_steps
+        assert "compute_infeasibility_explanation()" in next_steps
         assert "display_variables_at_or_outside_bounds()" in next_steps
 
     @pytest.mark.component
@@ -1143,7 +1142,7 @@ The following pairs of variables are nearly parallel:
         assert "display_variables_with_extreme_jacobians()" in next_steps
         assert "display_constraints_with_extreme_jacobians()" in next_steps
         assert "display_constraints_with_large_residuals()" in next_steps
-        assert "compute_infeasibility_explanation(solver=)" in next_steps
+        assert "compute_infeasibility_explanation()" in next_steps
 
     @pytest.mark.component
     def test_collect_numerical_cautions(self, model):
@@ -1395,7 +1394,7 @@ Model Statistics
 Suggested next steps:
 
     display_constraints_with_large_residuals()
-    compute_infeasibility_explanation(solver=)
+    compute_infeasibility_explanation()
     display_near_parallel_constraints()
     display_near_parallel_variables()
 
@@ -1435,7 +1434,7 @@ Model Statistics
 Suggested next steps:
 
     display_constraints_with_large_residuals()
-    compute_infeasibility_explanation(solver=)
+    compute_infeasibility_explanation()
     display_variables_at_or_outside_bounds()
 
 ====================================================================================
@@ -1484,7 +1483,7 @@ Model Statistics
 Suggested next steps:
 
     display_constraints_with_large_residuals()
-    compute_infeasibility_explanation(solver=)
+    compute_infeasibility_explanation()
     display_variables_with_extreme_jacobians()
     display_constraints_with_extreme_jacobians()
     display_near_parallel_variables()
@@ -4037,10 +4036,11 @@ class TestComputeInfeasibilityExplanation:
     @pytest.mark.component
     @pytest.mark.solver
     def test_output(self, model):
+        dt = DiagnosticsToolbox(model)
+
         stream = StringIO()
 
-        solver = get_solver()
-        compute_infeasibility_explanation(model, solver, stream=stream)
+        dt.compute_infeasibility_explanation(stream=stream)
 
         expected = """Computed Minimal Intractable System (MIS)!
 Constraints / bounds in MIS:

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -1089,8 +1089,9 @@ The following pairs of variables are nearly parallel:
         assert "WARNING: 1 Constraint with large residuals (>1.0E-05)" in warnings
         assert "WARNING: 1 Variable at or outside bounds (tol=0.0E+00)" in warnings
 
-        assert len(next_steps) == 2
+        assert len(next_steps) == 3
         assert "display_constraints_with_large_residuals()" in next_steps
+        assert "compute_infeasibility_explanation(solver=)" in next_steps
         assert "display_variables_at_or_outside_bounds()" in next_steps
 
     @pytest.mark.component
@@ -1138,10 +1139,11 @@ The following pairs of variables are nearly parallel:
         )
         assert "WARNING: 1 Constraint with large residuals (>1.0E-05)" in warnings
 
-        assert len(next_steps) == 4
+        assert len(next_steps) == 5
         assert "display_variables_with_extreme_jacobians()" in next_steps
         assert "display_constraints_with_extreme_jacobians()" in next_steps
         assert "display_constraints_with_large_residuals()" in next_steps
+        assert "compute_infeasibility_explanation(solver=)" in next_steps
 
     @pytest.mark.component
     def test_collect_numerical_cautions(self, model):
@@ -1393,6 +1395,7 @@ Model Statistics
 Suggested next steps:
 
     display_constraints_with_large_residuals()
+    compute_infeasibility_explanation(solver=)
     display_near_parallel_constraints()
     display_near_parallel_variables()
 
@@ -1432,6 +1435,7 @@ Model Statistics
 Suggested next steps:
 
     display_constraints_with_large_residuals()
+    compute_infeasibility_explanation(solver=)
     display_variables_at_or_outside_bounds()
 
 ====================================================================================
@@ -1480,6 +1484,7 @@ Model Statistics
 Suggested next steps:
 
     display_constraints_with_large_residuals()
+    compute_infeasibility_explanation(solver=)
     display_variables_with_extreme_jacobians()
     display_constraints_with_extreme_jacobians()
     display_near_parallel_variables()


### PR DESCRIPTION
## Fixes #1405 

## Summary/Motivation:
See discussion on #1405

## Changes proposed in this PR:
- Add basic wrapper for `pyomo.contrib.iis.mis.compute_infeasibility_explanation` to `idaes.core.util.model_diagnositics` (6099416)
- Add test for wrapper (199e2b7)
- Integrate `compute_infeasibility_explanation` into the `DiagnosticsToolbox` (a931a77)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
