### PR TITLE
Better error messages for Modular Properties when config dict in not unpacked

### DIFF
--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -304,7 +304,8 @@ class GenericParameterData(PhysicalParameterBlock):
         # Add Phase objects
         if self.config.phases is None:
             raise ConfigurationError(
-                "{} was not provided with a phases argument.".format(self.name)
+                f"{self.name} was not provided with a phases argument. "
+                "Did you forget to unpack the configurations dictionary?"
             )
 
         # Add a flag indicating whether this is an electrolyte system or not

--- a/idaes/models/properties/modular_properties/base/generic_reaction.py
+++ b/idaes/models/properties/modular_properties/base/generic_reaction.py
@@ -199,6 +199,13 @@ class GenericReactionParameterData(ReactionParameterBlock):
         # and cannot be set until the config block is created by super.build
         super(ReactionParameterBlock, self).build()
 
+        # Check to make sure a property block was assigned
+        if self.config.property_package is None:
+            raise ConfigurationError(
+                f"{self.name} was not assigned a property package. "
+                "Did you forget to unpack the configuration dictionary?"
+            )
+
         # Set base units of measurement
         self.get_metadata().add_default_units(self.config.base_units)
 

--- a/idaes/models/properties/modular_properties/base/tests/test_generic_property.py
+++ b/idaes/models/properties/modular_properties/base/tests/test_generic_property.py
@@ -199,7 +199,7 @@ class TestGenericParameterBlock(object):
 
         with pytest.raises(
             ConfigurationError,
-            match="params was not provided with a components " "argument.",
+            match="params was not provided with a components argument.",
         ):
             m.params = DummyParameterBlock(
                 phases={
@@ -215,11 +215,32 @@ class TestGenericParameterBlock(object):
 
         with pytest.raises(
             ConfigurationError,
-            match="params was not provided with a phases " "argument.",
+            match="params was not provided with a phases argument. "
+            "Did you forget to unpack the configurations dictionary?",
         ):
             m.params = DummyParameterBlock(
                 components={"a": {}, "b": {}, "c": {}}, base_units=base_units
             )
+
+    @pytest.mark.unit
+    def test_packed_dict(self):
+        m = ConcreteModel()
+
+        dummy_dict = {
+            "phases": {
+                "p1": {"equation_of_state": "foo"},
+                "p2": {"equation_of_state": "bar"},
+            },
+        }
+
+        with pytest.raises(
+            ConfigurationError,
+            match=re.escape(
+                "params[phases] was not provided with a phases argument. "
+                "Did you forget to unpack the configurations dictionary?"
+            ),
+        ):
+            m.params = DummyParameterBlock(dummy_dict)
 
     @pytest.mark.unit
     def test_invalid_component_in_phase_component_list(self):

--- a/idaes/models/properties/modular_properties/base/tests/test_generic_reaction.py
+++ b/idaes/models/properties/modular_properties/base/tests/test_generic_reaction.py
@@ -194,6 +194,17 @@ class TestGenericReactionParameterBlock(object):
             )
 
     @pytest.mark.unit
+    def test_packed_config_dict(self, m):
+        with pytest.raises(
+            ConfigurationError,
+            match=re.escape(
+                "rxn_params[property_package] was not assigned a property package. "
+                "Did you forget to unpack the configuration dictionary?"
+            ),
+        ):
+            m.rxn_params = GenericReactionParameterBlock({"property_package": m.params})
+
+    @pytest.mark.unit
     def test_rate_build_invalid_phase_stoichiometry(self, m):
         with pytest.raises(
             ConfigurationError,


### PR DESCRIPTION
## Fixes 1205


## Summary/Motivation:
The Modular Properties did not give very useful error messages when given a dict of arguments instead of the unpacked arguments (`**kwargs`).

## Changes proposed in this PR:
- Add catches for cases where when the dict might not have been unpacked and raise a useful error message.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
