### PR TITLE
Remove usage of pkg_resources which has been deprecated

### DIFF
--- a/idaes/core/util/env_info.py
+++ b/idaes/core/util/env_info.py
@@ -19,8 +19,8 @@ __author__ = "John Eslick"
 import sys
 import platform
 import json
-import importlib
-import pkg_resources
+import importlib.metadata
+from packaging.requirements import Requirement
 
 import pyomo
 import pyomo.environ as pyo
@@ -72,22 +72,21 @@ class EnvironmentInfo:
         self.pyomo_version = pyomo.version.__version__
         # Get dependency info
         self.dependency_versions = {}
-        reqs = pkg_resources.get_distribution("idaes-pse").requires()
-        for dep in [x.name for x in reqs]:
+        reqs = importlib.metadata.requires("idaes-pse")
+        for req in reqs:
+            dep = Requirement(req).name
             if dep == "pyomo":
                 continue  # pyomo is special
             try:
-                self.dependency_versions[dep] = pkg_resources.get_distribution(
-                    dep
-                ).version
-            except pkg_resources.DistributionNotFound:
+                self.dependency_versions[dep] = importlib.metadata.version(dep)
+            except importlib.metadata.PackageNotFoundError:
                 self.dependency_versions[dep] = None
         # Extra packages, users must install these for esoteric features
         self.extra_versions = {}
         for dep in self.extras:
             try:
-                self.extra_versions[dep] = pkg_resources.get_distribution(dep).version
-            except pkg_resources.DistributionNotFound:
+                self.extra_versions[dep] = importlib.metadata.version(dep)
+            except importlib.metadata.PackageNotFoundError:
                 self.extra_versions[dep] = None
         self.solver_versions = {}
         for s in self.known_solvers + list(additional_solvers):


### PR DESCRIPTION
## Summary/Motivation:
`pkg_resources` has been removed from `setuptools`. Most common uses of `pkg_resources` have been superseded by `importlib.metadata`. This PR replaces uses of `pkg_resources` with functionality from `importlib.metadata`.

## Changes proposed in this PR:
- Replace deprecated uses of `pkg_resources`
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
