### PR TITLE
Activating IPOPT_V2 with presolver

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -323,6 +323,103 @@ def _new_idaes_config_block():
     )
 
     cfg.declare(
+        "ipopt_v2",
+        pyomo.common.config.ConfigBlock(
+            implicit=False,
+            description="Default config for 'ipopt' solver",
+            doc="Default config for 'ipopt' solver",
+        ),
+    )
+    cfg["ipopt_v2"].declare(
+        "options",
+        pyomo.common.config.ConfigBlock(
+            implicit=True,
+            description="Default solver options for 'ipopt'",
+            doc="Default solver options for 'ipopt' solver",
+        ),
+    )
+
+    cfg["ipopt_v2"]["options"].declare(
+        "nlp_scaling_method",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="gradient-based",
+            description="Ipopt NLP scaling method",
+            doc="Ipopt NLP scaling method",
+        ),
+    )
+
+    cfg["ipopt_v2"]["options"].declare(
+        "tol",
+        pyomo.common.config.ConfigValue(
+            domain=float,
+            default=1e-6,
+            description="Ipopt tol option",
+            doc="Ipopt tol option",
+        ),
+    )
+
+    cfg["ipopt_v2"]["options"].declare(
+        "max_iter",
+        pyomo.common.config.ConfigValue(
+            domain=int,
+            default=200,
+            description="Ipopt max_iter option",
+            doc="Ipopt max_iter option",
+        ),
+    )
+
+    cfg["ipopt_v2"]["options"].declare(
+        "linear_solver",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="ma57",
+            description="Linear solver to be used by IPOPT",
+            doc="Linear solver to be used by IPOPT",
+        ),
+    )
+
+    cfg["ipopt_v2"]["options"].declare(
+        "ma57_automatic_scaling",
+        pyomo.common.config.ConfigValue(
+            domain=str,
+            default="yes",
+            description="Whether to use automatic scaling in MA57",
+            doc="Whether to use automatic scaling in MA57. "
+            "Valid values: 'yes' (default), 'no'.",
+        ),
+    )
+
+    cfg["ipopt_v2"].declare(
+        "writer_config",
+        pyomo.common.config.ConfigBlock(
+            implicit=True,
+            description="Default writer configuration for 'ipopt'",
+            doc="Default writer configuration for 'ipopt' solver",
+        ),
+    )
+
+    cfg["ipopt_v2"]["writer_config"].declare(
+        "scale_model",
+        pyomo.common.config.ConfigValue(
+            domain=bool,
+            default=False,  # TODO: Change to true once transition complete
+            description="Whether to apply model scaling in writer",
+            doc="Whether to apply model scaling in writer",
+        ),
+    )
+
+    cfg["ipopt_v2"]["writer_config"].declare(
+        "linear_presolve",
+        pyomo.common.config.ConfigValue(
+            domain=bool,
+            default=True,
+            description="Whether to apply linear presolve in writer",
+            doc="Whether to apply linear presolve in writer",
+        ),
+    )
+
+    cfg.declare(
         "ipopt_l1",
         pyomo.common.config.ConfigBlock(
             implicit=False,

--- a/idaes/core/initialization/initializer_base.py
+++ b/idaes/core/initialization/initializer_base.py
@@ -551,7 +551,7 @@ class ModularInitializerBase(InitializerBase):
     CONFIG.declare(
         "solver",
         ConfigValue(
-            default=None,  # TODO: Can we add a square problem solver as the default here?
+            default="ipopt_v2",  # TODO: Can we add a square problem solver as the default here?
             # At the moment there is an issue with the scipy solvers not supporting the tee argument.
             description="Solver to use for initialization",
         ),
@@ -561,6 +561,13 @@ class ModularInitializerBase(InitializerBase):
         ConfigDict(
             implicit=True,
             description="Dict of options to pass to solver",
+        ),
+    )
+    CONFIG.declare(
+        "writer_config",
+        ConfigDict(
+            implicit=True,
+            description="Dict of writer_config arguments to pass to solver",
         ),
     )
     CONFIG.declare(
@@ -820,6 +827,10 @@ class ModularInitializerBase(InitializerBase):
 
     def _get_solver(self):
         if self._solver is None:
-            self._solver = get_solver(self.config.solver, self.config.solver_options)
+            self._solver = get_solver(
+                self.config.solver,
+                solver_options=self.config.solver_options,
+                writer_config=self.config.writer_config,
+            )
 
         return self._solver

--- a/idaes/core/initialization/tests/test_initializer_base.py
+++ b/idaes/core/initialization/tests/test_initializer_base.py
@@ -706,8 +706,9 @@ class TestModularInitializerBase:
         assert initializer.config.default_submodel_initializer is None
 
         assert initializer._solver is None
-        assert initializer.config.solver is None
+        assert initializer.config.solver == "ipopt_v2"
         assert initializer.config.solver_options == {}
+        assert initializer.config.writer_config == {}
 
     @pytest.mark.unit
     def test_get_submodel_initializer_specific_model(self):

--- a/idaes/core/solvers/config.py
+++ b/idaes/core/solvers/config.py
@@ -10,15 +10,22 @@
 # All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
 # for full copyright and license information.
 #################################################################################
-# TODO: Missing doc strings
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-class-docstring
+"""
+Wrapper for Pyomo solvers to allow us to define default solver options
+"""
+
+from copy import deepcopy
 
 from pyomo.environ import SolverFactory
+
 import idaes
 
 
 class SolverWrapper(object):
+    """
+    Wrapper for Pyomo solvers to allow us to define default solver options
+    """
+
     def __init__(self, name, register=True):
         if name is None:
             name = "default"
@@ -43,13 +50,11 @@ class SolverWrapper(object):
             name = self.name
             solver = self.solver
         if name in idaes.cfg and (
-            idaes.cfg.use_idaes_solver_config
-            or name == "default"
-            or not self.registered
+            idaes.cfg.use_idaes_solver_config or not self.registered
         ):
             for k, v in idaes.cfg[name].items():
                 if k not in kwargs:
-                    kwargs[k] = v
+                    kwargs[k] = deepcopy(v)
                 elif k == "options":
                     # options is in ConfigBlock and in kwargs, treat "options"
                     # special so individual options can have defaults not just
@@ -57,6 +62,14 @@ class SolverWrapper(object):
                     for opk, opv in v.items():
                         if opk not in kwargs["options"]:
                             kwargs["options"][opk] = opv
+                elif k == "writer_config":
+                    # writer_config is in ConfigBlock and in kwargs, treat "writer_config"
+                    # special so individual options can have defaults not just
+                    # the whole options block
+                    for opk, opv in v.items():
+                        if opk not in kwargs["writer_config"]:
+                            kwargs["writer_config"][opk] = opv
+
         return solver(*args, **kwargs)
 
 

--- a/idaes/core/solvers/get_solver.py
+++ b/idaes/core/solvers/get_solver.py
@@ -14,6 +14,7 @@
 """
 This module contains the IDAES get_solver method.
 """
+from pyomo.contrib.solver.base import LegacySolverWrapper
 
 import idaes.logger as idaeslog
 import idaes.core.solvers
@@ -22,25 +23,54 @@ _log = idaeslog.getLogger(__name__)
 
 
 # Author: Andrew Lee
-def get_solver(solver=None, options=None):
+def get_solver(
+    solver=None,
+    solver_options: dict = None,
+    writer_config: dict = None,
+    options: dict = None,
+):
     """
     General method for getting a solver object which defaults to the standard
     IDAES solver (defined in the IDAES configuration).
 
     Args:
         solver: string name for desired solver. Default=None, use default solver
-        options: dict of solver options to use, overwrites any settings
+        solver_options: dict of solver options to use, overwrites any settings
                  provided by IDAES configuration. Default = None, use default
                  solver options.
+        writer_config: dict of configuration options for solver writer, overwrites
+                 ny settings provided by IDAES configuration. Default = None, use
+                 default solver options.
+        options: DEPRECATED. Alias of solver_options.
 
     Returns:
         A Pyomo solver object
     """
+    if solver_options is not None:
+        if options is not None:
+            raise ValueError(
+                "Cannot provide both the 'options' and 'solver_options' argument. "
+                "'options' has been deprecated in favor of 'solver_options'."
+            )
+        options = solver_options
+
     if solver is None:
         solver = "default"
     solver_obj = idaes.core.solvers.SolverWrapper(solver, register=False)()
 
-    if options is not None:
-        solver_obj.options.update(options)
+    if isinstance(solver_obj, LegacySolverWrapper):
+        if options is not None:
+            for k, v in options.items():
+                solver_obj.options[k] = v
+        if writer_config is not None:
+            for k, v in writer_config.items():
+                solver_obj.config.writer_config[k] = v
+    else:
+        if options is not None:
+            solver_obj.options.update(options)
+        if writer_config is not None:
+            _log.info(
+                "Older Pyomo solver interface does not support writer_config argument: ignoring."
+            )
 
     return solver_obj

--- a/idaes/core/solvers/tests/test_solvers.py
+++ b/idaes/core/solvers/tests/test_solvers.py
@@ -10,12 +10,13 @@
 # All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
 # for full copyright and license information.
 #################################################################################
-import pyomo.environ as pyo
 import pytest
+
+import pyomo.environ as pyo
+from pyomo.contrib.solver.base import LegacySolverWrapper
+
 from idaes.core.solvers.features import lp, milp, nlp, minlp, nle, dae
-from idaes.core.solvers import ipopt_has_linear_solver
-from idaes.core.solvers import petsc
-from idaes.core.solvers import ipopt_l1
+from idaes.core.solvers import get_solver, ipopt_has_linear_solver, petsc
 
 
 @pytest.mark.unit
@@ -259,3 +260,88 @@ def test_clp_idaes_solve():
     solver = pyo.SolverFactory("clp")
     solver.solve(m)
     assert pytest.approx(x) == pyo.value(m.x)
+
+
+@pytest.mark.skipif(not pyo.SolverFactory("ipopt").available(False), reason="no Ipopt")
+@pytest.mark.unit
+def test_get_solver_default():
+    solver = get_solver()
+
+    assert not isinstance(solver, LegacySolverWrapper)
+
+    assert solver.options == {
+        "nlp_scaling_method": "gradient-based",
+        "tol": 1e-6,
+        "max_iter": 200,
+    }
+
+
+@pytest.mark.skipif(not pyo.SolverFactory("ipopt").available(False), reason="no Ipopt")
+@pytest.mark.unit
+def test_get_solver_default_solver_w_options(caplog):
+    solver = get_solver(
+        options={"foo": "bar", "tol": 1e-5}, writer_config={"foo": "bar"}
+    )
+
+    assert not isinstance(solver, LegacySolverWrapper)
+
+    assert solver.options == {
+        "nlp_scaling_method": "gradient-based",
+        "tol": 1e-5,
+        "max_iter": 200,
+        "foo": "bar",
+    }
+
+    assert (
+        "Older Pyomo solver interface does not support writer_config argument: ignoring."
+        in caplog.text
+    )
+
+
+@pytest.mark.skipif(not pyo.SolverFactory("ipopt").available(False), reason="no Ipopt")
+@pytest.mark.unit
+def test_get_solver_ipopt_v2():
+    solver = get_solver("ipopt_v2")
+
+    assert isinstance(solver, LegacySolverWrapper)
+
+    assert solver.options.nlp_scaling_method == "gradient-based"
+    assert solver.options.tol == 1e-6
+    assert solver.options.max_iter == 200
+
+    assert solver.config.writer_config.linear_presolve
+    assert not solver.config.writer_config.scale_model
+
+
+@pytest.mark.skipif(not pyo.SolverFactory("ipopt").available(False), reason="no Ipopt")
+@pytest.mark.unit
+def test_get_solver_ipopt_v2_w_options():
+    solver = get_solver(
+        "ipopt_v2",
+        options={"tol": 1e-5, "foo": "bar"},
+        writer_config={"linear_presolve": False},
+    )
+
+    assert isinstance(solver, LegacySolverWrapper)
+
+    print(solver.options)
+    assert solver.options.nlp_scaling_method == "gradient-based"
+    assert solver.options.tol == 1e-5
+    assert solver.options.max_iter == 200
+    assert solver.options.foo == "bar"
+
+    assert not solver.config.writer_config.linear_presolve
+    assert not solver.config.writer_config.scale_model
+
+
+@pytest.mark.unit
+def test_get_solver_ipopt_options_and_solver_options():
+    with pytest.raises(
+        ValueError,
+        match="Cannot provide both the 'options' and 'solver_options' argument. "
+        "'options' has been deprecated in favor of 'solver_options'.",
+    ):
+        get_solver(
+            options={"tol": 1e-5, "foo": "bar"},
+            solver_options={"tol": 1e-5, "foo": "bar"},
+        )

--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -761,7 +761,7 @@ class DiagnosticsToolbox:
 
         """
         if solver is None:
-            solver = get_solver()
+            solver = get_solver("ipopt_v2")
         if stream is None:
             stream = sys.stdout
 

--- a/idaes/core/util/tests/test_initialization.py
+++ b/idaes/core/util/tests/test_initialization.py
@@ -65,7 +65,7 @@ __author__ = "Andrew Lee"
 
 
 # Set up solver
-solver = get_solver()
+solver = get_solver("ipopt_v2")
 
 
 @declare_process_block_class("AqueousEnzymeParameterBlock")

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -504,7 +504,8 @@ class TestDiagnosticsToolbox:
         m.b.v5.fix(2)
         m.b.v6.fix(0)
 
-        solver = get_solver()
+        # Presolver identifies problem as trivially infeasible (correctly). Turn off presolve.
+        solver = get_solver("ipopt_v2", writer_config={"linear_presolve": False})
         solver.solve(m)
 
         return m
@@ -1101,7 +1102,8 @@ The following pairs of variables are nearly parallel:
         m.b.v3.setlb(-5)
         m.b.v5.setub(10)
 
-        solver = get_solver()
+        # Presolver identifies problem as trivially infeasible (correctly). Turn off presolve.
+        solver = get_solver("ipopt_v2", writer_config={"linear_presolve": False})
         solver.solve(m)
 
         dt = DiagnosticsToolbox(model=m.b)
@@ -1216,7 +1218,8 @@ The following pairs of variables are nearly parallel:
         # Fix numerical issues
         m.b.v3.setlb(-5)
 
-        solver = get_solver()
+        # Presolver identifies problem as trivially infeasible (correctly). Turn off presolve.
+        solver = get_solver("ipopt_v2", writer_config={"linear_presolve": False})
         solver.solve(m)
 
         dt = DiagnosticsToolbox(model=m.b)

--- a/idaes/core/util/tests/test_pid_initialization.py
+++ b/idaes/core/util/tests/test_pid_initialization.py
@@ -53,7 +53,7 @@ import idaes.logger as idaeslog
 __author__ = "Robert Parker"
 
 
-solver = get_solver()
+solver = get_solver("ipopt_v2")
 
 
 def make_model(horizon=6, ntfe=60, ntcp=2, inlet_E=11.91, inlet_S=12.92):

--- a/idaes/core/util/tests/test_utility_minimization.py
+++ b/idaes/core/util/tests/test_utility_minimization.py
@@ -52,7 +52,7 @@ from idaes.core.util.utility_minimization import (
 #     Chemical Engineering Series - L. T. Biegler, I. E. Grossmann,
 #     A. W. Westerberg, page 529, Example 16.1
 # Get default solver for testing
-solver = get_solver()
+solver = get_solver("ipopt_v2")
 
 
 @pytest.mark.unit

--- a/idaes/models/unit_models/heat_exchanger_lc.py
+++ b/idaes/models/unit_models/heat_exchanger_lc.py
@@ -254,6 +254,9 @@ be included in the overall energy balance,
         self._add_wall_variables()
         self._add_wall_variable_constraints()
 
+        self.delta_temperature_in.setlb(1e-8)
+        self.delta_temperature_out.setlb(1e-8)
+
         if self.config.dynamic_heat_balance:
 
             s1_metadata = self.hot_side.config.property_package.get_metadata()

--- a/idaes/models_extra/temperature_swing_adsorption/initializer.py
+++ b/idaes/models_extra/temperature_swing_adsorption/initializer.py
@@ -32,7 +32,6 @@ from idaes.core.initialization.initializer_base import StoreState
 from idaes.core.util.exceptions import InitializationError
 from idaes.core.util.model_serializer import to_json, from_json
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.solvers import get_solver
 
 from idaes.models_extra.temperature_swing_adsorption import SteamCalculationType
 
@@ -107,10 +106,7 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
         )
 
         # create solver
-        if self.config.solver is None:
-            self.opt = get_solver(self.config.solver, self.config.solver_options)
-        else:
-            self.opt = self.config.solver
+        solver = self._get_solver()
 
         # initialization of fixed bed TSA model unit
         init_log.info("Starting fixed bed TSA initialization")
@@ -313,7 +309,7 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
         if degrees_of_freedom(blk) == 0:
 
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                res = self.opt.solve(blk, tee=slc.tee)
+                res = solver.solve(blk, tee=slc.tee)
 
             if check_optimal_termination(res):
                 init_log.info(
@@ -384,7 +380,7 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
 
                 # re-solve compressor model
                 with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                    res = self.opt.solve(blk.compressor, tee=slc.tee)
+                    res = solver.solve(blk.compressor, tee=slc.tee)
 
                 if check_optimal_termination(res):
                     init_log.info(
@@ -461,7 +457,7 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
                     )
 
                     with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                        res = self.opt.solve(blk.steam_heater, tee=slc.tee)
+                        res = solver.solve(blk.steam_heater, tee=slc.tee)
 
                     if check_optimal_termination(res):
                         init_log.info_high(
@@ -501,7 +497,7 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
                     )
 
                     with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                        res = self.opt.solve(blk.steam_heater, tee=slc.tee)
+                        res = solver.solve(blk.steam_heater, tee=slc.tee)
 
                     if check_optimal_termination(res):
                         init_log.info_high(
@@ -570,7 +566,7 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
             if degrees_of_freedom(blk) == 0:
 
                 with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                    res = self.opt.solve(blk, tee=slc.tee)
+                    res = solver.solve(blk, tee=slc.tee)
                 if (
                     blk.config.compressor
                     and blk.config.steam_calculation != SteamCalculationType.none
@@ -682,8 +678,9 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
         )
 
         # solve cycle step
+        solver = self._get_solver()
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = self.opt.solve(cycle_step, tee=slc.tee)
+            res = solver.solve(cycle_step, tee=slc.tee)
 
         if check_optimal_termination(res):
             init_log.info(
@@ -735,8 +732,9 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
         count = 1
 
         # solve model
+        solver = self._get_solver()
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            res = self.opt.solve(cycle_step, tee=slc.tee)
+            res = solver.solve(cycle_step, tee=slc.tee)
 
         if check_optimal_termination(res):
             init_log.info_high(
@@ -778,7 +776,7 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
 
             # solve model
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                res = self.opt.solve(cycle_step, tee=slc.tee)
+                res = solver.solve(cycle_step, tee=slc.tee)
 
             if check_optimal_termination(res):
                 init_log.info_high(
@@ -843,7 +841,7 @@ class FixedBedTSA0DInitializer(ModularInitializerBase):
 
             # solve model
             with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-                res = self.opt.solve(cycle_step, tee=slc.tee)
+                res = solver.solve(cycle_step, tee=slc.tee)
 
             if check_optimal_termination(res):
                 init_log.info_high(

--- a/idaes/models_extra/temperature_swing_adsorption/tests/test_fixed_bed_tsa0d.py
+++ b/idaes/models_extra/temperature_swing_adsorption/tests/test_fixed_bed_tsa0d.py
@@ -47,10 +47,7 @@ from idaes.models_extra.temperature_swing_adsorption import (
     SteamCalculationType,
     TransformationScheme,
 )
-from idaes.models_extra.temperature_swing_adsorption.util import (
-    plot_tsa_profiles,
-    tsa_summary,
-)
+from idaes.models_extra.temperature_swing_adsorption.util import tsa_summary
 import idaes.core.util.scaling as iscale
 
 # -----------------------------------------------------------------------------
@@ -182,10 +179,6 @@ class TestTsaZeolite:
         assert "Cycle time [h]" in summary_df.index
         assert "Pressure drop [Pa]" in summary_df.index
 
-    @pytest.mark.unit
-    def test_plotting(self, model):
-        plot_tsa_profiles(model.fs.unit)
-
 
 class TestTsaMgmof:
     # also testing calculate beds and simple steam calcs
@@ -249,7 +242,7 @@ class TestTsaMgmof:
     @pytest.mark.skipif(solver is None, reason="Solver not available")
     @pytest.mark.component
     def test_initialize(self, model):
-        initializer = FixedBedTSA0DInitializer()
+        initializer = FixedBedTSA0DInitializer(constraint_tolerance=1e-4)
         initializer.initialize(
             model.fs.unit, heating_time_guess=2000, cooling_time_guess=900
         )


### PR DESCRIPTION
## Replaces #1415


## Summary/Motivation: Second attempt at implementing new solver interface with presolve. Due to the need to maintain backward compatibility, the old `model.initialize()` methods will continue to use the old `ipopt` solver interface, whilst the new `Initializers` and core tests will switch to `ipopt_v2`. The default solver will remain `ipopt` for now until all the examples have been switched over (or updated to explicitly use `ipopt`), at which point will will deprecate the use of `ipopt` as the default.


## Changes proposed in this PR:
- [x] Basic infrastructure to support new solver interface (mainly the introduction of the new `writer_config` argument and deprecating `options` for `solver_options`).
- [ ] Moving common `Initializers` to use `ipopt_v2`.
- [ ] Switch all `idaes/core` and `idaes/models` tests to use `ipopt_v2`.
- [ ] Where possible ,swithc `idaes/apps` and `idaes/models_extra` tests to use `ipopt_v2`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
