### PR TITLE
Add Smooth Heaviside Function to Math

### DIFF
--- a/idaes/core/util/math.py
+++ b/idaes/core/util/math.py
@@ -197,10 +197,10 @@ def smooth_heaviside(x, k):
     """
     Provides a smooth, continuous approximation of the Heaviside step function using the logistic function
     Args:
-        x : Independent variable; as x increases, the function decreases from 1 to 0
+        x : Independent variable; as x increases, the function increases from 0 to 1
         k : Smoothing parameter proportional to the slope of the discontinuity
     Returns:
-        function : Continuous approximation of a discontinuous function which approximately equals 0 when x > 0 and approximately equals 1 when x < 0
+        function : Continuous approximation of a discontinuous function which approximately equals 0 when x < 0 and approximately equals 1 when x > 0
     """
-    function = 1 / (1 + exp(k * x))
+    function = 1 / (1 + exp(-k * x))
     return function

--- a/idaes/core/util/math.py
+++ b/idaes/core/util/math.py
@@ -197,10 +197,10 @@ def smooth_heaviside(x, k):
     """
     Provides a smooth, continuous approximation of the Heaviside step function using the logistic function
     Args:
-        x : Independent variable; as x increases, the function increases from 0 to 1
+        x : Independent variable; as x increases, the function decreases from 1 to 0
         k : Smoothing parameter proportional to the slope of the discontinuity
     Returns:
-        function : Continuous approximation of a discontinuous function which approximately equals 1 when x > 0 and approximately equals 0 when x < 0
+        function : Continuous approximation of a discontinuous function which approximately equals 0 when x > 0 and approximately equals 1 when x < 0
     """
     function = 1 / (1 + exp(k * x))
     return function

--- a/idaes/core/util/math.py
+++ b/idaes/core/util/math.py
@@ -16,7 +16,7 @@ This module contains utility functions for mathematical operators of use in
 equation oriented models.
 """
 
-from pyomo.environ import Param, log, sqrt
+from pyomo.environ import Param, log, sqrt, exp
 
 __author__ = "Andrew Lee"
 
@@ -191,3 +191,16 @@ def safe_log(a, eps=1e-4):
         approximately log(max(a, eps))
     """
     return log(smooth_max(a, eps, eps=eps))
+
+
+def smooth_heaviside(x, k):
+    """
+    Provides a smooth, continuous approximation of a discontinuous function
+    Args:
+        x : Independent variable; as x increases, the function increases from 0 to 1
+        k : Smoothing parameter representing the slope of the discontinuity
+    Returns:
+        function : Continuous approximation of a discontinuous function
+    """
+    function = 1 / (1 + exp(-2 * k * x))
+    return function

--- a/idaes/core/util/math.py
+++ b/idaes/core/util/math.py
@@ -195,12 +195,12 @@ def safe_log(a, eps=1e-4):
 
 def smooth_heaviside(x, k):
     """
-    Provides a smooth, continuous approximation of a discontinuous function
+    Provides a smooth, continuous approximation of the Heaviside step function using the logistic function
     Args:
         x : Independent variable; as x increases, the function increases from 0 to 1
-        k : Smoothing parameter representing the slope of the discontinuity
+        k : Smoothing parameter proportional to the slope of the discontinuity
     Returns:
-        function : Continuous approximation of a discontinuous function
+        function : Continuous approximation of a discontinuous function which approximately equals 1 when x > 0 and approximately equals 0 when x < 0
     """
-    function = 1 / (1 + exp(-2 * k * x))
+    function = 1 / (1 + exp(k * x))
     return function

--- a/idaes/core/util/tests/test_math.py
+++ b/idaes/core/util/tests/test_math.py
@@ -207,14 +207,14 @@ def test_smooth_min(simple_model):
 def test_smooth_heaviside():
     # Test that smooth_heaviside gives correct values
     # Ensure that the slope of the function is sharper when k is larger
-    assert smooth_heaviside(-1, 1) == pytest.approx(0.7310586, abs=1e-4)
-    assert smooth_heaviside(-0.5, 1) == pytest.approx(0.6224593, abs=1e-4)
+    assert smooth_heaviside(-1, 1) == pytest.approx(0.2689414, abs=1e-4)
+    assert smooth_heaviside(-0.5, 1) == pytest.approx(0.37754067, abs=1e-4)
     assert smooth_heaviside(0, 1) == pytest.approx(0.5, abs=1e-4)
-    assert smooth_heaviside(0.5, 1) == pytest.approx(0.37754067, abs=1e-4)
-    assert smooth_heaviside(1, 1) == pytest.approx(0.2689414, abs=1e-4)
+    assert smooth_heaviside(0.5, 1) == pytest.approx(0.6224593, abs=1e-4)
+    assert smooth_heaviside(1, 1) == pytest.approx(0.7310586, abs=1e-4)
 
-    assert smooth_heaviside(-1, 10) == pytest.approx(0.9999546, abs=1e-4)
-    assert smooth_heaviside(-0.5, 10) == pytest.approx(0.9933071, abs=1e-4)
+    assert smooth_heaviside(-1, 10) == pytest.approx(4.53979e-5, abs=1e-4)
+    assert smooth_heaviside(-0.5, 10) == pytest.approx(0.00669285, abs=1e-4)
     assert smooth_heaviside(0, 10) == pytest.approx(0.5, abs=1e-4)
-    assert smooth_heaviside(0.5, 10) == pytest.approx(0.00669285, abs=1e-4)
-    assert smooth_heaviside(1, 10) == pytest.approx(4.53979e-5, rel=1e-4)
+    assert smooth_heaviside(0.5, 10) == pytest.approx(0.9933071, abs=1e-4)
+    assert smooth_heaviside(1, 10) == pytest.approx(0.9999546, rel=1e-4)

--- a/idaes/core/util/tests/test_math.py
+++ b/idaes/core/util/tests/test_math.py
@@ -42,7 +42,7 @@ def simple_model():
 
 @pytest.mark.unit
 def test_smooth_abs_maths():
-    # Test basic smooth_abs functionalliy
+    # Test basic smooth_abs functionality
     assert smooth_abs(4, 0) == 4.0
     assert smooth_abs(-4, 0) == 4.0
     assert smooth_abs(10.0, 0.0) == 10.0
@@ -206,9 +206,10 @@ def test_smooth_min(simple_model):
 @pytest.mark.unit
 def test_smooth_heaviside():
     # Test that smooth_heaviside gives correct values
+    print(value(smooth_heaviside(0.5, 10)))
     assert smooth_heaviside(0, 1) == pytest.approx(0.5, abs=1e-4)
     assert smooth_heaviside(0, 1000) == pytest.approx(0.5, abs=1e-4)
-    assert smooth_heaviside(0.5, 1) == pytest.approx(0.731059, abs=1e-4)
+    assert smooth_heaviside(0.5, 1) == pytest.approx(0.37754067, abs=1e-4)
     assert smooth_heaviside(0.5, 10) == pytest.approx(0.9999546, abs=1e-4)
     assert smooth_heaviside(0.5, 100) == pytest.approx(1, abs=1e-4)
     assert smooth_heaviside(0.5, 1000) == pytest.approx(1, abs=1e-4)

--- a/idaes/core/util/tests/test_math.py
+++ b/idaes/core/util/tests/test_math.py
@@ -23,6 +23,7 @@ from idaes.core.util.math import (
     smooth_max,
     safe_sqrt,
     safe_log,
+    smooth_heaviside,
 )
 
 __author__ = "Andrew Lee"
@@ -200,3 +201,16 @@ def test_smooth_min(simple_model):
     assert value(safe_log(simple_model.a, simple_model.e)) == pytest.approx(
         1.386294, abs=1e-4
     )
+
+
+@pytest.mark.unit
+def test_smooth_heaviside():
+    # Test that smooth_heaviside gives correct values
+    assert smooth_heaviside(0, 1) == pytest.approx(0.5, abs=1e-4)
+    assert smooth_heaviside(0, 1000) == pytest.approx(0.5, abs=1e-4)
+    assert smooth_heaviside(0.5, 1) == pytest.approx(0.731059, abs=1e-4)
+    assert smooth_heaviside(0.5, 10) == pytest.approx(0.9999546, abs=1e-4)
+    assert smooth_heaviside(0.5, 100) == pytest.approx(1, abs=1e-4)
+    assert smooth_heaviside(0.5, 1000) == pytest.approx(1, abs=1e-4)
+    assert smooth_heaviside(5, 1) == pytest.approx(1, abs=1e-4)
+    assert smooth_heaviside(5, 1000) == pytest.approx(1, abs=1e-4)

--- a/idaes/core/util/tests/test_math.py
+++ b/idaes/core/util/tests/test_math.py
@@ -206,12 +206,15 @@ def test_smooth_min(simple_model):
 @pytest.mark.unit
 def test_smooth_heaviside():
     # Test that smooth_heaviside gives correct values
-    print(value(smooth_heaviside(0.5, 10)))
+    # Ensure that the slope of the function is sharper when k is larger
+    assert smooth_heaviside(-1, 1) == pytest.approx(0.7310586, abs=1e-4)
+    assert smooth_heaviside(-0.5, 1) == pytest.approx(0.6224593, abs=1e-4)
     assert smooth_heaviside(0, 1) == pytest.approx(0.5, abs=1e-4)
-    assert smooth_heaviside(0, 1000) == pytest.approx(0.5, abs=1e-4)
     assert smooth_heaviside(0.5, 1) == pytest.approx(0.37754067, abs=1e-4)
-    assert smooth_heaviside(0.5, 10) == pytest.approx(0.9999546, abs=1e-4)
-    assert smooth_heaviside(0.5, 100) == pytest.approx(1, abs=1e-4)
-    assert smooth_heaviside(0.5, 1000) == pytest.approx(1, abs=1e-4)
-    assert smooth_heaviside(5, 1) == pytest.approx(1, abs=1e-4)
-    assert smooth_heaviside(5, 1000) == pytest.approx(1, abs=1e-4)
+    assert smooth_heaviside(1, 1) == pytest.approx(0.2689414, abs=1e-4)
+
+    assert smooth_heaviside(-1, 10) == pytest.approx(0.9999546, abs=1e-4)
+    assert smooth_heaviside(-0.5, 10) == pytest.approx(0.9933071, abs=1e-4)
+    assert smooth_heaviside(0, 10) == pytest.approx(0.5, abs=1e-4)
+    assert smooth_heaviside(0.5, 10) == pytest.approx(0.00669285, abs=1e-4)
+    assert smooth_heaviside(1, 10) == pytest.approx(4.53979e-5, rel=1e-4)


### PR DESCRIPTION
## Summary/Motivation:
Addresses a comment made [here](https://github.com/watertap-org/watertap/pull/1563#discussion_r2019371484) to add the smooth_heaviside function into IDAES rather than WaterTAP

## Changes proposed in this PR:
- Adds the smooth_heaviside function to math
- Updates the testing

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
