### PR TITLE
Fix get default scaling factor

### DIFF
--- a/idaes/core/scaling/custom_scaler_base.py
+++ b/idaes/core/scaling/custom_scaler_base.py
@@ -229,18 +229,31 @@ class CustomScalerBase(ScalerBase):
         Returns:
             default scaling factor if it exists, else None
         """
-        try:
-            return self.default_scaling_factors[component.local_name]
-        except KeyError:
-            # Might be indexed, see if parent component has default scaling
-            parent = component.parent_component()
-            try:
-                return self.default_scaling_factors[parent.local_name]
-            except KeyError:
-                # No default scaling found, give up
-                pass
+        blk = component.parent_block()
+        parent_default = None
+        # We're not just returning self.default_scaling_factors[component.local_name]
+        # because the component finder has additional logic to handle, e.g., spaces
+        # separating indices for elements of an indexed component. We want the user
+        # to be able to provide either "var[a,b]" or "var[a, b]" (with a space following
+        # the comma) and still find the right component
 
-            # Log a message and return nothing
+        # If the user provides both "var[a,b]" and "var[a, b]", then whichever is
+        # encountered first when iterating through the keys will be returned. This
+        # behavior is not ideal. TODO dictionary validation
+
+        # Iterating through every key is certainly not the most efficient way to go
+        # about this look-up process, but it's also probably not going to be the
+        # rate limiting step, especially considering these default dictionaries
+        # should be relatively short.
+        for key in self.default_scaling_factors:
+            comp2 = blk.find_component(key)
+            if comp2 is component:
+                return self.default_scaling_factors[key]
+            elif comp2 is component.parent_component():
+                parent_default = self.default_scaling_factors[key]
+        if parent_default is not None:
+            return parent_default
+        else:
             _log.debug(f"No default scaling factor found for {component.name}")
             return None
 

--- a/idaes/core/scaling/tests/test_util.py
+++ b/idaes/core/scaling/tests/test_util.py
@@ -1528,7 +1528,22 @@ class TestGetScalingFactor:
             get_scaling_factor(m)
 
     @pytest.mark.unit
-    def test_get_scaling_factor(self):
+    def test_get_scaling_factor(self, caplog):
+        m = ConcreteModel()
+        m.v = Var()
+
+        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        m.scaling_factor[m.v] = 10
+
+        m.scaling_hint = Suffix(direction=Suffix.EXPORT)
+        m.scaling_hint[m.v] = 13
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.v, default=17, warning=True)
+        assert len(caplog.text) == 0
+        assert sf == 10
+
+    @pytest.mark.unit
+    def test_get_scaling_factor_warning_false(self, caplog):
         m = ConcreteModel()
         m.v = Var()
 
@@ -1538,10 +1553,14 @@ class TestGetScalingFactor:
         m.scaling_hint = Suffix(direction=Suffix.EXPORT)
         m.scaling_hint[m.v] = 13
 
-        assert get_scaling_factor(m.v) == 10
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.v, default=17, warning=False)
+        assert len(caplog.text) == 0
+
+        assert sf == 10
 
     @pytest.mark.unit
-    def test_get_scaling_factor_none(self):
+    def test_get_scaling_factor_none_warning_true(self, caplog):
         m = ConcreteModel()
         m.v = Var()
 
@@ -1549,8 +1568,54 @@ class TestGetScalingFactor:
         m.scaling_hint[m.v] = 13
 
         m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.v, warning=True)
+        assert len(caplog.records) == 1
+        assert "Missing scaling factor for v" in caplog.text
+        assert sf is None
 
-        assert get_scaling_factor(m.v) is None
+    @pytest.mark.unit
+    def test_get_scaling_factor_none_warning_false(self, caplog):
+        m = ConcreteModel()
+        m.v = Var()
+
+        m.scaling_hint = Suffix(direction=Suffix.EXPORT)
+        m.scaling_hint[m.v] = 13
+
+        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.v, warning=False)
+        assert len(caplog.text) == 0
+        assert sf is None
+
+    @pytest.mark.unit
+    def test_get_scaling_factor_none_warning_true_default(self, caplog):
+        m = ConcreteModel()
+        m.v = Var()
+
+        m.scaling_hint = Suffix(direction=Suffix.EXPORT)
+        m.scaling_hint[m.v] = 13
+
+        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.v, default=7, warning=True)
+        assert len(caplog.records) == 1
+        assert "Missing scaling factor for v" in caplog.text
+        assert sf == 7
+
+    @pytest.mark.unit
+    def test_get_scaling_factor_none_warning_false_default(self, caplog):
+        m = ConcreteModel()
+        m.v = Var()
+
+        m.scaling_hint = Suffix(direction=Suffix.EXPORT)
+        m.scaling_hint[m.v] = 13
+
+        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.v, default=7, warning=False)
+        assert len(caplog.text) == 0
+        assert sf == 7
 
     @pytest.mark.unit
     def test_get_scaling_factor_no_suffix(self):
@@ -1563,7 +1628,7 @@ class TestGetScalingFactor:
         assert get_scaling_factor(m.v) is None
 
     @pytest.mark.unit
-    def test_get_scaling_factor_expression(self):
+    def test_get_scaling_factor_expression(self, caplog):
         m = ConcreteModel()
         m.e = Expression(expr=4)
 
@@ -1576,11 +1641,13 @@ class TestGetScalingFactor:
 
         m.scaling_hint = Suffix(direction=Suffix.EXPORT)
         m.scaling_hint[m.e] = 10
-
-        assert get_scaling_factor(m.e) == 10
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.e, default=17)
+        assert len(caplog.text) == 0
+        assert sf == 10
 
     @pytest.mark.unit
-    def test_get_scaling_factor_none(self):
+    def test_get_scaling_factor_none(self, caplog):
         m = ConcreteModel()
         m.e = Expression(expr=4)
         m.scaling_factor = Suffix(direction=Suffix.EXPORT)
@@ -1588,7 +1655,63 @@ class TestGetScalingFactor:
 
         m.scaling_hint = Suffix(direction=Suffix.EXPORT)
 
-        assert get_scaling_factor(m.e) is None
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.e)
+        assert len(caplog.records) == 1
+        assert "Missing scaling factor for e" in caplog.text
+        assert sf is None
+
+    @pytest.mark.unit
+    def test_get_scaling_factor_expression_warning_false(self, caplog):
+        m = ConcreteModel()
+        m.e = Expression(expr=4)
+
+        # We don't want expression scaling hints to be
+        # stored in the scaling factor suffix, but in
+        # the event that one ends up there we want to
+        # guarantee good behavior
+        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        m.scaling_factor[m.e] = 13
+
+        m.scaling_hint = Suffix(direction=Suffix.EXPORT)
+        m.scaling_hint[m.e] = 10
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.e, warning=False)
+        assert len(caplog.text) == 0
+        assert sf == 10
+
+    @pytest.mark.unit
+    def test_get_scaling_factor_none_default(self, caplog):
+        m = ConcreteModel()
+        m.e = Expression(expr=4)
+        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        m.scaling_factor[m.e] = 13
+
+        m.scaling_hint = Suffix(direction=Suffix.EXPORT)
+
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.e, default=17)
+        assert len(caplog.records) == 1
+        assert "Missing scaling factor for e" in caplog.text
+        assert sf == 17
+
+    @pytest.mark.unit
+    def test_get_scaling_factor_expression_warning_false_default(self, caplog):
+        m = ConcreteModel()
+        m.e = Expression(expr=4)
+
+        # We don't want expression scaling hints to be
+        # stored in the scaling factor suffix, but in
+        # the event that one ends up there we want to
+        # guarantee good behavior
+        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        m.scaling_factor[m.e] = 13
+
+        m.scaling_hint = Suffix(direction=Suffix.EXPORT)
+        with caplog.at_level(idaeslog.WARNING):
+            sf = get_scaling_factor(m.e, default=17, warning=False)
+        assert len(caplog.text) == 0
+        assert sf == 17
 
     @pytest.mark.unit
     def test_get_scaling_factor_no_suffix(self):

--- a/idaes/core/scaling/util.py
+++ b/idaes/core/scaling/util.py
@@ -444,7 +444,7 @@ def _suffix_from_dict(
             )
 
 
-def get_scaling_factor(component, default=None):
+def get_scaling_factor(component, default: float = None, warning=True):
     """
     Get scaling factor for component.
 
@@ -467,6 +467,8 @@ def get_scaling_factor(component, default=None):
         return sfx[component]
     except (AttributeError, KeyError):
         # No scaling factor found, return the default value
+        if warning:
+            _log.warning(f"Missing scaling factor for {component.name}")
         return default
 
 


### PR DESCRIPTION
## Fixes
`get_default_scaling_factor` formerly looked for `component.local_name` in the `default_scaling_factors` dictionary. However, that caused problems for indexed variables, where the user could plausibly set `default_scaling_factors[mole_frac_phase_comp[Liq, H2O]` and have it be ignored because of the space after the comma. This PR fixes that using the component finder. The implementation, which iterates over all entries in the dictionary, isn't particularly efficient, but we don't expect these dictionaries to be that long---we can always optimize later.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
