### PR TITLE
Add PDF generation by ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,9 @@ sphinx:
     fail_on_warning: false
     configuration: docs/conf.py
 
+formats:
+  - pdf
+
 python:
     install:
         - requirements: requirements-dev.txt


### PR DESCRIPTION
## Fixes
The lack of PDF version of our docs at RTD

## Summary/Motivation:
This is a test to see if we want to have RTD produce a PDF version of the docs

## Changes proposed in this PR:
- add format: pdf to .readthedocs.yml
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
