### PR TITLE
Pin CoolProp version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ class ExtraDependencies:
         "gridx-prescient>=2.2.1",  # idaes.tests.prescient
     ]
     coolprop = [
-        "coolprop",  # idaes.generic_models.properties.general.coolprop
+        "coolprop==6.8",  # idaes.generic_models.properties.general.coolprop
     ]
     testing = [
         "pytest",


### PR DESCRIPTION
## Summary/Motivation:
CoolProp 7.0 introduced [a discrepancy between physical parameter values returned by different methods.](https://github.com/CoolProp/CoolProp/issues/2590) This discrepancy causes tests to break. We'll pin CoolProp to 6.8 until we get some clarity about whether this behavior is intended and decide on a long-term solution.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
