### PR TITLE
Add minimal pytest plugin to verify that generated files are cleaned up by tests

### DIFF
--- a/idaes/conftest.py
+++ b/idaes/conftest.py
@@ -18,7 +18,6 @@ import importlib.abc
 import importlib.machinery
 import subprocess
 import sys
-from pathlib import Path
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -248,9 +247,15 @@ class VerifyCleanup:
 
     def _get_files(self):
         try:
-            text = subprocess.check_output([
-                "git", "ls-files", "--others", "--exclude-standard",
-            ], text=True).strip()
+            text = subprocess.check_output(
+                [
+                    "git",
+                    "ls-files",
+                    "--others",
+                    "--exclude-standard",
+                ],
+                text=True,
+            ).strip()
         except subprocess.CalledProcessError as e:
             text = str(e)
         return text.splitlines()
@@ -274,7 +279,9 @@ class VerifyCleanup:
             for file in files:
                 tr.write_line(f"\t{file}")
         if self._added_by_mod:
-            tr.write_line(f"{len(self._added_by_mod)} test modules did not clean up after themselves")
+            tr.write_line(
+                f"{len(self._added_by_mod)} test modules did not clean up after themselves"
+            )
             tr.write_line("The exit status of the test session will be set to failed")
 
     @pytest.hookimpl(trylast=True)


### PR DESCRIPTION
## Summary/Motivation:

- @andrewlee94 discovered that a conspicuous number of untracked files are generated when running the test suite
- I was able to confirm his intuition that this was most likely a regression introduced by #1484
- It's not entirely clear how exactly the presence of the DMF code was causing generated files not to be saved when running test modules in different parts of the codebase
- My best guess (mostly based on gut feeling, i.e. without any rigorous investigation) is that it might have something to do with the code formerly in `idaes.core.dmf.util` through manipulation of temporary directories and/or the working directory

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
