### PR TITLE
fix typo

### DIFF
--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -2241,7 +2241,7 @@ class GenericStateBlockData(StateBlockData):
                     iscale.set_scaling_factor(v, sf_rho * sf_x)
 
         if self.is_property_constructed("_energy_density_term"):
-            for k, v in self._enthalpy_flow_term.items():
+            for k, v in self.energy_density_term.items():
                 if iscale.get_scaling_factor(v) is None:
                     sf_rho = iscale.get_scaling_factor(
                         self.dens_mol_phase[k], default=1, warning=True


### PR DESCRIPTION
Fixes
Fixed a typo in the code:
Changed _enthalpy_flow_term → self.energy_density_term

Summary/Motivation
This PR corrects a minor typo in the variable name to maintain consistency and avoid potential errors in calculations.

Changes proposed in this PR:
Renamed _enthalpy_flow_term to self.energy_density_term
Ensured all related references are updated accordingly
Legal Acknowledgement
By contributing to this software project, I agree to the following terms and conditions:

My contributions are submitted under the license terms mentioned in the LICENSE.txt file at the top level of this directory.
I confirm that I have the right to make these contributions and grant the necessary license. If my employer holds any intellectual property rights related to these contributions, I confirm that I have obtained the required permission to make these changes on their behalf.