### PR TITLE
Add Solver Config Option to IPOPT Convergence Analysis

### DIFF
--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -3559,7 +3559,7 @@ class IpoptConvergenceAnalysis:
 
     CONFIG = CACONFIG()
 
-    def __init__(self, model, **kwargs):
+    def __init__(self, model, solver=SolverFactory("ipopt"), **kwargs):
         # TODO: In future may want to generalise this to accept indexed blocks
         # However, for now some of the tools do not support indexed blocks
         if not isinstance(model, BlockData):
@@ -3575,7 +3575,8 @@ class IpoptConvergenceAnalysis:
 
         self._model = model
 
-        solver = SolverFactory("ipopt")
+        self._solver = solver
+
         if self.config.solver_options is not None:
             solver.options = self.config.solver_options
 

--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -3559,7 +3559,7 @@ class IpoptConvergenceAnalysis:
 
     CONFIG = CACONFIG()
 
-    def __init__(self, model, solver=SolverFactory("ipopt"), **kwargs):
+    def __init__(self, model, solver=None, **kwargs):
         # TODO: In future may want to generalise this to accept indexed blocks
         # However, for now some of the tools do not support indexed blocks
         if not isinstance(model, BlockData):
@@ -3575,6 +3575,8 @@ class IpoptConvergenceAnalysis:
 
         self._model = model
 
+        if solver is None:
+            solver = SolverFactory("ipopt")
         self._solver = solver
 
         if self.config.solver_options is not None:

--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -3559,7 +3559,7 @@ class IpoptConvergenceAnalysis:
 
     CONFIG = CACONFIG()
 
-    def __init__(self, model, solver=None, **kwargs):
+    def __init__(self, model, solver_obj=None, **kwargs):
         # TODO: In future may want to generalise this to accept indexed blocks
         # However, for now some of the tools do not support indexed blocks
         if not isinstance(model, BlockData):
@@ -3575,12 +3575,12 @@ class IpoptConvergenceAnalysis:
 
         self._model = model
 
-        if solver is None:
-            solver = SolverFactory("ipopt")
-        self._solver = solver
+        if solver_obj is None:
+            solver_obj = SolverFactory("ipopt")
+        self._solver_obj = solver_obj
 
         if self.config.solver_options is not None:
-            solver.options = self.config.solver_options
+            solver_obj.options = self.config.solver_options
 
         self._psweep = self.config.workflow_runner(
             input_specification=self.config.input_specification,
@@ -3590,7 +3590,7 @@ class IpoptConvergenceAnalysis:
             build_outputs=self._build_outputs,
             halt_on_error=self.config.halt_on_error,
             handle_solver_error=self._recourse,
-            solver=solver,
+            solver=solver_obj,
         )
 
     @property

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -2847,6 +2847,20 @@ class TestIpoptConvergenceAnalysis:
         assert ca.config.solver_options is None
 
     @pytest.mark.unit
+    def test_init_solver_options(self, model):
+        solver_obj = SolverFactory("ipopt")
+        options = solver_obj.options["max_iter"] = 100
+        ca = IpoptConvergenceAnalysis(
+            model, solver_obj=solver_obj, solver_options=options
+        )
+
+        assert ca._model is model
+        assert isinstance(ca._psweep, SequentialSweepRunner)
+        assert isinstance(ca.results, dict)
+        assert ca.config.input_specification is None
+        assert ca.config.solver_options is not None
+
+    @pytest.mark.unit
     def test_build_model(self, model):
         ca = IpoptConvergenceAnalysis(model)
 


### PR DESCRIPTION
## Summary/Motivation:
Addresses an issue in https://github.com/watertap-org/watertap/pull/1563 where tests are passing locally but failing on GitHub. This is believed to be a result of this tool defaulting the solver to ipopt, whereas WaterTAP requires ipopt-watertap.


## Changes proposed in this PR:
- Adds a config option to IPOPTConvergenceAnalysis

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
