### PR TITLE
Update pre-commit hook with updated version of black (26.1.0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 26.1.0
     hooks:
     - id: black
       language_version: python3


### PR DESCRIPTION
## Fixes

## Summary/Motivation:
.pre-commit-config.yaml has black set to older version 24. 

## Changes proposed in this PR:
- Updating this hook now that the black upgrade has happened to 26.1.0

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
