### PR TITLE
Modular properties fixes

### DIFF
--- a/idaes/core/initialization/initializer_base.py
+++ b/idaes/core/initialization/initializer_base.py
@@ -275,9 +275,9 @@ class InitializerBase:
         Returns:
             None
         """
-        try:
+        if hasattr(model, "fix_initialization_states"):
             model.fix_initialization_states()
-        except AttributeError:
+        else:
             _log.info_high(
                 f"Model {model.name} does not have a fix_initialization_states method - attempting to continue."
             )

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1290,7 +1290,7 @@ class ModularPropertiesInitializer(InitializerBase):
         scaler_block = [blk for blk in model.values()][0]
 
         if hasattr(scaler_block, "inherent_equilibrium_constraint") and (
-            not scaler_block.params._electrolyte
+            not scaler_block.params._electrolyte # TODO why do we need this check?
             or scaler_block.params.config.state_components == StateIndex.true
         ):
             init_log.debug(

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1274,10 +1274,10 @@ class ModularPropertiesInitializer(InitializerBase):
         """
         # Setup loggers
         init_log = idaeslog.getInitLogger(
-            model.name, self.config.output_level, tag="properties"
+            model.name, self.get_output_level(), tag="properties"
         )
         solve_log = idaeslog.getSolveLogger(
-            model.name, self.config.output_level, tag="properties"
+            model.name, self.get_output_level(), tag="properties"
         )
 
         # Create solver object
@@ -1286,6 +1286,32 @@ class ModularPropertiesInitializer(InitializerBase):
             solver_options=self.config.solver_options,
             writer_config=self.config.solver_writer_config,
         )
+
+        scaler_block = [blk for blk in model.values()][0]
+
+        if hasattr(scaler_block, "inherent_equilibrium_constraint") and (
+            not scaler_block.params._electrolyte
+            or scaler_block.params.config.state_components == StateIndex.true
+        ):
+            init_log.debug(
+                "Cannot converge inherent reaction constraints "
+                "at the state block level. They need to be solved "
+                "at the control volume level, when material and "
+                "energy balances are included. Ignoring "
+                "constraints with large residuals."
+            )
+            self.config.constraint_tolerance = float("inf")
+
+        if "flow_mol_phase_comp" or "mole_frac_phase_comp" in scaler_block.define_state_vars():
+            init_log.debug(
+                "Cannot converge phase equilibrium constraints "
+                "at the state block level due to using phase component "
+                "flows as state variables. These constraints need to be "
+                "solved at the control volume level, when material and "
+                "energy balances are included. Ignoring "
+                "constraints with large residuals."
+            )
+            self.config.constraint_tolerance = float("inf")
 
         init_log.info("Starting initialization routine")
 
@@ -1489,7 +1515,10 @@ class ModularPropertiesInitializer(InitializerBase):
                         # For systems where the state variables fully define the
                         # phase equilibrium, we cannot activate the equilibrium
                         # constraint at this stage.
-                        if "flow_mol_phase_comp" not in b.define_state_vars():
+                        if (
+                           "flow_mol_phase_comp" not in b.define_state_vars()
+                           and "mole_frac_phase_comp" not in b.define_state_vars()
+                        ):
                             c.activate()
 
                 for pp in b.params._pe_pairs:
@@ -1651,12 +1680,16 @@ class _GenericStateBlock(StateBlock):
         # Fix state variables
         fix_state_vars(self)
 
-        # Also need to deactivate sum of mole fraction constraint
         for k in self.values():
+            # Also need to deactivate sum of mole fraction constraint
             try:
                 k.sum_mole_frac_out.deactivate()
             except AttributeError:
                 pass
+            # Don't need equilibrium constraint for phase component flows
+            if "flow_mol_phase_comp" or "mole_frac_phase_comp" in k.define_state_vars():
+                k.equilibrium_constraint.deactivate()
+            # TODO Inherent reactions with a true component basis will fail here too
 
     def initialize(
         blk,
@@ -2251,7 +2284,7 @@ class GenericStateBlockData(StateBlockData):
                     iscale.set_scaling_factor(v, sf_rho * sf_x)
 
         if self.is_property_constructed("_energy_density_term"):
-            for k, v in self._energy_density_term.items():
+            for k, v in self._enthalpy_flow_term.items():
                 if iscale.get_scaling_factor(v) is None:
                     sf_rho = iscale.get_scaling_factor(
                         self.dens_mol_phase[k], default=1, warning=True
@@ -2267,6 +2300,24 @@ class GenericStateBlockData(StateBlockData):
                 # for small molecules. For large molecules, this value will be inappropriate
                 iscale.set_scaling_factor(self.cp_mol_phase[p], 1 / 50, overwrite=False)
 
+        if self.is_property_constructed("fug_phase_comp"):
+            for idx in self.fug_phase_comp:
+                sf_x = iscale.get_scaling_factor(
+                    self.mole_frac_phase_comp[idx],
+                    default=1e3, # I'd prefer 10, but this is consistent with existing scaling
+                    warning=True
+                )
+                sf_P = iscale.get_scaling_factor(
+                    self.pressure,
+                    default=1e-5,
+                    warning=True
+                )
+                iscale.set_scaling_factor(
+                    self.fug_phase_comp[idx],
+                    sf_P*sf_x,
+                    overwrite=False
+                )
+
         # Phase equilibrium constraint
         if hasattr(self, "equilibrium_constraint"):
             pe_form_config = self.params.config.phase_equilibrium_state
@@ -2280,7 +2331,6 @@ class GenericStateBlockData(StateBlockData):
                         .config.phase_equilibrium_form[(k[0], k[1])]
                         .calculate_scaling_factors(self, k[0], k[1], k[2])
                     )
-
                     iscale.constraint_scaling_transform(
                         self.equilibrium_constraint[k], sf_fug, overwrite=False
                     )

--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1687,7 +1687,10 @@ class _GenericStateBlock(StateBlock):
             except AttributeError:
                 pass
             # Don't need equilibrium constraint for phase component flows
-            if "flow_mol_phase_comp" or "mole_frac_phase_comp" in k.define_state_vars():
+            if (
+                "flow_mol_phase_comp" in k.define_state_vars()
+                or "mole_frac_phase_comp" in k.define_state_vars()
+            ):
                 k.equilibrium_constraint.deactivate()
             # TODO Inherent reactions with a true component basis will fail here too
 

--- a/idaes/models/properties/modular_properties/base/utility.py
+++ b/idaes/models/properties/modular_properties/base/utility.py
@@ -58,7 +58,7 @@ class GenericPropertyPackageError(PropertyPackageError):
         )
 
 
-def get_method(self, config_arg, comp=None, phase=None):
+def get_method(self, config_arg, comp=None, phase=None, log=False):
     """
     Method to inspect configuration argument and return the user-defined
     construction method associated with it.
@@ -103,10 +103,13 @@ def get_method(self, config_arg, comp=None, phase=None):
 
     # Try to get the return_expression method from c_arg
     # Otherwise assume c_arg is the return_expression method
-    try:
-        mthd = c_arg.return_expression
-    except AttributeError:
-        mthd = c_arg
+    if not log:
+        try:
+            mthd = c_arg.return_expression
+        except AttributeError:
+            mthd = c_arg
+    else:
+        mthd = c_arg.return_log_expression
 
     # Call the return_expression method
     if callable(mthd):

--- a/idaes/models/properties/modular_properties/phase_equil/bubble_dew.py
+++ b/idaes/models/properties/modular_properties/phase_equil/bubble_dew.py
@@ -131,7 +131,7 @@ class IdealBubbleDew:
         Scaling method for bubble temperature
         """
         sf_P = iscale.get_scaling_factor(b.pressure, default=1e-5, warning=True)
-        sf_mf = iscale.get_scaling_factor(b.mole_frac_comp, default=1e3, warning=True)
+        sf_mf = iscale.min_scaling_factor(b.mole_frac_comp.values(), default=1e3, warning=True)
 
         for pp in b.params._pe_pairs:
             for j in b.component_list:
@@ -261,7 +261,7 @@ class IdealBubbleDew:
         Scaling method for dew temperature
         """
         sf_P = iscale.get_scaling_factor(b.pressure, default=1e-5, warning=True)
-        sf_mf = iscale.get_scaling_factor(b.mole_frac_comp, default=1e3, warning=True)
+        sf_mf = iscale.min_scaling_factor(b.mole_frac_comp.values(), default=1e3, warning=True)
 
         for pp in b.params._pe_pairs:
             for j in b.component_list:
@@ -270,12 +270,12 @@ class IdealBubbleDew:
                     v_phase,
                     vl_comps,
                     _,
+                    l_only_comps,
                     _,
-                    v_only_comps,
                 ) = identify_VL_component_list(b, pp)
                 if l_phase is None or v_phase is None:
                     continue
-                elif v_only_comps != []:
+                elif l_only_comps != []:
                     continue
 
                 if j in vl_comps:

--- a/idaes/models/properties/modular_properties/phase_equil/forms.py
+++ b/idaes/models/properties/modular_properties/phase_equil/forms.py
@@ -33,27 +33,23 @@ class fugacity:
 
     @staticmethod
     def calculate_scaling_factors(b, phase1, phase2, comp):
-        with b.lock_attribute_creation_context():
-            if hasattr(b, "fug_phase_comp_eq"):
-                sf_1 = iscale.get_scaling_factor(
-                    b.fug_phase_comp[phase1, comp], default=1, warning=True
-                )
-                sf_2 = iscale.get_scaling_factor(
-                    b.fug_phase_comp[phase2, comp], default=1, warning=True
-                )
-
-                return min(sf_1, sf_2)
-            elif hasattr(b, "fug_phase_comp"):
-                sf_1 = iscale.get_scaling_factor(
-                    b.fug_phase_comp[phase1, comp], default=1, warning=True
-                )
-                sf_2 = iscale.get_scaling_factor(
-                    b.fug_phase_comp[phase2, comp], default=1, warning=True
-                )
-
-                return min(sf_1, sf_2)
-            else:
-                return 1
+            sf_xp1 = iscale.get_scaling_factor(
+                b.mole_frac_phase_comp[phase1, comp],
+                default=1e3, # I'd prefer 10, but this is consistent with existing scaling
+                warning=True
+            )
+            sf_xp2 = iscale.get_scaling_factor(
+                b.mole_frac_phase_comp[phase2, comp],
+                default=1e3, # I'd prefer 10, but this is consistent with existing scaling
+                warning=True
+            )
+            sf_x = min(sf_xp1, sf_xp2)
+            sf_P = iscale.get_scaling_factor(
+                b.pressure,
+                default=1e-5,
+                warning=True
+            )
+            return sf_x * sf_P
 
 
 class log_fugacity:

--- a/idaes/models/properties/modular_properties/pure/RPP5.py
+++ b/idaes/models/properties/modular_properties/pure/RPP5.py
@@ -104,6 +104,12 @@ class RPP5(object):
 
             units = b.params.get_metadata().derived_units
 
+            h_form = (
+                cobj.enth_mol_form_vap_comp_ref
+                if b.params.config.include_enthalpy_of_formation
+                else 0 * units.ENERGY_MOLE
+            )
+
             h = (
                 pyunits.convert(
                     (
@@ -116,7 +122,7 @@ class RPP5(object):
                     * const.gas_constant,
                     units.ENERGY_MOLE,
                 )
-                + cobj.enth_mol_form_vap_comp_ref
+                + h_form
             )
 
             return h
@@ -214,3 +220,32 @@ class RPP5(object):
             base_units = b.params.get_metadata().default_units
             dp_units = base_units.PRESSURE * base_units.TEMPERATURE**-1
             return pyunits.convert(p_sat_dT, to_units=dp_units)
+
+        @staticmethod
+        def return_log_expression(b, cobj, T, dT=False):
+            if dT:
+                return RPP5.pressure_sat_comp.dT_expression(b, cobj, T)
+
+            log_psat = (
+                log(10)
+                * (
+                    cobj.pressure_sat_comp_coeff_A
+                    - (
+                        cobj.pressure_sat_comp_coeff_B
+                        / (T + cobj.pressure_sat_comp_coeff_C - 273.15 * pyunits.degK)
+                    )
+                )
+            )
+            base_units = b.params.get_metadata().default_units
+            p_units = base_units.PRESSURE
+            return log_psat +  log(pyunits.convert(1* pyunits.bar, to_units=p_units) / p_units)
+        
+        @staticmethod
+        def dT_log_expression(b, cobj, T):
+            log_p_sat_dT = (
+                cobj.pressure_sat_comp_coeff_B
+                * log(10)
+                / (T + cobj.pressure_sat_comp_coeff_C - 273.15 * pyunits.degK) ** 2
+            )
+            base_units = b.params.get_metadata().default_units
+            return log_p_sat_dT  / base_units.TEMPERATURE

--- a/idaes/models/unit_models/feed.py
+++ b/idaes/models/unit_models/feed.py
@@ -22,7 +22,7 @@ from idaes.core import declare_process_block_class, UnitModelBlockData, useDefau
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.tables import create_stream_table_dataframe
 import idaes.logger as idaeslog
-from idaes.core.initialization import InitializerBase
+from idaes.core.initialization import ModularInitializerBase
 
 
 __author__ = "Andrew Lee"
@@ -32,7 +32,7 @@ __author__ = "Andrew Lee"
 _log = idaeslog.getLogger(__name__)
 
 
-class FeedInitializer(InitializerBase):
+class FeedInitializer(ModularInitializerBase):
     """
     Initializer for blocks with a single state (Feed, Product, StateJunction).
 
@@ -56,9 +56,15 @@ class FeedInitializer(InitializerBase):
             None
         """
         # Get initializer for State Block
-        sinit = model.properties.default_initializer()
+        sinit = self.get_submodel_initializer(model.properties)
+        for key, val in self.config.items():
+            if key in sinit.config:
+                sinit.config[key] = val
 
-        sinit.initialize(model.properties)
+        sinit.initialize(
+            model.properties,
+            output_level=self.get_output_level()
+        )
 
 
 @declare_process_block_class("Feed")


### PR DESCRIPTION
## Fixes
- Modular properties initializer now correctly uses the passed log level
- Updated initialization to ensure we have 0 degrees of freedom for FpcTP initialization
- Updated initialization to ensure that the postcheck doesn't raise an error because the VLE constraints are not satisfied
- VLE in `Ideal` equation of state now uses equilibrium temperature rather than actual temperature
- Log fugacity in `Ideal` now uses log-form variables for mole fraction
- Antoine equation now returns log expression directly for `RPP5`
- `RPP5` now responds to configuration about whether or not to include enthalpy of formation in enthalpy calculations

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
