### PR TITLE
Fix subcritical power plant model

### DIFF
--- a/idaes/models/control/controller.py
+++ b/idaes/models/control/controller.py
@@ -469,7 +469,9 @@ class PIDControllerData(UnitModelBlockData):
 
         # deactivate the time 0 mv_eqn instead of skip, should be fine since
         # first time step always exists.
-        if self.config.calculate_initial_integral:
+        #TODO: should this happen for True or False? Seems this change caused subcritical power plant to fail
+        # setting to not gets subcritical power plant to work, but steam cycle fails
+        if not self.config.calculate_initial_integral:
             self.mv_eqn[t0].deactivate()
 
         if self.config.controller_type in [ControllerType.PI, ControllerType.PID]:

--- a/idaes/models_extra/power_generation/flowsheets/subcritical_power_plant/subcritical_power_plant.py
+++ b/idaes/models_extra/power_generation/flowsheets/subcritical_power_plant/subcritical_power_plant.py
@@ -573,12 +573,15 @@ def main_dynamic():
     m_dyn.fs_main.fs_stc.spray_ctrl.mv_ref.value = (
         m_dyn.fs_main.fs_stc.spray_valve.valve_opening[t0].value
     )
+
+    #TODO: integral_component_ref was replaced with mv_integral_component_dot
+    # 'ref' does not exist anymore, not sure what this should be set to
     # For two bounded controllers, set the initial mv_integral_component
     m_dyn.fs_main.fs_stc.makeup_ctrl.mv_integral_component[:].value = pyo.value(
-        m_dyn.fs_main.fs_stc.makeup_ctrl.mv_integral_component_ref[t0]
+        m_dyn.fs_main.fs_stc.makeup_ctrl.mv_integral_component_dot[t0]
     )
     m_dyn.fs_main.fs_stc.spray_ctrl.mv_integral_component[:].value = pyo.value(
-        m_dyn.fs_main.fs_stc.spray_ctrl.mv_integral_component_ref[t0]
+        m_dyn.fs_main.fs_stc.spray_ctrl.mv_integral_component_dot[t0]
     )
 
     # Controllers on the main flowsheet
@@ -692,7 +695,7 @@ def main_dynamic():
     time_used = end_time - start_time
     _log.info("simulation time={}".format(time_used))
     write_data_to_txt_file(plot_data)
-    plot_results(plot_data)
+    # plot_results(plot_data)
     return m_dyn
 
 
@@ -2279,9 +2282,9 @@ if __name__ == "__main__":
     # to 100% load and holding for 20 minutes.
     # uncomment the code (line 1821) to run this simulation,
     # note that this simulation takes around ~60 minutes to complete
-    # m_dyn = main_dynamic()
+    m_dyn = main_dynamic()
 
     # This method builds and runs a steady state subcritical coal-fired power
     # plant, the simulation consists of a typical base load case.
-    m_ss = main_steady_state()
-    print_pfd_results(m_ss)
+    # m_ss = main_steady_state()
+    # print_pfd_results(m_ss)

--- a/idaes/models_extra/power_generation/flowsheets/subcritical_power_plant/subcritical_power_plant.py
+++ b/idaes/models_extra/power_generation/flowsheets/subcritical_power_plant/subcritical_power_plant.py
@@ -2238,12 +2238,14 @@ def print_pfd_results(m):
         except AttributeError:
             pass
         try:
-            tags[i + "_yN2"] = s.mole_frac_comp["N2"]
-            tags[i + "_yO2"] = s.mole_frac_comp["O2"]
-            tags[i + "_yNO"] = s.mole_frac_comp["NO"]
-            tags[i + "_yCO2"] = s.mole_frac_comp["CO2"]
-            tags[i + "_yH2O"] = s.mole_frac_comp["H2O"]
-            tags[i + "_ySO2"] = s.mole_frac_comp["SO2"]
+            # Fix for missing components (just H20 in steam portion)
+            #TODO: Incorporate in logging system. 
+            print("Processing molecules for stream :{}".format(s))
+            for key in ['N2', 'O2', 'NO', 'CO2', 'H2O', 'SO2']:
+                if key in s.mole_frac_comp.keys():
+                    tags[i + "_y{}".format(key)] = s.mole_frac_comp[key]
+                else:
+                    print("{} was not found".format(key))
         except AttributeError:
             pass
 

--- a/idaes/models_extra/power_generation/flowsheets/subcritical_power_plant/tests/test_subcritical_flowsheets.py
+++ b/idaes/models_extra/power_generation/flowsheets/subcritical_power_plant/tests/test_subcritical_flowsheets.py
@@ -144,14 +144,31 @@ def test_subc_power_plant():
 @pytest.mark.skipif(not helmholtz_available(), reason="General Helmholtz not available")
 @pytest.mark.integration
 def test_dynamic_power_plant_build():
-    # constructing and initializing dynamic power plant
+    # constructing dynamic power plant
     # not solving due to simulation time >20 min
     m = subcrit_plant.get_model(dynamic=True, init=False)
     assert m.dynamic is True
     # Lost 11 degrees of freedom because PIDControllers.mv_eqn[t0]
     # is no longer deactivated if calculate_initial_integral=False
-    assert degrees_of_freedom(m) == 157
+    assert degrees_of_freedom(m) == 168
 
+
+@pytest.mark.skipif(not helmholtz_available(), reason="General Helmholtz not available")
+@pytest.mark.integration
+def test_dynamic_power_plant_build_init():
+    # constructing and initializing dynamic power plant
+
+    num_step = [2, 2]
+    # The time step sizes for the two models are 30 s and 60 s, respectively
+    step_size = [30, 60]
+    m = subcrit_plant.get_model(
+        dynamic=True, time_set=[0, num_step[0] * step_size[0]], nstep=num_step[0]
+    )
+    assert m.dynamic is True
+
+    DOF = degrees_of_freedom(m)
+    if not DOF == 0:
+        raise ValueError(f"degrees of freedom was {DOF}")
 
 @pytest.mark.skipif(not helmholtz_available(), reason="General Helmholtz not available")
 @pytest.mark.component


### PR DESCRIPTION
## Fixes

This fixes issue #1287. 
Possibly fixes the handling of calculate_initial_integral in idaes/models/control/controller.py. 

## Summary/Motivation:

This is a few minimal fixes to get the subcritical power plant model running. 

There appears to have been some changes to PID models that was not coordinated with the subcritical power plant model. See the commit made by @dallan-keylogic here: https://github.com/aspitarl/idaes-pse/blame/db028bdab41c92cabe1b5c05e63aeeb84ba8a82b/idaes/models_extra/power_generation/flowsheets/subcritical_power_plant/tests/test_subcritical_flowsheets.py#L151. The second commit of this PR does some fixes regarding the calculate_initial_integral keyword argument that seemed to work, but need to be checked.

## Changes proposed in this PR:
- During tagging of the power plant svg in `print_pfd_results`, there is now a check that chemical species exist within a tagged stream. This was the underlying issue behind #1287 as there were multiple property packages and the flue gas species that the code was trying to check for did not exist in the other property package. 
- Some changes to PID models, in particular a potential fix to the logic of the calculate_initial_integral argument. 
    - https://github.com/aspitarl/idaes-pse/commit/db028bdab41c92cabe1b5c05e63aeeb84ba8a82b#diff-19b5677ae20b9cb50f50e22505a513e4a19bbfcf4f39a8b38ba266708651671bR472 
- Fixed the dynamic power plant test degrees of freedom, and added a new test that separates out flowsheet construction from initialization. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
