### PR TITLE
Use `el8` binaries when we encounter RHEL9

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -48,15 +48,15 @@ base_platforms = (
 # Map some platform names to others for get-extensions
 binary_distro_map = {
     "macos": "darwin",
-    "el9": "ubuntu2204",
+    "el9": "el8",
     "rhel7": "el7",
     "rhel8": "el8",
-    "rhel9": "ubuntu2204",
+    "rhel9": "el8",
     "scientific7": "el7",
     "centos7": "el7",
     "centos8": "el8",
     "rocky8": "el8",
-    "rocky9": "ubuntu2204",
+    "rocky9": "el8",
     "almalinux8": "el8",
     "almalinux9": "ubuntu2204",
     "debian9": "el7",


### PR DESCRIPTION
## Fixes #1456 
Hopefully. I don't have RHEL9 or Rocky9, so I haven't tested.

## Changes proposed in this PR:
- Change `el9`, `rhel9`, and `rocky9` to point to our `el8` binaries

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
