### PR TITLE
docs(getting_started): fix 'get-extension' -> 'get-extensions' CLI name

### DIFF
--- a/docs/tutorials/getting_started/index.rst
+++ b/docs/tutorials/getting_started/index.rst
@@ -80,7 +80,7 @@ assuming that the installation was done using one of the methods described earli
 
         idaes --version
 
-3. Run the ``idaes get-extension`` command to install compiled binaries compatible with the newly upgraded IDAES version. The ``--extra petsc`` argument installs the optional PETSc solver. These binaries include solvers and function libraries.  See :ref:`Binary Packages <tutorials/getting_started/binaries:Binary Packages>` for more details.::
+3. Run the ``idaes get-extensions`` command to install compiled binaries compatible with the newly upgraded IDAES version. The ``--extra petsc`` argument installs the optional PETSc solver. These binaries include solvers and function libraries.  See :ref:`Binary Packages <tutorials/getting_started/binaries:Binary Packages>` for more details.::
 
     idaes get-extensions --extra petsc
 


### PR DESCRIPTION
Fixes #1778.

Line 83 of `docs/tutorials/getting_started/index.rst` said `idaes get-extension` but the CLI command used on line 85 (and the actual installed binary) is `idaes get-extensions` — reporter flagged the inconsistency. Missing 's'.

```diff
- 3. Run the ``idaes get-extension`` command to install ...
+ 3. Run the ``idaes get-extensions`` command to install ...
```

Single-character RST docs fix. No code/test changes.