### PR TITLE
Off boarding lbianchi-lbl from code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,19 +2,19 @@
 # for developmental and contributed code
 
 # Overall (non-specific)
-* @lbianchi-lbl @ksbeattie
+* @sufikaur @ksbeattie
 # packaging
-setup.py @lbianchi-lbl @ksbeattie
-requirements*.txt @lbianchi-lbl @ksbeattie 
+setup.py @sufikaur @ksbeattie
+requirements*.txt @sufikaur @ksbeattie 
 
 # CI infra
-.github/ @lbianchi-lbl @ksbeattie 
+.github/ @sufikaur @ksbeattie 
 # spellchecker configuration
-.github/workflows/typos.toml @bpaul4 @lbianchi-lbl
+.github/workflows/typos.toml @bpaul4 @sufikaur
 
 # testing
-pytest*.ini @lbianchi-lbl
-conftest.py @lbianchi-lbl
+pytest*.ini @sufikaur @ksbeattie
+conftest.py @sufikaur @ksbeattie
 
 # Docs
 /docs @dangunter @bpaul4
@@ -23,7 +23,7 @@ conftest.py @lbianchi-lbl
 /idaes/commands/ @dangunter
 
 # Core
-/idaes/core/ @agarciadiego @dallan-keylogic @lbianchi-lbl
+/idaes/core/ @agarciadiego @dallan-keylogic
 /idaes/core/dmf/ @dangunter
 /idaes/core/surrogate/ @bpaul4 @avdudchenko @rundxdi
 /idaes/core/ui/ @dangunter


### PR DESCRIPTION
## Fixes
[Issue 1660](https://github.com/IDAES/idaes-pse/issues/1660)

## Summary/Motivation:

Remove ludovico's required approval of certain PRs/ as code owner. 

## Changes proposed in this PR:
- Remove or replace lbnianchi-lbl from code ownership document


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
