### PR TITLE
Fix issue with enthalpy based states trying to use EoS before construciton

### DIFF
--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -2105,6 +2105,15 @@ class GenericStateBlockData(StateBlockData):
             pobj = self.params.get_phase(p)
             pobj.config.equation_of_state.common(self, pobj)
 
+        # Check to see if state definition uses enthalpy
+        if self.is_property_constructed("enth_mol"):
+            # State definition uses enthalpy, need to add constraint on phase enthalpies
+            @self.Constraint(doc="Total molar enthalpy mixing rule")
+            def enth_mol_eqn(b):
+                return b.enth_mol == sum(
+                    b.enth_mol_phase[p] * b.phase_frac[p] for p in b.phase_list
+                )
+
         # Add phase equilibrium constraints if necessary
         if self.params.config.phases_in_equilibrium is not None and (
             not self.config.defined_state or self.always_flash

--- a/idaes/models/properties/modular_properties/base/tests/dummy_eos.py
+++ b/idaes/models/properties/modular_properties/base/tests/dummy_eos.py
@@ -103,7 +103,7 @@ class DummyEoS(EoSBase):
 
     @staticmethod
     def enth_mol_phase(b, p):
-        return 1e2 * b.temperature
+        return 1e2 * pyunits.J / pyunits.mol / pyunits.K * b.temperature
 
     @staticmethod
     def enth_mol_phase_comp(b, p, j):

--- a/idaes/models/properties/modular_properties/state_definitions/FPhx.py
+++ b/idaes/models/properties/modular_properties/state_definitions/FPhx.py
@@ -176,15 +176,6 @@ def define_state(b):
             expr=1 == sum(b.mole_frac_comp[i] for i in b.component_list)
         )
 
-    def rule_enth_mol(b):
-        return b.enth_mol == sum(
-            b.enth_mol_phase[p] * b.phase_frac[p] for p in b.phase_list
-        )
-
-    b.enth_mol_eq = Constraint(
-        rule=rule_enth_mol, doc="Total molar enthalpy mixing rule"
-    )
-
     if len(b.phase_list) == 1:
 
         def rule_total_mass_balance(b):
@@ -451,7 +442,7 @@ def calculate_scaling_factors(b):
             b.sum_mole_frac_out, min(sf_mf.values()), overwrite=False
         )
 
-    iscale.constraint_scaling_transform(b.enth_mol_eq, sf_h, overwrite=False)
+    iscale.constraint_scaling_transform(b.enth_mol_eqn, sf_h, overwrite=False)
 
     if len(b.phase_list) == 1:
         iscale.constraint_scaling_transform(

--- a/idaes/models/properties/modular_properties/state_definitions/FcPh.py
+++ b/idaes/models/properties/modular_properties/state_definitions/FcPh.py
@@ -182,15 +182,6 @@ def define_state(b):
 
     b.mole_frac_comp_eq = Constraint(b.component_list, rule=rule_mole_frac_comp)
 
-    def rule_enth_mol(b):
-        return b.enth_mol == sum(
-            b.enth_mol_phase[p] * b.phase_frac[p] for p in b.phase_list
-        )
-
-    b.enth_mol_eq = Constraint(
-        rule=rule_enth_mol, doc="Total molar enthalpy mixing rule"
-    )
-
     if len(b.phase_list) == 1:
 
         def rule_total_mass_balance(b):
@@ -456,7 +447,7 @@ def calculate_scaling_factors(b):
             b.mole_frac_comp_eq[j], sf_j, overwrite=False
         )
 
-    iscale.constraint_scaling_transform(b.enth_mol_eq, sf_h, overwrite=False)
+    iscale.constraint_scaling_transform(b.enth_mol_eqn, sf_h, overwrite=False)
 
     if len(b.phase_list) == 1:
         iscale.constraint_scaling_transform(

--- a/idaes/models/properties/modular_properties/state_definitions/tests/test_FPhx.py
+++ b/idaes/models/properties/modular_properties/state_definitions/tests/test_FPhx.py
@@ -47,6 +47,7 @@ import idaes.logger as idaeslog
 pytestmark = pytest.mark.unit
 
 
+# Note: The state definition is set by importing functions for the relevant module above
 @declare_process_block_class("DummyParameterBlock")
 class DummyParameterData(GenericParameterData):
     pass
@@ -137,7 +138,7 @@ class TestInvalidBounds(object):
 
 class Test1PhaseDefinedStateFalseNoBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -263,7 +264,7 @@ class Test1PhaseDefinedStateFalseNoBounds(object):
 
 class Test1PhaseDefinedStateTrueWithBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -389,7 +390,7 @@ class Test1PhaseDefinedStateTrueWithBounds(object):
 
 class Test2PhaseDefinedStateFalseNoBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -551,7 +552,7 @@ class Test2PhaseDefinedStateFalseNoBounds(object):
 
 class Test2PhaseDefinedStateTrueWithBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -712,7 +713,7 @@ class Test2PhaseDefinedStateTrueWithBounds(object):
 
 class Test3PhaseDefinedStateFalseNoBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -862,7 +863,7 @@ class Test3PhaseDefinedStateFalseNoBounds(object):
 
 class Test3PhaseDefinedStateTrueWithBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -1020,7 +1021,7 @@ class Test3PhaseDefinedStateTrueWithBounds(object):
 
 
 class TestCommon(object):
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 

--- a/idaes/models/properties/modular_properties/state_definitions/tests/test_FTPx.py
+++ b/idaes/models/properties/modular_properties/state_definitions/tests/test_FTPx.py
@@ -55,6 +55,7 @@ from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
 
 
+# Note: The state definition is set by importing functions for the relevant module above
 @declare_process_block_class("DummyParameterBlock")
 class DummyParameterData(GenericParameterData):
     pass

--- a/idaes/models/properties/modular_properties/state_definitions/tests/test_FcPh.py
+++ b/idaes/models/properties/modular_properties/state_definitions/tests/test_FcPh.py
@@ -51,6 +51,7 @@ from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
 
 
+# Note: The state definition is set by importing functions for the relevant module above
 @declare_process_block_class("DummyParameterBlock")
 class DummyParameterData(GenericParameterData):
     pass
@@ -141,7 +142,7 @@ class TestInvalidBounds(object):
 
 class Test1PhaseDefinedStateFalseNoBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -276,7 +277,7 @@ class Test1PhaseDefinedStateFalseNoBounds(object):
 
 class Test1PhaseDefinedStateTrueWithBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -429,7 +430,7 @@ class Test1PhaseDefinedStateTrueWithBounds(object):
 
 class Test2PhaseDefinedStateFalseNoBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -600,7 +601,7 @@ class Test2PhaseDefinedStateFalseNoBounds(object):
 
 class Test2PhaseDefinedStateTrueWithBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -788,7 +789,7 @@ class Test2PhaseDefinedStateTrueWithBounds(object):
 
 class Test3PhaseDefinedStateFalseNoBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -947,7 +948,7 @@ class Test3PhaseDefinedStateFalseNoBounds(object):
 
 class Test3PhaseDefinedStateTrueWithBounds(object):
     # Test define_state method with no bounds and defined_State = False
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 
@@ -1121,7 +1122,7 @@ class Test3PhaseDefinedStateTrueWithBounds(object):
 
 
 class TestCommon(object):
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def frame(self):
         m = ConcreteModel()
 

--- a/idaes/models/properties/modular_properties/state_definitions/tests/test_FcTP.py
+++ b/idaes/models/properties/modular_properties/state_definitions/tests/test_FcTP.py
@@ -50,6 +50,7 @@ from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
 
 
+# Note: The state definition is set by importing functions for the relevant module above
 @declare_process_block_class("DummyParameterBlock")
 class DummyParameterData(GenericParameterData):
     pass

--- a/idaes/models/properties/modular_properties/state_definitions/tests/test_FpcTP.py
+++ b/idaes/models/properties/modular_properties/state_definitions/tests/test_FpcTP.py
@@ -58,6 +58,7 @@ import idaes.logger as idaeslog
 from idaes.core.util.model_statistics import degrees_of_freedom, large_residuals_set
 
 
+# Note: The state definition is set by importing functions for the relevant module above
 @declare_process_block_class("DummyParameterBlock")
 class DummyParameterData(GenericParameterData):
     pass


### PR DESCRIPTION
## Fixes #1483


## Summary/Motivation:
Issue #1483 identified that enthalpy-based state definitions in the modular property framework triggered calls to components constructed by the equation of state module before these had been instantiated. This PR defers the construction of the constraint relating total molar enthalpy to the phase molar enthalpies until after the EoS components have been instantiated.

## Changes proposed in this PR:
- Defer construction of `enth_mol_eqn` in enthalpy based state definitions.
- Fix some issues of cross-contamination in tests resulting in unexpected behaviors with this change
- Added units to partial molar enthalpy in DummyEoS to address unit consistency issue in tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
