### PR TITLE
Test `.py` files from `examples` as part of Integration tests

### DIFF
--- a/.github/actions/run-examples/action.yml
+++ b/.github/actions/run-examples/action.yml
@@ -31,6 +31,16 @@ inputs:
     required: false
     default: ''
 
+  run-notebooks:
+    description: "Run notebook tests (via nbmake)"
+    required: false
+    default: 'true'
+
+  run-pyfiles:
+    description: "Run Python *.py tests (test_*.py, *_test.py)"
+    required: false
+    default: 'true'
+
 runs:
   using: composite
   steps:
@@ -63,6 +73,8 @@ runs:
       shell: bash -l {0}
       env:
         PYTHONPATH: ${{ github.action_path }}
+        EXAMPLES_RUN_NOTEBOOKS: ${{ inputs.run-notebooks }}
+        EXAMPLES_RUN_PYFILES: ${{ inputs.run-pyfiles }}
         PYTEST_ADDOPTS: >-
           --color=yes
           --durations=0


### PR DESCRIPTION
## Fixes NA


## Summary/Motivation:
We recently found out that the integration tests only running the notebooks can actually cause us to miss some regressions between idaes-pse and examples (see PR #1677 ). This turns on testing both notebooks _and_ `test_*.py` files in the `examples` repo as part of the integration tests.

## Changes proposed in this PR:
- Introduce new environment variables to control both notebook and `.py` files into the driver
- Modify the action appropriately

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
