### PR TITLE
Add support for python 3.14

### DIFF
--- a/.github/actions/run-examples/examples_for_idaes_ci.py
+++ b/.github/actions/run-examples/examples_for_idaes_ci.py
@@ -4,6 +4,7 @@ pytest plugin for testing IDAES "through" IDAES/examples within the IDAES/idaes-
 
 from contextlib import contextmanager
 import fnmatch
+from importlib.util import find_spec
 import os
 from pathlib import Path
 import sys
@@ -31,7 +32,7 @@ def _matches_pattern(item: pytest.Item, pattern: str) -> bool:
 
 
 def pytest_configure(config: pytest.Config):
-    config.stash[matchmarker] = {
+    markers = {
         "*/held/*": pytest.mark.xfail(run=False, reason="notebook has 'held' status"),
         "*/archive/*": pytest.mark.skip(reason="notebook is archived"),
         "*/surrogates/sco2/alamo/*": pytest.mark.xfail(
@@ -39,6 +40,25 @@ def pytest_configure(config: pytest.Config):
             reason="notebooks require ALAMO to run",
         ),
     }
+
+    # TODO: Remove these exclusions and the Python version marker in
+    # pyproject.toml when a stable TensorFlow release provides Python 3.14
+    # distributions.
+    if find_spec("tensorflow") is None:
+        requires_tensorflow = pytest.mark.xfail(
+            run=False,
+            reason="notebook requires TensorFlow to run",
+        )
+        for pattern in (
+            "*/surrogates/best_practices_optimization_test.ipynb",
+            "*/surrogates/omlt/keras_flowsheet_optimization_test.ipynb",
+            "*/surrogates/sco2/omlt/flowsheet_optimization_test.ipynb",
+            "*/surrogates/sco2/omlt/keras_training_test.ipynb",
+            "*/surrogates/sco2/omlt/surrogate_embedding_test.ipynb",
+        ):
+            markers[pattern] = requires_tensorflow
+
+    config.stash[matchmarker] = markers
     config.stash[marked] = []
 
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.14"]
         os:
           - linux
           - win64

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.14 ']
         os:
           - linux
           - win64
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.14']
         os:
           - linux
           - win64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os:
           - linux
           - win64
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os:
           - linux
           - win64

--- a/README.md
+++ b/README.md
@@ -86,10 +86,15 @@ for Python 3. The following sub-versions are supported:
 * Python 3.11
 * Python 3.12
 * Python 3.13
+* Python 3.14
 
 
 > [!IMPORTANT]
 > Note that Python 3.8 is no longer officially supported.
+>
+> TensorFlow does not currently provide distributions for Python 3.14. The
+> `omlt` optional dependency supports ONNX surrogates on Python 3.14, but Keras
+> surrogates require Python 3.13 or earlier until TensorFlow adds support.
 
 ## Contacts and more information
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ grid = [
 ]
 omlt = [
   "omlt==1.1",  # fix the version for now as package evolves
-  # TensorFlow does not yet publish distributions for Python 3.14.
+  # TODO: Remove the marker when TensorFlow publishes Python 3.14 distributions.
   "tensorflow; python_version < '3.14'",
   "onnx",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Mathematics",
   "Topic :: Scientific/Engineering :: Chemistry",
@@ -64,7 +65,8 @@ grid = [
 ]
 omlt = [
   "omlt==1.1",  # fix the version for now as package evolves
-  "tensorflow",
+  # TensorFlow does not yet publish distributions for Python 3.14.
+  "tensorflow; python_version < '3.14'",
   "onnx",
 ]
 testing = ["pytest", "addheader", "pyyaml"]


### PR DESCRIPTION
## Fixes

#1753 

## Summary/Motivation:
Python 3.14 has been out for a while. We should add support for it. It is complicated by the fact that one of the optional dependencies, `tensorflow`, does not support python 3.14 yet.

## Changes proposed in this PR:
- Add 3.14 python to CI (integration and core checks)
- Updated the `omlt` optional dependency group in `pyproject.toml` to only install TensorFlow for Python versions earlier than 3.14, due to lack of TensorFlow support for Python 3.14. 
- Added documentation notes in `README.md` about TensorFlow and Keras surrogate support limitations on Python 3.14.
- Enhanced the test configuration in `examples_for_idaes_ci.py` to automatically skip or mark as expected-fail any notebooks requiring TensorFlow if it is not installed (e.g., on Python 3.14).


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
