### PR TITLE
[WIP] Add a command to install CyIpopt

### DIFF
--- a/idaes/commands/extensions.py
+++ b/idaes/commands/extensions.py
@@ -247,7 +247,9 @@ def install_cyipopt():
     # TODO: Possibly set IPOPTWINDIR on Windows? I haven't been able to get this to
     # work on GHA, so I'd like some advice from somebody who has built CyIpopt
     # on Windows before staring to make assumptions. -RBP
-    ret = subprocess.run(["pip", "install", "cyipopt"], env=subprocess_environ)
+    ret = subprocess.run(
+        ["pip", "install", "cyipopt"], env=subprocess_environ, check=False
+    )
     if ret.returncode == 1:
         # CyIpopt wheels don't build on Python 3.9 (see
         # https://github.com/mechmotum/cyipopt/issues/225), so we have this workaround
@@ -272,11 +274,12 @@ def install_cyipopt():
                     "clone",
                     "https://github.com/mechmotum/cyipopt.git",
                     "--branch=v1.4.1",
-                ]
+                ],
+                check=False,
             )
             os.chdir(cyipopt_dir)
             ret = subprocess.run(
-                ["python", "setup.py", "develop"], env=subprocess_environ
+                ["python", "setup.py", "develop"], env=subprocess_environ, check=False
             )
         finally:
             os.chdir(orig_cwd)

--- a/idaes/commands/extensions.py
+++ b/idaes/commands/extensions.py
@@ -247,10 +247,7 @@ def install_cyipopt():
     # TODO: Possibly set IPOPTWINDIR on Windows? I haven't been able to get this to
     # work on GHA, so I'd like some advice from somebody who has built CyIpopt
     # on Windows before staring to make assumptions. -RBP
-    ret = subprocess.run(
-        ["pip", "install", "cyipopt"],
-        env=subprocess_environ,
-    )
+    ret = subprocess.run(["pip", "install", "cyipopt"], env=subprocess_environ)
     if ret.returncode == 1:
         # CyIpopt wheels don't build on Python 3.9 (see
         # https://github.com/mechmotum/cyipopt/issues/225), so we have this workaround
@@ -275,7 +272,7 @@ def install_cyipopt():
                     "clone",
                     "https://github.com/mechmotum/cyipopt.git",
                     "--branch=v1.4.1",
-                ],
+                ]
             )
             os.chdir(cyipopt_dir)
             ret = subprocess.run(
@@ -302,5 +299,5 @@ def install_cyipopt():
         f" configuration file (e.g. {bashrc_file} for Bash or {zshrc_file} for Zsh):"
         # Or $PROFILE for PowerShell?
     )
-    export_rhs = os.pathsep.join(["$"+lib_envvar, libdir])
+    export_rhs = os.pathsep.join(["$" + lib_envvar, libdir])
     click.echo(f"\n    export {lib_envvar}={export_rhs}\n")

--- a/idaes/commands/extensions.py
+++ b/idaes/commands/extensions.py
@@ -26,10 +26,11 @@ import subprocess
 
 import click
 
+from pyomo.common.dependencies import attempt_import
 import idaes
 import idaes.commands.util.download_bin
 from idaes.commands import cb
-from pyomo.common.dependencies import attempt_import
+
 
 _log = logging.getLogger("idaes.commands.extensions")
 

--- a/idaes/commands/util/download_bin.py
+++ b/idaes/commands/util/download_bin.py
@@ -402,8 +402,21 @@ def download_binaries(
     _verify_checksums(checksum, pname, ptar, ftar)
 
     # Extract solvers
+    tars_to_unpack = list(ptar)
+    idaes_local_tarname = f"idaes-local-{platform}.tar.gz"
+    if "darwin" in idaes_local_tarname:
+        # We neglected to change the name of the idaes-local tar.gz file from *aarch64
+        # to *arm64 on ARM Mac, so we have to manually patch the name here. I believe
+        # this is fixed in the idaes-ext main branch, so this can be removed when
+        # we update to binaries compiled from this branch. -RBP
+        idaes_local_tarname = idaes_local_tarname.replace("aarch64", "arm64")
+    idaes_local_tarname = os.path.join(to_path, idaes_local_tarname)
+    # In addition to the tar.gz files we downloaded, we want to unpack the idaes-local
+    # tar.gz file. This is included in idaes-solvers, so we can unpack it in the same
+    # directory after we've unpacked idaes-solvers.
+    tars_to_unpack.append(idaes_local_tarname)
     links = {}
-    for n, p in zip(pname, ptar):
+    for p in tars_to_unpack:
         _log.debug(f"Extracting files in {p} to {to_path}")
         with tarfile.open(p, "r") as f:
             _verify_tar_member_targets(f, to_path, links)

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -752,14 +752,33 @@ def setup_environment(bin_directory, use_idaes_solvers):
         return
     oe = orig_environ
     if use_idaes_solvers:
-        os.environ["PATH"] = os.pathsep.join([bin_directory, oe.get("PATH", "")])
+        os.environ["PATH"] = os.pathsep.join(
+            # As below, we add idaes/bin/lib to the path so we can (hopefully)
+            # pick up the ipopt libraries on Windows.
+            [bin_directory, os.path.join(bin_directory, "lib"), oe.get("PATH", "")]
+        )
     else:
-        os.environ["PATH"] = os.pathsep.join([oe.get("PATH", ""), bin_directory])
+        os.environ["PATH"] = os.pathsep.join(
+            [oe.get("PATH", ""), bin_directory, os.path.join(bin_directory, "lib")]
+        )
     if os.name != "nt":  # If not Windows set lib search path, Windows uses PATH
         os.environ["LD_LIBRARY_PATH"] = os.pathsep.join(
-            [oe.get("LD_LIBRARY_PATH", ""), bin_directory]
+            [
+                oe.get("LD_LIBRARY_PATH", ""),
+                bin_directory,
+                # We add .idaes/bin/lib to LD_LIBRARY_PATH to pick up any libraries
+                # we introduced by unpacking the idaes-local tar.gz file. This
+                # directory should be changed when/if the IDAES extensions directory 
+                # structure changes (e.g. to .idaes/lib). -RBP
+                os.path.join(bin_directory, "lib"),
+            ]
         )
         # This is for macOS, but won't hurt other UNIX
         os.environ["DYLD_LIBRARY_PATH"] = os.pathsep.join(
-            [oe.get("DYLD_LIBRARY_PATH", ""), bin_directory]
+            [
+                oe.get("DYLD_LIBRARY_PATH", ""),
+                bin_directory,
+                # As above, we are picking up the unpacked idaes-local file here.
+                os.path.join(bin_directory, "lib"),
+            ]
         )

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -78,9 +78,7 @@ binary_arch_map = {
     "arm64": "aarch64",
 }
 # Set of extra binary packages and basic build platform where available
-extra_binaries = {
-    "petsc": base_platforms,
-}
+extra_binaries = {"petsc": base_platforms}
 # Store the original environment variable values so we can revert changes
 orig_environ = {
     "PATH": os.environ.get("PATH", ""),
@@ -199,8 +197,7 @@ def _new_idaes_config_block():
         "blank_format", pyomo.common.config.ConfigBlock(implicit=True)
     )
     cfg["logging"]["formatters"]["blank_format"].declare(
-        "format",
-        pyomo.common.config.ConfigValue(domain=str, default="%(message)s"),
+        "format", pyomo.common.config.ConfigValue(domain=str, default="%(message)s")
     )
     cfg["logging"].declare("handlers", pyomo.common.config.ConfigBlock(implicit=True))
     cfg["logging"]["handlers"].declare(
@@ -226,8 +223,7 @@ def _new_idaes_config_block():
         pyomo.common.config.ConfigValue(domain=str, default="logging.StreamHandler"),
     )
     cfg["logging"]["handlers"]["console_blank"].declare(
-        "formatter",
-        pyomo.common.config.ConfigValue(domain=str, default="blank_format"),
+        "formatter", pyomo.common.config.ConfigValue(domain=str, default="blank_format")
     )
     cfg["logging"]["handlers"]["console_blank"].declare(
         "stream",
@@ -326,59 +322,48 @@ def _new_idaes_config_block():
     cfg.declare(
         "ipopt_v2",
         pyomo.common.config.ConfigBlock(
-            implicit=False,
-            description="Default config for 'ipopt' solver",
+            implicit=False, description="Default config for 'ipopt' solver"
         ),
     )
     cfg["ipopt_v2"].declare(
         "options",
         pyomo.common.config.ConfigBlock(
-            implicit=True,
-            description="Default solver options for 'ipopt'",
+            implicit=True, description="Default solver options for 'ipopt'"
         ),
     )
 
     cfg["ipopt_v2"]["options"].declare(
         "nlp_scaling_method",
         pyomo.common.config.ConfigValue(
-            domain=str,
-            default="gradient-based",
-            description="Ipopt NLP scaling method",
+            domain=str, default="gradient-based", description="Ipopt NLP scaling method"
         ),
     )
 
     cfg["ipopt_v2"]["options"].declare(
         "tol",
         pyomo.common.config.ConfigValue(
-            domain=float,
-            default=1e-6,
-            description="Ipopt tol option",
+            domain=float, default=1e-6, description="Ipopt tol option"
         ),
     )
 
     cfg["ipopt_v2"]["options"].declare(
         "max_iter",
         pyomo.common.config.ConfigValue(
-            domain=int,
-            default=200,
-            description="Ipopt max_iter option",
+            domain=int, default=200, description="Ipopt max_iter option"
         ),
     )
 
     cfg["ipopt_v2"]["options"].declare(
         "linear_solver",
         pyomo.common.config.ConfigValue(
-            domain=str,
-            default="ma57",
-            description="Linear solver to be used by IPOPT",
+            domain=str, default="ma57", description="Linear solver to be used by IPOPT"
         ),
     )
 
     cfg["ipopt_v2"].declare(
         "writer_config",
         pyomo.common.config.ConfigBlock(
-            implicit=True,
-            description="Default writer configuration for 'ipopt'",
+            implicit=True, description="Default writer configuration for 'ipopt'"
         ),
     )
 
@@ -604,8 +589,7 @@ def _new_idaes_config_block():
     cfg.declare(
         "logger_capture_solver",
         pyomo.common.config.ConfigValue(
-            default=True,
-            description="Solver output captured by logger?",
+            default=True, description="Solver output captured by logger?"
         ),
     )
 
@@ -768,7 +752,7 @@ def setup_environment(bin_directory, use_idaes_solvers):
                 bin_directory,
                 # We add .idaes/bin/lib to LD_LIBRARY_PATH to pick up any libraries
                 # we introduced by unpacking the idaes-local tar.gz file. This
-                # directory should be changed when/if the IDAES extensions directory 
+                # directory should be changed when/if the IDAES extensions directory
                 # structure changes (e.g. to .idaes/lib). -RBP
                 os.path.join(bin_directory, "lib"),
             ]


### PR DESCRIPTION
## Fixes
In conjuction with #1473, addresses part of https://github.com/IDAES/idaes-ext/issues/261. (Not sure if this works on Windows...)

## Summary/Motivation:
CyIpopt needs to be able to find a copy of the Ipopt shared library and header files, which it does (at least on Linux and Mac) using `pkg-config`. To install with Ipopt in a non-standard location (such as IDAES's Ipopt), we need to set the `PKG_CONFIG_PATH` environment variable (to include `.idaes/bin/lib/pkgconfig`, which will likely change in new idaes-ext releases). To make this a little bit easier for users, I propose to add a command to install CyIpopt in the current Python environment, e.g.:
```
idaes install-cyipopt
```
This basically just runs `pip install cyipopt` with `PKG_CONFIG_PATH` set appropriately.

I believe users will still need to set `LD_LIBRARY_PATH` (or `DYLD_LIBRARY_PATH`/`PATH` on Mac/Windows) to actually use CyIpopt. `import idaes` does set these variables, but I believe `import cyipopt` uses the value of the variables at the time the Python process started, not the current values in `os.environ`.

**This will only work with idaes-ext 3.4.2**

## Changes proposed in this PR:
- Unpack `idaes-local*` when the `get-extensions` command is run
- Add an `install-cyipopt` command

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
