### PR TITLE
CI modernization and node 24 migration

### DIFF
--- a/.github/actions/environment-summary/action.yml
+++ b/.github/actions/environment-summary/action.yml
@@ -1,0 +1,115 @@
+name: Environment Summary
+description: Writes environment info to the job summary and uploads environment files as an artifact
+
+inputs:
+  python-version:
+    required: true
+    description: Python version used in the matrix
+  os:
+    required: true
+    description: OS label used in the matrix (e.g. linux, win64)
+  job-name:
+    required: false
+    description: Optional label to distinguish jobs with the same python/os (e.g. "tests", "notebooks")
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Generate environment summary
+      if: always()
+      shell: bash -l {0}
+      run: |
+        JOB_LABEL="${{ inputs.job-name }}"
+        [ -n "$JOB_LABEL" ] && JOB_LABEL=" ($JOB_LABEL)"
+
+        HAS_CONDA=false
+        command -v conda &>/dev/null && HAS_CONDA=true
+
+        {
+          # ── Heading ──────────────────────────────────────────────────────────
+          echo "#### Environment: py${{ inputs.python-version }} / ${{ inputs.os }}${JOB_LABEL}"
+          echo ""
+
+          # ── Overview table ───────────────────────────────────────────────────
+          echo "| Property | Value |"
+          echo "| --- | --- |"
+          echo "| Python | \`$(python --version 2>&1)\` |"
+          echo "| OS | ${{ runner.os }} (${{ runner.arch }}) |"
+          echo "| Conda available | $HAS_CONDA |"
+          echo "| Workflow | \`${{ github.workflow }}\` |"
+          echo "| Run ID / Attempt | \`${{ github.run_id }}\` / \`${{ github.run_attempt }}\` |"
+          echo "| Commit | \`${{ github.sha }}\` |"
+          echo ""
+
+          # ── Key packages ─────────────────────────────────────────────────────
+          echo "### Key Packages"
+          echo ""
+          echo "| Package | Version |"
+          echo "| --- | --- |"
+          for pkg in idaes-pse pyomo watertap numpy scipy pandas; do
+            version=$(pip show "$pkg" 2>/dev/null | grep "^Version:" | cut -d' ' -f2)
+            if [ -n "$version" ]; then
+              echo "| \`$pkg\` | \`$version\` |"
+            else
+              echo "| \`$pkg\` | _(not installed)_ |"
+            fi
+          done
+          echo ""
+
+          # ── Full conda list (only when conda is present) ──────────────────────
+          if [ "$HAS_CONDA" = "true" ]; then
+            echo "<details><summary>Full conda list</summary>"
+            echo ""
+            echo '```'
+            conda list
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+          fi
+
+          # ── Full pip list ────────────────────────────────────────────────────
+          echo "<details><summary>Full pip list</summary>"
+          echo ""
+          echo '```'
+          pip list
+          echo '```'
+          echo ""
+          echo "</details>"
+
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Export environment files
+      if: always()
+      shell: bash -l {0}
+      run: |
+        HAS_CONDA=false
+        command -v conda &>/dev/null && HAS_CONDA=true
+
+        if [ "$HAS_CONDA" = "true" ]; then
+          # --from-history: only explicitly requested packages — cleaner for diffing
+          conda env export --from-history > environment-conda-history.yml
+          # full export with build strings — useful for exact reproduction
+          conda env export > environment-conda-full.yml
+        else
+          echo "# conda not available in this job" > environment-conda-history.yml
+          echo "# conda not available in this job" > environment-conda-full.yml
+        fi
+
+        # pip freeze: pinned versions, editable installs visible — better for reproducibility
+        pip freeze > requirements-pip.txt
+
+    - name: Upload environment as artifact
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: >-
+          environment-${{
+            inputs.job-name != '' && format('{0}-', inputs.job-name) || ''
+          }}py${{ inputs.python-version }}-${{ inputs.os }}-attempt${{ github.run_attempt }}
+        path: |
+          environment-conda-history.yml
+          environment-conda-full.yml
+          requirements-pip.txt
+        if-no-files-found: error

--- a/.github/actions/environment-summary/action.yml
+++ b/.github/actions/environment-summary/action.yml
@@ -48,7 +48,7 @@ runs:
           echo "| Package | Version |"
           echo "| --- | --- |"
           for pkg in idaes-pse pyomo watertap numpy scipy pandas; do
-            version=$(pip show "$pkg" 2>/dev/null | grep "^Version:" | cut -d' ' -f2)
+            version="$(pip show "$pkg" 2>/dev/null | awk -F': ' '/^Version:/{print $2; exit}' || true)"
             if [ -n "$version" ]; then
               echo "| \`$pkg\` | \`$version\` |"
             else

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -113,6 +113,8 @@ jobs:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: 'true'
       - name: Set up idaes
         uses: ./.github/actions/setup-idaes
         with:
@@ -176,6 +178,8 @@ jobs:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: 'true'
       - name: Install pandoc
         run: conda install -c conda-forge pandoc
       - name: Set up idaes
@@ -214,6 +218,8 @@ jobs:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: 'true'
       - name: Set up idaes
         uses: ./.github/actions/setup-idaes
         with:
@@ -248,6 +254,8 @@ jobs:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: 'true'
       - name: Set up idaes
         uses: ./.github/actions/setup-idaes
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -53,9 +53,9 @@ jobs:
     # OS and/or Python version don't make a difference, so we choose ubuntu and 3.10 for performance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Install Black
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Spell Checker
         uses: crate-ci/typos@v1.24.5
@@ -99,16 +99,16 @@ jobs:
             runner-image: ubuntu-24.04
           - os: win64
             runner-image: windows-2022
-          - python-version: "3.11"
+          - python-version: "3.12"
             # only generate coverage report for a single python version in the matrix
             # to avoid overloading Codecov
             cov-report: true
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
@@ -128,7 +128,7 @@ jobs:
           pytest --pyargs idaes -m "not integration"
       - name: Upload coverage report as GHA workflow artifact
         if: matrix.cov-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report-${{ matrix.os }}
           path: coverage.xml
@@ -144,13 +144,13 @@ jobs:
         report-variant: ["linux", "win64"]
     steps:
       # the checkout step is needed to have access to codecov.yml
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: coverage-report-${{ matrix.report-variant }}
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true
           verbose: true
@@ -161,17 +161,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           # pinning version after v0.7.0 broke tokenless upload
           # see codecov/codecov-action#1487
-          version: v0.7.1
+          # version: v0.7.1
 
   build-docs:
     name: Build Sphinx docs
     runs-on: ubuntu-latest
     needs: [code-formatting, spell-check]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -188,7 +188,7 @@ jobs:
           cd docs/
           python build.py --timeout 600
       - name: Publish built docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: idaes-pse-docs-html
           path: docs/build/html/
@@ -203,13 +203,13 @@ jobs:
       pylint_output_path: pylint.json
       pylint_todo_sentinel: PYLINT-TODO
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # NOTE: using Conda instead of actions/setup-python in this job is not strictly necessary
       # as it doesn't need to run on Windows or use the setup-idaes local action,
       # but we do it for consistency with the other jobs
 
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -240,10 +240,10 @@ jobs:
     name: Compatibility tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -135,6 +135,13 @@ jobs:
           name: coverage-report-${{ matrix.os }}
           path: coverage.xml
           if-no-files-found: error
+      - name: Environment summary
+        if: always()
+        uses: ./.github/actions/environment-summary
+        with:
+          python-version: ${{ matrix.python-version }}
+          os: ${{ matrix.os }}
+          job-name: pytest
 
   upload-coverage:
     name: Upload coverage report (Codecov)
@@ -148,7 +155,7 @@ jobs:
       # the checkout step is needed to have access to codecov.yml
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-report-${{ matrix.report-variant }}
       - name: Upload coverage report to Codecov
@@ -197,6 +204,13 @@ jobs:
           name: idaes-pse-docs-html
           path: docs/build/html/
           retention-days: 7
+      - name: Environment summary
+        if: always()
+        uses: ./.github/actions/environment-summary
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          os: linux
+          job-name: build-docs
 
   pylint:
     name: Pylint
@@ -241,6 +255,13 @@ jobs:
           grep_opts=( --recursive --include '*.py' --color=always --after-context=2 --line-number --initial-tab )
 
           grep "$pylint_todo_sentinel" "${grep_opts[@]}" "$pylint_target_dir" || echo "No \"$pylint_todo_sentinel\" comments found in $pylint_target_dir"
+      - name: Environment summary
+        if: always()
+        uses: ./.github/actions/environment-summary
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          os: linux
+          job-name: pylint
 
   compat:
     name: Compatibility tests
@@ -267,3 +288,10 @@ jobs:
         run: |
           pip install "git+https://github.com/IDAES/idaes-compatibility@0.23.8"
           pytest --pyargs idaes_compatibility
+      - name: Environment summary
+        if: always()
+        uses: ./.github/actions/environment-summary
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          os: linux
+          job-name: compat

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,7 +64,7 @@ jobs:
       is-pr-approved: ${{ steps.check-pr-approval.outputs.is-approved }}
       workflow-trigger: ${{ steps.determine-trigger.outputs.workflow-trigger }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/display-debug-info
       - id: check-pr-approval
         uses: ./.github/actions/check-pr-approval
@@ -136,10 +136,10 @@ jobs:
           - os: win64
             runner-image: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         channels: conda-forge
         conda-remove-defaults: 'true'
         with:
@@ -176,10 +176,10 @@ jobs:
           - os: win64
             runner-image: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
@@ -233,9 +233,9 @@ jobs:
             pip-install-target: '.'
             dependencies-to-uninstall: omlt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: idaes-env
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,6 +140,8 @@ jobs:
       - uses: ./.github/actions/display-debug-info
       - name: Set up Conda environment
         uses: conda-incubator/setup-miniconda@v3
+        channels: conda-forge
+        conda-remove-defaults: 'true'
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
@@ -182,6 +184,8 @@ jobs:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: 'true'
       - name: Set up idaes
         uses: ./.github/actions/setup-idaes
         with:
@@ -236,6 +240,8 @@ jobs:
           activate-environment: idaes-env
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: 'true'
       - name: Set up idaes (non-editable installation)
         uses: ./.github/actions/setup-idaes
         with:


### PR DESCRIPTION
## Fixes
#1792 

## Summary/Motivation:
We are facing warnings galore in our CI. Additionally, there will be a hard node 20 -> 24 migration the first week of june I am taking this opportunity to update all workflows to use node 24 compatible actions and address other desires/needs to modernize the workflow. 

## Changes proposed in this PR:
**Workflow action version upgrades:**

* Updated `actions/checkout` to v6 in all jobs

**Conda environment improvements:**

* Updated `conda-incubator/setup-miniconda` from v3 to v4 in all relevant jobs.
* Added explicit `channels: conda-forge` and `conda-remove-defaults: 'true'` to all Conda setup steps to ensure environments are built solely from conda-forge

**Test matrix updates:**
* Changed the default Python version in the test matrix from 3.11 to 3.12

**Other improvements:**

* Removed explicit `version` pin for `codecov/codecov-action` because technically tokenless upload issues that motivated us pinning is no longer an issue -- need some input to confirm this. 
### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
