### PR TITLE
Adding USD_2022 to units library as the most recently published value

### DIFF
--- a/idaes/core/base/costing_base.py
+++ b/idaes/core/base/costing_base.py
@@ -92,6 +92,7 @@ def register_idaes_currency_units():
                 "USD_2019 = 500/607.5 * USD_CE500",
                 "USD_2020 = 500/596.2 * USD_CE500",
                 "USD_2021 = 500/708.0 * USD_CE500",
+                "USD_2022 = 500/816.0 * USD_CE500",
             ]
         )
 

--- a/idaes/core/base/tests/test_costing_base.py
+++ b/idaes/core/base/tests/test_costing_base.py
@@ -72,6 +72,7 @@ def test_register_idaes_currency_units():
         "USD_2019": 607.5,
         "USD_2020": 596.2,
         "USD_2021": 708.0,
+        "USD_2022": 816.0,
     }
 
     for c, conv in CEI.items():


### PR DESCRIPTION
## Fixes
Append USD_YYYY list with USD_2022 value from https://toweringskills.com/financial-analysis/cost-indices/

## Summary/Motivation:
Add more up to date values for USD

## Changes proposed in this PR:
- Append USD_YYYY list with USD_2022 value from https://toweringskills.com/financial-analysis/cost-indices/

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
