### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
           - linux
           - win64
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
           - linux
           - win64

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ for Python 3. The following sub-versions are supported:
 * Python 3.11
 * Python 3.12
 
+> [!IMPORTANT]
+> Note that Python 3.8 is no longer officially supported.
+
 ## Contacts and more information
 
 General, background and overview information is available at the [IDAES main website](https://www.idaes.org).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Most of the functionality is implemented in Python. In accordance with
 the end-of-life for many Python 2 libraries, the IDAES Toolkit is written
 for Python 3. The following sub-versions are supported:
 
-* Python 3.8
 * Python 3.9
 * Python 3.10
 * Python 3.11

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ exclude_patterns = ["apidoc/*tests*"]
 todo_include_todos = False
 
 # Global constants for supported Python versions
-IDAES_PV_MIN, IDAES_PV_MAX, IDAES_PV_DEFAULT = "3.8", "3.12", "3.10"
+IDAES_PV_MIN, IDAES_PV_MAX, IDAES_PV_DEFAULT = "3.9", "3.12", "3.10"
 
 # This block of text will be virtually present at the end of every file.
 # Used here to define substitutions for re-used URLs, e.g. just add "|examples-site|" to

--- a/docs/explanations/faq.rst
+++ b/docs/explanations/faq.rst
@@ -66,3 +66,6 @@ missing the win32api DLL. There is a relatively easy fix::
 
   pip uninstall pywin32
   pip install pywin32==225
+
+.. IMPORTANT::
+   Python 3.8 is no longer officially supported.

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class ExtraDependencies:
         "idaes-ui @ git+https://github.com/IDAES/idaes-ui@main",
     ]
     _ipython = [
-        'ipython <= 8.12; python_version == "3.8"',
+        'ipython',
     ]
     dmf = [
         # all modules relative to idaes.core.dmf
@@ -200,7 +200,6 @@ kwargs = dict(
         "Operating System :: Unix",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class ExtraDependencies:
         "idaes-ui @ git+https://github.com/IDAES/idaes-ui@main",
     ]
     _ipython = [
-        'ipython',
+        "ipython",
     ]
     dmf = [
         # all modules relative to idaes.core.dmf


### PR DESCRIPTION
## Resolves #1462

## Changes proposed in this PR:
- Remove Python 3.8 from supported versions in docs and `setup.py`
- Remove Python 3.8 from CI workflows

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
