### PR TITLE
Change to scale_model=True

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -385,7 +385,7 @@ def _new_idaes_config_block():
         "scale_model",
         pyomo.common.config.ConfigValue(
             domain=Bool,
-            default=False,  # TODO: Change to true once transition complete
+            default=True,
             description="Whether to apply model scaling in writer",
         ),
     )

--- a/idaes/core/scaling/tests/test_scaling_profiler.py
+++ b/idaes/core/scaling/tests/test_scaling_profiler.py
@@ -239,7 +239,7 @@ def test_constraint_scaling_transform():
     with pytest.raises(
         RuntimeError,
         match=re.escape(
-            "Attempted to set constraint scaling factor for transformed constraint."
+            "Attempted to set constraint scaling factor for transformed constraint. "
             "Please use only one of set_scaling_factor and constraint_scaling_transform "
             "per constraint to avoid double scaling."
         ),
@@ -255,7 +255,7 @@ def test_constraint_scaling_transform():
     with pytest.raises(
         RuntimeError,
         match=re.escape(
-            "Attempted to set constraint scaling factor for transformed constraint."
+            "Attempted to set constraint scaling factor for transformed constraint. "
             "Please use only one of set_scaling_factor and constraint_scaling_transform "
             "per constraint to avoid double scaling."
         ),

--- a/idaes/core/scaling/tests/test_util.py
+++ b/idaes/core/scaling/tests/test_util.py
@@ -1144,12 +1144,14 @@ class TestSetScalingFactor:
         m.c1 = Constraint(expr=m.x <= 1e3)
         m.c2 = Constraint(expr=m.x == 1e3)
         m.c3 = Constraint(expr=m.x >= 1e3)
+
         def indexed_constraint_rule(b, idx):
             return b.x == 1e3
+
         m.c4 = Constraint([1, 2, 3], rule=indexed_constraint_rule)
-        
+
         match = re.escape(
-            "Attempted to set constraint scaling factor for transformed constraint."
+            "Attempted to set constraint scaling factor for transformed constraint. "
             "Please use only one of set_scaling_factor and constraint_scaling_transform "
             "per constraint to avoid double scaling."
         )
@@ -1173,12 +1175,13 @@ class TestSetScalingFactor:
                 "with transformed ConstraintData children. Please use only one of "
                 "set_scaling_factor and constraint_scaling_transform "
                 "per constraint to avoid double scaling."
-            )
+            ),
         ):
             set_scaling_factor(m.c4, 1e-3)
         for idx in m.c4:
             with pytest.raises(RuntimeError, match=match):
                 set_scaling_factor(m.c4[idx], 1e-3)
+
 
 class TestDelScalingFactor:
     @pytest.mark.unit

--- a/idaes/core/scaling/util.py
+++ b/idaes/core/scaling/util.py
@@ -384,7 +384,7 @@ def set_scaling_factor(component, scaling_factor: float, overwrite: bool = False
         xform_factor = get_constraint_transform_applied_scaling_factor(component)
         if xform_factor is not None:
             raise RuntimeError(
-                "Attempted to set constraint scaling factor for transformed constraint."
+                "Attempted to set constraint scaling factor for transformed constraint. "
                 "Please use only one of set_scaling_factor and constraint_scaling_transform "
                 "per constraint to avoid double scaling."
             )

--- a/idaes/core/solvers/tests/test_solvers.py
+++ b/idaes/core/solvers/tests/test_solvers.py
@@ -299,7 +299,7 @@ def test_get_solver_ipopt_v2():
     assert solver.options.max_iter == 200
 
     assert solver.config.writer_config.linear_presolve
-    assert not solver.config.writer_config.scale_model
+    assert solver.config.writer_config.scale_model
 
 
 @pytest.mark.skipif(not pyo.SolverFactory("ipopt").available(False), reason="no Ipopt")
@@ -308,7 +308,7 @@ def test_get_solver_ipopt_v2_w_options():
     solver = get_solver(
         "ipopt_v2",
         options={"tol": 1e-5, "foo": "bar"},
-        writer_config={"linear_presolve": False},
+        writer_config={"linear_presolve": False, "scale_model": False},
     )
 
     assert isinstance(solver, LegacySolverWrapper)

--- a/idaes/core/util/scaling.py
+++ b/idaes/core/util/scaling.py
@@ -238,7 +238,7 @@ def set_scaling_factor(c, v, data_objects=True, overwrite=True):
         xform_factor = get_constraint_transform_applied_scaling_factor(c)
         if xform_factor is not None:
             raise RuntimeError(
-                "Attempted to set constraint scaling factor for transformed constraint."
+                "Attempted to set constraint scaling factor for transformed constraint. "
                 "Please use only one of set_scaling_factor and constraint_scaling_transform "
                 "per constraint to avoid double scaling."
             )
@@ -486,7 +486,7 @@ def constraint_scaling_transform(c, s, overwrite=True):
     scaling_factor = sfFinder.find(component_data=c)
     if scaling_factor is not None:
         raise RuntimeError(
-            "Attempted to transform constraint with existing scaling factor!"
+            "Attempted to transform constraint with existing scaling factor. "
             "Please use only one of set_scaling_factor and constraint_scaling_transform "
             "per constraint to avoid double scaling."
         )

--- a/idaes/core/util/tests/test_scaling.py
+++ b/idaes/core/util/tests/test_scaling.py
@@ -478,7 +478,7 @@ def test_set_scaling_factor_transformed_constraint():
     m.c4 = pyo.Constraint([1, 2, 3], rule=indexed_constraint_rule)
 
     match = re.escape(
-        "Attempted to set constraint scaling factor for transformed constraint."
+        "Attempted to set constraint scaling factor for transformed constraint. "
         "Please use only one of set_scaling_factor and constraint_scaling_transform "
         "per constraint to avoid double scaling."
     )
@@ -758,7 +758,7 @@ def test_constraint_scaling_transform_existing_scaling_factor():
     m.c4 = pyo.Constraint([1, 2, 3], rule=indexed_constraint_rule)
 
     match = re.escape(
-        "Attempted to transform constraint with existing scaling factor!"
+        "Attempted to transform constraint with existing scaling factor. "
         "Please use only one of set_scaling_factor and constraint_scaling_transform "
         "per constraint to avoid double scaling."
     )

--- a/idaes/models/flowsheets/demo_flowsheet.py
+++ b/idaes/models/flowsheets/demo_flowsheet.py
@@ -141,19 +141,6 @@ def set_scaling(m):
     )
     iscale.set_scaling_factor(m.fs.M01.mixed_state[0].enthalpy_flow_terms["Liq"], 1)
     iscale.set_scaling_factor(m.fs.M01.mixed_state[0].enthalpy_flow_terms["Vap"], 1)
-    iscale.set_scaling_factor(m.fs.M01.mixed_state[0].eq_total, 1)
-    iscale.set_scaling_factor(m.fs.M01.mixed_state[0].eq_sum_mol_frac, 1)
-    iscale.set_scaling_factor(m.fs.M01.mixed_state[0].eq_mol_frac_out, 1)
-    iscale.set_scaling_factor(m.fs.M01.mixed_state[0].eq_comp["benzene"], 1)
-    iscale.set_scaling_factor(m.fs.M01.mixed_state[0].eq_comp["toluene"], 1)
-    iscale.set_scaling_factor(
-        m.fs.M01.mixed_state[0].eq_phase_equilibrium["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.M01.mixed_state[0].eq_phase_equilibrium["toluene"], 1
-    )
-    iscale.set_scaling_factor(m.fs.M01.mixed_state[0].eq_P_vap["benzene"], 1)
-    iscale.set_scaling_factor(m.fs.M01.mixed_state[0].eq_P_vap["toluene"], 1)
 
     iscale.set_scaling_factor(m.fs.M01.mixed_state[0].pressure, 1e-5)
     iscale.set_scaling_factor(m.fs.M01.mixed_state[0].pressure_sat_comp, 1e-5)
@@ -215,42 +202,6 @@ def set_scaling(m):
         1e-4,
     )
     iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_in[0].eq_comp["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_in[0].eq_comp["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_out[0].eq_comp["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_out[0].eq_comp["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_in[0].eq_phase_equilibrium["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_in[0].eq_phase_equilibrium["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_out[0].eq_phase_equilibrium["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_out[0].eq_phase_equilibrium["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_in[0.0].eq_P_vap["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_in[0.0].eq_P_vap["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_out[0.0].eq_P_vap["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_out[0.0].eq_P_vap["toluene"], 1
-    )
-    iscale.set_scaling_factor(
         m.fs.H02.control_volume.properties_out[0].enth_mol_phase_comp["Liq", "benzene"],
         1e-4,
     )
@@ -265,17 +216,6 @@ def set_scaling(m):
     iscale.set_scaling_factor(
         m.fs.H02.control_volume.properties_out[0].enth_mol_phase_comp["Vap", "toluene"],
         1e-4,
-    )
-    iscale.set_scaling_factor(m.fs.H02.control_volume.properties_in[0.0].eq_total, 1)
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_in[0.0].eq_sum_mol_frac, 1
-    )
-    iscale.set_scaling_factor(m.fs.H02.control_volume.properties_out[0.0].eq_total, 1)
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_out[0.0].eq_sum_mol_frac, 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.H02.control_volume.properties_out[0.0].eq_mol_frac_out, 1
     )
 
     iscale.set_scaling_factor(
@@ -336,18 +276,6 @@ def set_scaling(m):
         m.fs.F03.control_volume.properties_in[0].mole_frac_comp["toluene"], 1e1
     )
 
-    iscale.set_scaling_factor(m.fs.F03.control_volume.properties_in[0.0].eq_total, 1)
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_in[0.0].eq_sum_mol_frac, 1
-    )
-    iscale.set_scaling_factor(m.fs.F03.control_volume.properties_out[0.0].eq_total, 1)
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_out[0.0].eq_sum_mol_frac, 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_out[0.0].eq_mol_frac_out, 1
-    )
-
     iscale.set_scaling_factor(
         m.fs.F03.control_volume.properties_in[0].enth_mol_phase_comp["Liq", "benzene"],
         1e-4,
@@ -379,43 +307,6 @@ def set_scaling(m):
     iscale.set_scaling_factor(
         m.fs.F03.control_volume.properties_out[0].enth_mol_phase_comp["Vap", "toluene"],
         1e-4,
-    )
-
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_in[0].eq_comp["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_in[0].eq_comp["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_out[0].eq_comp["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_out[0].eq_comp["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_in[0].eq_phase_equilibrium["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_in[0].eq_phase_equilibrium["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_out[0].eq_phase_equilibrium["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_out[0].eq_phase_equilibrium["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_in[0.0].eq_P_vap["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_in[0.0].eq_P_vap["toluene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_out[0.0].eq_P_vap["benzene"], 1
-    )
-    iscale.set_scaling_factor(
-        m.fs.F03.control_volume.properties_out[0.0].eq_P_vap["toluene"], 1
     )
     iscale.set_scaling_factor(
         m.fs.F03.control_volume.properties_in[0.0].material_flow_terms[


### PR DESCRIPTION
## Summary/Motivation:
Changes `scale_model` to `True` in the .nl writer config to enable IDAES to take advantage of writer-time scaling. Additionally, `Exceptions` have been added when the user attempts to use `set_scaling_factor` on a constraint that has already been transformed using `constraint_scaling_transform` and, conversely, when the user attempts to use `constraint_scaling_transform` on a constraint which already has a scaling factor.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
