### PR TITLE
external functions with string arguments

### DIFF
--- a/idaes/core/scaling/tests/test_nominal_value_walker.py
+++ b/idaes/core/scaling/tests/test_nominal_value_walker.py
@@ -26,6 +26,7 @@ from idaes.models.properties.modular_properties.eos.ceos_common import (
     CubicThermoExpressions,
     CubicType as CubicEoS,
 )
+from idaes.models.properties import iapws95
 
 __author__ = "Andrew Lee"
 
@@ -700,6 +701,19 @@ class TestNominalValueExtractionVisitor:
         m.a.set_value(2)
         m.b.set_value(4)
         assert pyo.value(Z) == pytest.approx(expected_mag, rel=1e-8)
+
+    @pytest.mark.component
+    @pytest.mark.skipif(
+        not iapws95.iapws95_available(), reason="IAPWS95 is not available"
+    )
+    def test_external_function_w_string_argument(self):
+        m = pyo.ConcreteModel()
+        m.properties = iapws95.Iapws95ParameterBlock()
+        m.state = m.properties.build_state_block([0])
+
+        assert NominalValueExtractionVisitor().walk_expression(
+            expr=m.state[0].temperature
+        ) == [pytest.approx(270.4877112932626, rel=1e-8)]
 
     @pytest.mark.unit
     def test_Expression(self, m):

--- a/idaes/core/scaling/util.py
+++ b/idaes/core/scaling/util.py
@@ -987,10 +987,14 @@ class NominalValueExtractionVisitor(EXPR.StreamBasedExpressionVisitor):
 
     def _get_nominal_value_external_function(self, node, child_nominal_values):
         # First, need to get expected magnitudes of input terms, which may be sub-expressions
-        input_mag = [
-            self._get_nominal_value_for_sum_subexpression(i)
-            for i in child_nominal_values
-        ]
+        input_mag = []
+        for i in child_nominal_values:
+            if isinstance(i[0], str):
+                # Sometimes external functions might have string arguments
+                # Check here, and return the string if true
+                input_mag.append(i[0])
+            else:
+                input_mag.append(self._get_nominal_value_for_sum_subexpression(i))
 
         # Next, create a copy of the external function with expected magnitudes as inputs
         newfunc = node.create_node_with_local_data(input_mag)


### PR DESCRIPTION
## Summary/Motivation:
Fixes error with `NominalValueExpressionWalker` for external functions with string arguments.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
