### PR TITLE
Remove gridx-precient dependency temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ omlt = [
 testing = ["pytest", "addheader", "pyyaml"]
 
 # this will install all optional dependencies
-all = ["idaes-pse[ui,grid,omlt,coolprop]"]
+all = ["idaes-pse[ui,omlt,coolprop]"]
 
 # we have to investigate why scm_tools is not working as expected
 # [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,6 @@ ui = ["idaes-ui", "idaes-connectivity"]
 coolprop = [
   "coolprop>=7.0", # idaes.generic_models.properties.general.coolprop
 ]
-grid = [
-  "gridx-prescient>=2.2.1", # idaes.tests.prescient
-]
 omlt = [
   "omlt==1.1",  # fix the version for now as package evolves
   "tensorflow",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ pre-commit
 addheader>=0.2.2
 
 # this will install IDAES in editable mode using the dependencies defined under the `extras_require` tags defined in `setup.py`
---editable .[ui,grid,omlt,coolprop]
+--editable .[ui,omlt,coolprop]
 # to customize this (e.g. to install a local clone of the Pyomo git repository), add the desired alternate requirements below
 
 # for flowsheet_processor


### PR DESCRIPTION
## Fixes
#1789 

## Summary/Motivation:
While waiting for fix in egret, remove the optional dependency

## Changes proposed in this PR:
- remove gridx-precient dependency from pyproject.toml 
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
