### PR TITLE
get_relative_path helper function

### DIFF
--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -246,14 +246,15 @@ def print_compact_form(expr, stream=None):
 
     stream.write(compact_expression_to_string(expr))
 
+
 def get_relative_path(comp: ComponentBase, blk: pyo.Block):
     """
     Finds the path of a component relative to a block.
 
-    For example if blk = m.fs.unit and 
+    For example if blk = m.fs.unit and
     comp = m.fs.unit.control_volume.properties_in[0].temperature,
     get_relative_path(comp, blk) would return
-    "control_volume.properties_in[0].temperature". 
+    "control_volume.properties_in[0].temperature".
 
     Converse operation to the Block.find_component method.
 
@@ -285,6 +286,4 @@ def get_relative_path(comp: ComponentBase, blk: pyo.Block):
         path_str = parent_blk.local_name + "." + path_str
         parent_blk = parent_blk.parent_block()
 
-    raise ValueError(
-        f"Block {blk.name} is not a ancestor of component {comp.name}."
-    )
+    raise ValueError(f"Block {blk.name} is not a ancestor of component {comp.name}.")

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -21,6 +21,7 @@ import sys
 import pyomo.environ as pyo
 from pyomo.common.config import ConfigBlock
 from pyomo.core.expr.visitor import _ToStringVisitor
+from pyomo.core.base.component import ComponentBase
 from pyomo.core.base.expression import ExpressionData
 
 import idaes.logger as idaeslog
@@ -244,3 +245,46 @@ def print_compact_form(expr, stream=None):
         expr = expr.expr
 
     stream.write(compact_expression_to_string(expr))
+
+def get_relative_path(comp: ComponentBase, blk: pyo.Block):
+    """
+    Finds the path of a component relative to a block.
+
+    For example if blk = m.fs.unit and 
+    comp = m.fs.unit.control_volume.properties_in[0].temperature,
+    get_relative_path(comp, blk) would return
+    "control_volume.properties_in[0].temperature". 
+
+    Converse operation to the Block.find_component method.
+
+    Args:
+        comp: Pyomo component to get relative path of
+        blk: Pyomo block to define base of relative path
+
+    Returns:
+        rel_path: str giving relative path of comp on blk
+    """
+    if not comp.model() is blk.model():
+        # Should this be an attribute error?
+        raise ValueError(
+            f"Component {comp.name} and block {blk.name} are not "
+            "on the same Pyomo model."
+        )
+    if blk.is_indexed():
+        raise TypeError(
+            f"Cannot find a path relative to the indexed block {blk.name}. Call this function "
+            "with either its parent block or its BlockData children instead."
+        )
+
+    parent_blk = comp.parent_block()
+    path_str = comp.local_name
+    # blk.parent_block() returns None if blk is the parent ConcreteModel
+    while parent_blk is not None:
+        if blk is parent_blk:
+            return path_str
+        path_str = parent_blk.local_name + "." + path_str
+        parent_blk = parent_blk.parent_block()
+
+    raise ValueError(
+        f"Block {blk.name} is not a ancestor of component {comp.name}."
+    )

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -24,9 +24,10 @@ from pyomo.core.base.units_container import UnitsError
 
 from idaes.core.util.misc import (
     add_object_reference,
-    set_param_from_config,
     compact_expression_to_string,
+    get_relative_path,
     print_compact_form,
+    set_param_from_config,
 )
 import idaes.logger as idaeslog
 
@@ -415,3 +416,112 @@ class TestToExprStringVisitor:
         print_compact_form(m.c1, stream=stream)
 
         assert stream.getvalue() == expected
+
+class TestGetRelativePath:
+    @pytest.fixture
+    def model(self):
+        m = ConcreteModel()
+        m.s = Set(initialize=[1, 2, 3, 4])
+
+        m.v = Var(m.s)
+
+        @m.Constraint(m.s)
+        def c(b, i):
+            return b.v[i] == i
+
+        @m.Expression()
+        def e1(b):
+            return sum(b.v[k] for k in b.s)
+
+        def rule_indexed_block(blk, j):
+            def e2_rule(b, k):
+                return k * b.v2
+            
+            blk.v2 = Var()
+            blk.e2 = Expression(m.s, rule=e2_rule)
+            blk.sb = Block()
+            blk.sb.x = Var()
+
+        m.b = Block(m.s, rule=rule_indexed_block)
+
+        m.b2 = Block()
+        m.b2.z = Var()
+        m.b2.sb = Block(m.s, rule=rule_indexed_block)
+
+        return m
+
+    @pytest.mark.unit
+    def test_idempotence(self, model):
+        # get_relative_path should be the converse operation
+        # to find_component---the latter finds a Pyomo component
+        # on a block from a relative path, while the former finds
+        # a relative path from a Pyomo component and Block
+
+        # Therefore blk.find_component(get_relative_path(comp, blk))
+        # should be comp.
+        counter = 0
+        for comp in model.component_data_objects():
+            loop_components = [comp]
+            # for indexed components, we want to test both the
+            # parent component and its component data children
+            if comp.is_indexed():
+                for compdata in comp.values():
+                    loop_components.append(compdata)
+
+            for subcomp in loop_components:
+                parent_block = subcomp.parent_block()
+                while parent_block is not None:
+                    counter += 1
+                    rel_path = get_relative_path(subcomp, parent_block)
+                    converse_comp = parent_block.find_component(rel_path)
+                    assert subcomp is converse_comp
+                    
+                    parent_block = parent_block.parent_block()
+        
+        # Perform a check-sum so that we know that these loops
+        # are hitting all the components (and not just terminating
+        # after zero iterations).
+        assert counter == 173
+
+    @pytest.mark.unit
+    def test_get_relative_path(self, model):
+        m = model
+
+        assert get_relative_path(m.v, m) == "v"
+
+        assert get_relative_path(m.b, m) == "b"
+        assert get_relative_path(m.b[1].v2, m) == "b[1].v2"
+        assert get_relative_path(m.b[1].v2, m.b[1]) == "v2"
+        assert get_relative_path(m.b[3].sb.x, m) == "b[3].sb.x"
+        assert get_relative_path(m.b[3].sb.x, m.b[3]) == "sb.x"
+        assert get_relative_path(m.b[3].sb.x, m.b[3].sb) == "x"
+
+        assert get_relative_path(m.b2.z, m) == "b2.z"
+        assert get_relative_path(m.b2.z, m.b2) == "z"
+        assert get_relative_path(m.b2.sb[1].e2, m.b2) == "sb[1].e2"
+        assert get_relative_path(m.b2.sb[1].e2[2], m.b2) == "sb[1].e2[2]"
+
+    @pytest.mark.unit
+    def test_indexed_block(self, model):
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "Cannot find a path relative to the indexed block b. Call this function "
+                "with either its parent block or its BlockData children instead."
+            )
+        ):
+            _ = get_relative_path(model.b[1].v2, model.b)
+
+    @pytest.mark.unit
+    def test_two_models(self, model):
+        m2 = ConcreteModel()
+        m2.x = Var()
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+            f"Component x and block b are not "
+            "on the same Pyomo model."
+            )
+        ):
+            _ = get_relative_path(m2.x, model.b)
+        

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -417,6 +417,7 @@ class TestToExprStringVisitor:
 
         assert stream.getvalue() == expected
 
+
 class TestGetRelativePath:
     @pytest.fixture
     def model(self):
@@ -436,7 +437,7 @@ class TestGetRelativePath:
         def rule_indexed_block(blk, j):
             def e2_rule(b, k):
                 return k * b.v2
-            
+
             blk.v2 = Var()
             blk.e2 = Expression(m.s, rule=e2_rule)
             blk.sb = Block()
@@ -475,9 +476,9 @@ class TestGetRelativePath:
                     rel_path = get_relative_path(subcomp, parent_block)
                     converse_comp = parent_block.find_component(rel_path)
                     assert subcomp is converse_comp
-                    
+
                     parent_block = parent_block.parent_block()
-        
+
         # Perform a check-sum so that we know that these loops
         # are hitting all the components (and not just terminating
         # after zero iterations).
@@ -508,7 +509,7 @@ class TestGetRelativePath:
             match=re.escape(
                 "Cannot find a path relative to the indexed block b. Call this function "
                 "with either its parent block or its BlockData children instead."
-            )
+            ),
         ):
             _ = get_relative_path(model.b[1].v2, model.b)
 
@@ -519,9 +520,7 @@ class TestGetRelativePath:
         with pytest.raises(
             ValueError,
             match=re.escape(
-            f"Component x and block b are not "
-            "on the same Pyomo model."
-            )
+                f"Component x and block b are not " "on the same Pyomo model."
+            ),
         ):
             _ = get_relative_path(m2.x, model.b)
-        

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -519,8 +519,14 @@ class TestGetRelativePath:
         m2.x = Var()
         with pytest.raises(
             ValueError,
-            match=re.escape(
-                f"Component x and block b are not " "on the same Pyomo model."
-            ),
+            match=re.escape("Component x and block b are not on the same Pyomo model."),
         ):
             _ = get_relative_path(m2.x, model.b)
+
+    @pytest.mark.unit
+    def test_no_relative_path(self, model):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(f"Block b[1] is not a ancestor of component b2.z."),
+        ):
+            _ = get_relative_path(model.b2.z, model.b[1])


### PR DESCRIPTION
## Summary/Motivation:
As part of a separate branch, I needed a helper function that took a Pyomo component and block and returned the path to the Pyomo component from that block. Essentially, it's a converse function to `Block.find_component`. That other PR ended up not working out for unrelated reasons, but this helper function works and has tests.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
