### PR TITLE
Add mapping to use ubuntu2204 build of idaes-ext on Ubuntu 24.04

### DIFF
--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -48,7 +48,7 @@ runs:
         echo '::endgroup::'
 
         echo '::group::Output of test commands for IDAES binaries'
-        PATH="$PATH:$(idaes bin-directory)" ipopt -v
+        PATH="$(idaes bin-directory)" ipopt -v
         echo '::endgroup::'
     - name: Install AMPL SCIP (${{ inputs.ampl-scip-pip-target }})
       if: inputs.ampl-scip-pip-target

--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -48,7 +48,7 @@ runs:
         echo '::endgroup::'
 
         echo '::group::Output of test commands for IDAES binaries'
-        PATH="$(idaes bin-directory)" ipopt -v
+        "$(idaes bin-directory)"/ipopt -v
         echo '::endgroup::'
     - name: Install AMPL SCIP (${{ inputs.ampl-scip-pip-target }})
       if: inputs.ampl-scip-pip-target

--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -47,6 +47,16 @@ runs:
         idaes get-extensions --extra petsc --verbose
         echo '::endgroup::'
 
+        # extra dependencies must be installed on Ubuntu 24.04
+        if [ -f "/etc/os-release" ]; then
+          . /etc/os-release
+          if [ "$ID" = "ubuntu" ] && [ "$VERSION_ID" = "24.04" ]; then
+          echo '::group::Output of "apt install" for required OS packages'
+          sudo apt install libgfortran5 libgomp1 liblapack3 libblas3
+          echo '::endgroup::'
+          fi
+        fi
+
         echo '::group::Output of test commands for IDAES binaries'
         "$(idaes bin-directory)"/ipopt -v
         echo '::endgroup::'

--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -46,6 +46,10 @@ runs:
         echo '::group::Output of "idaes get-extensions" command'
         idaes get-extensions --extra petsc --verbose
         echo '::endgroup::'
+
+        echo '::group::Output of test commands for IDAES binaries'
+        PATH="$PATH:$(idaes bin-directory)" ipopt -v
+        echo '::endgroup::'
     - name: Install AMPL SCIP (${{ inputs.ampl-scip-pip-target }})
       if: inputs.ampl-scip-pip-target
       shell: bash -l {0}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -92,9 +92,15 @@ jobs:
         os:
           - linux
           - win64
+          - ubuntu-22
+          - ubuntu-24
         include:
           - os: linux
             runner-image: ubuntu-20.04
+          - os: ubuntu-22
+            runner-image: ubuntu-22.04
+          - os: ubuntu-24
+            runner-image: ubuntu-22.04
           - os: win64
             runner-image: windows-2022
           - python-version: '3.11'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -90,13 +90,10 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
-          - linux
           - win64
           - ubuntu-22
           - ubuntu-24
         include:
-          - os: linux
-            runner-image: ubuntu-20.04
           - os: ubuntu-22
             runner-image: ubuntu-22.04
           - os: ubuntu-24

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -97,7 +97,7 @@ jobs:
           - os: ubuntu-22
             runner-image: ubuntu-22.04
           - os: ubuntu-24
-            runner-image: ubuntu-22.04
+            runner-image: ubuntu-24.04
           - os: win64
             runner-image: windows-2022
           - python-version: '3.11'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -90,13 +90,10 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
+          - linux
           - win64
-          - ubuntu-22
-          - ubuntu-24
         include:
-          - os: ubuntu-22
-            runner-image: ubuntu-22.04
-          - os: ubuntu-24
+          - os: linux
             runner-image: ubuntu-24.04
           - os: win64
             runner-image: windows-2022
@@ -231,7 +228,7 @@ jobs:
 
   compat:
     name: Compatibility tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Conda environment

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ defaults:
 jobs:
   precheck:
     name: (util) Check if should run
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # the ">-" YAML syntax will result in a single string without terminating newline
     # it is used here to make the relatively complex if clause more readable by adding line breaks
     if: >-
@@ -224,7 +224,7 @@ jobs:
           - linux
         include:
           - os: linux
-            runner-image: ubuntu-20.04
+            runner-image: ubuntu-22.04
           - install-mode: pip-default
             pip-install-target: '.'
           - install-mode: pip-complete

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -141,7 +141,7 @@ jobs:
           - os: ubuntu-22
             runner-image: ubuntu-22.04
           - os: ubuntu-24
-            runner-image: ubuntu-22.04
+            runner-image: ubuntu-24.04
           - os: win64
             runner-image: windows-2022
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -134,11 +134,14 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
-          - linux
           - win64
+          - ubuntu-22
+          - ubuntu-24
         include:
-          - os: linux
-            runner-image: ubuntu-20.04
+          - os: ubuntu-22
+            runner-image: ubuntu-22.04
+          - os: ubuntu-24
+            runner-image: ubuntu-22.04
           - os: win64
             runner-image: windows-2022
     steps:
@@ -172,11 +175,14 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
-          - linux
           - win64
+          - ubuntu-22
+          - ubuntu-24
         include:
-          - os: linux
-            runner-image: ubuntu-20.04
+          - os: ubuntu-22
+            runner-image: ubuntu-22.04
+          - os: ubuntu-24
+            runner-image: ubuntu-22.04
           - os: win64
             runner-image: windows-2022
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ defaults:
 jobs:
   precheck:
     name: (util) Check if should run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # the ">-" YAML syntax will result in a single string without terminating newline
     # it is used here to make the relatively complex if clause more readable by adding line breaks
     if: >-
@@ -134,13 +134,10 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
+          - linux
           - win64
-          - ubuntu-22
-          - ubuntu-24
         include:
-          - os: ubuntu-22
-            runner-image: ubuntu-22.04
-          - os: ubuntu-24
+          - os: linux
             runner-image: ubuntu-24.04
           - os: win64
             runner-image: windows-2022
@@ -175,14 +172,11 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
+          - linux
           - win64
-          - ubuntu-22
-          - ubuntu-24
         include:
-          - os: ubuntu-22
-            runner-image: ubuntu-22.04
-          - os: ubuntu-24
-            runner-image: ubuntu-22.04
+          - os: linux
+            runner-image: ubuntu-24.04
           - os: win64
             runner-image: windows-2022
     steps:
@@ -230,7 +224,7 @@ jobs:
           - linux
         include:
           - os: linux
-            runner-image: ubuntu-22.04
+            runner-image: ubuntu-24.04
           - install-mode: pip-default
             pip-install-target: '.'
           - install-mode: pip-complete

--- a/idaes/config.py
+++ b/idaes/config.py
@@ -70,6 +70,7 @@ binary_distro_map = {
     "xubuntu2004": "ubuntu2004",
     "xubuntu2204": "ubuntu2204",
     "pop22": "ubuntu2204",
+    "ubuntu2404": "ubuntu2204",
 }
 # Machine map
 binary_arch_map = {


### PR DESCRIPTION
## Summary/Motivation:

Try the easiest possible way to resolve #1557 and similar issues before new `idaes-ext` builds are available

## Changes proposed in this PR:
- Add mapping in `idaes/config.py` to use existing ubuntu2204 version if ubuntu2404 is detected
- Add ubuntu22.04 and 24.04 to CI job matrix

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
