### PR TITLE
Pressure changer initialization guesses

### DIFF
--- a/idaes/models/unit_models/pressure_changer.py
+++ b/idaes/models/unit_models/pressure_changer.py
@@ -944,9 +944,13 @@ see property package for documentation.}""",
                     # Fixed outlet pressure, use this value
                     state_args_out[k] = value(cv.properties_out[t0].pressure)
                 elif blk.deltaP[t0].fixed:
-                    state_args_out[k] = value(cv.properties_in[t0].pressure + blk.deltaP[t0])
+                    state_args_out[k] = value(
+                        cv.properties_in[t0].pressure + blk.deltaP[t0]
+                    )
                 elif blk.ratioP[t0].fixed:
-                    state_args_out[k] = value(cv.properties_in[t0].pressure * blk.ratioP[t0])
+                    state_args_out[k] = value(
+                        cv.properties_in[t0].pressure * blk.ratioP[t0]
+                    )
                 else:
                     # Not obvious what to do, use inlet state
                     state_args_out[k] = value(cv.properties_in[t0].pressure)
@@ -1088,9 +1092,13 @@ see property package for documentation.}""",
                     # Fixed outlet pressure, use this value
                     state_args_out[k] = value(cv.properties_out[t0].pressure)
                 elif blk.deltaP[t0].fixed:
-                    state_args_out[k] = value(cv.properties_in[t0].pressure + blk.deltaP[t0])
+                    state_args_out[k] = value(
+                        cv.properties_in[t0].pressure + blk.deltaP[t0]
+                    )
                 elif blk.ratioP[t0].fixed:
-                    state_args_out[k] = value(cv.properties_in[t0].pressure * blk.ratioP[t0])
+                    state_args_out[k] = value(
+                        cv.properties_in[t0].pressure * blk.ratioP[t0]
+                    )
                 else:
                     # Not obvious what to do, use inlet state
                     state_args_out[k] = value(cv.properties_in[t0].pressure)

--- a/idaes/models/unit_models/pressure_changer.py
+++ b/idaes/models/unit_models/pressure_changer.py
@@ -1060,23 +1060,6 @@ see property package for documentation.}""",
                 else:
                     state_args[k] = state_dict[k].value
 
-        # Get initialisation guesses for outlet and isentropic states
-        for k in state_args:
-            if k == "pressure" and k not in state_args_out:
-                # Work out how to estimate outlet pressure
-                if cv.properties_out[t0].pressure.fixed:
-                    # Fixed outlet pressure, use this value
-                    state_args_out[k] = value(cv.properties_out[t0].pressure)
-                elif blk.deltaP[t0].fixed:
-                    state_args_out[k] = value(state_args[k] + blk.deltaP[t0])
-                elif blk.ratioP[t0].fixed:
-                    state_args_out[k] = value(state_args[k] * blk.ratioP[t0])
-                else:
-                    # Not obvious what to do, use inlet state
-                    state_args_out[k] = state_args[k]
-            elif k not in state_args_out:
-                state_args_out[k] = state_args[k]
-
         # Initialize state blocks
         flags = cv.properties_in.initialize(
             outlvl=outlvl,
@@ -1085,6 +1068,32 @@ see property package for documentation.}""",
             hold_state=True,
             state_args=state_args,
         )
+
+        # Get initialisation guesses for outlet and isentropic states
+        # refresh state_dict (may have changed during initialization)
+        state_dict = cv.properties_in[t0].define_port_members()
+        for k in state_args:
+            if k == "pressure" and k not in state_args_out:
+                # Work out how to estimate outlet pressure
+                if cv.properties_out[t0].pressure.fixed:
+                    # Fixed outlet pressure, use this value
+                    state_args_out[k] = value(cv.properties_out[t0].pressure)
+                elif blk.deltaP[t0].fixed:
+                    state_args_out[k] = value(cv.properties_in[t0].pressure + blk.deltaP[t0])
+                elif blk.ratioP[t0].fixed:
+                    state_args_out[k] = value(cv.properties_in[t0].pressure * blk.ratioP[t0])
+                else:
+                    # Not obvious what to do, use inlet state
+                    state_args_out[k] = value(cv.properties_in[t0].pressure)
+            elif k not in state_args_out:
+                # use the inlet state as a guess for the outlet state
+                if state_dict[k].is_indexed():
+                    state_args_out[k] = {}
+                    for m in state_dict[k].keys():
+                        state_args_out[k][m] = state_dict[k][m].value
+                else:
+                    state_args_out[k] = state_dict[k].value
+
         cv.properties_out.initialize(
             outlvl=outlvl,
             optarg=optarg,


### PR DESCRIPTION
## Fixes # .


## Summary/Motivation:

 The pressure changer initialization routine does not use the normal control volume initialization routine. I assume this is because it needs to take into account `ratioP` for its outlet pressure guess? See https://github.com/IDAES/idaes-pse/commit/d15028f5a78b13357eedd0e7726ad7413f2add14.

The pressure changer initialization differs in that it sets up guesses for the outlet state before the inlet state is initialized. This means if the values of the inlet state vars were to change during the inlet initialization, the guesses for the outlet state are now incorrect. (The control volume initialization does not have this problem since it estimates the outlet state after inlet state initialization).

This occurs for me since I am setting constraints to "define" the state variables. The inlet guess may well be the default value, and change during initialization to conform to a constraint. Which is fine, except that the same (stale) inlet guess is used when initializing the outlet state block, and it may be fixed there... leading to problems in later stages of initialization.

Instead, the outlet guesses should be created from the inlet state _after_ the inlet state is initialized.

## Changes proposed in this PR:
- Move setting guesses in `state_args_out` to after the `properties_in` initialization
- Load guesses directly from the current inlet properties (taking into account deltaP/ratioP) - instead of using the guesses that were used previously.
- Apply the same logic to both `init_isentropic` and `init_adiabatic`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
