### PR TITLE
SVD Toolbox displays singular values and newline for print_compact_form

### DIFF
--- a/idaes/core/util/diagnostics_tools/svd_toolbox.py
+++ b/idaes/core/util/diagnostics_tools/svd_toolbox.py
@@ -47,6 +47,7 @@ from idaes.core.util.diagnostics_tools.writer_utils import (
     MAX_STR_LENGTH,
     TAB,
 )
+from idaes.core.util.misc import make_ordinal
 import idaes.logger as idaeslog
 
 _log = idaeslog.getLogger(__name__)
@@ -327,14 +328,16 @@ class SVDToolbox:
             # First, make sure values are feasible
             if e > len(self.s):
                 raise ValueError(
-                    f"Cannot display the {e}-th smallest singular value. "
+                    f"Cannot display the {make_ordinal(e)} smallest singular value. "
                     f"Only {len(self.s)} small singular values have been "
                     "calculated. You can set the number_of_smallest_singular_values "
                     "config argument and call run_svd_analysis again to get more "
                     "singular values."
                 )
 
-            stream.write(f"{TAB}Smallest Singular Value {e}:\n\n")
+            stream.write(
+                f"{TAB}{make_ordinal(e)} Smallest Singular Value: {self.s[e - 1]:.3e}\n\n"
+            )
             stream.write(f"{2 * TAB}Variables:\n\n")
             for v in np.where(abs(self.v[:, e - 1]) > tol)[0]:
                 stream.write(f"{3 * TAB}{self._var_list[v].name}\n")

--- a/idaes/core/util/diagnostics_tools/tests/test_svd_toolbox.py
+++ b/idaes/core/util/diagnostics_tools/tests/test_svd_toolbox.py
@@ -242,7 +242,7 @@ Number of Singular Values less than 1.0E+00 is 1
         expected = """====================================================================================
 Constraints and Variables associated with smallest singular values
 
-    Smallest Singular Value 1:
+    1st Smallest Singular Value: 1.000e-01
 
         Variables:
 
@@ -252,7 +252,7 @@ Constraints and Variables associated with smallest singular values
 
             dummy_eqn[3]
 
-    Smallest Singular Value 2:
+    2nd Smallest Singular Value: 1.000e+00
 
         Variables:
 
@@ -262,7 +262,7 @@ Constraints and Variables associated with smallest singular values
 
             dummy_eqn[1]
 
-    Smallest Singular Value 3:
+    3rd Smallest Singular Value: 5.000e+00
 
         Variables:
 
@@ -272,7 +272,7 @@ Constraints and Variables associated with smallest singular values
 
             dummy_eqn[4]
 
-    Smallest Singular Value 4:
+    4th Smallest Singular Value: 1.000e+01
 
         Variables:
 
@@ -301,7 +301,7 @@ Constraints and Variables associated with smallest singular values
         expected = """====================================================================================
 Constraints and Variables associated with smallest singular values
 
-    Smallest Singular Value 1:
+    1st Smallest Singular Value: 1.000e-01
 
         Variables:
 
@@ -326,7 +326,7 @@ Constraints and Variables associated with smallest singular values
         expected = """====================================================================================
 Constraints and Variables associated with smallest singular values
 
-    Smallest Singular Value 1:
+    1st Smallest Singular Value: 1.000e-01
 
         Variables:
 
@@ -334,7 +334,7 @@ Constraints and Variables associated with smallest singular values
         Constraints:
 
 
-    Smallest Singular Value 2:
+    2nd Smallest Singular Value: 1.000e+00
 
         Variables:
 
@@ -342,7 +342,7 @@ Constraints and Variables associated with smallest singular values
         Constraints:
 
 
-    Smallest Singular Value 3:
+    3rd Smallest Singular Value: 5.000e+00
 
         Variables:
 
@@ -350,7 +350,7 @@ Constraints and Variables associated with smallest singular values
         Constraints:
 
 
-    Smallest Singular Value 4:
+    4th Smallest Singular Value: 1.000e+01
 
         Variables:
 

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -244,3 +244,24 @@ def print_compact_form(expr, stream=None):
         expr = expr.expr
 
     stream.write(compact_expression_to_string(expr))
+
+
+# Credit to Florian Brucker on Stack Overflow for this implementation
+# https://stackoverflow.com/a/50992575
+def make_ordinal(n: int):
+    """
+    Convert an integer into its ordinal representation.
+    For example, it turns "1" into "1st, "3" into "3rd",
+    and "62" into "62nd".
+
+    Args:
+        n: integer from which to form an ordinal
+
+    Returns:
+        ord: string representation of ordinal
+    """
+    if 11 <= (n % 100) <= 13:
+        suffix = "th"
+    else:
+        suffix = ["th", "st", "nd", "rd", "th"][min(n % 10, 4)]
+    return str(n) + suffix

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -235,15 +235,16 @@ def print_compact_form(expr, stream=None):
     Returns:
         None
     """
-    if stream is None:
-        stream = sys.stdout
 
     if hasattr(expr, "expr"):
         # We have a Constraint or Expression
         # We want to print the expression, not the object name
         expr = expr.expr
 
-    stream.write(compact_expression_to_string(expr))
+    if stream is None:
+        print(compact_expression_to_string(expr))
+    else:
+        stream.write(compact_expression_to_string(expr))
 
 
 # Credit to Florian Brucker on Stack Overflow for this implementation

--- a/idaes/core/util/misc.py
+++ b/idaes/core/util/misc.py
@@ -16,7 +16,6 @@ This module contains miscellaneous utility functions for use in IDAES models.
 """
 
 from enum import Enum
-import sys
 
 import pyomo.environ as pyo
 from pyomo.common.config import ConfigBlock

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -368,8 +368,8 @@ class TestSetParamFromConfig:
 
 
 class TestToExprStringVisitor:
-    @pytest.mark.unit
-    def test_compact_expression_to_string(self):
+    @pytest.fixture
+    def model(self):
         m = ConcreteModel()
         m.v1 = Var()
         m.v2 = Var()
@@ -378,44 +378,35 @@ class TestToExprStringVisitor:
         m.e1 = Expression(expr=m.v1 + m.v2)
         m.c1 = Constraint(expr=0 == m.v3 * m.e1)
 
-        str = compact_expression_to_string(m.c1.expr)
-        expected = "v3*e1  ==  0"
-
-        assert str == expected
+        return m
 
     @pytest.mark.unit
-    def test_print_compact_form_expr(self):
-        m = ConcreteModel()
-        m.v1 = Var()
-        m.v2 = Var()
-        m.v3 = Var()
+    def test_compact_expression_to_string(self, model):
+        assert compact_expression_to_string(model.c1.expr) == "v3*e1  ==  0"
 
-        m.e1 = Expression(expr=m.v1 + m.v2)
-        m.c1 = Constraint(expr=0 == m.v3 * m.e1)
-
-        expected = "v3*e1  ==  0"
-
-        stream = StringIO()
-        print_compact_form(m.c1.expr, stream=stream)
-
-        assert stream.getvalue() == expected
-
+    @pytest.mark.parametrize("use_stream", [False, True])
+    @pytest.mark.parametrize("print_component", [False, True])
     @pytest.mark.unit
-    def test_print_compact_form_component(self):
-        m = ConcreteModel()
-        m.v1 = Var()
-        m.v2 = Var()
-        m.v3 = Var()
-
-        m.e1 = Expression(expr=m.v1 + m.v2)
-        m.c1 = Constraint(expr=0 == m.v3 * m.e1)
-
+    def test_print_compact_form_expr(self, use_stream, print_component, model, capsys):
         expected = "v3*e1  ==  0"
+        if use_stream:
+            stream = StringIO()
+        else:
+            stream = None
 
-        stream = StringIO()
-        print_compact_form(m.c1, stream=stream)
+        if print_component:
+            print_compact_form(model.c1, stream=stream)
+        else:
+            print_compact_form(model.c1.expr, stream=stream)
 
-        assert stream.getvalue() == expected
+        captured = capsys.readouterr()
+        if use_stream:
+            assert stream.getvalue() == expected
+            assert len(captured.out) == 0
+            assert len(captured.err) == 0
+        else:
+            assert captured.out == expected + "\n"
+            assert len(captured.err) == 0
 
 
 @pytest.mark.unit

--- a/idaes/core/util/tests/test_misc.py
+++ b/idaes/core/util/tests/test_misc.py
@@ -27,6 +27,7 @@ from idaes.core.util.misc import (
     set_param_from_config,
     compact_expression_to_string,
     print_compact_form,
+    make_ordinal,
 )
 import idaes.logger as idaeslog
 
@@ -415,3 +416,40 @@ class TestToExprStringVisitor:
         print_compact_form(m.c1, stream=stream)
 
         assert stream.getvalue() == expected
+
+
+@pytest.mark.unit
+def test_make_ordinal():
+    assert make_ordinal(0) == "0th"
+    assert make_ordinal(1) == "1st"
+    assert make_ordinal(2) == "2nd"
+    assert make_ordinal(3) == "3rd"
+    assert make_ordinal(4) == "4th"
+    assert make_ordinal(5) == "5th"
+    assert make_ordinal(6) == "6th"
+    assert make_ordinal(7) == "7th"
+    assert make_ordinal(8) == "8th"
+    assert make_ordinal(9) == "9th"
+    assert make_ordinal(10) == "10th"
+
+    assert make_ordinal(11) == "11th"
+    assert make_ordinal(12) == "12th"
+    assert make_ordinal(13) == "13th"
+    assert make_ordinal(14) == "14th"
+    assert make_ordinal(16) == "16th"
+    assert make_ordinal(19) == "19th"
+
+    assert make_ordinal(20) == "20th"
+    assert make_ordinal(21) == "21st"
+    assert make_ordinal(22) == "22nd"
+    assert make_ordinal(23) == "23rd"
+    assert make_ordinal(24) == "24th"
+    assert make_ordinal(29) == "29th"
+
+    assert make_ordinal(44) == "44th"
+    assert make_ordinal(52) == "52nd"
+    assert make_ordinal(63) == "63rd"
+    assert make_ordinal(91) == "91st"
+    assert make_ordinal(102) == "102nd"
+    assert make_ordinal(111) == "111th"
+    assert make_ordinal(121) == "121st"


### PR DESCRIPTION
## Changes proposed in this PR:
- Add helper function `make_ordinal` to, e.g., convert `3` into `"3rd"`.
- Improved output from `SVDToolbox.display_underdetrmined_variables_and_constraints` so it actually displays singular values
- Modified `print_compact_form` to use `print` if no text stream is provided, so that each item printed in an interactive session is followed by a newline.

Fixes #1781

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
