### PR TITLE
Add support for isothermal conditions in control volumes.

### DIFF
--- a/docs/reference_guides/core/control_volume_0d.rst
+++ b/docs/reference_guides/core/control_volume_0d.rst
@@ -282,3 +282,31 @@ A single pressure balance is written for the entire mixture.
 .. math:: 0 = s_{pressure} \times P_{in, t} - s_{pressure} \times P_{out, t} + s_{pressure} \times \Delta P_t + s_{pressure} \times \Delta P_{custom, t}
 
 The :math:`\Delta P_{custom, t}` term allows the user to provide custom terms  which will be added into the pressure balance.
+
+
+Extended 0D Control Volume Class
+--------------------------------
+
+The ExtendedControlVolume0DBlock block builds upon ControlVolume0DBlock by adding some new balance options. It is envisioned that this will
+merge with ControlVolume0DBlock, however to ensure backward compatibility these additions have been kept separate until unit models can
+be updated to restrict (or allow) these new options if necessary. The core functionality is the same as for ControlVolume0DBlock, with the
+addition of one extra energy balance type; isothermal.
+
+.. module:: idaes.core.base.extended_control_volume0d
+
+.. autoclass:: ExtendedControlVolume0DBlock
+    :members:
+
+.. autoclass:: ExtendedControlVolume0DBlockData
+    :members:
+
+add_isothermal_constraint
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A constraint equating temperature at the inlet and outlet of the control volume is written.
+
+**Constraints**
+
+`enthalpy_balances(t)`:
+
+.. math:: P_{in, t} == P_{out, t}

--- a/docs/reference_guides/core/control_volume_0d.rst
+++ b/docs/reference_guides/core/control_volume_0d.rst
@@ -307,6 +307,6 @@ A constraint equating temperature at the inlet and outlet of the control volume 
 
 **Constraints**
 
-`enthalpy_balances(t)`:
+`isothermal_constraint(t)`:
 
 .. math:: T_{in, t} == T_{out, t}

--- a/docs/reference_guides/core/control_volume_1d.rst
+++ b/docs/reference_guides/core/control_volume_1d.rst
@@ -311,3 +311,33 @@ The :math:`\Delta P_{custom, t, x}` term allows the user to provide custom terms
 `pressure_linking_constraint(t, x)`:
 
 This constraint is an internal constraint used to link the pressure terms in the StateBlocks into a single indexed variable. This is required as Pyomo.DAE requires a single indexed variable to create the associated DerivativeVars and their numerical expansions.
+
+
+Extended 1D Control Volume Class
+--------------------------------
+
+The ExtendedControlVolume1DBlock block builds upon ControlVolume1DBlock by adding some new balance options. It is envisioned that this will
+merge with ControlVolume1DBlock, however to ensure backward compatibility these additions have been kept separate until unit models can
+be updated to restrict (or allow) these new options if necessary. The core functionality is the same as for ControlVolume1DBlock, with the
+addition of one extra energy balance type; isothermal.
+
+.. module:: idaes.core.base.extended_control_volume1d
+
+.. autoclass:: ExtendedControlVolume1DBlock
+    :members:
+
+.. autoclass:: ExtendedControlVolume1DBlockData
+    :members:
+
+add_isothermal_constraint
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A constraint equating temperature along the length domain of the control volume is written.
+
+**Constraints**
+
+`enthalpy_balances(t)`:
+
+.. math:: P_{t, x-1} == P_{t, x}
+
+This constraint is skipped at the inlet to the control volume.

--- a/docs/reference_guides/core/control_volume_1d.rst
+++ b/docs/reference_guides/core/control_volume_1d.rst
@@ -336,7 +336,7 @@ A constraint equating temperature along the length domain of the control volume 
 
 **Constraints**
 
-`enthalpy_balances(t)`:
+`isothermal_constraint(t, x)`:
 
 .. math:: T_{t, x-1} == T_{t, x}
 

--- a/idaes/core/__init__.py
+++ b/idaes/core/__init__.py
@@ -33,6 +33,8 @@ from .base.control_volume_base import (
 )
 from .base.control_volume0d import ControlVolume0DBlock
 from .base.control_volume1d import ControlVolume1DBlock, DistributedVars
+from .base.extended_control_volume0d import ExtendedControlVolume0DBlock
+from .base.extended_control_volume1d import ExtendedControlVolume1DBlock
 from .base.phases import (
     Phase,
     LiquidPhase,

--- a/idaes/core/base/control_volume0d.py
+++ b/idaes/core/base/control_volume0d.py
@@ -1352,6 +1352,16 @@ class ControlVolume0DBlockData(ControlVolumeBlockData):
             "add_total_energy_balances.".format(self.name)
         )
 
+    def add_isothermal_constraint(self, *args, **kwargs):
+        """
+        Requires ExtendedControlVolume0D
+        """
+        raise BalanceTypeNotSupportedError(
+            f"{self.name} ControlVolume0D does not support isothermal energy balances. "
+            "Please consider using ExtendedControlVolume0D in your model if you require "
+            "support for isothermal balances."
+        )
+
     def add_total_pressure_balances(self, has_pressure_change=False, custom_term=None):
         """
         This method constructs a set of 0D pressure balances indexed by time.

--- a/idaes/core/base/control_volume1d.py
+++ b/idaes/core/base/control_volume1d.py
@@ -1737,6 +1737,16 @@ argument).""",
             "add_total_energy_balances.".format(self.name)
         )
 
+    def add_isothermal_constraint(self, *args, **kwargs):
+        """
+        Requires ExtendedControlVolume1D
+        """
+        raise BalanceTypeNotSupportedError(
+            f"{self.name} ControlVolume1D does not support isothermal energy balances. "
+            "Please consider using ExtendedControlVolume1D in your model if you require "
+            "support for isothermal balances."
+        )
+
     def add_total_pressure_balances(self, has_pressure_change=False, custom_term=None):
         """
         This method constructs a set of 1D pressure balances indexed by time.

--- a/idaes/core/base/control_volume_base.py
+++ b/idaes/core/base/control_volume_base.py
@@ -71,6 +71,7 @@ class EnergyBalanceType(Enum):
     enthalpyTotal = 2
     energyPhase = 3
     energyTotal = 4
+    isothermal = 5
 
 
 # Enumerate options for momentum balances
@@ -618,6 +619,8 @@ have a config block which derives from CONFIG_Base,
             eb = self.add_total_energy_balances(**kwargs)
         elif balance_type == EnergyBalanceType.energyPhase:
             eb = self.add_phase_energy_balances(**kwargs)
+        elif balance_type == EnergyBalanceType.isothermal:
+            eb = self.add_isothermal_constraint(**kwargs)
         else:
             raise ConfigurationError(
                 "{} invalid balance_type for add_energy_balances."
@@ -841,6 +844,18 @@ have a config block which derives from CONFIG_Base,
             "{} control volume class has not implemented a method for "
             "add_total_energy_balances. Please contact the "
             "developer of the ControlVolume class you are using.".format(self.name)
+        )
+
+    def add_isothermal_constraint(self, *args, **kwargs):
+        """
+        Method for adding an isothermal constraint to the control volume.
+
+        See specific control volume documentation for details.
+        """
+        raise NotImplementedError(
+            f"{self.name} control volume class has not implemented a method for "
+            "add_isothermal_constraint. Please contact the "
+            "developer of the ControlVolume class you are using."
         )
 
     def add_phase_pressure_balances(self, *args, **kwargs):

--- a/idaes/core/base/extended_control_volume0d.py
+++ b/idaes/core/base/extended_control_volume0d.py
@@ -73,7 +73,7 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
                 Method should accept time and phase list as arguments.
 
         Returns:
-            Constraint object representing enthalpy balances
+            Constraint object representing isothermal constraint
         """
         if has_heat_transfer:
             raise ConfigurationError(

--- a/idaes/core/base/extended_control_volume0d.py
+++ b/idaes/core/base/extended_control_volume0d.py
@@ -1,0 +1,109 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2024 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+"""
+0D Control Volume class with support for isothermal energy balance.
+"""
+
+__author__ = "Andrew Lee"
+
+# Import Pyomo libraries
+from pyomo.environ import Constraint, Reals, units as pyunits, Var, value
+
+# Import IDAES cores
+from idaes.core.base.control_volume0d import ControlVolume0DBlockData
+from idaes.core import declare_process_block_class
+from idaes.core.util.exceptions import ConfigurationError
+
+import idaes.logger as idaeslog
+
+_log = idaeslog.getLogger(__name__)
+
+
+@declare_process_block_class(
+    "ExtendedControlVolume0DBlock",
+    doc="""
+    ExtendedControlVolume0DBlock is an extension of the ControlVolume0D
+    block with support for isothermal conditions in place of a formal
+    energy balance.""",
+)
+class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
+    """
+    Extended 0-Dimensional (Non-Discretized) ControlVolume Class
+
+    This class extends the existing ControlVolume0DBlockData class
+    with support for isothermal energy balances.
+    """
+
+    def add_isothermal_constraint(
+        self,
+        has_heat_of_reaction=False,
+        has_heat_transfer=False,
+        has_work_transfer=False,
+        has_enthalpy_transfer=False,
+        custom_term=None,
+    ):
+        """
+        This method constructs an isothermal constraint for the control volume.
+
+        Arguments are supported for compatibility with other forms but must be False
+        or None otherwise an Exception is raised.
+
+        Args:
+            has_heat_of_reaction: whether terms for heat of reaction should
+                be included in enthalpy balance
+            has_heat_transfer: whether terms for heat transfer should be
+                included in enthalpy balances
+            has_work_transfer: whether terms for work transfer should be
+                included in enthalpy balances
+            has_enthalpy_transfer: whether terms for enthalpy transfer due to
+                mass transfer should be included in enthalpy balance. This
+                should generally be the same as the has_mass_transfer
+                argument in the material balance methods
+            custom_term: a Python method which returns Pyomo expressions representing
+                custom terms to be included in enthalpy balances.
+                Method should accept time and phase list as arguments.
+
+        Returns:
+            Constraint object representing enthalpy balances
+        """
+        if has_heat_transfer:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option requires that has_heat_transfer is False. "
+                "If you are trying to solve for heat duty to achieve isothermal operation, please use "
+                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+            )
+        if has_work_transfer:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option requires that has_work_transfer is False. "
+                "If you are trying to solve for work under isothermal operation, please use "
+                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+            )
+        if has_enthalpy_transfer:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option does not support enthalpy transfer. "
+            )
+        if has_heat_of_reaction:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option requires that has_heat_of_reaction is False. "
+                "If you are trying to solve for heat duty to achieve isothermal operation, please use "
+                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+            )
+        if custom_term is not None:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option does not support custom terms. "
+            )
+
+        # Add isothermal constraint
+        @self.Constraint(self.flowsheet().time, doc="Energy balances")
+        def enthalpy_balances(b, t):
+            return b.properties_in[t].temperature == b.properties_out[t].temperature

--- a/idaes/core/base/extended_control_volume0d.py
+++ b/idaes/core/base/extended_control_volume0d.py
@@ -77,13 +77,13 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
             raise ConfigurationError(
                 f"{self.name}: isothermal energy balance option requires that has_heat_transfer is False. "
                 "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+                "a full energy balance and add a constraint to equate inlet and outlet temperatures."
             )
         if has_work_transfer:
             raise ConfigurationError(
                 f"{self.name}: isothermal energy balance option requires that has_work_transfer is False. "
                 "If you are trying to solve for work under isothermal operation, please use "
-                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+                "a full energy balance and add a constraint to equate inlet and outlet temperatures."
             )
         if has_enthalpy_transfer:
             raise ConfigurationError(
@@ -93,7 +93,7 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
             raise ConfigurationError(
                 f"{self.name}: isothermal energy balance option requires that has_heat_of_reaction is False. "
                 "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+                "a full energy balance and add a constraint to equate inlet and outlet temperatures."
             )
         if custom_term is not None:
             raise ConfigurationError(

--- a/idaes/core/base/extended_control_volume0d.py
+++ b/idaes/core/base/extended_control_volume0d.py
@@ -16,9 +16,6 @@
 
 __author__ = "Andrew Lee"
 
-# Import Pyomo libraries
-from pyomo.environ import Constraint, Reals, units as pyunits, Var, value
-
 # Import IDAES cores
 from idaes.core.base.control_volume0d import ControlVolume0DBlockData
 from idaes.core import declare_process_block_class

--- a/idaes/core/base/extended_control_volume0d.py
+++ b/idaes/core/base/extended_control_volume0d.py
@@ -45,11 +45,11 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
 
     def add_isothermal_constraint(
         self,
-        has_heat_of_reaction: bool =False,
-        has_heat_transfer: bool =False,
-        has_work_transfer: bool =False,
-        has_enthalpy_transfer: bool =False,
-        custom_term: Expression =None,
+        has_heat_of_reaction: bool = False,
+        has_heat_transfer: bool = False,
+        has_work_transfer: bool = False,
+        has_enthalpy_transfer: bool = False,
+        custom_term: Expression = None,
     ) -> Constraint:
         """
         This method constructs an isothermal constraint for the control volume.
@@ -103,7 +103,9 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
             )
 
         # Add isothermal constraint
-        @self.Constraint(self.flowsheet().time, doc="Isothermal constraint - replaces energy balance")
+        @self.Constraint(
+            self.flowsheet().time, doc="Isothermal constraint - replaces energy balance"
+        )
         def isothermal_constraint(b, t):
             return b.properties_in[t].temperature == b.properties_out[t].temperature
 

--- a/idaes/core/base/extended_control_volume0d.py
+++ b/idaes/core/base/extended_control_volume0d.py
@@ -90,7 +90,7 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
             )
         if has_enthalpy_transfer:
             raise ConfigurationError(
-                f"{self.name}: isothermal energy balance option does not support enthalpy transfer. "
+                f"{self.name}: isothermal energy balance option does not support enthalpy transfer."
             )
         if has_heat_of_reaction:
             raise ConfigurationError(
@@ -100,7 +100,7 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
             )
         if custom_term is not None:
             raise ConfigurationError(
-                f"{self.name}: isothermal energy balance option does not support custom terms. "
+                f"{self.name}: isothermal energy balance option does not support custom terms."
             )
 
         # Add isothermal constraint

--- a/idaes/core/base/extended_control_volume0d.py
+++ b/idaes/core/base/extended_control_volume0d.py
@@ -16,6 +16,8 @@
 
 __author__ = "Andrew Lee"
 
+from pyomo.environ import Constraint, Expression
+
 # Import IDAES cores
 from idaes.core.base.control_volume0d import ControlVolume0DBlockData
 from idaes.core import declare_process_block_class
@@ -43,12 +45,12 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
 
     def add_isothermal_constraint(
         self,
-        has_heat_of_reaction=False,
-        has_heat_transfer=False,
-        has_work_transfer=False,
-        has_enthalpy_transfer=False,
-        custom_term=None,
-    ):
+        has_heat_of_reaction: bool =False,
+        has_heat_transfer: bool =False,
+        has_work_transfer: bool =False,
+        has_enthalpy_transfer: bool =False,
+        custom_term: Expression =None,
+    ) -> Constraint:
         """
         This method constructs an isothermal constraint for the control volume.
 
@@ -101,6 +103,8 @@ class ExtendedControlVolume0DBlockData(ControlVolume0DBlockData):
             )
 
         # Add isothermal constraint
-        @self.Constraint(self.flowsheet().time, doc="Energy balances")
-        def enthalpy_balances(b, t):
+        @self.Constraint(self.flowsheet().time, doc="Isothermal constraint - replaces energy balance")
+        def isothermal_constraint(b, t):
             return b.properties_in[t].temperature == b.properties_out[t].temperature
+
+        return self.isothermal_constraint

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -48,11 +48,11 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
 
     def add_isothermal_constraint(
         self,
-        has_heat_of_reaction: bool =False,
-        has_heat_transfer: bool =False,
-        has_work_transfer: bool =False,
-        has_enthalpy_transfer: bool =False,
-        custom_term: Expression =None,
+        has_heat_of_reaction: bool = False,
+        has_heat_transfer: bool = False,
+        has_work_transfer: bool = False,
+        has_enthalpy_transfer: bool = False,
+        custom_term: Expression = None,
     ) -> None:
         """
         This method constructs an isothermal constraint for the control volume.
@@ -107,7 +107,9 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
 
         # Add isothermal constraint
         @self.Constraint(
-            self.flowsheet().time, self.length_domain, doc="Isothermal constraint - replaces energy balances"
+            self.flowsheet().time,
+            self.length_domain,
+            doc="Isothermal constraint - replaces energy balances",
         )
         def isothermal_constraint(b, t, x):
             if x == b.length_domain.first():

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -74,7 +74,7 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
                 Method should accept time and phase list as arguments.
 
         Returns:
-            Constraint object representing enthalpy balances
+            Constraint object representing isothermal constraints
         """
         if has_heat_transfer:
             raise ConfigurationError(

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -17,7 +17,7 @@
 __author__ = "Andrew Lee"
 
 # Import Pyomo libraries
-from pyomo.environ import Constraint, Reals, units as pyunits, Var, value
+from pyomo.environ import Constraint
 
 # Import IDAES cores
 from idaes.core.base.control_volume1d import ControlVolume1DBlockData
@@ -104,7 +104,9 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
             )
 
         # Add isothermal constraint
-        @self.Constraint(self.flowsheet().time, self.length_domain, doc="Energy balances")
+        @self.Constraint(
+            self.flowsheet().time, self.length_domain, doc="Energy balances"
+        )
         def enthalpy_balances(b, t, x):
             if (
                 b.config.transformation_scheme != "FORWARD"
@@ -114,5 +116,8 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
                 and x == b.length_domain.last()
             ):
                 return Constraint.Skip
-            else:
-                return b.properties[t, b.length_domain.prev(x)].temperature == b.properties[t, x].temperature
+
+            return (
+                b.properties[t, b.length_domain.prev(x)].temperature
+                == b.properties[t, x].temperature
+            )

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -108,13 +108,7 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
             self.flowsheet().time, self.length_domain, doc="Energy balances"
         )
         def enthalpy_balances(b, t, x):
-            if (
-                b.config.transformation_scheme != "FORWARD"
-                and x == b.length_domain.first()
-            ) or (
-                b.config.transformation_scheme == "FORWARD"
-                and x == b.length_domain.last()
-            ):
+            if x == b.length_domain.first():
                 return Constraint.Skip
 
             return (

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -16,10 +16,8 @@
 
 __author__ = "Andrew Lee"
 
-from pyomo.environ import Constraint, Expression
-
 # Import Pyomo libraries
-from pyomo.environ import Constraint
+from pyomo.environ import Constraint, Expression
 
 # Import IDAES cores
 from idaes.core.base.control_volume1d import ControlVolume1DBlockData

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -1,0 +1,118 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2024 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+"""
+1D Control Volume class with support for isothermal energy balance.
+"""
+
+__author__ = "Andrew Lee"
+
+# Import Pyomo libraries
+from pyomo.environ import Constraint, Reals, units as pyunits, Var, value
+
+# Import IDAES cores
+from idaes.core.base.control_volume1d import ControlVolume1DBlockData
+from idaes.core import declare_process_block_class
+from idaes.core.util.exceptions import ConfigurationError
+
+import idaes.logger as idaeslog
+
+_log = idaeslog.getLogger(__name__)
+
+
+@declare_process_block_class(
+    "ExtendedControlVolume1DBlock",
+    doc="""
+    ExtendedControlVolume1DBlock is an extension of the ControlVolume1D
+    block with support for isothermal conditions in place of a formal
+    energy balance.""",
+)
+class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
+    """
+    Extended 1-Dimensional ControlVolume Class
+
+    This class extends the existing ControlVolume1DBlockData class
+    with support for isothermal energy balances.
+    """
+
+    def add_isothermal_constraint(
+        self,
+        has_heat_of_reaction=False,
+        has_heat_transfer=False,
+        has_work_transfer=False,
+        has_enthalpy_transfer=False,
+        custom_term=None,
+    ):
+        """
+        This method constructs an isothermal constraint for the control volume.
+
+        Arguments are supported for compatibility with other forms but must be False
+        or None otherwise an Exception is raised.
+
+        Args:
+            has_heat_of_reaction: whether terms for heat of reaction should
+                be included in enthalpy balance
+            has_heat_transfer: whether terms for heat transfer should be
+                included in enthalpy balances
+            has_work_transfer: whether terms for work transfer should be
+                included in enthalpy balances
+            has_enthalpy_transfer: whether terms for enthalpy transfer due to
+                mass transfer should be included in enthalpy balance. This
+                should generally be the same as the has_mass_transfer
+                argument in the material balance methods
+            custom_term: a Python method which returns Pyomo expressions representing
+                custom terms to be included in enthalpy balances.
+                Method should accept time and phase list as arguments.
+
+        Returns:
+            Constraint object representing enthalpy balances
+        """
+        if has_heat_transfer:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option requires that has_heat_transfer is False. "
+                "If you are trying to solve for heat duty to achieve isothermal operation, please use "
+                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+            )
+        if has_work_transfer:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option requires that has_work_transfer is False. "
+                "If you are trying to solve for work under isothermal operation, please use "
+                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+            )
+        if has_enthalpy_transfer:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option does not support enthalpy transfer. "
+            )
+        if has_heat_of_reaction:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option requires that has_heat_of_reaction is False. "
+                "If you are trying to solve for heat duty to achieve isothermal operation, please use "
+                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+            )
+        if custom_term is not None:
+            raise ConfigurationError(
+                f"{self.name}: isothermal energy balance option does not support custom terms. "
+            )
+
+        # Add isothermal constraint
+        @self.Constraint(self.flowsheet().time, doc="Energy balances")
+        def enthalpy_balances(b, t, x):
+            if (
+                b.config.transformation_scheme != "FORWARD"
+                and x == b.length_domain.first()
+            ) or (
+                b.config.transformation_scheme == "FORWARD"
+                and x == b.length_domain.last()
+            ):
+                return Constraint.Skip
+            else:
+                return b.properties[t, b.length_domain.prev(x)].temperature == b.properties[t, x].temperature

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -16,6 +16,8 @@
 
 __author__ = "Andrew Lee"
 
+from pyomo.environ import Constraint, Expression
+
 # Import Pyomo libraries
 from pyomo.environ import Constraint
 
@@ -46,12 +48,12 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
 
     def add_isothermal_constraint(
         self,
-        has_heat_of_reaction=False,
-        has_heat_transfer=False,
-        has_work_transfer=False,
-        has_enthalpy_transfer=False,
-        custom_term=None,
-    ):
+        has_heat_of_reaction: bool =False,
+        has_heat_transfer: bool =False,
+        has_work_transfer: bool =False,
+        has_enthalpy_transfer: bool =False,
+        custom_term: Expression =None,
+    ) -> None:
         """
         This method constructs an isothermal constraint for the control volume.
 
@@ -105,9 +107,9 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
 
         # Add isothermal constraint
         @self.Constraint(
-            self.flowsheet().time, self.length_domain, doc="Energy balances"
+            self.flowsheet().time, self.length_domain, doc="Isothermal constraint - replaces energy balances"
         )
-        def enthalpy_balances(b, t, x):
+        def isothermal_constraint(b, t, x):
             if x == b.length_domain.first():
                 return Constraint.Skip
 
@@ -115,3 +117,5 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
                 b.properties[t, b.length_domain.prev(x)].temperature
                 == b.properties[t, x].temperature
             )
+
+        return self.isothermal_constraint

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -104,7 +104,7 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
             )
 
         # Add isothermal constraint
-        @self.Constraint(self.flowsheet().time, doc="Energy balances")
+        @self.Constraint(self.flowsheet().time, self.length_domain, doc="Energy balances")
         def enthalpy_balances(b, t, x):
             if (
                 b.config.transformation_scheme != "FORWARD"

--- a/idaes/core/base/extended_control_volume1d.py
+++ b/idaes/core/base/extended_control_volume1d.py
@@ -80,13 +80,13 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
             raise ConfigurationError(
                 f"{self.name}: isothermal energy balance option requires that has_heat_transfer is False. "
                 "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+                "a full energy balance and add a constraint to equate inlet and outlet temperatures."
             )
         if has_work_transfer:
             raise ConfigurationError(
                 f"{self.name}: isothermal energy balance option requires that has_work_transfer is False. "
                 "If you are trying to solve for work under isothermal operation, please use "
-                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+                "a full energy balance and add a constraint to equate inlet and outlet temperatures."
             )
         if has_enthalpy_transfer:
             raise ConfigurationError(
@@ -96,7 +96,7 @@ class ExtendedControlVolume1DBlockData(ControlVolume1DBlockData):
             raise ConfigurationError(
                 f"{self.name}: isothermal energy balance option requires that has_heat_of_reaction is False. "
                 "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-                "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+                "a full energy balance and add a constraint to equate inlet and outlet temperatures."
             )
         if custom_term is not None:
             raise ConfigurationError(

--- a/idaes/core/base/tests/test_control_volume_0d.py
+++ b/idaes/core/base/tests/test_control_volume_0d.py
@@ -2285,14 +2285,10 @@ def test_add_isothermal_energy_balances():
     m = ConcreteModel()
     m.fs = Flowsheet(dynamic=False)
     m.fs.pp = PhysicalParameterTestBlock()
-    m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
-    m.fs.pp.del_component(m.fs.pp.phase_equilibrium_idx)
 
-    m.fs.cv = ControlVolume0DBlock(property_package=m.fs.pp, reaction_package=m.fs.rp)
+    m.fs.cv = ControlVolume0DBlock(property_package=m.fs.pp)
 
-    m.fs.cv.add_geometry()
     m.fs.cv.add_state_blocks(has_phase_equilibrium=True)
-    m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
     with pytest.raises(BalanceTypeNotSupportedError):
         m.fs.cv.add_isothermal_constraint()

--- a/idaes/core/base/tests/test_control_volume_1d.py
+++ b/idaes/core/base/tests/test_control_volume_1d.py
@@ -3442,6 +3442,30 @@ def test_add_total_energy_balances():
         m.fs.cv.add_total_energy_balances()
 
 
+@pytest.mark.unit
+def test_add_isothermal_energy_balances():
+    m = ConcreteModel()
+    m.fs = Flowsheet(dynamic=False)
+    m.fs.pp = PhysicalParameterTestBlock()
+    m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
+    m.fs.pp.del_component(m.fs.pp.phase_equilibrium_idx)
+
+    m.fs.cv = ControlVolume1DBlock(
+        property_package=m.fs.pp,
+        reaction_package=m.fs.rp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
+
+    m.fs.cv.add_geometry()
+    m.fs.cv.add_state_blocks(has_phase_equilibrium=True)
+    m.fs.cv.add_reaction_blocks(has_equilibrium=False)
+
+    with pytest.raises(BalanceTypeNotSupportedError):
+        m.fs.cv.add_isothermal_constraint()
+
+
 # -----------------------------------------------------------------------------
 # Test add total pressure balances
 @pytest.mark.unit

--- a/idaes/core/base/tests/test_control_volume_1d.py
+++ b/idaes/core/base/tests/test_control_volume_1d.py
@@ -3447,12 +3447,9 @@ def test_add_isothermal_energy_balances():
     m = ConcreteModel()
     m.fs = Flowsheet(dynamic=False)
     m.fs.pp = PhysicalParameterTestBlock()
-    m.fs.rp = ReactionParameterTestBlock(property_package=m.fs.pp)
-    m.fs.pp.del_component(m.fs.pp.phase_equilibrium_idx)
 
     m.fs.cv = ControlVolume1DBlock(
         property_package=m.fs.pp,
-        reaction_package=m.fs.rp,
         transformation_method="dae.finite_difference",
         transformation_scheme="BACKWARD",
         finite_elements=10,
@@ -3460,7 +3457,6 @@ def test_add_isothermal_energy_balances():
 
     m.fs.cv.add_geometry()
     m.fs.cv.add_state_blocks(has_phase_equilibrium=True)
-    m.fs.cv.add_reaction_blocks(has_equilibrium=False)
 
     with pytest.raises(BalanceTypeNotSupportedError):
         m.fs.cv.add_isothermal_constraint()

--- a/idaes/core/base/tests/test_control_volume_base.py
+++ b/idaes/core/base/tests/test_control_volume_base.py
@@ -55,7 +55,7 @@ def test_material_balance_type():
 
 @pytest.mark.unit
 def test_energy_balance_type():
-    assert len(EnergyBalanceType) == 6
+    assert len(EnergyBalanceType) == 7
 
     # Test that error is raised when given non-member
     with pytest.raises(AttributeError):

--- a/idaes/core/base/tests/test_extended_control_volume_0d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_0d.py
@@ -51,11 +51,12 @@ def test_add_isothermal_constraint():
     m.fs.cv.add_geometry()
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
 
-    m.fs.cv.add_isothermal_constraint()
+    cons = m.fs.cv.add_isothermal_constraint()
 
-    assert isinstance(m.fs.cv.enthalpy_balances, Constraint)
-    assert len(m.fs.cv.enthalpy_balances) == 1
-    assert str(m.fs.cv.enthalpy_balances[0].expr) == str(
+    assert cons is m.fs.cv.isothermal_constraint
+    assert isinstance(m.fs.cv.isothermal_constraint, Constraint)
+    assert len(m.fs.cv.isothermal_constraint) == 1
+    assert str(m.fs.cv.isothermal_constraint[0].expr) == str(
         m.fs.cv.properties_in[0].temperature == m.fs.cv.properties_out[0].temperature
     )
 
@@ -75,10 +76,10 @@ def test_add_isothermal_constraint_dynamic():
 
     m.fs.cv.add_isothermal_constraint()
 
-    assert isinstance(m.fs.cv.enthalpy_balances, Constraint)
-    assert len(m.fs.cv.enthalpy_balances) == 4
+    assert isinstance(m.fs.cv.isothermal_constraint, Constraint)
+    assert len(m.fs.cv.isothermal_constraint) == 4
     for t in m.fs.time:
-        assert str(m.fs.cv.enthalpy_balances[t].expr) == str(
+        assert str(m.fs.cv.isothermal_constraint[t].expr) == str(
             m.fs.cv.properties_in[t].temperature
             == m.fs.cv.properties_out[t].temperature
         )

--- a/idaes/core/base/tests/test_extended_control_volume_0d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_0d.py
@@ -79,7 +79,8 @@ def test_add_isothermal_constraint_dynamic():
     assert len(m.fs.cv.enthalpy_balances) == 4
     for t in m.fs.time:
         assert str(m.fs.cv.enthalpy_balances[t].expr) == str(
-            m.fs.cv.properties_in[t].temperature == m.fs.cv.properties_out[t].temperature
+            m.fs.cv.properties_in[t].temperature
+            == m.fs.cv.properties_out[t].temperature
         )
 
     assert_units_consistent(m.fs.cv)
@@ -97,7 +98,7 @@ def test_add_isothermal_constraint_heat_transfer():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_heat_transfer is False. "
         "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_heat_transfer=True)
 
@@ -114,7 +115,7 @@ def test_add_isothermal_constraint_work_transfer():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_work_transfer is False. "
         "If you are trying to solve for work under isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_work_transfer=True)
 
@@ -129,7 +130,7 @@ def test_add_isothermal_constraint_enthalpy_transfer():
 
     with pytest.raises(
         ConfigurationError,
-        match="fs.cv: isothermal energy balance option does not support enthalpy transfer."
+        match="fs.cv: isothermal energy balance option does not support enthalpy transfer.",
     ):
         m.fs.cv.add_isothermal_constraint(has_enthalpy_transfer=True)
 
@@ -146,7 +147,7 @@ def test_add_isothermal_constraint_heat_of_rxn():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_heat_of_reaction is False. "
         "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_heat_of_reaction=True)
 
@@ -161,6 +162,6 @@ def test_add_isothermal_constraint_custom_term():
 
     with pytest.raises(
         ConfigurationError,
-        match="fs.cv: isothermal energy balance option does not support custom terms."
+        match="fs.cv: isothermal energy balance option does not support custom terms.",
     ):
         m.fs.cv.add_isothermal_constraint(custom_term="foo")

--- a/idaes/core/base/tests/test_extended_control_volume_0d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_0d.py
@@ -11,7 +11,7 @@
 # for full copyright and license information.
 #################################################################################
 """
-Tests for ControlVolumeBlockData.
+Tests for ExtendedControlVolumeBlockData.
 
 Author: Andrew Lee
 """
@@ -20,7 +20,7 @@ from pyomo.environ import ConcreteModel, Constraint, Expression, Set, units, Var
 from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent
 from pyomo.common.config import ConfigBlock
 from idaes.core import (
-    ControlVolume0DBlock,
+    ExtendedControlVolume0DBlock as ControlVolume0DBlock,
     ControlVolumeBlockData,
     FlowsheetBlockData,
     declare_process_block_class,

--- a/idaes/core/base/tests/test_extended_control_volume_0d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_0d.py
@@ -98,7 +98,7 @@ def test_add_isothermal_constraint_heat_transfer():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_heat_transfer is False. "
         "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
+        "a full energy balance and add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_heat_transfer=True)
 
@@ -115,7 +115,7 @@ def test_add_isothermal_constraint_work_transfer():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_work_transfer is False. "
         "If you are trying to solve for work under isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
+        "a full energy balance and add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_work_transfer=True)
 
@@ -147,7 +147,7 @@ def test_add_isothermal_constraint_heat_of_rxn():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_heat_of_reaction is False. "
         "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
+        "a full energy balance and add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_heat_of_reaction=True)
 

--- a/idaes/core/base/tests/test_extended_control_volume_1d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_1d.py
@@ -114,7 +114,7 @@ def test_add_isothermal_constraint_heat_transfer():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_heat_transfer is False. "
         "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_heat_transfer=True)
 
@@ -136,7 +136,7 @@ def test_add_isothermal_constraint_work_transfer():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_work_transfer is False. "
         "If you are trying to solve for work under isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_work_transfer=True)
 
@@ -156,7 +156,7 @@ def test_add_isothermal_constraint_enthalpy_transfer():
 
     with pytest.raises(
         ConfigurationError,
-        match="fs.cv: isothermal energy balance option does not support enthalpy transfer."
+        match="fs.cv: isothermal energy balance option does not support enthalpy transfer.",
     ):
         m.fs.cv.add_isothermal_constraint(has_enthalpy_transfer=True)
 
@@ -178,7 +178,7 @@ def test_add_isothermal_constraint_heat_of_rxn():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_heat_of_reaction is False. "
         "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures."
+        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_heat_of_reaction=True)
 
@@ -198,6 +198,6 @@ def test_add_isothermal_constraint_custom_term():
 
     with pytest.raises(
         ConfigurationError,
-        match="fs.cv: isothermal energy balance option does not support custom terms."
+        match="fs.cv: isothermal energy balance option does not support custom terms.",
     ):
         m.fs.cv.add_isothermal_constraint(custom_term="foo")

--- a/idaes/core/base/tests/test_extended_control_volume_1d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_1d.py
@@ -60,17 +60,21 @@ def test_add_isothermal_constraint():
     m.fs.cv.apply_transformation()
 
     assert isinstance(m.fs.cv.enthalpy_balances, Constraint)
-    assert len(m.fs.cv.enthalpy_balances) == (5-1)*1  # x==0 so (5-1) spatial points and 1 time point
+    assert (
+        len(m.fs.cv.enthalpy_balances) == (5 - 1) * 1
+    )  # x==0 so (5-1) spatial points and 1 time point
 
     assert (0, 0) not in m.fs.cv.enthalpy_balances
     assert str(m.fs.cv.enthalpy_balances[0, 0.25].expr) == str(
         m.fs.cv.properties[0, 0].temperature == m.fs.cv.properties[0, 0.25].temperature
     )
     assert str(m.fs.cv.enthalpy_balances[0, 0.5].expr) == str(
-        m.fs.cv.properties[0, 0.25].temperature == m.fs.cv.properties[0, 0.5].temperature
+        m.fs.cv.properties[0, 0.25].temperature
+        == m.fs.cv.properties[0, 0.5].temperature
     )
     assert str(m.fs.cv.enthalpy_balances[0, 0.75].expr) == str(
-        m.fs.cv.properties[0, 0.5].temperature == m.fs.cv.properties[0, 0.75].temperature
+        m.fs.cv.properties[0, 0.5].temperature
+        == m.fs.cv.properties[0, 0.75].temperature
     )
     assert str(m.fs.cv.enthalpy_balances[0, 1].expr) == str(
         m.fs.cv.properties[0, 0].temperature == m.fs.cv.properties[0, 1].temperature
@@ -101,18 +105,23 @@ def test_add_isothermal_constraint_dynamic():
     m.fs.cv.apply_transformation()
 
     assert isinstance(m.fs.cv.enthalpy_balances, Constraint)
-    assert len(m.fs.cv.enthalpy_balances) == (5-1)*4  # x==0 so (5-1) spatial points and 4 time points
+    assert (
+        len(m.fs.cv.enthalpy_balances) == (5 - 1) * 4
+    )  # x==0 so (5-1) spatial points and 4 time points
 
     for t in m.fs.time:
         assert (t, 0) not in m.fs.cv.enthalpy_balances
         assert str(m.fs.cv.enthalpy_balances[t, 0.25].expr) == str(
-            m.fs.cv.properties[t, 0].temperature == m.fs.cv.properties[t, 0.25].temperature
+            m.fs.cv.properties[t, 0].temperature
+            == m.fs.cv.properties[t, 0.25].temperature
         )
         assert str(m.fs.cv.enthalpy_balances[t, 0.5].expr) == str(
-            m.fs.cv.properties[t, 0.25].temperature == m.fs.cv.properties[t, 0.5].temperature
+            m.fs.cv.properties[t, 0.25].temperature
+            == m.fs.cv.properties[t, 0.5].temperature
         )
         assert str(m.fs.cv.enthalpy_balances[t, 0.75].expr) == str(
-            m.fs.cv.properties[t, 0.5].temperature == m.fs.cv.properties[t, 0.75].temperature
+            m.fs.cv.properties[t, 0.5].temperature
+            == m.fs.cv.properties[t, 0.75].temperature
         )
         assert str(m.fs.cv.enthalpy_balances[t, 1].expr) == str(
             m.fs.cv.properties[t, 0].temperature == m.fs.cv.properties[t, 1].temperature

--- a/idaes/core/base/tests/test_extended_control_volume_1d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_1d.py
@@ -56,27 +56,29 @@ def test_add_isothermal_constraint():
 
     m.fs.cv.add_geometry()
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
-    m.fs.cv.add_isothermal_constraint()
+    cons = m.fs.cv.add_isothermal_constraint()
     m.fs.cv.apply_transformation()
 
-    assert isinstance(m.fs.cv.enthalpy_balances, Constraint)
+    assert cons is m.fs.cv.isothermal_constraint
+
+    assert isinstance(m.fs.cv.isothermal_constraint, Constraint)
     assert (
-        len(m.fs.cv.enthalpy_balances) == (5 - 1) * 1
+        len(m.fs.cv.isothermal_constraint) == (5 - 1) * 1
     )  # x==0 so (5-1) spatial points and 1 time point
 
-    assert (0, 0) not in m.fs.cv.enthalpy_balances
-    assert str(m.fs.cv.enthalpy_balances[0, 0.25].expr) == str(
+    assert (0, 0) not in m.fs.cv.isothermal_constraint
+    assert str(m.fs.cv.isothermal_constraint[0, 0.25].expr) == str(
         m.fs.cv.properties[0, 0].temperature == m.fs.cv.properties[0, 0.25].temperature
     )
-    assert str(m.fs.cv.enthalpy_balances[0, 0.5].expr) == str(
+    assert str(m.fs.cv.isothermal_constraint[0, 0.5].expr) == str(
         m.fs.cv.properties[0, 0.25].temperature
         == m.fs.cv.properties[0, 0.5].temperature
     )
-    assert str(m.fs.cv.enthalpy_balances[0, 0.75].expr) == str(
+    assert str(m.fs.cv.isothermal_constraint[0, 0.75].expr) == str(
         m.fs.cv.properties[0, 0.5].temperature
         == m.fs.cv.properties[0, 0.75].temperature
     )
-    assert str(m.fs.cv.enthalpy_balances[0, 1].expr) == str(
+    assert str(m.fs.cv.isothermal_constraint[0, 1].expr) == str(
         m.fs.cv.properties[0, 0].temperature == m.fs.cv.properties[0, 1].temperature
     )
 
@@ -104,26 +106,26 @@ def test_add_isothermal_constraint_dynamic():
     m.fs.cv.add_isothermal_constraint()
     m.fs.cv.apply_transformation()
 
-    assert isinstance(m.fs.cv.enthalpy_balances, Constraint)
+    assert isinstance(m.fs.cv.isothermal_constraint, Constraint)
     assert (
-        len(m.fs.cv.enthalpy_balances) == (5 - 1) * 4
+        len(m.fs.cv.isothermal_constraint) == (5 - 1) * 4
     )  # x==0 so (5-1) spatial points and 4 time points
 
     for t in m.fs.time:
-        assert (t, 0) not in m.fs.cv.enthalpy_balances
-        assert str(m.fs.cv.enthalpy_balances[t, 0.25].expr) == str(
+        assert (t, 0) not in m.fs.cv.isothermal_constraint
+        assert str(m.fs.cv.isothermal_constraint[t, 0.25].expr) == str(
             m.fs.cv.properties[t, 0].temperature
             == m.fs.cv.properties[t, 0.25].temperature
         )
-        assert str(m.fs.cv.enthalpy_balances[t, 0.5].expr) == str(
+        assert str(m.fs.cv.isothermal_constraint[t, 0.5].expr) == str(
             m.fs.cv.properties[t, 0.25].temperature
             == m.fs.cv.properties[t, 0.5].temperature
         )
-        assert str(m.fs.cv.enthalpy_balances[t, 0.75].expr) == str(
+        assert str(m.fs.cv.isothermal_constraint[t, 0.75].expr) == str(
             m.fs.cv.properties[t, 0.5].temperature
             == m.fs.cv.properties[t, 0.75].temperature
         )
-        assert str(m.fs.cv.enthalpy_balances[t, 1].expr) == str(
+        assert str(m.fs.cv.isothermal_constraint[t, 1].expr) == str(
             m.fs.cv.properties[t, 0].temperature == m.fs.cv.properties[t, 1].temperature
         )
 

--- a/idaes/core/base/tests/test_extended_control_volume_1d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_1d.py
@@ -114,7 +114,7 @@ def test_add_isothermal_constraint_heat_transfer():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_heat_transfer is False. "
         "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
+        "a full energy balance and add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_heat_transfer=True)
 
@@ -136,7 +136,7 @@ def test_add_isothermal_constraint_work_transfer():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_work_transfer is False. "
         "If you are trying to solve for work under isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
+        "a full energy balance and add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_work_transfer=True)
 
@@ -178,7 +178,7 @@ def test_add_isothermal_constraint_heat_of_rxn():
         ConfigurationError,
         match="fs.cv: isothermal energy balance option requires that has_heat_of_reaction is False. "
         "If you are trying to solve for heat duty to achieve isothermal operation, please use "
-        "a full energy balance as add a constraint to equate inlet and outlet temperatures.",
+        "a full energy balance and add a constraint to equate inlet and outlet temperatures.",
     ):
         m.fs.cv.add_isothermal_constraint(has_heat_of_reaction=True)
 

--- a/idaes/core/base/tests/test_extended_control_volume_1d.py
+++ b/idaes/core/base/tests/test_extended_control_volume_1d.py
@@ -20,7 +20,7 @@ from pyomo.environ import ConcreteModel, Constraint, units
 from pyomo.util.check_units import assert_units_consistent
 
 from idaes.core import (
-    ExtendedControlVolume0DBlock,
+    ExtendedControlVolume1DBlock,
     FlowsheetBlockData,
     declare_process_block_class,
 )
@@ -46,7 +46,12 @@ def test_add_isothermal_constraint():
     m.fs = Flowsheet(dynamic=False)
     m.fs.pp = PhysicalParameterTestBlock()
 
-    m.fs.cv = ExtendedControlVolume0DBlock(property_package=m.fs.pp)
+    m.fs.cv = ExtendedControlVolume1DBlock(
+        property_package=m.fs.pp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
 
     m.fs.cv.add_geometry()
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
@@ -54,10 +59,11 @@ def test_add_isothermal_constraint():
     m.fs.cv.add_isothermal_constraint()
 
     assert isinstance(m.fs.cv.enthalpy_balances, Constraint)
-    assert len(m.fs.cv.enthalpy_balances) == 1
-    assert str(m.fs.cv.enthalpy_balances[0].expr) == str(
-        m.fs.cv.properties_in[0].temperature == m.fs.cv.properties_out[0].temperature
+    assert len(m.fs.cv.enthalpy_balances) == 1  # x==0 is skipped
+    assert str(m.fs.cv.enthalpy_balances[0, 1].expr) == str(
+        m.fs.cv.properties[0, 0].temperature == m.fs.cv.properties[0, 1].temperature
     )
+    assert (0, 0) not in m.fs.cv.enthalpy_balances
 
     assert_units_consistent(m.fs.cv)
 
@@ -68,7 +74,12 @@ def test_add_isothermal_constraint_dynamic():
     m.fs = Flowsheet(dynamic=True, time_set=[0, 1, 2, 3], time_units=units.s)
     m.fs.pp = PhysicalParameterTestBlock()
 
-    m.fs.cv = ExtendedControlVolume0DBlock(property_package=m.fs.pp)
+    m.fs.cv = ExtendedControlVolume1DBlock(
+        property_package=m.fs.pp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
 
     m.fs.cv.add_geometry()
     m.fs.cv.add_state_blocks(has_phase_equilibrium=False)
@@ -76,11 +87,12 @@ def test_add_isothermal_constraint_dynamic():
     m.fs.cv.add_isothermal_constraint()
 
     assert isinstance(m.fs.cv.enthalpy_balances, Constraint)
-    assert len(m.fs.cv.enthalpy_balances) == 4
+    assert len(m.fs.cv.enthalpy_balances) == 4  # x==0 is skipped
     for t in m.fs.time:
-        assert str(m.fs.cv.enthalpy_balances[t].expr) == str(
-            m.fs.cv.properties_in[t].temperature == m.fs.cv.properties_out[t].temperature
+        assert str(m.fs.cv.enthalpy_balances[t, 1].expr) == str(
+            m.fs.cv.properties[t, 0].temperature == m.fs.cv.properties[t, 1].temperature
         )
+        assert (t, 0) not in m.fs.cv.enthalpy_balances
 
     assert_units_consistent(m.fs.cv)
 
@@ -91,7 +103,12 @@ def test_add_isothermal_constraint_heat_transfer():
     m.fs = Flowsheet(dynamic=False)
     m.fs.pp = PhysicalParameterTestBlock()
 
-    m.fs.cv = ExtendedControlVolume0DBlock(property_package=m.fs.pp)
+    m.fs.cv = ExtendedControlVolume1DBlock(
+        property_package=m.fs.pp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
 
     with pytest.raises(
         ConfigurationError,
@@ -108,7 +125,12 @@ def test_add_isothermal_constraint_work_transfer():
     m.fs = Flowsheet(dynamic=False)
     m.fs.pp = PhysicalParameterTestBlock()
 
-    m.fs.cv = ExtendedControlVolume0DBlock(property_package=m.fs.pp)
+    m.fs.cv = ExtendedControlVolume1DBlock(
+        property_package=m.fs.pp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
 
     with pytest.raises(
         ConfigurationError,
@@ -125,7 +147,12 @@ def test_add_isothermal_constraint_enthalpy_transfer():
     m.fs = Flowsheet(dynamic=False)
     m.fs.pp = PhysicalParameterTestBlock()
 
-    m.fs.cv = ExtendedControlVolume0DBlock(property_package=m.fs.pp)
+    m.fs.cv = ExtendedControlVolume1DBlock(
+        property_package=m.fs.pp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
 
     with pytest.raises(
         ConfigurationError,
@@ -140,7 +167,12 @@ def test_add_isothermal_constraint_heat_of_rxn():
     m.fs = Flowsheet(dynamic=False)
     m.fs.pp = PhysicalParameterTestBlock()
 
-    m.fs.cv = ExtendedControlVolume0DBlock(property_package=m.fs.pp)
+    m.fs.cv = ExtendedControlVolume1DBlock(
+        property_package=m.fs.pp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
 
     with pytest.raises(
         ConfigurationError,
@@ -157,7 +189,12 @@ def test_add_isothermal_constraint_custom_term():
     m.fs = Flowsheet(dynamic=False)
     m.fs.pp = PhysicalParameterTestBlock()
 
-    m.fs.cv = ExtendedControlVolume0DBlock(property_package=m.fs.pp)
+    m.fs.cv = ExtendedControlVolume1DBlock(
+        property_package=m.fs.pp,
+        transformation_method="dae.finite_difference",
+        transformation_scheme="BACKWARD",
+        finite_elements=10,
+    )
 
     with pytest.raises(
         ConfigurationError,


### PR DESCRIPTION
## Fixes None


## Summary/Motivation:

WateTAP has a number of cases where they would like to use isothermal conditions in place of an energy balance. Currently, they use a mix-in to support this, but this adds an addition argument that is effectively redundant. Instead, it would be better to have explicit support for isothermal conditions as part of the core ControlVolume classes.

However, isothermal conditions do not make sense for all unit models, and there are a few cases where unit models have effectively implemented their own isothermal conditions (notable PressureChanger). Thus, to avoid potential edge cases in unit models until they can be updated, a new ExtendedControlVolume0D and ExtenededControlVolume1D class have been created as an interim solution. It is envisioned that unit models will gradually be updated to be more explicit about what balance types make sense, at which point the new and old control volumes can be merged.

## Changes proposed in this PR:
- Added new `isothermal` option to `EnergyBalanceType` `Enum`.
- Added `BalanceTypeNotSupported` exceptions to `ControlVolume0D` and `ControlVolume1D` if `isothermal` option is selected, with pointer to the new control volume classes.
- New `ExtendedControlVolume0D` and `ExtendedControlVolume1D` classes with support for isothermal balances.
- Docs and tests.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
