### PR TITLE
Limiting pint version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ kwargs = dict(
     # Concrete dependencies go in requirements[-dev].txt
     install_requires=[
         "pyomo >= 6.7.3",
-        "pint",  # required to use Pyomo units
+        "pint<0.24",  # required to use Pyomo units. Pint 0.24 only supported on Python >=3.10
         "networkx",  # required to use Pyomo network
         "numpy<2",
         # pandas constraint added on 2023-08-30 b/c bug in v2.1


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:
Pint recently released v0.24 which changed some behavior in how dimensionless quantities are displayed and thus causes tests to start failing. However, v0.24 is only supported on Python 3.10 and greater, and thus we cannot switch tho the new version as we still support older version of Python.

## Changes proposed in this PR:
- Limit pint version to <0.24
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
