### PR TITLE
Repair erroneous units for material_holdup in CV0D when mass basis defined

### DIFF
--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -287,7 +287,6 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
             if f_time_units is None:
                 acc_units = None
-                holdup_units = None
             elif (
                 self.properties_in[
                     self.flowsheet().time.first()
@@ -295,7 +294,6 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 == MaterialFlowBasis.molar
             ):
                 acc_units = units("amount") / f_time_units
-                holdup_units = units("amount")
             elif (
                 self.properties_in[
                     self.flowsheet().time.first()
@@ -303,10 +301,8 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 == MaterialFlowBasis.mass
             ):
                 acc_units = units("mass") / f_time_units
-                holdup_units = units("mass")
             else:
                 acc_units = None
-                holdup_units = None
 
         # Check if reaction package exists, and get units
         if hasattr(self.config, "reaction_package"):
@@ -345,6 +341,17 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
         # Material holdup and accumulation
         if has_holdup:
+            if (
+                self.properties_in[
+                    self.flowsheet().time.first()
+                ].get_material_flow_basis()
+                == MaterialFlowBasis.mass
+            ):
+                holdup_units = units("mass")
+              # TODO: Revisit the following: Preserving the original implementation and assigning units("amount") for molar flow and any other
+            else:
+                holdup_units = units("amount")
+         
             self.material_holdup = Var(
                 self.flowsheet().time,
                 pc_set,

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -294,6 +294,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 == MaterialFlowBasis.molar
             ):
                 acc_units = units("amount") / f_time_units
+                holdup_units = units("amount")
             elif (
                 self.properties_in[
                     self.flowsheet().time.first()
@@ -301,8 +302,10 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 == MaterialFlowBasis.mass
             ):
                 acc_units = units("mass") / f_time_units
+                holdup_units = units("mass")
             else:
                 acc_units = None
+                holdup_units = None
 
         # Check if reaction package exists, and get units
         if hasattr(self.config, "reaction_package"):
@@ -347,7 +350,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 domain=Reals,
                 initialize=1.0,
                 doc="Material holdup in control volume",
-                units=units("amount"),
+                units=holdup_units,
             )
         if dynamic:
             self.material_accumulation = DerivativeVar(

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -348,10 +348,10 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 == MaterialFlowBasis.mass
             ):
                 holdup_units = units("mass")
-              # TODO: Revisit the following: Preserving the original implementation and assigning units("amount") for molar flow and any other
+            # TODO: Revisit the following: Preserving the original implementation and assigning units("amount") for molar flow and any other
             else:
                 holdup_units = units("amount")
-         
+
             self.material_holdup = Var(
                 self.flowsheet().time,
                 pc_set,

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -357,7 +357,8 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 holdup_units = units("amount")
             else:
                 holdup_units = None
-
+                # volume units will need to be updated to None for unit consistency in material_holdup_calculation
+                self.volume._units = None
             self.material_holdup = Var(
                 self.flowsheet().time,
                 pc_set,

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -357,8 +357,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 holdup_units = units("amount")
             else:
                 holdup_units = None
-                # volume units will need to be updated to None for unit consistency in material_holdup_calculation
-                self.volume._units = None
+
             self.material_holdup = Var(
                 self.flowsheet().time,
                 pc_set,

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -287,6 +287,7 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
 
             if f_time_units is None:
                 acc_units = None
+                holdup_units = None
             elif (
                 self.properties_in[
                     self.flowsheet().time.first()

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -348,9 +348,15 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
                 == MaterialFlowBasis.mass
             ):
                 holdup_units = units("mass")
-            # TODO: Revisit the following: Preserving the original implementation and assigning units("amount") for molar flow and any other
-            else:
+            elif (
+                self.properties_in[
+                    self.flowsheet().time.first()
+                ].get_material_flow_basis()
+                == MaterialFlowBasis.molar
+            ):
                 holdup_units = units("amount")
+            else:
+                holdup_units = None
 
             self.material_holdup = Var(
                 self.flowsheet().time,

--- a/idaes/core/base/flowsheet_model.py
+++ b/idaes/core/base/flowsheet_model.py
@@ -322,10 +322,10 @@ within this flowsheet if not otherwise specified,
         elif self.config.time_units is None and self.config.dynamic:
             raise ConfigurationError(
                 f"{self.name} - no units were specified for the time domain. "
-                f"Units must be be specified for dynamic models."
+                f"Units must be specified for dynamic models."
             )
         elif self.config.time_units is None and not self.config.dynamic:
-            _log.debug("No units specified for stady-state time domain.")
+            _log.debug("No units specified for steady-state time domain.")
         elif not isinstance(self.config.time_units, _PyomoUnit):
             raise ConfigurationError(
                 "{} unrecognised value for time_units argument. This must be "

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -2663,7 +2663,9 @@ def test_dynamic_mass_basis():
     m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
     m.fs.pp.basis_switch = 2
     m.fs.cv = ControlVolume0DBlock(
-        property_package=m.fs.pp, reaction_package=m.fs.rp, dynamic=True
+        property_package=m.fs.pp,
+        reaction_package=m.fs.rp,
+        dynamic=True,
     )
 
     m.fs.cv.add_geometry()

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -2681,3 +2681,32 @@ def test_dynamic_mass_basis():
     assert_units_consistent(m)
     assert_units_equivalent(m.fs.cv.material_holdup, units.kg)
     assert_units_equivalent(m.fs.cv.material_accumulation, units.kg / units.s)
+
+
+@pytest.mark.unit
+def test_dynamic_other_basis():
+    m = ConcreteModel()
+    m.fs = Flowsheet(dynamic=True, time_units=units.s)
+    m.fs.pp = PhysicalParameterTestBlock()
+    m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
+    m.fs.pp.basis_switch = 3
+    m.fs.cv = ControlVolume0DBlock(
+        property_package=m.fs.pp, reaction_package=m.fs.rp, dynamic=True
+    )
+
+    m.fs.cv.add_geometry()
+    m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
+    m.fs.cv.add_reaction_blocks(has_equilibrium=False)
+
+    mb = m.fs.cv.add_phase_component_balances()
+
+    assert isinstance(mb, Constraint)
+    assert len(mb) == 8
+    assert isinstance(m.fs.cv.phase_fraction, Var)
+    assert isinstance(m.fs.cv.material_holdup, Var)
+    assert isinstance(m.fs.cv.material_accumulation, Var)
+
+    assert_units_consistent(m)
+    assert_units_equivalent(m.fs.cv.material_holdup, None)
+    assert_units_equivalent(m.fs.cv.material_accumulation, None)
+    assert_units_equivalent(m.fs.cv.volume, None)

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -689,6 +689,8 @@ def test_add_phase_component_balances_dynamic():
     assert isinstance(m.fs.cv.material_accumulation, Var)
 
     assert_units_consistent(m)
+    assert_units_equivalent(m.fs.cv.material_holdup, units.mol)
+    assert_units_equivalent(m.fs.cv.material_accumulation, units.mol/units.s)
 
 
 @pytest.mark.unit
@@ -2651,3 +2653,30 @@ def test_reports():
     m.fs.cv.add_momentum_balances(has_pressure_change=True)
 
     m.fs.cv.report()
+
+@pytest.mark.unit
+def test_dynamic_mass_basis():
+    m = ConcreteModel()
+    m.fs = Flowsheet(dynamic=True, time_units=units.s)
+    m.fs.pp = PhysicalParameterTestBlock()
+    m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
+    m.fs.pp.basis_switch = 2
+    m.fs.cv = ControlVolume0DBlock(
+        property_package=m.fs.pp, reaction_package=m.fs.rp, dynamic=True
+    )
+
+    m.fs.cv.add_geometry()
+    m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
+    m.fs.cv.add_reaction_blocks(has_equilibrium=False)
+
+    mb = m.fs.cv.add_phase_component_balances()
+
+    assert isinstance(mb, Constraint)
+    assert len(mb) == 8
+    assert isinstance(m.fs.cv.phase_fraction, Var)
+    assert isinstance(m.fs.cv.material_holdup, Var)
+    assert isinstance(m.fs.cv.material_accumulation, Var)
+
+    assert_units_consistent(m)
+    assert_units_equivalent(m.fs.cv.material_holdup, units.kg)
+    assert_units_equivalent(m.fs.cv.material_accumulation, units.kg/units.s)

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -690,7 +690,7 @@ def test_add_phase_component_balances_dynamic():
 
     assert_units_consistent(m)
     assert_units_equivalent(m.fs.cv.material_holdup, units.mol)
-    assert_units_equivalent(m.fs.cv.material_accumulation, units.mol/units.s)
+    assert_units_equivalent(m.fs.cv.material_accumulation, units.mol / units.s)
 
 
 @pytest.mark.unit
@@ -2654,6 +2654,7 @@ def test_reports():
 
     m.fs.cv.report()
 
+
 @pytest.mark.unit
 def test_dynamic_mass_basis():
     m = ConcreteModel()
@@ -2679,4 +2680,4 @@ def test_dynamic_mass_basis():
 
     assert_units_consistent(m)
     assert_units_equivalent(m.fs.cv.material_holdup, units.kg)
-    assert_units_equivalent(m.fs.cv.material_accumulation, units.kg/units.s)
+    assert_units_equivalent(m.fs.cv.material_accumulation, units.kg / units.s)

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -2681,32 +2681,3 @@ def test_dynamic_mass_basis():
     assert_units_consistent(m)
     assert_units_equivalent(m.fs.cv.material_holdup, units.kg)
     assert_units_equivalent(m.fs.cv.material_accumulation, units.kg / units.s)
-
-
-@pytest.mark.unit
-def test_dynamic_other_basis():
-    m = ConcreteModel()
-    m.fs = Flowsheet(dynamic=True, time_units=units.s)
-    m.fs.pp = PhysicalParameterTestBlock()
-    m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
-    m.fs.pp.basis_switch = 3
-    m.fs.cv = ControlVolume0DBlock(
-        property_package=m.fs.pp, reaction_package=m.fs.rp, dynamic=True
-    )
-
-    m.fs.cv.add_geometry()
-    m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
-    m.fs.cv.add_reaction_blocks(has_equilibrium=False)
-
-    mb = m.fs.cv.add_phase_component_balances()
-
-    assert isinstance(mb, Constraint)
-    assert len(mb) == 8
-    assert isinstance(m.fs.cv.phase_fraction, Var)
-    assert isinstance(m.fs.cv.material_holdup, Var)
-    assert isinstance(m.fs.cv.material_accumulation, Var)
-
-    assert_units_consistent(m)
-    assert_units_equivalent(m.fs.cv.material_holdup, None)
-    assert_units_equivalent(m.fs.cv.material_accumulation, None)
-    assert_units_equivalent(m.fs.cv.volume, None)

--- a/idaes/core/base/tests/test_control_volume_0d_scaling.py
+++ b/idaes/core/base/tests/test_control_volume_0d_scaling.py
@@ -147,7 +147,6 @@ def test_full_auto_scaling():
     # rate_reaction_extent (2 reactions)
     # equilibrium_reaction_extent  (2 reactions)
     # cp at inlet and outlet
-    [print(i) for i in unscaled_var_list]
     assert len(unscaled_var_list) == 6
     # check that all constraints have been scaled
     unscaled_constraint_list = list(iscale.unscaled_constraints_generator(m))

--- a/idaes/core/base/tests/test_control_volume_0d_scaling.py
+++ b/idaes/core/base/tests/test_control_volume_0d_scaling.py
@@ -147,6 +147,7 @@ def test_full_auto_scaling():
     # rate_reaction_extent (2 reactions)
     # equilibrium_reaction_extent  (2 reactions)
     # cp at inlet and outlet
+    [print(i) for i in unscaled_var_list]
     assert len(unscaled_var_list) == 6
     # check that all constraints have been scaled
     unscaled_constraint_list = list(iscale.unscaled_constraints_generator(m))

--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -259,6 +259,8 @@ class StateTestBlockData(StateBlockData):
         self.material_dens_mol = Var(initialize=1, units=units.mol / units.m**3)
         self.material_flow_mass = Var(initialize=1, units=units.kg / units.s)
         self.material_dens_mass = Var(initialize=1, units=units.kg / units.m**3)
+        self.material_flow_dimensionless = Var(initialize=1, units=units.dimensionless)
+        self.material_dens_dimensionless = Var(initialize=1, units=units.dimensionless)
         self.pressure = Var(initialize=1e5, units=units.Pa)
         self.temperature = Var(initialize=300, units=units.K)
 
@@ -280,14 +282,18 @@ class StateTestBlockData(StateBlockData):
     def get_material_flow_terms(b, p, j):
         if b.config.parameters.basis_switch == 2:
             return b.material_flow_mass
-        else:
+        elif b.config.parameters.basis_switch == 1:
             return b.material_flow_mol
+        else:
+            return b.material_flow_dimensionless
 
     def get_material_density_terms(b, p, j):
         if b.config.parameters.basis_switch == 2:
             return b.material_dens_mass
-        else:
+        elif b.config.parameters.basis_switch == 1:
             return b.material_dens_mol
+        else:
+            return b.material_dens_dimensionless
 
     def get_enthalpy_flow_terms(b, p):
         return b.enthalpy_flow

--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -200,7 +200,6 @@ class _PhysicalParameterBlock(PhysicalParameterBlock):
         self.set_default_scaling("material_flow_dimensionless", 116)
         self.set_default_scaling("material_dens_dimensionless", 117)
 
-
     @classmethod
     def define_metadata(cls, obj):
         obj.add_properties(

--- a/idaes/core/util/testing.py
+++ b/idaes/core/util/testing.py
@@ -197,6 +197,9 @@ class _PhysicalParameterBlock(PhysicalParameterBlock):
         self.set_default_scaling("material_dens_mol", 113)
         self.set_default_scaling("material_flow_mass", 114)
         self.set_default_scaling("material_dens_mass", 115)
+        self.set_default_scaling("material_flow_dimensionless", 116)
+        self.set_default_scaling("material_dens_dimensionless", 117)
+
 
     @classmethod
     def define_metadata(cls, obj):


### PR DESCRIPTION
## Fixes: #1461 
## Summary/Motivation:
This PR adjusts the units defined for the material_holdup variable constructed in ControlVolume0D, which currently only sets units as `mol` regardless of whether a mole or mass flow basis is defined. This is a problem when working with a mass flow basis. 

Notably, you would only notice this issue if you were constructing a dynamic ControlVolume0D using a mass flow basis, as we are starting to do on WaterTAP.

## Changes proposed in this PR:
- set units to mol or mass basis for material_holdup, depending on basis defined for the prop pack
- add tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
