### PR TITLE
Add explicit configuration path for ReadtheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     fail_on_warning: false
+    configuration: docs/conf.py
 
 python:
     install:


### PR DESCRIPTION
## Fixes #1551 


## Summary/Motivation:

RTD now requires an explicit path to the `conf.py` file

## Changes proposed in this PR:
- Add explicit path

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
