### PR TITLE
Temporarily exclude sphinx 8.2.0 to fix doctests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 ### docs
 # Newer sphinx needed for proper type hint support in docstrings
-sphinx>=3.0.0
+sphinx>=3.0.0,!=8.2.0
 sphinxcontrib-napoleon>=0.5.0
 # sphinx-argparse 0.4.0 is the last version to support Python 3.9
 # see https://sphinx-argparse.readthedocs.io/en/latest/changelog.html#id3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 ### docs
 # Newer sphinx needed for proper type hint support in docstrings
-sphinx>=3.0.0,!=8.2.0
+sphinx>=3.0.0
 sphinxcontrib-napoleon>=0.5.0
 # sphinx-argparse 0.4.0 is the last version to support Python 3.9
 # see https://sphinx-argparse.readthedocs.io/en/latest/changelog.html#id3


### PR DESCRIPTION
## Summary/Motivation:
Doctests started failing with the latest Sphinx release. We noticed similar issues in Pyomo that could be traced to Sphinx extensions that don't yet support Sphinx 8.2.0. This PR excludes this version of Sphinx for now to get IDAES tests passing again. I haven't identified which Sphinx extension is the underlying cause of the issue.

## Changes proposed in this PR:
- Exclude Sphinx version 8.2.0

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
