### PR TITLE
Fixed typo/mistake in documentation

### DIFF
--- a/docs/reference_guides/model_libraries/generic/unit_models/pressure_changer.rst
+++ b/docs/reference_guides/model_libraries/generic/unit_models/pressure_changer.rst
@@ -56,7 +56,7 @@ The isothermal assumption writes one additional Constraint:
 Adiabatic Assumption
 ~~~~~~~~~~~~~~~~~~~~
 
-The isothermal assumption writes one additional Constraint:
+The adiabatic assumption writes one additional Constraint:
 
 .. math:: H_{out} = H_{in}
 


### PR DESCRIPTION
## Fixes

## Summary/Motivation:
- Copy/past typo in the documentation

## Changes proposed in this PR:
- Replaces "isothermal" with "adiabatic"

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
