### PR TITLE
Two quick fixes: units on PH and TS diagrams, documentation for macOS

### DIFF
--- a/docs/tutorials/advanced_install/index.rst
+++ b/docs/tutorials/advanced_install/index.rst
@@ -97,7 +97,7 @@ Now that conda and pip are installed, and you are in the "idaes" conda environme
     idaes get-extensions
 
 .. warning::
-    The IDAES binary extensions are not fully supported on macOS with an Intel processor and are missing solvers with the HSL linear algebra libraries. Complete binary extensions are available for macOS with Apple Silicon (M1+) processors. If you are using macOS (Intel), you can `build the extensions from source <https://github.com/IDAES/idaes-ext>`_ or `compile the COIN-OR solvers with HSL <https://coin-or.github.io/user_introduction.html>_`. Please note, the optimization solvers are more performant (e.g., reliable, faster) with the HSL libraries.
+    The IDAES binary extensions are not fully supported on macOS with an Intel processor and are missing solvers with the HSL linear algebra libraries. Complete binary extensions are available for macOS with Apple Silicon (M1+) processors. If you are using macOS (Intel), you can `build the extensions from source <https://github.com/IDAES/idaes-ext>`_ or `compile the COIN-OR solvers with HSL <https://coin-or.github.io/user_introduction.html>`_. Please note, the optimization solvers are more performant (e.g., reliable, faster) with the HSL libraries.
 
 .. note::
     This ``pip install`` command would override any package within the conda environment,

--- a/docs/tutorials/advanced_install/index.rst
+++ b/docs/tutorials/advanced_install/index.rst
@@ -97,7 +97,7 @@ Now that conda and pip are installed, and you are in the "idaes" conda environme
     idaes get-extensions
 
 .. warning::
-    The IDAES binary extensions are not yet supported on Mac/OSX
+    The IDAES binary extensions are not yet supported on macOS with an Intel processor but are available for macOS with Apple Silicon (M1) processors. If you are using macOS (Intel), you can `build the extensions from source <https://github.com/IDAES/idaes-ext>`_.
 
 .. note::
     This ``pip install`` command would override any package within the conda environment,

--- a/docs/tutorials/advanced_install/index.rst
+++ b/docs/tutorials/advanced_install/index.rst
@@ -97,7 +97,7 @@ Now that conda and pip are installed, and you are in the "idaes" conda environme
     idaes get-extensions
 
 .. warning::
-    The IDAES binary extensions are not yet supported on macOS with an Intel processor, but are available for macOS with Apple Silicon (M1+) processors. If you are using macOS (Intel), you can `build the extensions from source <https://github.com/IDAES/idaes-ext>`_.
+    The IDAES binary extensions are not fully supported on macOS with an Intel processor and are missing solvers with the HSL linear algebra libraries. Complete binary extensions are available for macOS with Apple Silicon (M1+) processors. If you are using macOS (Intel), you can `build the extensions from source <https://github.com/IDAES/idaes-ext>`_ or `compile the COIN-OR solvers with HSL <https://coin-or.github.io/user_introduction.html>_`. Please note, the optimization solvers are more performant (e.g., reliable, faster) with the HSL libraries.
 
 .. note::
     This ``pip install`` command would override any package within the conda environment,

--- a/docs/tutorials/advanced_install/index.rst
+++ b/docs/tutorials/advanced_install/index.rst
@@ -97,7 +97,7 @@ Now that conda and pip are installed, and you are in the "idaes" conda environme
     idaes get-extensions
 
 .. warning::
-    The IDAES binary extensions are not yet supported on macOS with an Intel processor but are available for macOS with Apple Silicon (M1) processors. If you are using macOS (Intel), you can `build the extensions from source <https://github.com/IDAES/idaes-ext>`_.
+    The IDAES binary extensions are not yet supported on macOS with an Intel processor, but are available for macOS with Apple Silicon (M1+) processors. If you are using macOS (Intel), you can `build the extensions from source <https://github.com/IDAES/idaes-ext>`_.
 
 .. note::
     This ``pip install`` command would override any package within the conda environment,

--- a/idaes/models/properties/general_helmholtz/helmholtz_functions.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_functions.py
@@ -2183,7 +2183,7 @@ change.
         ax.set_title(f"P-H Diagram for {self.pure_component}")
 
         if self.config.amount_basis == AmountBasis.MOLE:
-            ax.set_xlabel("Enthalpy (kJ/mol)")
+            ax.set_xlabel("Enthalpy (kJ/kmol)")
         elif self.config.amount_basis == AmountBasis.MASS:
             ax.set_xlabel("Enthalpy (kJ/kg)")
         else:
@@ -2257,7 +2257,7 @@ change.
 
         ax.set_title(f"T-S Diagram for {self.pure_component}")
         if self.config.amount_basis == AmountBasis.MOLE:
-            ax.set_xlabel("Entropy (kJ/mol/K)")
+            ax.set_xlabel("Entropy (kJ/kmol/K)")
         elif self.config.amount_basis == AmountBasis.MASS:
             ax.set_xlabel("Entropy (kJ/kg/K)")
         else:

--- a/idaes/models/properties/general_helmholtz/helmholtz_functions.py
+++ b/idaes/models/properties/general_helmholtz/helmholtz_functions.py
@@ -2181,7 +2181,13 @@ change.
 
         # Titles
         ax.set_title(f"P-H Diagram for {self.pure_component}")
-        ax.set_xlabel("Enthalpy (kJ/kg)")
+
+        if self.config.amount_basis == AmountBasis.MOLE:
+            ax.set_xlabel("Enthalpy (kJ/mol)")
+        elif self.config.amount_basis == AmountBasis.MASS:
+            ax.set_xlabel("Enthalpy (kJ/kg)")
+        else:
+            raise ConfigurationError("Invalid amount basis")
         ax.set_ylabel("Pressure (kPa)")
         return fig, ax
 
@@ -2250,7 +2256,12 @@ change.
         plt.plot(x, y, c="black")
 
         ax.set_title(f"T-S Diagram for {self.pure_component}")
-        ax.set_xlabel("Entropy (kJ/kg/K)")
+        if self.config.amount_basis == AmountBasis.MOLE:
+            ax.set_xlabel("Entropy (kJ/mol/K)")
+        elif self.config.amount_basis == AmountBasis.MASS:
+            ax.set_xlabel("Entropy (kJ/kg/K)")
+        else:
+            raise ConfigurationError("Invalid amount basis")
         ax.set_ylabel("Temperature (K)")
         return fig, ax
 


### PR DESCRIPTION
## Fixes


## Summary/Motivation:
- The units on the labels for PH and TS diagrams did not update when changing the amount basis
- The documentation was outdated regarding the availability of macOS binaries

## Changes proposed in this PR:
- Added logic to detect `amount_basis` and update the units accordingly
- Verified results for R134a against https://www.imperial.ac.uk/media/imperial-college/research-centres-and-groups/thermophysics/Chart-p-h-R134a.pdf
- Minor update to installation documentation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
