### PR TITLE
Fix typo of _enthalpy_density_term

### DIFF
--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -2251,7 +2251,7 @@ class GenericStateBlockData(StateBlockData):
                     iscale.set_scaling_factor(v, sf_rho * sf_x)
 
         if self.is_property_constructed("_energy_density_term"):
-            for k, v in self._enthalpy_flow_term.items():
+            for k, v in self._energy_density_term.items():
                 if iscale.get_scaling_factor(v) is None:
                     sf_rho = iscale.get_scaling_factor(
                         self.dens_mol_phase[k], default=1, warning=True


### PR DESCRIPTION
## Fixes

This fixes issue #1586

This fixes the typo in [idaes-pse/idaes/models/properties/modular_properties/base/generic_property.py](https://github.com/IDAES/idaes-pse/blob/5f3b33bf6ffdce40b085fab16820eb7d9812f67c/idaes/models/properties/modular_properties/base/generic_property.py#L2243-L2244) as described in issue #1586. 

## Summary/Motivation:

This throws an error when calculating scaling factors with a generic property package

## Changes proposed in this PR:
- fixed _enthalpy_flow_term to _energy_density_term

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
