### PR TITLE
Default scaler objects for properties and reactions

### DIFF
--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -110,6 +110,7 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
 
         # By default, property packages do not include inherent reactions
         self._has_inherent_reactions = False
+        self._default_state_scaler = None
 
     @property
     def state_block_class(self):
@@ -125,6 +126,39 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
     @property
     def has_inherent_reactions(self):
         return self._has_inherent_reactions
+    
+    @property
+    def has_default_state_scaler(self):
+        if self._default_state_scaler is None:
+            return False
+        else:
+            return True
+
+    @property
+    def default_state_scaler(self):
+        if self._default_state_scaler is not None:
+            return self._default_state_scaler
+        else:
+            raise AttributeError(
+                f"{self.name} has not been provided with a default scaler object "
+                "to use on state blocks."
+            )
+
+    @default_state_scaler.setter
+    def default_state_scaler(self, scaler_obj):
+        # Defer import to avoid circular import
+        from idaes.core.scaling.scaling_base import ScalerBase
+        
+        if isinstance(scaler_obj, ScalerBase):
+            self._default_state_scaler = scaler_obj
+        else:
+            raise TypeError(
+                f"Expected a subclass of ScalerBase, but instead got {type(scaler_obj)}."
+            )
+
+    @default_state_scaler.deleter
+    def default_state_scaler(self):
+        self._default_state_scaler = None
 
     def build_state_block(self, *args, **kwargs):
         """

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -636,7 +636,10 @@ should be constructed in this state block,
 
     @property
     def default_scaler(self):
-        return self.parent_component().default_scaler
+        if self is self.parent_component():
+            return self.params._state_block_class.default_scaler
+        else:
+            return self.parent_component().default_scaler
 
     def build(self):
         """

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -117,7 +117,7 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
         if self._state_block_class is not None:
             return self._state_block_class
         else:
-            # Python catches the error and raises its own AttributeError
+            # Pyomo catches the error and raises its own AttributeError
             # with its own message. Leave the error, though, in case
             # the user looks through the code and ends up here.
             raise AttributeError(

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -639,12 +639,12 @@ should be constructed in this state block,
 
     @property
     def default_scaler(self):
-        if self is self.parent_component():
-            # pylint: disable=protected-access
-            return self.params._state_block_class.default_scaler
-            # pylint: enable=protected-access
-        else:
-            return self.parent_component().default_scaler
+        for parent_class in type(self).__bases__:
+            if issubclass(parent_class, StateBlock):
+                # Scalar state block
+                return super(parent_class, self).default_scaler
+        # Child of indexed block
+        return self.parent_component().default_scaler
 
     def build(self):
         """

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -149,7 +149,8 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
 
     @default_state_scaler_object.setter
     def default_state_scaler_object(self, scaler_obj):
-        # Defer import to avoid circular import
+        # Top-level import creates circular import
+        # pylint: disable=import-outside-toplevel
         from idaes.core.scaling.scaling_base import ScalerBase
 
         if isinstance(scaler_obj, ScalerBase):

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -139,7 +139,7 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
         if self._default_state_scaler_object is not None:
             return self._default_state_scaler_object
         else:
-            # Python catches the error and raises its own AttributeError
+            # Pyomo catches the error and raises its own AttributeError
             # with its own message. Leave the error, though, in case
             # the user looks through the code and ends up here.
             raise AttributeError(

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -110,13 +110,16 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
 
         # By default, property packages do not include inherent reactions
         self._has_inherent_reactions = False
-        self._default_state_scaler = None
+        self._default_state_scaler_object = None
 
     @property
     def state_block_class(self):
         if self._state_block_class is not None:
             return self._state_block_class
         else:
+            # Python catches the error and raises its own AttributeError
+            # with its own message. Leave the error, though, in case
+            # the user looks through the code and ends up here.
             raise AttributeError(
                 "{} has not assigned a StateBlock class to be associated "
                 "with this property package. Please contact the developer of "
@@ -126,38 +129,38 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
     @property
     def has_inherent_reactions(self):
         return self._has_inherent_reactions
-    
-    @property
-    def has_default_state_scaler(self):
-        if self._default_state_scaler is None:
-            return False
-        else:
-            return True
 
     @property
-    def default_state_scaler(self):
-        if self._default_state_scaler is not None:
-            return self._default_state_scaler
+    def default_state_scaler_class(self):
+        return self._state_block_class.default_scaler
+
+    @property
+    def default_state_scaler_object(self):
+        if self._default_state_scaler_object is not None:
+            return self._default_state_scaler_object
         else:
+            # Python catches the error and raises its own AttributeError
+            # with its own message. Leave the error, though, in case
+            # the user looks through the code and ends up here.
             raise AttributeError(
                 f"{self.name} has not been provided with a default scaler object "
                 "to use on state blocks."
             )
 
-    @default_state_scaler.setter
-    def default_state_scaler(self, scaler_obj):
+    @default_state_scaler_object.setter
+    def default_state_scaler_object(self, scaler_obj):
         # Defer import to avoid circular import
         from idaes.core.scaling.scaling_base import ScalerBase
-        
+
         if isinstance(scaler_obj, ScalerBase):
-            self._default_state_scaler = scaler_obj
+            self._default_state_scaler_object = scaler_obj
         else:
             raise TypeError(
-                f"Expected a subclass of ScalerBase, but instead got {type(scaler_obj)}."
+                f"Expected an instance of a subclass of ScalerBase, but instead got {type(scaler_obj)}."
             )
 
-    @default_state_scaler.deleter
-    def default_state_scaler(self):
+    @default_state_scaler_object.deleter
+    def default_state_scaler_object(self):
         self._default_state_scaler = None
 
     def build_state_block(self, *args, **kwargs):

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -153,6 +153,8 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
         # pylint: disable=import-outside-toplevel
         from idaes.core.scaling.scaling_base import ScalerBase
 
+        # pylint: enable=import-outside-toplevel
+
         if isinstance(scaler_obj, ScalerBase):
             self._default_state_scaler_object = scaler_obj
         else:
@@ -638,7 +640,9 @@ should be constructed in this state block,
     @property
     def default_scaler(self):
         if self is self.parent_component():
+            # pylint: disable=protected-access
             return self.params._state_block_class.default_scaler
+            # pylint: enable=protected-access
         else:
             return self.parent_component().default_scaler
 

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -164,7 +164,7 @@ class PhysicalParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
 
     @default_state_scaler_object.deleter
     def default_state_scaler_object(self):
-        self._default_state_scaler = None
+        self._default_state_scaler_object = None
 
     def build_state_block(self, *args, **kwargs):
         """

--- a/idaes/core/base/reaction_base.py
+++ b/idaes/core/base/reaction_base.py
@@ -155,7 +155,7 @@ class ReactionParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
 
     @default_reaction_scaler_object.deleter
     def default_reaction_scaler_object(self):
-        self._default_reaction_scaler = None
+        self._default_reaction_scaler_object = None
 
     def build_reaction_block(self, *args, **kwargs):
         """

--- a/idaes/core/base/reaction_base.py
+++ b/idaes/core/base/reaction_base.py
@@ -311,13 +311,12 @@ should be constructed in this reaction block,
 
     @property
     def default_scaler(self):
-        if self.parent_component() is self:
-            # Scaler block
-            # pylint: disable=protected-access
-            return self.params.reaction_block_class.default_scaler
-            # pylint: enable=protected-access
-        else:
-            return self.parent_component().default_scaler
+        for parent_class in type(self).__bases__:
+            if issubclass(parent_class, ReactionBlockBase):
+                # Scalar reaction block
+                return super(parent_class, self).default_scaler
+        # Child of indexed block
+        return self.parent_component().default_scaler
 
     def lock_attribute_creation_context(self):
         """Returns a context manager that does not allow attributes to be created

--- a/idaes/core/base/reaction_base.py
+++ b/idaes/core/base/reaction_base.py
@@ -144,6 +144,8 @@ class ReactionParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
         # pylint: disable=import-outside-toplevel
         from idaes.core.scaling.scaling_base import ScalerBase
 
+        # pylint: enable=import-outside-toplevel
+
         if isinstance(scaler_obj, ScalerBase):
             self._default_reaction_scaler_object = scaler_obj
         else:
@@ -311,7 +313,9 @@ should be constructed in this reaction block,
     def default_scaler(self):
         if self.parent_component() is self:
             # Scaler block
+            # pylint: disable=protected-access
             return self.params.reaction_block_class.default_scaler
+            # pylint: enable=protected-access
         else:
             return self.parent_component().default_scaler
 

--- a/idaes/core/base/reaction_base.py
+++ b/idaes/core/base/reaction_base.py
@@ -130,7 +130,7 @@ class ReactionParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
         if self._default_reaction_scaler_object is not None:
             return self._default_reaction_scaler_object
         else:
-            # Python catches the error and raises its own AttributeError
+            # Pyomo catches the error and raises its own AttributeError
             # with its own message. Leave the error, though, in case
             # the user looks through the code and ends up here.
             raise AttributeError(

--- a/idaes/core/base/reaction_base.py
+++ b/idaes/core/base/reaction_base.py
@@ -140,7 +140,8 @@ class ReactionParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
 
     @default_reaction_scaler_object.setter
     def default_reaction_scaler_object(self, scaler_obj):
-        # Defer import to avoid circular import
+        # Top-level import creates circular import
+        # pylint: disable=import-outside-toplevel
         from idaes.core.scaling.scaling_base import ScalerBase
 
         if isinstance(scaler_obj, ScalerBase):

--- a/idaes/core/base/reaction_base.py
+++ b/idaes/core/base/reaction_base.py
@@ -108,6 +108,7 @@ class ReactionParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
         # TODO: Need way to tie reaction package to a specific property package
         self._validate_property_parameter_units()
         self._validate_property_parameter_properties()
+        self._default_reaction_scaler_object = None
 
     @property
     def reaction_block_class(self):
@@ -119,6 +120,39 @@ class ReactionParameterBlock(ProcessBlockData, property_meta.HasPropertyClassMet
                 "with this reaction package. Please contact the developer of "
                 "the reaction package.".format(self.name)
             )
+
+    @property
+    def default_reaction_scaler_class(self):
+        return self._reaction_block_class.default_scaler
+
+    @property
+    def default_reaction_scaler_object(self):
+        if self._default_reaction_scaler_object is not None:
+            return self._default_reaction_scaler_object
+        else:
+            # Python catches the error and raises its own AttributeError
+            # with its own message. Leave the error, though, in case
+            # the user looks through the code and ends up here.
+            raise AttributeError(
+                f"{self.name} has not been provided with a default scaler object "
+                "to use on state blocks."
+            )
+
+    @default_reaction_scaler_object.setter
+    def default_reaction_scaler_object(self, scaler_obj):
+        # Defer import to avoid circular import
+        from idaes.core.scaling.scaling_base import ScalerBase
+
+        if isinstance(scaler_obj, ScalerBase):
+            self._default_reaction_scaler_object = scaler_obj
+        else:
+            raise TypeError(
+                f"Expected an instance of a subclass of ScalerBase, but instead got {type(scaler_obj)}."
+            )
+
+    @default_reaction_scaler_object.deleter
+    def default_reaction_scaler_object(self):
+        self._default_reaction_scaler = None
 
     def build_reaction_block(self, *args, **kwargs):
         """
@@ -274,7 +308,11 @@ should be constructed in this reaction block,
 
     @property
     def default_scaler(self):
-        return self.parent_component().default_scaler
+        if self.parent_component() is self:
+            # Scaler block
+            return self.params.reaction_block_class.default_scaler
+        else:
+            return self.parent_component().default_scaler
 
     def lock_attribute_creation_context(self):
         """Returns a context manager that does not allow attributes to be created

--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -277,6 +277,18 @@ def test_default_state_scaler():
     assert m.p._default_state_scaler_object is scaler_obj
     assert m.p.default_state_scaler_object is scaler_obj
 
+    # Test deleter
+    del m.p.default_state_scaler_object
+
+    assert m.p._default_state_scaler_object is None
+    with pytest.raises(
+        AttributeError,
+        match=re.escape(
+            "_ScalarParameterBlock' object has no attribute 'default_state_scaler_object"
+        ),
+    ):
+        _ = m.p.default_state_scaler_object
+
 
 # -----------------------------------------------------------------------------
 # Test StateBlock

--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -599,7 +599,11 @@ class _Parameters(PhysicalParameterBlock):
         )
 
 
-@declare_process_block_class("StateTest", block_class=StateBlock)
+class _StateBlockTest(StateBlock):
+    default_scaler = ScalerBase
+
+
+@declare_process_block_class("StateTest", block_class=_StateBlockTest)
 class _StateTest(StateBlockData):
     def build(self):
         super(_StateTest, self).build()
@@ -637,6 +641,23 @@ def test_has_inherent_reactions_state_block():
     m.pb._has_inherent_reactions = True
 
     assert m.p.has_inherent_reactions
+
+
+@pytest.mark.unit
+def test_default_scaler_scalar():
+    m = ConcreteModel()
+    m.pb = Parameters()
+    m.p = StateTest(parameters=m.pb)
+    assert m.p.default_scaler is ScalerBase
+
+
+@pytest.mark.unit
+def test_default_scaler_indexed():
+    m = ConcreteModel()
+    m.pb = Parameters()
+    m.p = StateTest([1, 2, 3], parameters=m.pb)
+    assert m.p.default_scaler is ScalerBase
+    assert m.p[1].default_scaler is ScalerBase
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -262,6 +262,16 @@ def test_default_state_scaler():
     ):
         m.p.default_state_scaler_object = not_a_scaler_obj
 
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Expected an instance of a subclass of ScalerBase, but instead got <class 'type'>."
+        ),
+    ):
+        # Do not let the user set a scaler class. Instead force them to set
+        # an instance of a scaler class.
+        _ = m.p.default_state_scaler_object = ScalerBase
+
     scaler_obj = ScalerBase()
     m.p.default_state_scaler_object = scaler_obj
     assert m.p._default_state_scaler_object is scaler_obj

--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -15,7 +15,7 @@ Tests for flowsheet_model.
 
 Author: Andrew Lee
 """
-
+import re
 import pytest
 import types
 
@@ -33,6 +33,7 @@ from idaes.core import (
 )
 from idaes.core.util.exceptions import PropertyPackageError, PropertyNotSupportedError
 from idaes.core.base.property_meta import PropertyClassMetadata
+from idaes.core.scaling.scaling_base import ScalerBase
 
 
 # -----------------------------------------------------------------------------
@@ -228,6 +229,35 @@ def test_has_inherent_reactions():
 
     assert m.p.has_inherent_reactions
 
+@pytest.mark.unit
+def test_default_state_scaler():
+    m = ConcreteModel()
+    m.p = ParameterBlock()
+    
+    assert m.p._default_state_scaler is None
+    assert m.p.has_default_state_scaler == False
+    with pytest.raises(
+        AttributeError,
+        match=re.escape(
+            "_ScalarParameterBlock' object has no attribute 'default_state_scaler"
+        )
+    ):
+        _ = m.p.default_state_scaler
+    
+    not_a_scaler_obj = "foo"
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Expected a subclass of ScalerBase, but instead got <class 'str'>."
+        )
+    ):
+        m.p.default_state_scaler = not_a_scaler_obj
+    
+    scaler_obj = ScalerBase()
+    m.p.default_state_scaler = scaler_obj
+    assert m.p._default_state_scaler is scaler_obj
+    assert m.p.default_state_scaler is scaler_obj
+    
 
 # -----------------------------------------------------------------------------
 # Test StateBlock

--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -15,6 +15,7 @@ Tests for flowsheet_model.
 
 Author: Andrew Lee
 """
+
 import re
 import pytest
 import types
@@ -229,35 +230,43 @@ def test_has_inherent_reactions():
 
     assert m.p.has_inherent_reactions
 
+
 @pytest.mark.unit
 def test_default_state_scaler():
     m = ConcreteModel()
     m.p = ParameterBlock()
-    
-    assert m.p._default_state_scaler is None
-    assert m.p.has_default_state_scaler == False
+
     with pytest.raises(
         AttributeError,
         match=re.escape(
-            "_ScalarParameterBlock' object has no attribute 'default_state_scaler"
-        )
+            "_ScalarParameterBlock' object has no attribute 'default_state_scaler_class"
+        ),
     ):
-        _ = m.p.default_state_scaler
-    
+        _ = m.p.default_state_scaler_class
+
+    assert m.p._default_state_scaler_object is None
+    with pytest.raises(
+        AttributeError,
+        match=re.escape(
+            "_ScalarParameterBlock' object has no attribute 'default_state_scaler_object"
+        ),
+    ):
+        _ = m.p.default_state_scaler_object
+
     not_a_scaler_obj = "foo"
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "Expected a subclass of ScalerBase, but instead got <class 'str'>."
-        )
+            "Expected an instance of a subclass of ScalerBase, but instead got <class 'str'>."
+        ),
     ):
-        m.p.default_state_scaler = not_a_scaler_obj
-    
+        m.p.default_state_scaler_object = not_a_scaler_obj
+
     scaler_obj = ScalerBase()
-    m.p.default_state_scaler = scaler_obj
-    assert m.p._default_state_scaler is scaler_obj
-    assert m.p.default_state_scaler is scaler_obj
-    
+    m.p.default_state_scaler_object = scaler_obj
+    assert m.p._default_state_scaler_object is scaler_obj
+    assert m.p.default_state_scaler_object is scaler_obj
+
 
 # -----------------------------------------------------------------------------
 # Test StateBlock

--- a/idaes/core/base/tests/test_reaction_base.py
+++ b/idaes/core/base/tests/test_reaction_base.py
@@ -16,6 +16,7 @@ Tests for flowsheet_model.
 Author: Andrew Lee
 """
 
+import re
 import pytest
 import inspect
 from pyomo.environ import ConcreteModel, Constraint, Set, Var, units as pyunits
@@ -30,6 +31,7 @@ from idaes.core import (
     StateBlockData,
 )
 from idaes.core.util.exceptions import PropertyPackageError, PropertyNotSupportedError
+from idaes.core.scaling.scaling_base import ScalerBase
 
 
 # -----------------------------------------------------------------------------
@@ -338,6 +340,60 @@ def test_build():
 
     assert hasattr(m.rb, "state_ref")
     assert m.rb.params == m.rb.config.parameters
+
+
+@pytest.mark.unit
+def test_default_reaction_scaler():
+    m = ConcreteModel()
+    m.p = PropertyParameterBlock()
+
+    m.pb = DummyStateBlock(parameters=m.p)
+
+    m.r = ReactionParameterBlock6(property_package=m.p)
+    super(_ReactionParameterBlock6, m.r).build()
+
+    m.rb = ReactionBlock2(parameters=m.r, state_block=m.pb)
+
+    with pytest.raises(
+        AttributeError,
+        match=re.escape(
+            "_ScalarReactionParameterBlock6' object has no attribute 'default_reaction_scaler_class"
+        ),
+    ):
+        _ = m.r.default_reaction_scaler_class
+
+    assert m.r._default_reaction_scaler_object is None
+    with pytest.raises(
+        AttributeError,
+        match=re.escape(
+            "_ScalarReactionParameterBlock6' object has no attribute 'default_reaction_scaler_object"
+        ),
+    ):
+        _ = m.r.default_reaction_scaler_object
+
+    not_a_scaler_obj = "foo"
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Expected an instance of a subclass of ScalerBase, but instead got <class 'str'>."
+        ),
+    ):
+        m.r.default_reaction_scaler_object = not_a_scaler_obj
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Expected an instance of a subclass of ScalerBase, but instead got <class 'type'>."
+        ),
+    ):
+        # Do not let the user set a scaler class. Instead force them to set
+        # an instance of a scaler class.
+        _ = m.r.default_reaction_scaler_object = ScalerBase
+
+    scaler_obj = ScalerBase()
+    m.r.default_reaction_scaler_object = scaler_obj
+    assert m.r._default_reaction_scaler_object is scaler_obj
+    assert m.r.default_reaction_scaler_object is scaler_obj
 
 
 # -----------------------------------------------------------------------------

--- a/idaes/core/base/tests/test_reaction_base.py
+++ b/idaes/core/base/tests/test_reaction_base.py
@@ -432,8 +432,12 @@ class _Parameters(ReactionParameterBlock):
         )
 
 
-@declare_process_block_class("Reaction", block_class=ReactionBlockBase)
-class _Reaction(ReactionBlockDataBase):
+class _Reaction(ReactionBlockBase):
+    default_scaler = ScalerBase
+
+
+@declare_process_block_class("Reaction", block_class=_Reaction)
+class _ReactionBase(ReactionBlockDataBase):
     def build(self):
         super(ReactionBlockDataBase, self).build()
 
@@ -525,6 +529,23 @@ def test_getattr_not_supported(m):
 def test_getattr_raise_exception(m):
     with pytest.raises(Exception):
         m.p.cons = Constraint(expr=m.p.raise_exception == 1)
+
+
+@pytest.mark.unit
+def test_default_scaler_scalar():
+    m = ConcreteModel()
+    m.pb = Parameters()
+    m.p = Reaction(parameters=m.pb)
+    assert m.p.default_scaler is ScalerBase
+
+
+@pytest.mark.unit
+def test_default_scaler_indexed():
+    m = ConcreteModel()
+    m.pb = Parameters()
+    m.p = Reaction([1, 2, 3], parameters=m.pb)
+    assert m.p.default_scaler is ScalerBase
+    assert m.p[1].default_scaler is ScalerBase
 
 
 # TODO : Need a test for cases where method does not create property

--- a/idaes/core/base/tests/test_reaction_base.py
+++ b/idaes/core/base/tests/test_reaction_base.py
@@ -395,6 +395,18 @@ def test_default_reaction_scaler():
     assert m.r._default_reaction_scaler_object is scaler_obj
     assert m.r.default_reaction_scaler_object is scaler_obj
 
+    # Test deleter
+    del m.r.default_reaction_scaler_object
+
+    assert m.r._default_reaction_scaler_object is None
+    with pytest.raises(
+        AttributeError,
+        match=re.escape(
+            "_ScalarReactionParameterBlock6' object has no attribute 'default_reaction_scaler_object"
+        ),
+    ):
+        _ = m.r.default_reaction_scaler_object
+
 
 # -----------------------------------------------------------------------------
 # Test reaction __getattr__ method

--- a/idaes/core/scaling/custom_scaler_base.py
+++ b/idaes/core/scaling/custom_scaler_base.py
@@ -994,8 +994,11 @@ class CustomScalerBase(ScalerBase):
         Returns:
             None
         """
-        # Avoid a circular import
+        # Top-level import creates circular import
+        # pylint: disable=import-outside-toplevel
         from idaes.core.base.property_base import StateBlock, StateBlockData
+
+        # pylint: disable=import-outside-toplevel
         from idaes.core.base.reaction_base import (
             ReactionBlockBase,
             ReactionBlockDataBase,

--- a/idaes/core/scaling/custom_scaler_base.py
+++ b/idaes/core/scaling/custom_scaler_base.py
@@ -994,6 +994,8 @@ class CustomScalerBase(ScalerBase):
         Returns:
             None
         """
+        from idaes.core.base.property_base import StateBlock, StateBlockData
+
         if submodel_scalers is None:
             submodel_scalers = {}
 
@@ -1005,22 +1007,25 @@ class CustomScalerBase(ScalerBase):
                     # Check to see if Scaler is callable - this implies it is a class and not an instance
                     # Call the class to create an instance
                     scaler = scaler(**self.config)
-                _log.debug(f"Using user-defined Scaler for {submodel}.")
+                _log.debug(f"Using user-defined Scaler for {submodel}.")                
             else:
-                try:
-                    scaler = smdata.default_scaler
-                    _log.debug(f"Using default Scaler for {submodel}.")
-                except AttributeError:
-                    _log.debug(
-                        f"No default Scaler set for {submodel}. Cannot call {method}."
-                    )
-                    # TODO Is it possible for one index to have a scaler and another
-                    # not without user insanity?
-                    return
+                if (
+                    (isinstance(smdata, StateBlockData) or isinstance(smdata, StateBlock))
+                    and smdata.params.has_default_state_scaler
+                ):
+                    scaler = smdata.params.default_state_scaler
+                else:
+                    try:
+                        scaler = smdata.default_scaler
+                        _log.debug(f"Using default Scaler for {submodel}.")
+                    except AttributeError:
+                        _log.debug(
+                            f"No default Scaler set for {submodel}. Cannot call {method}."
+                        )
+                        return
                 if scaler is not None:
                     scaler = scaler(**self.config)
                 else:
-                    # TODO Why not return here but return above?
                     _log.debug(f"No Scaler found for {submodel}. Cannot call {method}.")
 
             # If a Scaler is found, call desired method

--- a/idaes/core/scaling/custom_scaler_base.py
+++ b/idaes/core/scaling/custom_scaler_base.py
@@ -1019,11 +1019,17 @@ class CustomScalerBase(ScalerBase):
                     (
                         StateBlockData,
                         StateBlock,
-                        ReactionBlockDataBase,
-                        ReactionBlockBase,
                     ),
                 ) and hasattr(smdata.params, "default_state_scaler_object"):
                     scaler = smdata.params.default_state_scaler_object
+                elif isinstance(
+                    smdata,
+                    (
+                        ReactionBlockDataBase,
+                        ReactionBlockBase,
+                    ),
+                ) and hasattr(smdata.params, "default_reaction_scaler_object"):
+                    scaler = smdata.params.default_reaction_scaler_object
                 else:
                     try:
                         scaler = smdata.default_scaler

--- a/idaes/core/scaling/custom_scaler_base.py
+++ b/idaes/core/scaling/custom_scaler_base.py
@@ -997,12 +997,12 @@ class CustomScalerBase(ScalerBase):
         # Top-level import creates circular import
         # pylint: disable=import-outside-toplevel
         from idaes.core.base.property_base import StateBlock, StateBlockData
-
-        # pylint: disable=import-outside-toplevel
         from idaes.core.base.reaction_base import (
             ReactionBlockBase,
             ReactionBlockDataBase,
         )
+
+        # pylint: enable=import-outside-toplevel
 
         if submodel_scalers is None:
             submodel_scalers = {}

--- a/idaes/core/scaling/custom_scaler_base.py
+++ b/idaes/core/scaling/custom_scaler_base.py
@@ -994,7 +994,12 @@ class CustomScalerBase(ScalerBase):
         Returns:
             None
         """
+        # Avoid a circular import
         from idaes.core.base.property_base import StateBlock, StateBlockData
+        from idaes.core.base.reaction_base import (
+            ReactionBlockBase,
+            ReactionBlockDataBase,
+        )
 
         if submodel_scalers is None:
             submodel_scalers = {}
@@ -1007,13 +1012,18 @@ class CustomScalerBase(ScalerBase):
                     # Check to see if Scaler is callable - this implies it is a class and not an instance
                     # Call the class to create an instance
                     scaler = scaler(**self.config)
-                _log.debug(f"Using user-defined Scaler for {submodel}.")                
+                _log.debug(f"Using user-defined Scaler for {submodel}.")
             else:
-                if (
-                    (isinstance(smdata, StateBlockData) or isinstance(smdata, StateBlock))
-                    and smdata.params.has_default_state_scaler
-                ):
-                    scaler = smdata.params.default_state_scaler
+                if isinstance(
+                    smdata,
+                    (
+                        StateBlockData,
+                        StateBlock,
+                        ReactionBlockDataBase,
+                        ReactionBlockBase,
+                    ),
+                ) and hasattr(smdata.params, "default_state_scaler_object"):
+                    scaler = smdata.params.default_state_scaler_object
                 else:
                     try:
                         scaler = smdata.default_scaler
@@ -1023,10 +1033,11 @@ class CustomScalerBase(ScalerBase):
                             f"No default Scaler set for {submodel}. Cannot call {method}."
                         )
                         return
-                if scaler is not None:
-                    scaler = scaler(**self.config)
-                else:
+                if scaler is None:
                     _log.debug(f"No Scaler found for {submodel}. Cannot call {method}.")
+                elif callable(scaler):
+                    scaler = scaler(**self.config)
+                # else we have already have a scaler object
 
             # If a Scaler is found, call desired method
             if scaler is not None:

--- a/idaes/core/scaling/tests/test_custom_scaler_base.py
+++ b/idaes/core/scaling/tests/test_custom_scaler_base.py
@@ -45,6 +45,9 @@ from idaes.core import (
     Component,
     StateBlock,
     StateBlockData,
+    ReactionParameterBlock,
+    ReactionBlockBase,
+    ReactionBlockDataBase,
 )
 from idaes.core.util.constants import Constants
 from idaes.core.util.testing import PhysicalParameterTestBlock
@@ -195,6 +198,51 @@ class _State(StateBlockData):
 
     def b_method(self):
         self.b = Var(initialize=1)
+
+    def _recursion1(self):
+        self.recursive_cons1 = Constraint(expr=self.recursion2 == 1)
+
+    def _recursion2(self):
+        self.recursive_cons2 = Constraint(expr=self.recursion1 == 1)
+
+    def _raise_exception(self):
+        # PYLINT-TODO
+        # pylint: disable-next=broad-exception-raised
+        raise Exception()
+
+    def _does_not_create_component(self):
+        pass
+
+
+@declare_process_block_class("ReactionParameters")
+class _ReactionParameters(ReactionParameterBlock):
+    def build(self):
+        super(ReactionParameterBlock, self).build()
+
+    @classmethod
+    def define_metadata(cls, obj):
+        obj.define_custom_properties(
+            {
+                "a": {"method": "a_method"},
+                "recursion1": {"method": "_recursion1"},
+                "recursion2": {"method": "_recursion2"},
+                "not_callable": {"method": "test_obj"},
+                "raise_exception": {"method": "_raise_exception"},
+                "not_supported": {"supported": False},
+                "does_not_create_component": {"method": "_does_not_create_component"},
+            }
+        )
+
+
+@declare_process_block_class("Reaction", block_class=ReactionBlockBase)
+class _Reaction(ReactionBlockDataBase):
+    def build(self):
+        super(ReactionBlockDataBase, self).build()
+
+        self.test_obj = 1
+
+    def a_method(self):
+        self.a = Var(initialize=1)
 
     def _recursion1(self):
         self.recursive_cons1 = Constraint(expr=self.recursion2 == 1)
@@ -384,7 +432,7 @@ class TestCustomScalerBase:
         assert m.state._lock_attribute_creation == False
 
     @pytest.mark.unit
-    def test_default_scaler_object(self):
+    def test_default_scaler_object_properties(self):
         m = ConcreteModel()
         m.params = Parameters()
         m.params._state_block_class = State
@@ -414,7 +462,7 @@ class TestCustomScalerBase:
         del State.default_scaler
 
     @pytest.mark.unit
-    def test_provided_scaler_supercedes_default_scaler_object(self):
+    def test_provided_scaler_supercedes_default_scaler_object_properties(self):
         m = ConcreteModel()
         m.params = Parameters()
         m.params._state_block_class = State
@@ -446,6 +494,81 @@ class TestCustomScalerBase:
 
         # Undo global side effect
         del State.default_scaler
+
+    @pytest.mark.unit
+    def test_default_scaler_object_reactions(self):
+        m = ConcreteModel()
+        m.params = Parameters()
+        m.params._state_block_class = State
+        m.state = State(parameters=m.params)
+        add_object_reference(m.state, "_params", m.params)
+        m.state._block_data_config_default["parameters"] = m.params
+
+        m.rxn_params = ReactionParameters(property_package=m.params)
+        m.rxn_params._reaction_block_class = Reaction
+        m.rxn = Reaction(parameters=m.rxn_params)
+        add_object_reference(m.rxn, "_params", m.rxn_params)
+
+        with pytest.raises(AttributeError):
+            _ = m.rxn_params.default_reaction_scaler_class
+
+        Reaction.default_scaler = DummyScaler
+
+        assert m.rxn_params.default_reaction_scaler_class is DummyScaler
+        with pytest.raises(AttributeError):
+            _ = m.rxn_params.default_reaction_scaler_object
+        scaler_obj2 = DummyScaler2()
+        m.rxn_params.default_reaction_scaler_object = scaler_obj2
+
+        scaler_obj = DummyScaler()
+
+        scaler_obj.call_submodel_scaler_method(
+            m.rxn,
+            method="dummy_method",
+        )
+        assert m.rxn._dummy_scaler_test_2 == "foo"
+
+        # Undo global side effect
+        del Reaction.default_scaler
+
+    @pytest.mark.unit
+    def test_provided_scaler_supercedes_default_scaler_object_reactions(self):
+        m = ConcreteModel()
+        m.params = Parameters()
+        m.params._state_block_class = State
+        m.state = State(parameters=m.params)
+        add_object_reference(m.state, "_params", m.params)
+        m.state._block_data_config_default["parameters"] = m.params
+
+        m.rxn_params = ReactionParameters(property_package=m.params)
+        m.rxn_params._reaction_block_class = Reaction
+        m.rxn = Reaction(parameters=m.rxn_params)
+        add_object_reference(m.rxn, "_params", m.rxn_params)
+
+        with pytest.raises(AttributeError):
+            _ = m.rxn_params.default_reaction_scaler_class
+
+        Reaction.default_scaler = DummyScaler
+
+        assert m.rxn_params.default_reaction_scaler_class is DummyScaler
+        with pytest.raises(AttributeError):
+            _ = m.rxn_params.default_reaction_scaler_object
+        scaler_obj2 = DummyScaler2()
+        m.rxn_params.default_reaction_scaler_object = scaler_obj2
+        scaler_obj = DummyScaler()
+
+        scaler_obj3 = DummyScaler3()
+
+        cm = ComponentMap()
+        cm[m.rxn] = scaler_obj3
+
+        scaler_obj.call_submodel_scaler_method(
+            m.rxn, method="dummy_method", submodel_scalers=cm
+        )
+        assert m.rxn._dummy_scaler_test_2 == "bar"
+
+        # Undo global side effect
+        del Reaction.default_scaler
 
     @pytest.mark.unit
     def test_scale_variable_by_component(self, model, caplog):

--- a/idaes/core/scaling/tests/test_custom_scaler_base.py
+++ b/idaes/core/scaling/tests/test_custom_scaler_base.py
@@ -48,6 +48,7 @@ from idaes.core import (
 )
 from idaes.core.util.constants import Constants
 from idaes.core.util.testing import PhysicalParameterTestBlock
+from idaes.core.util.misc import add_object_reference
 
 # Dummy parameter block to test create-on-demand properties
 import idaes.logger as idaeslog
@@ -81,6 +82,66 @@ class DummyScaler(CustomScalerBase):
 
     def dummy_method(self, model, overwrite, submodel_scalers):
         model._dummy_scaler_test = overwrite
+
+
+class DummyScaler2(CustomScalerBase):
+    """
+    Create some dummy methods that will record that they ran in lists
+    """
+
+    def variable_scaling_routine(self, model, overwrite, submodel_scalers):
+        # Create some lists to show that each method was run
+        model._verification = []
+        model._subscalers = {}
+        model.overwrite = []
+
+        model._verification.append("variables2")
+        model._subscalers["variables2"] = submodel_scalers
+        model.overwrite.append(overwrite)
+
+    def constraint_scaling_routine(self, model, overwrite, submodel_scalers):
+        model._verification.append("constraints2")
+        model._subscalers["constraints2"] = submodel_scalers
+        model.overwrite.append(overwrite)
+
+    def fill_in_1(self, model):
+        model._verification.append("fill_in_1_2")
+
+    def fill_in_2(self, model):
+        model._verification.append("fill_in_2_2")
+
+    def dummy_method(self, model, overwrite, submodel_scalers):
+        model._dummy_scaler_test_2 = "foo"
+
+
+class DummyScaler3(CustomScalerBase):
+    """
+    Create some dummy methods that will record that they ran in lists
+    """
+
+    def variable_scaling_routine(self, model, overwrite, submodel_scalers):
+        # Create some lists to show that each method was run
+        model._verification = []
+        model._subscalers = {}
+        model.overwrite = []
+
+        model._verification.append("variables3")
+        model._subscalers["variables3"] = submodel_scalers
+        model.overwrite.append(overwrite)
+
+    def constraint_scaling_routine(self, model, overwrite, submodel_scalers):
+        model._verification.append("constraints3")
+        model._subscalers["constraints3"] = submodel_scalers
+        model.overwrite.append(overwrite)
+
+    def fill_in_1(self, model):
+        model._verification.append("fill_in_1_3")
+
+    def fill_in_2(self, model):
+        model._verification.append("fill_in_2_3")
+
+    def dummy_method(self, model, overwrite, submodel_scalers):
+        model._dummy_scaler_test_2 = "bar"
 
 
 # --------------------------------------------------------------------
@@ -235,7 +296,7 @@ class TestCustomScalerBase:
         ]
 
         # Check that overwrite was passed on
-        model.overwrite == [False, False]
+        assert model.overwrite == [False, False]
 
         # Check that submodel scalers were passed on to methods
         assert model._subscalers == {
@@ -321,6 +382,70 @@ class TestCustomScalerBase:
         m.state.b
         assert sb.get_default_scaling_factor(m.state.b) == 11
         assert m.state._lock_attribute_creation == False
+
+    @pytest.mark.unit
+    def test_default_scaler_object(self):
+        m = ConcreteModel()
+        m.params = Parameters()
+        m.params._state_block_class = State
+        m.state = State(parameters=m.params)
+        add_object_reference(m.state, "_params", m.params)
+        m.state._block_data_config_default["parameters"] = m.params
+
+        with pytest.raises(AttributeError):
+            _ = m.params.default_state_scaler_class
+
+        State.default_scaler = DummyScaler
+
+        assert m.params.default_state_scaler_class is DummyScaler
+        with pytest.raises(AttributeError):
+            _ = m.params.default_state_scaler_object
+        scaler_obj2 = DummyScaler2()
+        m.params.default_state_scaler_object = scaler_obj2
+        scaler_obj = DummyScaler()
+
+        scaler_obj.call_submodel_scaler_method(
+            m.state,
+            method="dummy_method",
+        )
+        assert m.state._dummy_scaler_test_2 == "foo"
+
+        # Undo global side effect
+        del State.default_scaler
+
+    @pytest.mark.unit
+    def test_provided_scaler_supercedes_default_scaler_object(self):
+        m = ConcreteModel()
+        m.params = Parameters()
+        m.params._state_block_class = State
+        m.state = State(parameters=m.params)
+        add_object_reference(m.state, "_params", m.params)
+        m.state._block_data_config_default["parameters"] = m.params
+
+        with pytest.raises(AttributeError):
+            _ = m.params.default_state_scaler_class
+
+        State.default_scaler = DummyScaler
+
+        assert m.params.default_state_scaler_class is DummyScaler
+        with pytest.raises(AttributeError):
+            _ = m.params.default_state_scaler_object
+        scaler_obj2 = DummyScaler2()
+        m.params.default_state_scaler_object = scaler_obj2
+        scaler_obj = DummyScaler()
+
+        scaler_obj3 = DummyScaler3()
+
+        cm = ComponentMap()
+        cm[m.state] = scaler_obj3
+
+        scaler_obj.call_submodel_scaler_method(
+            m.state, method="dummy_method", submodel_scalers=cm
+        )
+        assert m.state._dummy_scaler_test_2 == "bar"
+
+        # Undo global side effect
+        del State.default_scaler
 
     @pytest.mark.unit
     def test_scale_variable_by_component(self, model, caplog):

--- a/idaes/core/scaling/tests/test_custom_scaler_base.py
+++ b/idaes/core/scaling/tests/test_custom_scaler_base.py
@@ -224,12 +224,6 @@ class _ReactionParameters(ReactionParameterBlock):
         obj.define_custom_properties(
             {
                 "a": {"method": "a_method"},
-                "recursion1": {"method": "_recursion1"},
-                "recursion2": {"method": "_recursion2"},
-                "not_callable": {"method": "test_obj"},
-                "raise_exception": {"method": "_raise_exception"},
-                "not_supported": {"supported": False},
-                "does_not_create_component": {"method": "_does_not_create_component"},
             }
         )
 
@@ -243,20 +237,6 @@ class _Reaction(ReactionBlockDataBase):
 
     def a_method(self):
         self.a = Var(initialize=1)
-
-    def _recursion1(self):
-        self.recursive_cons1 = Constraint(expr=self.recursion2 == 1)
-
-    def _recursion2(self):
-        self.recursive_cons2 = Constraint(expr=self.recursion1 == 1)
-
-    def _raise_exception(self):
-        # PYLINT-TODO
-        # pylint: disable-next=broad-exception-raised
-        raise Exception()
-
-    def _does_not_create_component(self):
-        pass
 
 
 @pytest.fixture

--- a/idaes/core/scaling/tests/test_custom_scaler_base.py
+++ b/idaes/core/scaling/tests/test_custom_scaler_base.py
@@ -462,7 +462,7 @@ class TestCustomScalerBase:
         del State.default_scaler
 
     @pytest.mark.unit
-    def test_provided_scaler_supercedes_default_scaler_object_properties(self):
+    def test_provided_scaler_supersedes_default_scaler_object_properties(self):
         m = ConcreteModel()
         m.params = Parameters()
         m.params._state_block_class = State
@@ -532,7 +532,7 @@ class TestCustomScalerBase:
         del Reaction.default_scaler
 
     @pytest.mark.unit
-    def test_provided_scaler_supercedes_default_scaler_object_reactions(self):
+    def test_provided_scaler_supersedes_default_scaler_object_reactions(self):
         m = ConcreteModel()
         m.params = Parameters()
         m.params._state_block_class = State

--- a/idaes/models/properties/general_helmholtz/tests/test_stateblock.py
+++ b/idaes/models/properties/general_helmholtz/tests/test_stateblock.py
@@ -49,6 +49,7 @@ def test_scaler_object_mole_basis():
         pure_component="h2o", amount_basis=AmountBasis.MOLE
     )
 
+    # Test that scaler is set for indexed state block
     m.fs.sb = m.fs.prop_water.build_state_block([0])
 
     assert m.fs.sb[0].default_scaler is hstate.HelmholtzEoSScaler
@@ -102,26 +103,27 @@ def test_scaler_object_mass_basis():
         pure_component="h2o", amount_basis=AmountBasis.MASS
     )
 
-    m.fs.sb = m.fs.prop_water.build_state_block([0])
+    # Test that scaler is set for scalar state block
+    m.fs.sb = m.fs.prop_water.build_state_block()
 
-    assert m.fs.sb[0].default_scaler is hstate.HelmholtzEoSScaler
-    scaler_obj = m.fs.sb[0].default_scaler()
+    assert m.fs.sb.default_scaler is hstate.HelmholtzEoSScaler
+    scaler_obj = m.fs.sb.default_scaler()
 
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "This scaler requires the user to provide a default scaling factor for fs.sb[0].flow_mass, but no default scaling factor was set."
+            "This scaler requires the user to provide a default scaling factor for fs.sb.flow_mass, but no default scaling factor was set."
         ),
     ):
-        scaler_obj.scale_model(m.fs.sb[0])
+        scaler_obj.scale_model(m.fs.sb)
 
     scaler_obj.default_scaling_factors["flow_mass"] = 1 / 137
-    scaler_obj.scale_model(m.fs.sb[0])
+    scaler_obj.scale_model(m.fs.sb)
 
     from idaes.core.scaling import report_scaling_factors
 
     report_scaling_factors(m.fs.sb)
-    sb = m.fs.sb[0]
+    sb = m.fs.sb
     assert len(sb.scaling_factor) == 3
 
     # Variables


### PR DESCRIPTION
## Fixes
- #1686
- Item 5 of #1648

## Summary/Motivation:
When using the old scaling tools, we could set default scaling factors to use for all state blocks using a property package. With the new scaling tools, heretofore we have been forced to use changing the class attribute `DEFAULT_SCALING_FACTORS`. Global mutation is dangerous and ought be avoided when possible.

In this PR, I allow the user to specify a default scaler object to use for all instances of a property or reaction package in a flowsheet by setting the `default_state_scaler_object` or `default_reaction_scaler_object` on their respective parameter blocks.

Additionally, I fixed the issue with the default scaler object for scaler state and reaction blocks.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
