### PR TITLE
Add testing 3.13 python to workflow

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -106,14 +106,16 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
-        uses: actions/setup-python@v5
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
+          miniforge-version: latest
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+      - name: Set up idaes
+        uses: ./.github/actions/setup-idaes
+        with:
+          install-target: -r requirements-dev.txt
       - name: Add pytest CLI options for coverage
         if: matrix.cov-report
         run: |
@@ -128,7 +130,7 @@ jobs:
           name: coverage-report-${{ matrix.os }}
           path: coverage.xml
           if-no-files-found: error
-
+          
   upload-coverage:
     name: Upload coverage report (Codecov)
     needs: [pytest]

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9','3.10','3.11','3.12','3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os:
           - linux
           - win64
@@ -103,35 +103,14 @@ jobs:
             cov-report: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/display-debug-info
-
-      # Conda for <=3.12
       - name: Set up Conda environment
-        if: matrix.python-version != '3.13'
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
-          python-version: ${{ matrix.python-version }}
-          miniforge-version: latest
-
-      # Python.org for 3.13
-      - name: Set up Python 3.13
-        if: matrix.python-version == '3.13'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
 
-
-      # Install dependencies
-      - name: Set up idaes (conda)
-        if: matrix.python-version != '3.13'
-        uses: ./.github/actions/setup-idaes
-        with:
-          install-target: -r requirements-dev.txt
-
-      - name: Set up idaes (pip)
-        if: matrix.python-version == '3.13'
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.10','3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12','3.13']
+        python-version: ['3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -101,25 +101,40 @@ jobs:
             # only generate coverage report for a single python version in the matrix
             # to avoid overloading Codecov
             cov-report: true
+
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/display-debug-info
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
+      # Conda for <=3.12
       - name: Set up Conda environment
+        if: matrix.python-version != '3.13'
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
-      - name: Set up idaes
+
+      # Python.org for 3.13
+      - name: Set up Python 3.13
+        if: matrix.python-version == '3.13'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+
+      # Install dependencies
+      - name: Set up idaes (conda)
+        if: matrix.python-version != '3.13'
         uses: ./.github/actions/setup-idaes
         with:
           install-target: -r requirements-dev.txt
+
+      - name: Set up idaes (pip)
+        if: matrix.python-version == '3.13'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
       - name: Add pytest CLI options for coverage
         if: matrix.cov-report
         run: |

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10','3.13']
         os:
           - linux
           - win64
@@ -104,6 +104,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/display-debug-info
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Set up Conda environment
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9','3.10','3.11','3.12']
+        python-version: ['3.9','3.10','3.11','3.12','3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10','3.13']
+        python-version: ['3.10']
         os:
           - linux
           - win64

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12','3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10','3.13']
+        python-version: ['3.9','3.10','3.11','3.12']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os:
           - linux
           - win64
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12','3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -215,6 +215,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: ['3.10', '3.13']
         install-mode:
           - pip-default
           - pip-complete
@@ -240,7 +241,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: idaes-env
-          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
           miniforge-version: latest
       - name: Set up idaes (non-editable installation)
         uses: ./.github/actions/setup-idaes

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -142,7 +142,7 @@ jobs:
           - os: win64
             runner-image: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
         uses: conda-incubator/setup-miniconda@v3
@@ -235,7 +235,7 @@ jobs:
             pip-install-target: '.'
             dependencies-to-uninstall: omlt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Conda environment
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
           - linux
           - win64
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12','3.13']
         os:
           - linux
           - win64
@@ -180,7 +180,7 @@ jobs:
           - os: win64
             runner-image: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.13']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.10']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,7 +87,6 @@ jobs:
         run: |
           import json
           from os import environ as env
-
           def _display_on_run_dashboard(msg):
               # workflow warnings are displayed on the workflow run dashboard,
               # so we use this as a way to display a short summary of why this workflow is being run
@@ -95,16 +94,13 @@ jobs:
               print(f'::warning ::{msg}')
           def _set_output(name, val):
               print(f'::set-output name={name}::{val}')
-
           event_name = env["GITHUB_EVENT_NAME"]
           event_action = env["_GITHUB_EVENT_ACTION"]
           is_pr = 'pull_request' in event_name.lower()
           # if the event is not a PR event, the "is_pr_approved" env var will be set to an empty string,
           # which cannot be parsed as valid json
           is_pr_approved = json.loads(env.get("is_pr_approved") or "null")
-
           workflow_trigger = 'undetermined'
-
           if is_pr:
               if event_action == 'labeled':
                   workflow_trigger = 'user_dispatch'
@@ -114,11 +110,9 @@ jobs:
                   workflow_trigger = 'unapproved_pr'
           else:
               workflow_trigger = 'not_pr'
-
           msg = f'{workflow_trigger=}    event/action={event_name}/{event_action or "N/A"}    is_pr_approved={is_pr_approved or "N/A"}'
           _display_on_run_dashboard(msg)
           _set_output('workflow-trigger', workflow_trigger)
-
   pytest:
     name: pytest (py${{ matrix.python-version }}/${{ matrix.os }}/integration)
     runs-on: ${{ matrix.runner-image }}
@@ -132,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
           - linux
           - win64
@@ -142,7 +136,7 @@ jobs:
           - os: win64
             runner-image: windows-2022
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
         uses: conda-incubator/setup-miniconda@v3
@@ -170,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:
           - linux
           - win64
@@ -180,7 +174,7 @@ jobs:
           - os: win64
             runner-image: windows-2022
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
         uses: conda-incubator/setup-miniconda@v3
@@ -215,7 +209,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.13']
         install-mode:
           - pip-default
           - pip-complete
@@ -236,12 +229,12 @@ jobs:
             pip-install-target: '.'
             dependencies-to-uninstall: omlt
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Set up Conda environment
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: idaes-env
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           miniforge-version: latest
       - name: Set up idaes (non-editable installation)
         uses: ./.github/actions/setup-idaes

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.10']
         os:
           - linux
           - win64

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ for Python 3. The following sub-versions are supported:
 * Python 3.10
 * Python 3.11
 * Python 3.12
+* Python 3.113
+
 
 > [!IMPORTANT]
 > Note that Python 3.8 is no longer officially supported.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ for Python 3. The following sub-versions are supported:
 * Python 3.10
 * Python 3.11
 * Python 3.12
-* Python 3.113
+* Python 3.13
 
 
 > [!IMPORTANT]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ exclude_patterns = ["apidoc/*tests*"]
 todo_include_todos = False
 
 # Global constants for supported Python versions
-IDAES_PV_MIN, IDAES_PV_MAX, IDAES_PV_DEFAULT = "3.9", "3.12", "3.10"
+IDAES_PV_MIN, IDAES_PV_MAX, IDAES_PV_DEFAULT = "3.9", "3.13", "3.10"
 
 # This block of text will be virtually present at the end of every file.
 # Used here to define substitutions for re-used URLs, e.g. just add "|examples-site|" to

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ sphinx-copybutton==0.5.2
 pytest
 coverage
 pytest-cov
+greenlet=3.2.1
 # @lbianchi-lbl: both pylint and astroid should be tightly pinned; see .pylint/idaes_transform.py for more info
 pylint==3.0.3
 astroid==3.0.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,6 @@ sphinx-copybutton==0.5.2
 pytest
 coverage
 pytest-cov
-greenlet==3.2.1
 # @lbianchi-lbl: both pylint and astroid should be tightly pinned; see .pylint/idaes_transform.py for more info
 pylint==3.0.3
 astroid==3.0.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ sphinx-copybutton==0.5.2
 pytest
 coverage
 pytest-cov
-greenlet=3.2.1
+greenlet==3.2.1
 # @lbianchi-lbl: both pylint and astroid should be tightly pinned; see .pylint/idaes_transform.py for more info
 pylint==3.0.3
 astroid==3.0.3

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class ExtraDependencies:
     ui = [
         # FIXME this must be changed to the PyPI distribution for the release
         # "idaes-ui",
-        "idaes-ui @ git+https://github.com/IDAES/idaes-ui@main",
+        "idaes-ui @ git+https://github.com/sufikaur/idaes-ui@main",
     ]
     omlt = [
         "omlt==1.1",  # fix the version for now as package evolves

--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,7 @@ class ExtraDependencies:
     coolprop = [
         "coolprop>=7.0",  # idaes.generic_models.properties.general.coolprop
     ]
-    testing = [
-        "pytest",
-        "addheader",
-        "pyyaml"
-    ]
+    testing = ["pytest", "addheader", "pyyaml"]
 
     def __init__(self):
         self._data = dict(type(self).__dict__)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class ExtraDependencies:
     ui = [
         # FIXME this must be changed to the PyPI distribution for the release
         # "idaes-ui",
-        "idaes-ui @ git+https://github.com/sufikaur/idaes-ui@main",
+        "idaes-ui @ git+https://github.com/IDAES/idaes-ui@main",
     ]
     omlt = [
         "omlt==1.1",  # fix the version for now as package evolves

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ kwargs = dict(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Chemistry",

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,7 @@ class ExtraDependencies:
     """
 
     ui = [
-        # FIXME this must be changed to the PyPI distribution for the release
-        # "idaes-ui",
-        "idaes-ui @ git+https://github.com/sufikaur/idaes-ui@main",
+        "idaes-ui",
     ]
     omlt = [
         "omlt==1.1",  # fix the version for now as package evolves

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class ExtraDependencies:
     ui = [
         # FIXME this must be changed to the PyPI distribution for the release
         # "idaes-ui",
-        "idaes-ui @ git+https://github.com/IDAES/idaes-ui@main",
+        "idaes-ui @ git+https://github.com/sufikaur/idaes-ui@main",
     ]
     omlt = [
         "omlt==1.1",  # fix the version for now as package evolves
@@ -55,7 +55,7 @@ class ExtraDependencies:
     testing = [
         "pytest",
         "addheader",
-        "pyyaml",
+        "pyyaml"
     ]
 
     def __init__(self):


### PR DESCRIPTION
## Fixes
[Issue 1668](https://github.com/IDAES/idaes-pse/issues/1668)

## Summary/Motivation:
Catch up to current python releases. 3.14 will be released soon so understanding is supporting 3.13 is possible with the current state.

## Changes proposed in this PR:
- Add 3.13 python to the current workflow
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


Notes
current version of greenlet is 3.0.3. thus, the dependency is breaking for 3.13 tests (support added by greenlet for py3.13 with version[ 3.1.0](https://greenlet.readthedocs.io/en/stable/changes.html)