### PR TITLE
New port classes

### DIFF
--- a/idaes/core/__init__.py
+++ b/idaes/core/__init__.py
@@ -52,3 +52,4 @@ from .base.costing_base import (
 )
 from .base.var_like_expression import VarLikeExpression
 from .base.property_set import StandardPropertySet, ElectrolytePropertySet
+from .base.util import InletPort, OutletPort

--- a/idaes/core/__init__.py
+++ b/idaes/core/__init__.py
@@ -52,4 +52,4 @@ from .base.costing_base import (
 )
 from .base.var_like_expression import VarLikeExpression
 from .base.property_set import StandardPropertySet, ElectrolytePropertySet
-from .base.util import InletPort, OutletPort
+from .base.ports import InletPort, OutletPort

--- a/idaes/core/base/ports.py
+++ b/idaes/core/base/ports.py
@@ -105,5 +105,3 @@ class IndexedOutletPort(OutletPort):
     """
     Indexed OutletPort
     """
-
-    pass

--- a/idaes/core/base/ports.py
+++ b/idaes/core/base/ports.py
@@ -1,0 +1,111 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2026 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+from pyomo.core.base.indexed_component import UnindexedComponent_set
+from pyomo.core.base.global_set import UnindexedComponent_index
+from pyomo.network.port import Port, PortData
+
+__author__ = "Douglas Allan"
+# Classes for inlet and outlet ports to assist other functions
+# in classifying port and flowsheet topology
+
+# This diamond class structure was copied over from Pyomo
+# ____________________________________________________________________________________
+#
+# Pyomo: Python Optimization Modeling Objects
+# Copyright (c) 2008-2026 National Technology and Engineering Solutions of Sandia, LLC
+# Under the terms of Contract DE-NA0003525 with National Technology and Engineering
+# Solutions of Sandia, LLC, the U.S. Government retains certain rights in this
+# software.  This software is distributed under the 3-clause BSD License.
+# ____________________________________________________________________________________
+
+
+class InletPortData(PortData):
+    """
+    Element of an InletPort
+    """
+
+    pass
+
+
+class InletPort(Port):
+    """
+    Class to identify whether a port on a model is an inlet port.
+    """
+
+    def __new__(cls, *args, **kwds):
+        if cls != InletPort:
+            return super(Port, cls).__new__(cls)
+        if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
+            return ScalarInletPort.__new__(ScalarInletPort)
+        else:
+            return IndexedInletPort.__new__(IndexedInletPort)
+
+
+class ScalarInletPort(InletPort, InletPortData):
+    """
+    Unindexed InletPort
+    """
+
+    def __init__(self, *args, **kwd):
+        InletPortData.__init__(self, component=self)
+        InletPort.__init__(self, *args, **kwd)
+        self._index = UnindexedComponent_index
+
+
+class IndexedInletPort(InletPort):
+    """
+    Indexed InletPort
+    """
+
+    pass
+
+
+class OutletPortData(PortData):
+    """
+    Element of an OutletPort
+    """
+
+    pass
+
+
+class OutletPort(Port):
+    """
+    Class to identify whether a port on a model is an outlet port.
+    """
+
+    def __new__(cls, *args, **kwds):
+        if cls != OutletPort:
+            return super(Port, cls).__new__(cls)
+        if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
+            return ScalarOutletPort.__new__(ScalarOutletPort)
+        else:
+            return IndexedOutletPort.__new__(IndexedOutletPort)
+
+
+class ScalarOutletPort(OutletPort, OutletPortData):
+    """
+    Unindexed OutletPort
+    """
+
+    def __init__(self, *args, **kwd):
+        OutletPortData.__init__(self, component=self)
+        OutletPort.__init__(self, *args, **kwd)
+        self._index = UnindexedComponent_index
+
+
+class IndexedOutletPort(OutletPort):
+    """
+    Indexed OutletPort
+    """
+
+    pass

--- a/idaes/core/base/ports.py
+++ b/idaes/core/base/ports.py
@@ -10,13 +10,17 @@
 # All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
 # for full copyright and license information.
 #################################################################################
+"""
+Classes for inlet and outlet ports to assist other functions
+in classifying port and flowsheet topology
+"""
+
 from pyomo.core.base.indexed_component import UnindexedComponent_set
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.network.port import Port, PortData
 
 __author__ = "Douglas Allan"
-# Classes for inlet and outlet ports to assist other functions
-# in classifying port and flowsheet topology
+
 
 # This diamond class structure was copied over from Pyomo
 # ____________________________________________________________________________________
@@ -33,8 +37,6 @@ class InletPortData(PortData):
     """
     Element of an InletPort
     """
-
-    pass
 
 
 class InletPort(Port):
@@ -67,15 +69,11 @@ class IndexedInletPort(InletPort):
     Indexed InletPort
     """
 
-    pass
-
 
 class OutletPortData(PortData):
     """
     Element of an OutletPort
     """
-
-    pass
 
 
 class OutletPort(Port):

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -490,6 +490,7 @@ class StateBlock(ProcessBlock):
         doc=None,
         slice_index=None,
         index=None,
+        port_class=Port,
     ):
         """
         Constructs a Port based on this StateBlock attached to the target block.
@@ -499,6 +500,7 @@ class StateBlock(ProcessBlock):
             slice_index - Slice index (e.g. (slice(None), 0.0) that will be
                 used to index self when constructing port references. Default = None.
             index - time index to use when calling define_port_members. Default = None.
+            port_class - subclass of Port to use to build port. Default = Port.
 
         Returns:
             Port object and list of tuples with form (Reference, member name)
@@ -509,7 +511,7 @@ class StateBlock(ProcessBlock):
             index = self.index_set().first()
 
         # Create empty Port
-        p = Port(doc=doc)
+        p = port_class(doc=doc)
 
         # Get dict of Port members and names
         # Need to get a representative member of StateBlockDatas

--- a/idaes/core/base/tests/test_ports.py
+++ b/idaes/core/base/tests/test_ports.py
@@ -1,0 +1,622 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2026 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+"""
+Tests for flowsheet_model.
+
+Author: Douglas Lee
+"""
+
+import pytest
+import pyomo.common.unittest as unittest
+from io import StringIO
+
+from pyomo.environ import (
+    ConcreteModel,
+    AbstractModel,
+    Var,
+    Set,
+    NonNegativeReals,
+    Binary,
+    Reals,
+    Integers,
+    RangeSet,
+)
+from pyomo.network import Arc
+from idaes.core.base.ports import (
+    InletPortData,
+    InletPort,
+    ScalarInletPort,
+    IndexedInletPort,
+    OutletPortData,
+    OutletPort,
+    ScalarOutletPort,
+    IndexedOutletPort,
+)
+
+# These port tests were copied from Pyomo
+# ____________________________________________________________________________________
+#
+# Pyomo: Python Optimization Modeling Objects
+# Copyright (c) 2008-2026 National Technology and Engineering Solutions of Sandia, LLC
+# Under the terms of Contract DE-NA0003525 with National Technology and Engineering
+# Solutions of Sandia, LLC, the U.S. Government retains certain rights in this
+# software.  This software is distributed under the 3-clause BSD License.
+# ____________________________________________________________________________________
+
+
+# It's less than ideal that we end up creating inlet ports named OUT and outlet ports
+# named IN, but these port classes are intended to simply be renamed versions of
+# their Pyomo counterparts, so that we can use isinstance to check topology.
+class TestInletPort(unittest.TestCase):
+    _port_data_class = InletPortData
+    _port_class = InletPort
+    _scalar_port = ScalarInletPort
+    _indexed_port = IndexedInletPort
+
+    @pytest.mark.unit
+    def test_default_scalar_constructor(self):
+        model = ConcreteModel()
+        model.c = self._port_class()
+        self.assertEqual(len(model.c), 1)
+        self.assertEqual(len(model.c.vars), 0)
+
+        model = AbstractModel()
+        model.c = self._port_class()
+        self.assertEqual(len(model.c), 0)
+        # FIXME: Not sure I like this behavior: but since this is
+        # (currently) an attribute, there is no way to check for
+        # construction without converting it to a property.
+        #
+        # TODO: if we move away from multiple inheritance for
+        # simplevars, then this can trigger an exception (cleanly)
+        self.assertEqual(len(model.c.vars), 0)
+
+        inst = model.create_instance()
+        self.assertEqual(len(inst.c), 1)
+        self.assertEqual(len(inst.c.vars), 0)
+
+    @pytest.mark.unit
+    def test_default_indexed_constructor(self):
+        model = ConcreteModel()
+        model.c = self._port_class([1, 2, 3])
+        self.assertEqual(len(model.c), 3)
+        self.assertEqual(len(model.c[1].vars), 0)
+
+        model = AbstractModel()
+        model.c = self._port_class([1, 2, 3])
+        self.assertEqual(len(model.c), 0)
+        self.assertRaises(ValueError, model.c.__getitem__, 1)
+
+        inst = model.create_instance()
+        self.assertEqual(len(inst.c), 3)
+        self.assertEqual(len(inst.c[1].vars), 0)
+
+    @pytest.mark.unit
+    def test_add_scalar_vars(self):
+        pipe = ConcreteModel()
+        pipe.flow = Var()
+        pipe.pIn = Var(within=NonNegativeReals)
+        pipe.pOut = Var(within=NonNegativeReals)
+
+        pipe.OUT = self._port_class()
+        pipe.OUT.add(pipe.flow, "flow")
+        pipe.OUT.add(pipe.pOut, "pressure")
+        self.assertEqual(len(pipe.OUT), 1)
+        self.assertEqual(len(pipe.OUT.vars), 2)
+        self.assertFalse(pipe.OUT.vars["flow"].is_expression_type())
+
+        pipe.IN = self._port_class()
+        pipe.IN.add(-pipe.flow, "flow")
+        pipe.IN.add(pipe.pIn, "pressure")
+        self.assertEqual(len(pipe.IN), 1)
+        self.assertEqual(len(pipe.IN.vars), 2)
+        self.assertTrue(pipe.IN.vars["flow"].is_expression_type())
+
+    @pytest.mark.unit
+    def test_add_indexed_vars(self):
+        pipe = ConcreteModel()
+        pipe.SPECIES = Set(initialize=["a", "b", "c"])
+        pipe.flow = Var()
+        pipe.composition = Var(pipe.SPECIES)
+        pipe.pIn = Var(within=NonNegativeReals)
+
+        pipe.OUT = self._port_class()
+        pipe.OUT.add(pipe.flow, "flow")
+        pipe.OUT.add(pipe.composition, "composition")
+        pipe.OUT.add(pipe.pIn, "pressure")
+
+        self.assertEqual(len(pipe.OUT), 1)
+        self.assertEqual(len(pipe.OUT.vars), 3)
+
+    @pytest.mark.unit
+    def test_fixed(self):
+        pipe = ConcreteModel()
+        pipe.SPECIES = Set(initialize=["a", "b", "c"])
+        pipe.flow = Var()
+        pipe.composition = Var(pipe.SPECIES)
+        pipe.pIn = Var(within=NonNegativeReals)
+
+        pipe.OUT = self._port_class()
+        self.assertTrue(pipe.OUT.is_fixed())
+
+        pipe.OUT.add(pipe.flow, "flow")
+        self.assertFalse(pipe.OUT.is_fixed())
+
+        pipe.flow.fix(0)
+        self.assertTrue(pipe.OUT.is_fixed())
+
+        pipe.OUT.add(-pipe.pIn, "pressure")
+        self.assertFalse(pipe.OUT.is_fixed())
+
+        pipe.pIn.fix(1)
+        self.assertTrue(pipe.OUT.is_fixed())
+
+        pipe.OUT.add(pipe.composition, "composition")
+        self.assertFalse(pipe.OUT.is_fixed())
+
+        pipe.composition["a"].fix(1)
+        self.assertFalse(pipe.OUT.is_fixed())
+
+        pipe.composition["b"].fix(1)
+        pipe.composition["c"].fix(1)
+        self.assertTrue(pipe.OUT.is_fixed())
+
+        m = ConcreteModel()
+        m.SPECIES = Set(initialize=["a", "b", "c"])
+        m.flow = Var()
+        m.composition = Var(m.SPECIES)
+        m.pIn = Var(within=NonNegativeReals)
+
+        m.port = self._port_class()
+        m.port.add(m.flow, "flow")
+        m.port.add(-m.pIn, "pressure")
+        m.port.add(m.composition, "composition")
+        m.port.fix()
+        self.assertTrue(m.port.is_fixed())
+
+    @pytest.mark.unit
+    def test_polynomial_degree(self):
+        pipe = ConcreteModel()
+        pipe.SPECIES = Set(initialize=["a", "b", "c"])
+        pipe.flow = Var()
+        pipe.composition = Var(pipe.SPECIES)
+        pipe.pIn = Var(within=NonNegativeReals)
+
+        pipe.OUT = self._port_class()
+        self.assertEqual(pipe.OUT.polynomial_degree(), 0)
+
+        pipe.OUT.add(pipe.flow, "flow")
+        self.assertEqual(pipe.OUT.polynomial_degree(), 1)
+
+        pipe.flow.fix(0)
+        self.assertEqual(pipe.OUT.polynomial_degree(), 0)
+
+        pipe.OUT.add(-pipe.pIn, "pressure")
+        self.assertEqual(pipe.OUT.polynomial_degree(), 1)
+
+        pipe.pIn.fix(1)
+        self.assertEqual(pipe.OUT.polynomial_degree(), 0)
+
+        pipe.OUT.add(pipe.composition, "composition")
+        self.assertEqual(pipe.OUT.polynomial_degree(), 1)
+
+        pipe.composition["a"].fix(1)
+        self.assertEqual(pipe.OUT.polynomial_degree(), 1)
+
+        pipe.composition["b"].fix(1)
+        pipe.composition["c"].fix(1)
+        self.assertEqual(pipe.OUT.polynomial_degree(), 0)
+
+        pipe.OUT.add(pipe.flow * pipe.pIn, "quadratic")
+        self.assertEqual(pipe.OUT.polynomial_degree(), 0)
+
+        pipe.flow.unfix()
+        self.assertEqual(pipe.OUT.polynomial_degree(), 1)
+
+        pipe.pIn.unfix()
+        self.assertEqual(pipe.OUT.polynomial_degree(), 2)
+
+        pipe.OUT.add(pipe.flow / pipe.pIn, "nonLin")
+        self.assertEqual(pipe.OUT.polynomial_degree(), None)
+
+    @pytest.mark.unit
+    def test_potentially_variable(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.p = self._port_class()
+        self.assertTrue(m.p.is_potentially_variable())
+        m.p.add(-m.x)
+        self.assertTrue(m.p.is_potentially_variable())
+
+    @pytest.mark.unit
+    def test_binary(self):
+        m = ConcreteModel()
+        m.x = Var(domain=Binary)
+        m.y = Var(domain=Reals)
+        m.p = self._port_class()
+
+        self.assertTrue(m.p.is_binary())
+
+        m.p.add(m.x)
+        self.assertTrue(m.p.is_binary())
+
+        m.p.add(-m.x, "foo")
+        self.assertTrue(m.p.is_binary())
+
+        m.p.add(m.y)
+        self.assertFalse(m.p.is_binary())
+
+        m.p.remove("y")
+        self.assertTrue(m.p.is_binary())
+
+        m.p.add(-m.y, "bar")
+        self.assertFalse(m.p.is_binary())
+
+    @pytest.mark.unit
+    def test_integer(self):
+        m = ConcreteModel()
+        m.x = Var(domain=Integers)
+        m.y = Var(domain=Reals)
+        m.p = self._port_class()
+
+        self.assertTrue(m.p.is_integer())
+
+        m.p.add(m.x)
+        self.assertTrue(m.p.is_integer())
+
+        m.p.add(-m.x, "foo")
+        self.assertTrue(m.p.is_integer())
+
+        m.p.add(m.y)
+        self.assertFalse(m.p.is_integer())
+
+        m.p.remove("y")
+        self.assertTrue(m.p.is_integer())
+
+        m.p.add(-m.y, "bar")
+        self.assertFalse(m.p.is_integer())
+
+    @pytest.mark.unit
+    def test_continuous(self):
+        m = ConcreteModel()
+        m.x = Var(domain=Reals)
+        m.y = Var(domain=Integers)
+        m.p = self._port_class()
+
+        self.assertTrue(m.p.is_continuous())
+
+        m.p.add(m.x)
+        self.assertTrue(m.p.is_continuous())
+
+        m.p.add(-m.x, "foo")
+        self.assertTrue(m.p.is_continuous())
+
+        m.p.add(m.y)
+        self.assertFalse(m.p.is_continuous())
+
+        m.p.remove("y")
+        self.assertTrue(m.p.is_continuous())
+
+        m.p.add(-m.y, "bar")
+        self.assertFalse(m.p.is_continuous())
+
+    @pytest.mark.unit
+    def test_getattr(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.port = self._port_class()
+        m.port.add(m.x)
+        self.assertIs(m.port.x, m.x)
+
+    @pytest.mark.unit
+    def test_arc_lists(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.p1 = self._port_class()
+        m.p2 = self._port_class()
+        m.p3 = self._port_class()
+        m.p4 = self._port_class()
+        m.p5 = self._port_class()
+        m.p1.add(m.x)
+        m.p2.add(m.x)
+        m.p3.add(m.x)
+        m.p4.add(m.x)
+        m.p5.add(m.x)
+        m.a1 = Arc(source=m.p1, destination=m.p2)
+        m.a2 = Arc(source=m.p1, destination=m.p3)
+        m.a3 = Arc(source=m.p4, destination=m.p1)
+        m.a4 = Arc(source=m.p5, destination=m.p1)
+
+        self.assertEqual(len(m.p1.dests()), 2)
+        self.assertEqual(len(m.p1.sources()), 2)
+        self.assertEqual(len(m.p1.arcs()), 4)
+        self.assertEqual(len(m.p2.dests()), 0)
+        self.assertEqual(len(m.p2.sources()), 1)
+        self.assertEqual(len(m.p2.arcs()), 1)
+        self.assertIn(m.a1, m.p1.dests())
+        self.assertIn(m.a1, m.p2.sources())
+        self.assertNotIn(m.a1, m.p1.sources())
+        self.assertNotIn(m.a1, m.p2.dests())
+
+        self.assertEqual(len(m.p1.dests(active=True)), 2)
+        self.assertEqual(len(m.p1.sources(active=True)), 2)
+        self.assertEqual(len(m.p1.arcs(active=True)), 4)
+        self.assertEqual(len(m.p2.dests(active=True)), 0)
+        self.assertEqual(len(m.p2.sources(active=True)), 1)
+        self.assertEqual(len(m.p2.arcs(active=True)), 1)
+        self.assertIn(m.a1, m.p1.dests(active=True))
+        self.assertIn(m.a1, m.p2.sources(active=True))
+        self.assertNotIn(m.a1, m.p1.sources(active=True))
+        self.assertNotIn(m.a1, m.p2.dests(active=True))
+
+        m.a2.deactivate()
+
+        self.assertNotIn(m.a2, m.p1.dests(active=True))
+        self.assertNotIn(m.a2, m.p3.sources(active=True))
+        self.assertIn(m.a2, m.p1.dests(active=False))
+        self.assertIn(m.a2, m.p3.sources(active=False))
+        self.assertIn(m.a2, m.p1.arcs(active=False))
+        self.assertIn(m.a2, m.p3.arcs(active=False))
+        self.assertIn(m.a2, m.p1.dests())
+        self.assertIn(m.a2, m.p3.sources())
+        self.assertIn(m.a2, m.p1.arcs())
+        self.assertIn(m.a2, m.p3.arcs())
+
+    @pytest.mark.unit
+    def test_remove(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.port = self._port_class()
+        m.port.add(m.x)
+        self.assertIn("x", m.port.vars)
+        self.assertIn("x", m.port._rules)
+        m.port.remove("x")
+        self.assertNotIn("x", m.port.vars)
+        self.assertNotIn("x", m.port._rules)
+
+    @pytest.mark.unit
+    def test_extends(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.p1 = self._port_class()
+        m.p1.add(m.x, rule=self._port_class.Extensive)
+        m.p2 = self._port_class(extends=m.p1)
+        self.assertIs(m.p2.x, m.x)
+        self.assertIs(m.p2.rule_for("x"), self._port_class.Extensive)
+        self.assertTrue(m.p2.is_extensive("x"))
+        self.assertFalse(m.p2.is_equality("x"))
+
+    @pytest.mark.unit
+    def test_add_from_containers(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.p1 = self._port_class(initialize=[m.x, m.y])
+        m.p2 = self._port_class(
+            initialize=[
+                (m.x, self._port_class.Equality),
+                (m.y, self._port_class.Extensive),
+            ]
+        )
+        m.p3 = self._port_class(initialize=dict(this=m.x, that=m.y))
+        m.p4 = self._port_class(
+            initialize=dict(
+                this=(m.x, self._port_class.Equality),
+                that=(m.y, self._port_class.Extensive),
+            )
+        )
+
+        self.assertIs(m.p1.x, m.x)
+        self.assertIs(m.p1.y, m.y)
+        self.assertIs(m.p2.x, m.x)
+        self.assertTrue(m.p2.is_equality("x"))
+        self.assertIs(m.p2.y, m.y)
+        self.assertTrue(m.p2.is_extensive("y"))
+        self.assertIs(m.p3.this, m.x)
+        self.assertIs(m.p3.that, m.y)
+        self.assertIs(m.p4.this, m.x)
+        self.assertTrue(m.p4.is_equality("this"))
+        self.assertIs(m.p4.that, m.y)
+        self.assertTrue(m.p4.is_extensive("that"))
+
+    @pytest.mark.unit
+    def test_fix_unfix(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.port = self._port_class()
+        m.port.add(m.x)
+        m.x.value = 10
+        m.port.fix()
+        self.assertTrue(m.x.is_fixed())
+        m.port.unfix()
+        self.assertFalse(m.x.is_fixed())
+
+    @pytest.mark.unit
+    def test_iter_vars(self):
+        def contains(item, container):
+            # use this instead of "in" to avoid "==" operation
+            return any(item is mem for mem in container)
+
+        m = ConcreteModel()
+        m.s = RangeSet(5)
+        m.x = Var()
+        m.y = Var()
+        m.z = Var(m.s)
+        m.a = Var()
+        m.b = Var()
+        m.c = Var()
+        expr = m.a + m.b * m.c
+        p = m.p = self._port_class()
+
+        v = list(p.iter_vars())
+        self.assertEqual(len(v), 0)
+
+        p.add(m.x)
+        v = list(p.iter_vars())
+        self.assertEqual(len(v), 1)
+
+        p.add(m.y)
+        v = list(p.iter_vars())
+        self.assertEqual(len(v), 2)
+
+        p.add(m.z)
+        v = list(p.iter_vars())
+        self.assertEqual(len(v), 7)
+        self.assertTrue(contains(m.x, v))
+        self.assertTrue(contains(m.z[3], v))
+
+        p.add(expr, "expr")
+        v = list(p.iter_vars())
+        self.assertEqual(len(v), 8)
+        self.assertTrue(contains(m.x, v))
+        self.assertTrue(contains(m.z[3], v))
+        self.assertTrue(contains(expr, v))
+
+        m.x.fix(0)
+        v = list(p.iter_vars())
+        self.assertEqual(len(v), 8)
+
+        v = list(p.iter_vars(fixed=False))
+        self.assertEqual(len(v), 7)
+        self.assertTrue(contains(m.z[3], v))
+        self.assertTrue(contains(expr, v))
+
+        v = list(p.iter_vars(fixed=True))
+        self.assertEqual(len(v), 1)
+        self.assertIn(m.x, v)
+
+        v = list(p.iter_vars(expr_vars=True))
+        self.assertEqual(len(v), 10)
+        self.assertFalse(contains(expr, v))
+        self.assertTrue(contains(m.a, v))
+        self.assertTrue(contains(m.b, v))
+
+        m.a.fix(0)
+        v = list(p.iter_vars(expr_vars=True, fixed=False))
+        self.assertEqual(len(v), 8)
+
+        m.b.fix(0)
+        m.c.fix(0)
+        v = list(p.iter_vars(expr_vars=True, fixed=False))
+        self.assertEqual(len(v), 6)
+
+        v = list(p.iter_vars(fixed=False))
+        self.assertEqual(len(v), 6)
+        self.assertFalse(contains(expr, v))
+
+        v = list(p.iter_vars(expr_vars=True, names=True))
+        self.assertEqual(len(v), 10)
+        self.assertEqual(len(v[0]), 3)
+        for t in v:
+            if t[0] == "x":
+                self.assertIs(t[2], m.x)
+                break
+
+    @pytest.mark.unit
+    def test_pprint(self):
+        pipe = ConcreteModel()
+        pipe.SPECIES = Set(initialize=["a", "b", "c"])
+        pipe.flow = Var()
+        pipe.composition = Var(pipe.SPECIES)
+        pipe.pIn = Var(within=NonNegativeReals)
+
+        pipe.OUT = self._port_class(implicit=["imp"])
+        pipe.OUT.add(-pipe.flow, "flow")
+        pipe.OUT.add(pipe.composition, "composition")
+        pipe.OUT.add(pipe.composition["a"], "comp_a")
+        pipe.OUT.add(pipe.pIn, "pressure")
+
+        os = StringIO()
+        pipe.OUT.pprint(ostream=os)
+        self.assertEqual(
+            os.getvalue(),
+            """OUT : Size=1, Index=None
+    Key  : Name        : Size : Variable
+    None :      comp_a :    1 : composition[a]
+         : composition :    3 : composition
+         :        flow :    1 : - flow
+         :         imp :    - : None
+         :    pressure :    1 : pIn
+""",
+        )
+
+        def _IN(m, i):
+            return {"pressure": pipe.pIn, "flow": pipe.composition[i] * pipe.flow}
+
+        pipe.IN = self._port_class(pipe.SPECIES, rule=_IN)
+        os = StringIO()
+        pipe.IN.pprint(ostream=os)
+        self.assertEqual(
+            os.getvalue(),
+            """IN : Size=3, Index=SPECIES
+    Key : Name     : Size : Variable
+      a :     flow :    1 : composition[a]*flow
+        : pressure :    1 :                 pIn
+      b :     flow :    1 : composition[b]*flow
+        : pressure :    1 :                 pIn
+      c :     flow :    1 : composition[c]*flow
+        : pressure :    1 :                 pIn
+""",
+        )
+
+    @pytest.mark.unit
+    def test_display(self):
+        pipe = ConcreteModel()
+        pipe.SPECIES = Set(initialize=["a", "b", "c"])
+        pipe.flow = Var(initialize=10)
+        pipe.composition = Var(pipe.SPECIES, initialize=lambda m, i: ord(i) - ord("a"))
+        pipe.pIn = Var(within=NonNegativeReals, initialize=3.14)
+
+        pipe.OUT = self._port_class(implicit=["imp"])
+        pipe.OUT.add(-pipe.flow, "flow")
+        pipe.OUT.add(pipe.composition, "composition")
+        pipe.OUT.add(pipe.pIn, "pressure")
+
+        os = StringIO()
+        pipe.OUT.display(ostream=os)
+        self.assertEqual(
+            os.getvalue(),
+            """OUT : Size=1
+    Key  : Name        : Value
+    None : composition : {'a': 0, 'b': 1, 'c': 2}
+         :        flow : -10
+         :         imp : -
+         :    pressure : 3.14
+""",
+        )
+
+        def _IN(m, i):
+            return {"pressure": pipe.pIn, "flow": pipe.composition[i] * pipe.flow}
+
+        pipe.IN = self._port_class(pipe.SPECIES, rule=_IN)
+        os = StringIO()
+        pipe.IN.display(ostream=os)
+        self.assertEqual(
+            os.getvalue(),
+            """IN : Size=3
+    Key : Name     : Value
+      a :     flow :     0
+        : pressure :  3.14
+      b :     flow :    10
+        : pressure :  3.14
+      c :     flow :    20
+        : pressure :  3.14
+""",
+        )
+
+
+class TestOutletPort(TestInletPort):
+    _port_data_class = OutletPortData
+    _port_class = OutletPort
+    _scalar_port = ScalarOutletPort
+    _indexed_port = IndexedOutletPort

--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -32,6 +32,7 @@ from idaes.core import (
     Phase,
     Component,
 )
+from idaes.core import InletPort, OutletPort
 from idaes.core.util.exceptions import PropertyPackageError, PropertyNotSupportedError
 from idaes.core.base.property_meta import PropertyClassMetadata
 from idaes.core.scaling.scaling_base import ScalerBase
@@ -389,9 +390,9 @@ def test_StateBlock_NotImplementedErrors():
     with pytest.raises(NotImplementedError):
         m.p.calculate_dew_point_pressure()
 
-
+@pytest.mark.parametrize("port_class", [None, Port, InletPort, OutletPort])
 @pytest.mark.unit
-def test_StateBlock_build_port_1index():
+def test_StateBlock_build_port_1index(port_class):
     m = ConcreteModel()
 
     m.state_block = DummyStateBlock([1, 2, 3])
@@ -414,11 +415,25 @@ def test_StateBlock_build_port_1index():
         sbd.define_port_members = types.MethodType(define_port_members, sbd)
 
     # Call build_port
-    port, ref_name_list = m.state_block.build_port("test_doc")
+    if port_class is None:
+        port, ref_name_list = m.state_block.build_port("test_doc")
+    else:
+        port, ref_name_list = m.state_block.build_port("test_doc", port_class=port_class)
 
     # Check Port and members
     assert isinstance(port, Port)
     assert port.doc == "test_doc"
+    if port_class is None or port_class is Port:
+        assert not isinstance(Port, InletPort)
+        assert not isinstance(Port, OutletPort)
+    elif port_class is InletPort:
+        assert isinstance(Port, InletPort)
+        assert not isinstance(Port, OutletPort)
+    elif port_class is OutletPort:
+        assert not isinstance(Port, InletPort)
+        assert isinstance(Port, OutletPort)
+    else:
+        raise AssertionError()
 
     for i in m.state_block:
         assert port.ScalarVar[i] is m.state_block[i].scalar_var
@@ -446,9 +461,9 @@ def test_StateBlock_build_port_1index():
             # Catch for unexpected name
             raise ValueError
 
-
+@pytest.mark.parametrize("port_class", [None, Port, InletPort, OutletPort])
 @pytest.mark.unit
-def test_StateBlock_build_port_2index():
+def test_StateBlock_build_port_2index(port_class):
     m = ConcreteModel()
 
     m.state_block = DummyStateBlock([1, 2, 3], [10, 20])
@@ -471,11 +486,19 @@ def test_StateBlock_build_port_2index():
         sbd.define_port_members = types.MethodType(define_port_members, sbd)
 
     # Call build_port
-    port, ref_name_list = m.state_block.build_port("test_doc")
+    if port_class is None:
+        port, ref_name_list = m.state_block.build_port("test_doc")
+    else:
+        port, ref_name_list = m.state_block.build_port("test_doc", port_class=port_class)
+
 
     # Check Port and members
     assert isinstance(port, Port)
     assert port.doc == "test_doc"
+    if port_class is None:
+        assert port.__class__ is Port
+    else:
+        assert port.__class__ is port_class
 
     for i in m.state_block:
         assert port.ScalarVar[i] is m.state_block[i].scalar_var
@@ -505,9 +528,9 @@ def test_StateBlock_build_port_2index():
             # Catch for unexpected name
             raise ValueError
 
-
+@pytest.mark.parametrize("port_class", [None, Port, InletPort, OutletPort])
 @pytest.mark.unit
-def test_StateBlock_build_port_2index_subset():
+def test_StateBlock_build_port_2index_subset(port_class):
     m = ConcreteModel()
 
     m.state_block = DummyStateBlock([1, 2, 3], [10, 20])
@@ -530,11 +553,19 @@ def test_StateBlock_build_port_2index_subset():
         sbd.define_port_members = types.MethodType(define_port_members, sbd)
 
     # Call build_port
-    port, ref_name_list = m.state_block.build_port("test_doc")
+    if port_class is None:
+        port, ref_name_list = m.state_block.build_port("test_doc")
+    else:
+        port, ref_name_list = m.state_block.build_port("test_doc", port_class=port_class)
+
 
     # Check Port and members
     assert isinstance(port, Port)
     assert port.doc == "test_doc"
+    if port_class is None:
+        assert port.__class__ is Port
+    else:
+        assert port.__class__ is port_class
 
     for i in m.state_block:
         assert port.ScalarVar[i] is m.state_block[i].scalar_var

--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -390,6 +390,7 @@ def test_StateBlock_NotImplementedErrors():
     with pytest.raises(NotImplementedError):
         m.p.calculate_dew_point_pressure()
 
+
 @pytest.mark.parametrize("port_class", [None, Port, InletPort, OutletPort])
 @pytest.mark.unit
 def test_StateBlock_build_port_1index(port_class):
@@ -418,20 +419,22 @@ def test_StateBlock_build_port_1index(port_class):
     if port_class is None:
         port, ref_name_list = m.state_block.build_port("test_doc")
     else:
-        port, ref_name_list = m.state_block.build_port("test_doc", port_class=port_class)
+        port, ref_name_list = m.state_block.build_port(
+            "test_doc", port_class=port_class
+        )
 
     # Check Port and members
     assert isinstance(port, Port)
     assert port.doc == "test_doc"
     if port_class is None or port_class is Port:
-        assert not isinstance(Port, InletPort)
-        assert not isinstance(Port, OutletPort)
+        assert not isinstance(port, InletPort)
+        assert not isinstance(port, OutletPort)
     elif port_class is InletPort:
-        assert isinstance(Port, InletPort)
-        assert not isinstance(Port, OutletPort)
+        assert isinstance(port, InletPort)
+        assert not isinstance(port, OutletPort)
     elif port_class is OutletPort:
-        assert not isinstance(Port, InletPort)
-        assert isinstance(Port, OutletPort)
+        assert not isinstance(port, InletPort)
+        assert isinstance(port, OutletPort)
     else:
         raise AssertionError()
 
@@ -461,6 +464,7 @@ def test_StateBlock_build_port_1index(port_class):
             # Catch for unexpected name
             raise ValueError
 
+
 @pytest.mark.parametrize("port_class", [None, Port, InletPort, OutletPort])
 @pytest.mark.unit
 def test_StateBlock_build_port_2index(port_class):
@@ -489,16 +493,24 @@ def test_StateBlock_build_port_2index(port_class):
     if port_class is None:
         port, ref_name_list = m.state_block.build_port("test_doc")
     else:
-        port, ref_name_list = m.state_block.build_port("test_doc", port_class=port_class)
-
+        port, ref_name_list = m.state_block.build_port(
+            "test_doc", port_class=port_class
+        )
 
     # Check Port and members
     assert isinstance(port, Port)
     assert port.doc == "test_doc"
-    if port_class is None:
-        assert port.__class__ is Port
+    if port_class is None or port_class is Port:
+        assert not isinstance(port, InletPort)
+        assert not isinstance(port, OutletPort)
+    elif port_class is InletPort:
+        assert isinstance(port, InletPort)
+        assert not isinstance(port, OutletPort)
+    elif port_class is OutletPort:
+        assert not isinstance(port, InletPort)
+        assert isinstance(port, OutletPort)
     else:
-        assert port.__class__ is port_class
+        raise AssertionError()
 
     for i in m.state_block:
         assert port.ScalarVar[i] is m.state_block[i].scalar_var
@@ -528,6 +540,7 @@ def test_StateBlock_build_port_2index(port_class):
             # Catch for unexpected name
             raise ValueError
 
+
 @pytest.mark.parametrize("port_class", [None, Port, InletPort, OutletPort])
 @pytest.mark.unit
 def test_StateBlock_build_port_2index_subset(port_class):
@@ -556,16 +569,24 @@ def test_StateBlock_build_port_2index_subset(port_class):
     if port_class is None:
         port, ref_name_list = m.state_block.build_port("test_doc")
     else:
-        port, ref_name_list = m.state_block.build_port("test_doc", port_class=port_class)
-
+        port, ref_name_list = m.state_block.build_port(
+            "test_doc", port_class=port_class
+        )
 
     # Check Port and members
     assert isinstance(port, Port)
     assert port.doc == "test_doc"
-    if port_class is None:
-        assert port.__class__ is Port
+    if port_class is None or port_class is Port:
+        assert not isinstance(port, InletPort)
+        assert not isinstance(port, OutletPort)
+    elif port_class is InletPort:
+        assert isinstance(port, InletPort)
+        assert not isinstance(port, OutletPort)
+    elif port_class is OutletPort:
+        assert not isinstance(port, InletPort)
+        assert isinstance(port, OutletPort)
     else:
-        assert port.__class__ is port_class
+        raise AssertionError()
 
     for i in m.state_block:
         assert port.ScalarVar[i] is m.state_block[i].scalar_var

--- a/idaes/core/base/tests/test_unit_model.py
+++ b/idaes/core/base/tests/test_unit_model.py
@@ -31,6 +31,8 @@ from idaes.core import (
     ControlVolume1DBlock,
     MaterialBalanceType,
     FlowDirection,
+    InletPort,
+    OutletPort,
 )
 from idaes.core.util.exceptions import (
     BalanceTypeNotSupportedError,
@@ -222,7 +224,7 @@ def test_add_inlet_port_CV0D():
 
     p_obj = m.fs.u.add_inlet_port()
 
-    assert isinstance(p_obj, Port)
+    assert isinstance(p_obj, InletPort)
     assert m.fs.u.inlet is p_obj
     assert len(m.fs.u.inlet) == 1
 
@@ -258,7 +260,7 @@ def test_add_inlet_port_CV1D():
 
     p_obj = m.fs.u.add_inlet_port()
 
-    assert isinstance(p_obj, Port)
+    assert isinstance(p_obj, InletPort)
     assert m.fs.u.inlet is p_obj
     assert len(m.fs.u.inlet) == 1
 
@@ -294,7 +296,7 @@ def test_add_inlet_port_CV1D_backward():
 
     p_obj = m.fs.u.add_inlet_port()
 
-    assert isinstance(p_obj, Port)
+    assert isinstance(p_obj, InletPort)
     assert m.fs.u.inlet is p_obj
     assert len(m.fs.u.inlet) == 1
 
@@ -346,7 +348,7 @@ def test_add_inlet_port_CV0D_full_args():
 
     p_obj = m.fs.u.add_inlet_port(name="test_port", block=m.fs.u.cv, doc="Test")
 
-    assert isinstance(p_obj, Port)
+    assert isinstance(p_obj, InletPort)
     assert hasattr(m.fs.u, "test_port")
     assert len(m.fs.u.test_port) == 1
 
@@ -431,7 +433,7 @@ def test_add_outlet_port_CV0D():
 
     p_obj = m.fs.u.add_outlet_port()
 
-    assert isinstance(p_obj, Port)
+    assert isinstance(p_obj, OutletPort)
     assert m.fs.u.outlet is p_obj
     assert len(m.fs.u.outlet) == 1
 
@@ -467,7 +469,7 @@ def test_add_outlet_port_CV1D():
 
     p_obj = m.fs.u.add_outlet_port()
 
-    assert isinstance(p_obj, Port)
+    assert isinstance(p_obj, OutletPort)
     assert m.fs.u.outlet is p_obj
     assert len(m.fs.u.outlet) == 1
 
@@ -503,7 +505,7 @@ def test_add_outlet_port_CV1D_backward():
 
     p_obj = m.fs.u.add_outlet_port()
 
-    assert isinstance(p_obj, Port)
+    assert isinstance(p_obj, OutletPort)
     assert m.fs.u.outlet is p_obj
     assert len(m.fs.u.outlet) == 1
 
@@ -556,7 +558,7 @@ def test_add_outlet_port_CV0D_full_args():
 
     p_obj = m.fs.u.add_outlet_port(name="test_port", block=m.fs.u.cv, doc="Test")
 
-    assert isinstance(p_obj, Port)
+    assert isinstance(p_obj, OutletPort)
     assert hasattr(m.fs.u, "test_port")
     assert len(m.fs.u.test_port) == 1
 

--- a/idaes/core/base/unit_model.py
+++ b/idaes/core/base/unit_model.py
@@ -29,6 +29,7 @@ from idaes.core.base.control_volume_base import (
     FlowDirection,
     MaterialBalanceType,
 )
+from idaes.core.base.util import InletPort, OutletPort
 from idaes.core.util.exceptions import (
     BurntToast,
     ConfigurationError,
@@ -138,7 +139,7 @@ Must be True if dynamic = True,
         except AttributeError:
             pass
 
-    def add_port(self, name, block, doc=None):
+    def add_port(self, name, block, doc=None, port_class=Port):
         """
         This is a method to build Port objects in a unit model and
         connect these to a specified StateBlock.
@@ -148,13 +149,14 @@ Must be True if dynamic = True,
             block : an instance of a StateBlock to use as the source to
                     populate the Port object
             doc : doc string for Port object, default = None.
+            port_class: Subclass of Port to use. default = Port.
 
         Returns:
             A Pyomo Port object and associated components.
         """
         # Create Port
         try:
-            port, ref_name_list = block.build_port(doc)
+            port, ref_name_list = block.build_port(doc, port_class=port_class)
         except AttributeError:
             raise ConfigurationError(
                 f"{self.name} block object provided to add_port method is not an "
@@ -227,7 +229,7 @@ Must be True if dynamic = True,
             try:
                 # Try 0D first
                 sblock = block.properties_in
-                port, ref_name_list = sblock.build_port(doc)
+                port, ref_name_list = sblock.build_port(doc, port_class=InletPort)
             except AttributeError:
                 # Otherwise a 1D control volume
                 try:
@@ -246,6 +248,7 @@ Must be True if dynamic = True,
                         doc,
                         # pylint: disable-next=possibly-used-before-assignment
                         slice_index=(slice(None), _idx),
+                        port_class=InletPort,
                     )
 
                 except AttributeError:
@@ -257,7 +260,7 @@ Must be True if dynamic = True,
         else:
             # Assume a StateBlock indexed only by time
             sblock = block
-            port, ref_name_list = sblock.build_port(doc)
+            port, ref_name_list = sblock.build_port(doc, port_class=InletPort)
 
         # Add Port and References to unit model
         self.add_component(name, port)
@@ -327,7 +330,7 @@ Must be True if dynamic = True,
             try:
                 # Try 0D first
                 sblock = block.properties_out
-                port, ref_name_list = sblock.build_port(doc)
+                port, ref_name_list = sblock.build_port(doc, port_class=OutletPort)
             except AttributeError:
                 # Otherwise a 1D control volume
                 try:
@@ -346,6 +349,7 @@ Must be True if dynamic = True,
                         doc,
                         # pylint: disable-next=possibly-used-before-assignment
                         slice_index=(slice(None), _idx),
+                        port_class=OutletPort,
                     )
 
                 except AttributeError:
@@ -357,7 +361,7 @@ Must be True if dynamic = True,
         else:
             # Assume a StateBlock indexed only by time
             sblock = block
-            port, ref_name_list = sblock.build_port(doc)
+            port, ref_name_list = sblock.build_port(doc, port_class=OutletPort)
 
         # Add Port and References to unit model
         self.add_component(name, port)

--- a/idaes/core/base/unit_model.py
+++ b/idaes/core/base/unit_model.py
@@ -29,7 +29,7 @@ from idaes.core.base.control_volume_base import (
     FlowDirection,
     MaterialBalanceType,
 )
-from idaes.core.base.util import InletPort, OutletPort
+from idaes.core.base.ports import InletPort, OutletPort
 from idaes.core.util.exceptions import (
     BurntToast,
     ConfigurationError,

--- a/idaes/core/base/util.py
+++ b/idaes/core/base/util.py
@@ -16,9 +16,6 @@
 # Build on demand needs to play with some private attributes
 # pylint: disable=protected-access
 
-from pyomo.core.base.indexed_component import UnindexedComponent_set
-from pyomo.core.base.global_set import UnindexedComponent_index
-from pyomo.network.port import IndexedPort, Port, PortData, ScalarPort
 from idaes.core.util.exceptions import (
     PropertyPackageError,
     PropertyNotSupportedError,
@@ -26,68 +23,6 @@ from idaes.core.util.exceptions import (
 )
 
 __author__ = "John Eslick, Andrew Lee"
-
-
-# Classes for inlet and outlet ports to assist other functions
-# in classifying port and flowsheet topology
-
-
-class InletPortData(PortData):
-    pass
-
-
-class InletPort(Port):
-    """
-    Class to identify whether a port on a model is an inlet port.
-    """
-
-    def __new__(cls, *args, **kwds):
-        if cls != InletPort:
-            return super(Port, cls).__new__(cls)
-        if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
-            return ScalarInletPort.__new__(ScalarInletPort)
-        else:
-            return IndexedInletPort.__new__(IndexedInletPort)
-
-
-class ScalarInletPort(InletPort, InletPortData):
-    def __init__(self, *args, **kwd):
-        InletPortData.__init__(self, component=self)
-        InletPort.__init__(self, *args, **kwd)
-        self._index = UnindexedComponent_index
-
-
-class IndexedInletPort(InletPort):
-    pass
-
-
-class OutletPortData(PortData):
-    pass
-
-
-class OutletPort(Port):
-    """
-    Class to identify whether a port on a model is an outlet port.
-    """
-
-    def __new__(cls, *args, **kwds):
-        if cls != OutletPort:
-            return super(Port, cls).__new__(cls)
-        if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
-            return ScalarOutletPort.__new__(ScalarOutletPort)
-        else:
-            return IndexedOutletPort.__new__(IndexedOutletPort)
-
-
-class ScalarOutletPort(OutletPort, OutletPortData):
-    def __init__(self, *args, **kwd):
-        OutletPortData.__init__(self, component=self)
-        OutletPort.__init__(self, *args, **kwd)
-        self._index = UnindexedComponent_index
-
-
-class IndexedOutletPort(OutletPort):
-    pass
 
 
 def build_on_demand(self, attr):

--- a/idaes/core/base/util.py
+++ b/idaes/core/base/util.py
@@ -16,6 +16,7 @@
 # Build on demand needs to play with some private attributes
 # pylint: disable=protected-access
 
+from pyomo.network.port import IndexedPort, Port, PortData, SimplePort
 from idaes.core.util.exceptions import (
     PropertyPackageError,
     PropertyNotSupportedError,
@@ -23,6 +24,26 @@ from idaes.core.util.exceptions import (
 )
 
 __author__ = "John Eslick, Andrew Lee"
+
+
+# Classes for inlet and outlet ports to assist other functions
+# in classifying port and flowsheet topology
+
+
+class InletPort(Port):
+    """
+    Class to identify whether a port on a model is an inlet port.
+    """
+
+    pass
+
+
+class OutletPort(Port):
+    """
+    Class to identify whether a port on a model is an outlet port.
+    """
+
+    pass
 
 
 def build_on_demand(self, attr):

--- a/idaes/core/base/util.py
+++ b/idaes/core/base/util.py
@@ -16,7 +16,9 @@
 # Build on demand needs to play with some private attributes
 # pylint: disable=protected-access
 
-from pyomo.network.port import IndexedPort, Port, PortData, SimplePort
+from pyomo.core.base.indexed_component import UnindexedComponent_set
+from pyomo.core.base.global_set import UnindexedComponent_index
+from pyomo.network.port import IndexedPort, Port, PortData, ScalarPort
 from idaes.core.util.exceptions import (
     PropertyPackageError,
     PropertyNotSupportedError,
@@ -30,11 +32,36 @@ __author__ = "John Eslick, Andrew Lee"
 # in classifying port and flowsheet topology
 
 
+class InletPortData(PortData):
+    pass
+
+
 class InletPort(Port):
     """
     Class to identify whether a port on a model is an inlet port.
     """
 
+    def __new__(cls, *args, **kwds):
+        if cls != InletPort:
+            return super(Port, cls).__new__(cls)
+        if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
+            return ScalarInletPort.__new__(ScalarInletPort)
+        else:
+            return IndexedInletPort.__new__(IndexedInletPort)
+
+
+class ScalarInletPort(InletPort, InletPortData):
+    def __init__(self, *args, **kwd):
+        InletPortData.__init__(self, component=self)
+        InletPort.__init__(self, *args, **kwd)
+        self._index = UnindexedComponent_index
+
+
+class IndexedInletPort(InletPort):
+    pass
+
+
+class OutletPortData(PortData):
     pass
 
 
@@ -43,6 +70,23 @@ class OutletPort(Port):
     Class to identify whether a port on a model is an outlet port.
     """
 
+    def __new__(cls, *args, **kwds):
+        if cls != OutletPort:
+            return super(Port, cls).__new__(cls)
+        if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
+            return ScalarOutletPort.__new__(ScalarOutletPort)
+        else:
+            return IndexedOutletPort.__new__(IndexedOutletPort)
+
+
+class ScalarOutletPort(OutletPort, OutletPortData):
+    def __init__(self, *args, **kwd):
+        OutletPortData.__init__(self, component=self)
+        OutletPort.__init__(self, *args, **kwd)
+        self._index = UnindexedComponent_index
+
+
+class IndexedOutletPort(OutletPort):
     pass
 
 

--- a/idaes/models/unit_models/mixer.py
+++ b/idaes/models/unit_models/mixer.py
@@ -35,6 +35,8 @@ from idaes.core import (
     useDefault,
     MaterialBalanceType,
     MaterialFlowBasis,
+    InletPort,
+    OutletPort,
 )
 from idaes.core.base.control_volume_base import ControlVolumeScalerBase
 from idaes.core.util.config import (
@@ -1009,8 +1011,15 @@ objects linked to all inlet states and the mixed state,
             # Add ports
             for p in inlet_list:
                 i_state = getattr(self, p + "_state")
-                self.add_port(name=p, block=i_state, doc="Inlet Port")
-            self.add_port(name="outlet", block=mixed_block, doc="Outlet Port")
+                self.add_port(
+                    name=p, block=i_state, doc="Inlet Port", port_class=InletPort
+                )
+            self.add_port(
+                name="outlet",
+                block=mixed_block,
+                doc="Outlet Port",
+                port_class=OutletPort,
+            )
 
     def model_check(blk):
         """

--- a/idaes/models/unit_models/product.py
+++ b/idaes/models/unit_models/product.py
@@ -19,7 +19,13 @@ from pyomo.environ import Reference
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 
 # Import IDAES cores
-from idaes.core import declare_process_block_class, UnitModelBlockData, useDefault
+from idaes.core import (
+    declare_process_block_class,
+    InletPort,
+    OutletPort,
+    UnitModelBlockData,
+    useDefault,
+)
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.tables import create_stream_table_dataframe
 import idaes.logger as idaeslog
@@ -134,7 +140,9 @@ see property package for documentation.}""",
             setattr(self, s, r)
 
         # Add outlet port
-        self.add_port(name="inlet", block=self.properties, doc="Inlet Port")
+        self.add_port(
+            name="inlet", block=self.properties, doc="Inlet Port", port_class=InletPort
+        )
 
     def initialize_build(
         blk, state_args=None, outlvl=idaeslog.NOTSET, solver=None, optarg=None

--- a/idaes/models/unit_models/product.py
+++ b/idaes/models/unit_models/product.py
@@ -22,7 +22,6 @@ from pyomo.common.config import ConfigBlock, ConfigValue, In
 from idaes.core import (
     declare_process_block_class,
     InletPort,
-    OutletPort,
     UnitModelBlockData,
     useDefault,
 )

--- a/idaes/models/unit_models/separator.py
+++ b/idaes/models/unit_models/separator.py
@@ -35,11 +35,13 @@ from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf, Bool
 
 from idaes.core import (
     declare_process_block_class,
-    UnitModelBlockData,
-    useDefault,
+    InletPort,
     MaterialBalanceType,
     MomentumBalanceType,
     MaterialFlowBasis,
+    OutletPort,
+    UnitModelBlockData,
+    useDefault,
     VarLikeExpression,
 )
 from idaes.core.util.config import (
@@ -1063,7 +1065,9 @@ objects linked the mixed state and all outlet states,
             None
         """
         if self.config.construct_ports is True:
-            self.add_port(name="inlet", block=mixed_block, doc="Inlet Port")
+            self.add_port(
+                name="inlet", block=mixed_block, doc="Inlet Port", port_class=InletPort
+            )
 
     def add_outlet_port_objects(self, outlet_list, outlet_blocks):
         """
@@ -1079,7 +1083,9 @@ objects linked the mixed state and all outlet states,
             # Add ports
             for p in outlet_list:
                 o_state = getattr(self, p + "_state")
-                self.add_port(name=p, block=o_state, doc="Outlet Port")
+                self.add_port(
+                    name=p, block=o_state, doc="Outlet Port", port_class=OutletPort
+                )
 
     def add_split_fractions(self, outlet_list, mixed_block):
         """

--- a/idaes/models/unit_models/solid_liquid/sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/sl_separator.py
@@ -37,7 +37,6 @@ from pandas import DataFrame
 # Import Pyomo libraries
 from pyomo.environ import Reference
 from pyomo.common.config import ConfigBlock, ConfigValue, In
-from pyomo.network import Port
 
 # Import IDAES cores
 from idaes.core import (

--- a/idaes/models/unit_models/solid_liquid/sl_separator.py
+++ b/idaes/models/unit_models/solid_liquid/sl_separator.py
@@ -42,8 +42,10 @@ from pyomo.network import Port
 # Import IDAES cores
 from idaes.core import (
     declare_process_block_class,
+    InletPort,
     MaterialBalanceType,
     MomentumBalanceType,
+    OutletPort,
     UnitModelBlockData,
     useDefault,
 )
@@ -316,9 +318,10 @@ see property package for documentation.}""",
             name="liquid_inlet",
             block=self.liquid_inlet_state,
             doc="Liquid inlet to separator",
+            port_class=InletPort,
         )
-        self.recovered_liquid_outlet = Port(extends=self.split.recovered)
-        self.retained_liquid_outlet = Port(extends=self.split.retained)
+        self.recovered_liquid_outlet = OutletPort(extends=self.split.recovered)
+        self.retained_liquid_outlet = OutletPort(extends=self.split.retained)
 
         # Add liquid recovery
         self.liquid_recovery = Reference(self.split.split_fraction[:, "recovered"])

--- a/idaes/models/unit_models/solid_liquid/thickener.py
+++ b/idaes/models/unit_models/solid_liquid/thickener.py
@@ -40,8 +40,10 @@ from pyomo.network import Port
 # Import IDAES cores
 from idaes.core import (
     declare_process_block_class,
+    InletPort,
     MaterialBalanceType,
     MomentumBalanceType,
+    OutletPort,
     UnitModelBlockData,
     useDefault,
 )
@@ -239,9 +241,10 @@ class Thickener0DData(UnitModelBlockData):
             name="solid_inlet",
             block=self.solid_inlet_state,
             doc="Solid inlet to thickener",
+            port_class=InletPort,
         )
-        self.solid_underflow = Port(extends=self.solid_split.underflow)
-        self.solid_overflow = Port(extends=self.solid_split.overflow)
+        self.solid_underflow = OutletPort(extends=self.solid_split.underflow)
+        self.solid_overflow = OutletPort(extends=self.solid_split.overflow)
 
         # Build liquid Phase
         # Setup StateBlock argument dict

--- a/idaes/models/unit_models/translator.py
+++ b/idaes/models/unit_models/translator.py
@@ -18,7 +18,12 @@ Generic template for a translator block.
 from pyomo.common.config import ConfigBlock, ConfigValue, In, Bool
 
 # Import IDAES cores
-from idaes.core import declare_process_block_class, UnitModelBlockData
+from idaes.core import (
+    declare_process_block_class,
+    InletPort,
+    OutletPort,
+    UnitModelBlockData,
+)
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.exceptions import ConfigurationError
@@ -185,8 +190,18 @@ see property package for documentation.}""",
         )
 
         # Add outlet port
-        self.add_port(name="inlet", block=self.properties_in, doc="Inlet Port")
-        self.add_port(name="outlet", block=self.properties_out, doc="Outlet Port")
+        self.add_port(
+            name="inlet",
+            block=self.properties_in,
+            doc="Inlet Port",
+            port_class=InletPort,
+        )
+        self.add_port(
+            name="outlet",
+            block=self.properties_out,
+            doc="Outlet Port",
+            port_class=OutletPort,
+        )
 
     def initialize_build(
         blk,

--- a/idaes/models_extra/gas_distribution/unit_models/compressor.py
+++ b/idaes/models_extra/gas_distribution/unit_models/compressor.py
@@ -87,7 +87,7 @@ class IsothermalCompressorData(UnitModelBlockData):
             name="outlet_port",
             block=self.outlet_state,
             doc="The outlet from the compressor",
-            port_class=OutletPort
+            port_class=OutletPort,
         )
 
         self.add_state_material_balances(

--- a/idaes/models_extra/gas_distribution/unit_models/compressor.py
+++ b/idaes/models_extra/gas_distribution/unit_models/compressor.py
@@ -30,7 +30,9 @@ from pyomo.core.base.units_container import units as pyunits
 
 from idaes.core import (
     declare_process_block_class,
+    InletPort,
     MaterialBalanceType,
+    OutletPort,
     UnitModelBlockData,
 )
 from idaes.core.util.config import is_physical_parameter_block
@@ -79,11 +81,13 @@ class IsothermalCompressorData(UnitModelBlockData):
             name="inlet_port",
             block=self.inlet_state,
             doc="The inlet to the compressor",
+            port_class=InletPort,
         )
         self.add_port(
             name="outlet_port",
             block=self.outlet_state,
             doc="The outlet from the compressor",
+            port_class=OutletPort
         )
 
         self.add_state_material_balances(

--- a/idaes/models_extra/gas_distribution/unit_models/pipeline.py
+++ b/idaes/models_extra/gas_distribution/unit_models/pipeline.py
@@ -219,13 +219,13 @@ argument).""",
             name="inlet_port",
             block=inlet_state,
             doc="The inlet to the pipeline",
-            port_class=InletPort
+            port_class=InletPort,
         )
         self.add_port(
             name="outlet_port",
             block=outlet_state,
             doc="The outlet from the pipeline",
-            port_class=OutletPort
+            port_class=OutletPort,
         )
 
         self.add_isothermal_constraint()

--- a/idaes/models_extra/gas_distribution/unit_models/pipeline.py
+++ b/idaes/models_extra/gas_distribution/unit_models/pipeline.py
@@ -38,7 +38,9 @@ from pyomo.core.expr.numvalue import value as pyo_value
 from idaes.core import (
     declare_process_block_class,
     ControlVolume1DBlock,
+    InletPort,
     StateBlock,
+    OutletPort,
     UnitModelBlockData,
 )
 from idaes.core.util.config import (
@@ -217,11 +219,13 @@ argument).""",
             name="inlet_port",
             block=inlet_state,
             doc="The inlet to the pipeline",
+            port_class=InletPort
         )
         self.add_port(
             name="outlet_port",
             block=outlet_state,
             doc="The outlet from the pipeline",
+            port_class=OutletPort
         )
 
         self.add_isothermal_constraint()

--- a/idaes/models_extra/power_generation/unit_models/boiler_fireside.py
+++ b/idaes/models_extra/power_generation/unit_models/boiler_fireside.py
@@ -83,7 +83,13 @@ from pyomo.environ import (
 )
 
 # Import IDAES cores
-from idaes.core import declare_process_block_class, UnitModelBlockData, useDefault
+from idaes.core import (
+    declare_process_block_class,
+    InletPort,
+    OutletPort,
+    UnitModelBlockData,
+    useDefault,
+)
 
 from idaes.core.util.model_statistics import degrees_of_freedom
 
@@ -243,9 +249,9 @@ ratio, PA to coal ratio, and lower stoichiometric ratio,
             self.flowsheet().time, **self.config.property_package_args
         )
 
-        self.add_port("primary_air_inlet", self.primary_air)
-        self.add_port("secondary_air_inlet", self.secondary_air)
-        self.add_port("flue_gas_outlet", self.flue_gas)
+        self.add_port("primary_air_inlet", self.primary_air, port_class=InletPort)
+        self.add_port("secondary_air_inlet", self.secondary_air, port_class=InletPort)
+        self.add_port("flue_gas_outlet", self.flue_gas, port_class=OutletPort)
         # Construct performance equations
         self._make_params()
         self._make_vars()

--- a/idaes/models_extra/power_generation/unit_models/helm/mixer.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/mixer.py
@@ -19,8 +19,10 @@ from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 
 from idaes.core import (
     declare_process_block_class,
+    InletPort,
     UnitModelBlockData,
     useDefault,
+    OutletPort,
 )
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError
@@ -330,8 +332,18 @@ between flow and pressure driven simulations.}""",
             None
         """
         for p in self.inlet_list:
-            self.add_port(name=p, block=self.inlet_blocks[p], doc="Inlet Port")
-        self.add_port(name="outlet", block=self.mixed_state, doc="Outlet Port")
+            self.add_port(
+                name=p,
+                block=self.inlet_blocks[p],
+                doc="Inlet Port",
+                port_class=InletPort,
+            )
+        self.add_port(
+            name="outlet",
+            block=self.mixed_state,
+            doc="Outlet Port",
+            port_class=OutletPort,
+        )
 
     def use_minimum_inlet_pressure_constraint(self):
         """Activate the mixer pressure = minimum inlet pressure constraint and

--- a/idaes/models_extra/power_generation/unit_models/helm/phase_separator.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/phase_separator.py
@@ -26,7 +26,13 @@ from pyomo.common.config import ConfigBlock, ConfigValue, In
 from pyomo.environ import value
 
 # Import IDAES cores
-from idaes.core import declare_process_block_class, UnitModelBlockData, useDefault
+from idaes.core import (
+    declare_process_block_class,
+    InletPort,
+    OutletPort,
+    UnitModelBlockData,
+    useDefault,
+)
 from idaes.core.util.config import is_physical_parameter_block
 import idaes.logger as idaeslog
 from idaes.core.util.initialization import fix_state_vars, revert_state_vars
@@ -105,7 +111,7 @@ see property package for documentation.}""",
             self.flowsheet().time, **self.config.property_package_args
         )
 
-        self.add_port("inlet", self.mixed_state)
+        self.add_port("inlet", self.mixed_state, port_class=InletPort)
 
         self.vap_state = self.config.property_package.build_state_block(
             self.flowsheet().time, **self.config.property_package_args
@@ -115,8 +121,8 @@ see property package for documentation.}""",
             self.flowsheet().time, **self.config.property_package_args
         )
 
-        self.add_port("vap_outlet", self.vap_state)
-        self.add_port("liq_outlet", self.liq_state)
+        self.add_port("vap_outlet", self.vap_state, port_class=OutletPort)
+        self.add_port("liq_outlet", self.liq_state, port_class=OutletPort)
 
         # vapor outlet state
         @self.Constraint(self.flowsheet().time)

--- a/idaes/models_extra/power_generation/unit_models/helm/splitter.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/splitter.py
@@ -28,6 +28,8 @@ from pyomo.common.config import ConfigBlock, ConfigValue, In, ListOf
 
 from idaes.core import (
     declare_process_block_class,
+    InletPort,
+    OutletPort,
     UnitModelBlockData,
     useDefault,
 )
@@ -183,7 +185,9 @@ from 1 to num_outlets).}""",
             doc="Material properties of mixed (inlet) stream",
             **tmp_dict,
         )
-        self.add_port(name="inlet", block=self.mixed_state, doc="Inlet Port")
+        self.add_port(
+            name="inlet", block=self.mixed_state, doc="Inlet Port", port_class=InletPort
+        )
 
     def create_outlet_list(self):
         """
@@ -255,7 +259,9 @@ from 1 to num_outlets).}""",
         """
         self.outlet_ports = {}
         for p in self.outlet_list:
-            self.add_port(name=p, block=self.outlet_blocks[p], doc="Outlet")
+            self.add_port(
+                name=p, block=self.outlet_blocks[p], doc="Outlet", port_class=OutletPort
+            )
             self.outlet_ports[p] = getattr(self, p)
 
     def initialize_build(self, outlvl=idaeslog.NOTSET, optarg=None, solver=None):

--- a/idaes/models_extra/power_generation/unit_models/soc_submodels/solid_oxide_module_simple.py
+++ b/idaes/models_extra/power_generation/unit_models/soc_submodels/solid_oxide_module_simple.py
@@ -50,13 +50,18 @@ from functools import partial
 from pyomo.common.config import ConfigValue, ConfigBlock, Bool
 import pyomo.environ as pyo
 
-from idaes.core import declare_process_block_class, UnitModelBlockData
+from idaes.core import (
+    declare_process_block_class,
+    InletPort,
+    OutletPort,
+    UnitModelBlockData,
+)
 from idaes.core.util.config import is_physical_parameter_block
 import idaes.models_extra.power_generation.unit_models.soc_submodels as soc
 import idaes.models_extra.power_generation.unit_models.soc_submodels.common as common
 import idaes.core.util.scaling as iscale
 from idaes.core.solvers import get_solver
-from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.exceptions import BurntToast, ConfigurationError
 
 import idaes.logger as idaeslog
 
@@ -252,6 +257,7 @@ class SolidOxideModuleSimpleData(UnitModelBlockData):
                     ),
                 )
                 if direction == "in":
+                    port_class = InletPort
                     setattr(
                         self,
                         f"{port_name}_mole_frac_eqn",
@@ -260,7 +266,8 @@ class SolidOxideModuleSimpleData(UnitModelBlockData):
                             rule=partial(rule_mole_frac, port=port, comps=side_comps),
                         ),
                     )
-                if direction == "out":
+                elif direction == "out":
+                    port_class = OutletPort
                     setattr(
                         self,
                         f"{port_name}_absent_comp_eqn",
@@ -270,11 +277,20 @@ class SolidOxideModuleSimpleData(UnitModelBlockData):
                             rule=partial(rule_absent_comp, props=props),
                         ),
                     )
+                else:
+                    raise BurntToast(
+                        "direction should always be in or out "
+                        f"but instead we have {direction}. The "
+                        "end user should never encounter this error, "
+                        "please report this issue to the IDAES developers."
+                    )
+
                 # Add a different port at the module level
                 self.add_port(
                     name=port_name,
                     block=props,
                     doc=f"{side.capitalize()}-side {direction.capitalize()}let Port",
+                    port_class=port_class,
                 )
 
         # This is net flow of power *into* the cell. In fuel cell mode, this will


### PR DESCRIPTION
## Summary/Motivation:
A persistent problem in flowsheet visualization has been trying to determine whether a port corresponds to an inlet or outlet. The present "solution" has been to search for "inlet" or "outlet" in the port name. Here I added two subclasses of `Port`, so we can verify if something is an inlet, outlet, or neither using `isinstance`.

## Changes proposed in this PR:
- `InletPort` and `OutletPort` classes have been implemented
- Unit models have been updated to use them

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
