### PR TITLE
Fix initialization of FpcTP with one phase

### DIFF
--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -1691,15 +1691,14 @@ class _GenericStateBlock(StateBlock):
 
         for k in self.values():
             # Also need to deactivate sum of mole fraction constraint
-            try:
+            if k.is_property_constructed("sum_mole_frac_out"):
                 k.sum_mole_frac_out.deactivate()
-            except AttributeError:
-                pass
+
             # Don't need equilibrium constraint for phase component flows
             if (
                 "flow_mol_phase_comp" in k.define_state_vars()
                 or "mole_frac_phase_comp" in k.define_state_vars()
-            ):
+            ) and k.is_property_constructed("equilibrium_constraint"):
                 k.equilibrium_constraint.deactivate()
 
             if k.is_property_constructed("inherent_equilibrium_constraint") and (
@@ -1793,9 +1792,7 @@ class _GenericStateBlock(StateBlock):
             # When state vars are fixed, check that DoF is 0
             for k in blk.values():
                 if degrees_of_freedom(k) != 0:
-                    # PYLINT-TODO
-                    # pylint: disable-next=broad-exception-raised
-                    raise Exception(
+                    raise InitializationError(
                         "State vars fixed but degrees of "
                         "freedom for state block is not zero "
                         "during initialization."

--- a/idaes/models/properties/modular_properties/state_definitions/tests/test_FpcTP.py
+++ b/idaes/models/properties/modular_properties/state_definitions/tests/test_FpcTP.py
@@ -19,8 +19,16 @@ Authors: Andrew Lee
 import pytest
 import re
 from sys import modules
+from copy import deepcopy
 
-from pyomo.environ import ConcreteModel, Constraint, Expression, Var, units as pyunits
+from pyomo.environ import (
+    ConcreteModel,
+    Constraint,
+    Expression,
+    value,
+    Var,
+    units as pyunits,
+)
 from pyomo.util.check_units import check_units_equivalent, assert_units_consistent
 
 # Need define_default_scaling_factors, even though it is not used directly
@@ -55,6 +63,7 @@ from idaes.models.properties.modular_properties.phase_equil.bubble_dew import (
 )
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.logger as idaeslog
+import idaes.core.util.model_statistics as mstat
 from idaes.core.util.model_statistics import degrees_of_freedom, large_residuals_set
 
 
@@ -1504,3 +1513,71 @@ def test_phase_equilibrium_initializer_object():
             "fs.state[0.0].equilibrium_constraint[Vap,Liq,H2O]",
             "fs.state[0.0].equilibrium_constraint[Vap,Liq,CO2]",
         ]
+
+
+@pytest.mark.component
+def test_initializer_object_single_phase():
+    # This test ensures that FpcTP state variables can be
+    # initialized even if only a single phase is present
+    model = ConcreteModel()
+    model.fs = FlowsheetBlock(dynamic=False)
+
+    # Remove the liquid phase and phase equilibrium
+    # from the config dict
+    config = deepcopy(thermo_config_no_rxn)
+    config["phases"].pop("Liq")
+    config.pop("phases_in_equilibrium")
+    config.pop("phase_equilibrium_state")
+    config["components"]["H2O"].pop("phase_equilibrium_form")
+    config["components"]["CO2"].pop("phase_equilibrium_form")
+
+    model.fs.thermo_params = GenericParameterBlock(**config)
+
+    model.fs.state = model.fs.thermo_params.build_state_block(
+        model.fs.time, defined_state=False
+    )
+
+    model.fs.state[0].pressure.set_value(101325.0)
+    model.fs.state[0].temperature.set_value(398.0)
+
+    model.fs.state[0].flow_mol_phase_comp["Vap", "CO2"].set_value(0.005)
+    model.fs.state[0].flow_mol_phase_comp["Vap", "H2O"].set_value(0.0005)
+
+    assert_units_consistent(model)
+    # We expect 4 state variables: T, P, and two pc flows,
+    # and  2 non-state variables in mole_frac_phase_comp
+    # Because T and P don't appear in any constraints,
+    # they are not counted in degrees_of_freedom
+    vars_not_in_constraints = mstat.variables_not_in_activated_constraints_set(
+        model.fs.state[0]
+    )
+    assert len(vars_not_in_constraints) == 2
+    assert model.fs.state[0].pressure in vars_not_in_constraints
+    assert model.fs.state[0].temperature in vars_not_in_constraints
+
+    assert degrees_of_freedom(model) == 2
+
+    initializer = model.fs.state.default_initializer()
+
+    initializer.initialize(model.fs.state)
+
+    # Check that degrees of freedom are still the same
+    vars_not_in_constraints = mstat.variables_not_in_activated_constraints_set(
+        model.fs.state[0]
+    )
+    assert len(vars_not_in_constraints) == 2
+    assert model.fs.state[0].pressure in vars_not_in_constraints
+    assert model.fs.state[0].temperature in vars_not_in_constraints
+
+    assert degrees_of_freedom(model) == 2
+
+    assert value(model.fs.state[0].pressure) == 101325.0
+    assert value(model.fs.state[0].temperature) == 398.0
+    assert value(model.fs.state[0].flow_mol_phase_comp["Vap", "CO2"]) == 0.005
+    assert value(model.fs.state[0].flow_mol_phase_comp["Vap", "H2O"]) == 0.0005
+    assert value(model.fs.state[0].mole_frac_phase_comp["Vap", "CO2"]) == pytest.approx(
+        5 / 5.5
+    )
+    assert value(model.fs.state[0].mole_frac_phase_comp["Vap", "H2O"]) == pytest.approx(
+        0.5 / 5.5
+    )


### PR DESCRIPTION
## Summary/Motivation:
@blnicho and @mrmundt discovered a test failure in examples that was not picked up by the CI because we only run the notebooks in examples in the CI, not any tests in .py files. This PR fixes that issue, and I've verified that it works on my local machine.

When `FpcTP` state variables are used without any VLE present, `fix_initialization_states` attempts to deactivate `equilibirum_constraint`, which results in an `AttributeError`. This PR fixes that problem and adds a test to make sure the problem stays fixed.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
