### PR TITLE
pinned ubuntu version to resolve failing gha jobs until support avail…

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -225,7 +225,7 @@ jobs:
 
   compat:
     name: Compatibility tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Conda environment


### PR DESCRIPTION
…ble in idaes extension

## Fixes
issue #1499
https://github.com/IDAES/idaes-pse/issues/1499

## Summary/Motivation:
Widespread test failures with Ubuntu 24.04, including ubuntu-latest GHA runner image -- this won't work without a pinned version of Ubuntu -- the longer term fix will take a while as it requires updated binaries of IDAES

## Changes proposed in this PR:
Update the core.yml file to specify GHA is pinned to Ubuntu 22.04 
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
