### PR TITLE
Generic property package: Using constraints to define state variables

### DIFF
--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1490,7 +1490,7 @@ class ModularPropertiesInitializer(InitializerBase):
                             c.activate()
                     elif getattr(c, "defining_state_var", False):
                         # Allow using a constraint to define a state var
-                        # (rather than fixing it directly) by setting 
+                        # (rather than fixing it directly) by setting
                         # c.defining_state_var = True.
                         c.activate()
 
@@ -1945,7 +1945,7 @@ class _GenericStateBlock(StateBlock):
                             c.activate()
                     elif getattr(c, "defining_state_var", False):
                         # Allow using a constraint to define a state var
-                        # (rather than fixing it directly) by setting 
+                        # (rather than fixing it directly) by setting
                         # c.defining_state_var = True. This can be used in
                         # conjunction with setting state_vars_fixed = True
                         c.activate()

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1488,6 +1488,11 @@ class ModularPropertiesInitializer(InitializerBase):
                         # constraint at this stage.
                         if "flow_mol_phase_comp" not in b.define_state_vars():
                             c.activate()
+                    elif getattr(c, "defining_state_var", False):
+                        # Allow using a constraint to define a state var
+                        # (rather than fixing it directly) by setting 
+                        # c.defining_state_var = True.
+                        c.activate()
 
                 for pp in b.params._pe_pairs:
                     # Activate formulation specific constraints
@@ -1938,6 +1943,12 @@ class _GenericStateBlock(StateBlock):
                         # constraint at this stage.
                         if "flow_mol_phase_comp" not in b.define_state_vars():
                             c.activate()
+                    elif getattr(c, "defining_state_var", False):
+                        # Allow using a constraint to define a state var
+                        # (rather than fixing it directly) by setting 
+                        # c.defining_state_var = True. This can be used in
+                        # conjunction with setting state_vars_fixed = True
+                        c.activate()
 
                 for pp in b.params._pe_pairs:
                     # Activate formulation specific constraints


### PR DESCRIPTION
## Fixes # .


## Summary/Motivation:

As part of Ahuora we are using the generic property package framework to build custom property packages. 

The code looks something like this:

```python
m.fs.properties = GenericParameterBlock(**configuration)  # FTPx
m.fs.state = m.fs.properties.build_state_block([0], defined_state=True)
sb = m.fs.state[0]
sb.flow_mol.fix(1)  # mol/s
sb.temperature.fix(300)  # K
sb.pressure.fix(100000)  # Pa
sb.mole_frac_comp["benzene"].fix(0.5)
sb.mole_frac_comp["toluene"].fix(0.5)

m.fs.state.initialize()
```

Suppose that we know the value for `flow_mass` and want to use that instead. We can do this using a `Constraint`:

```python
sb.flow_mol.unfix()
sb.flow_mass_constraint = Constraint(rule=sb.flow_mass == 1)  # kg/s
```

However, this ends up running into issues during initialization:

- The initialization routine starts by fixing all state variables that are not currently fixed. This means `flow_mol` gets fixed anyway, and the block becomes over-defined. However, we are able to prevent this by setting the kwarg `state_vars_fixed=True`, which means initialization will skip trying to fix the state variables (and just check for 0 degrees of freedom). So this is not an issue at this stage.
- During the initialization routine, constraints are deactivated at the start and then re-activated during the different initialization steps. The constraint `flow_mass_constraint` gets deactivated during the "Bubble, dew, and critical point initialization" step (which is fine), but needs to be activated for the "Phase equilibrium initialization" step, to ensure 0 degrees of freedom. 

The specific error I get is 
```python
idaes.core.util.exceptions.InitializationError: fs.state Unexpected degrees of freedom during initialization at phase equilibrium step: 1.
```

## Changes proposed in this PR:

- This PR proposes an approach to activate the `flow_mass_constraint` (or other constraints as needed) before the "Phase equilibrium initialization" step. This is done by "tagging" the constraint with `defining_state_var = True` to indicate that this constraint defines a state variable, and should be activated.

For example,

```python
sb.flow_mol.unfix()
sb.flow_mass_constraint = Constraint(rule=sb.flow_mass == 1)  # kg/s
sb.flow_mass_constraint.defining_state_var = True
m.fs.state.initialize(state_vars_fixed=True)
```

I added this check to both the `_GenericStateBlock` and `ModularPropertiesInitializer` initialize methods. I am not too sure how the `ModularPropertiesInitializer` class is used (seems to be the same logic) but I assume the code fits in both.

Comments on this approach would be useful.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
