### PR TITLE
Fix for pytest=9.1.0

### DIFF
--- a/idaes/models/properties/tests/test_harness.py
+++ b/idaes/models/properties/tests/test_harness.py
@@ -69,8 +69,10 @@ class PropertyTestHarness(object):
         pass
 
     @pytest.fixture(scope="class")
-    def frame(self):
+    @classmethod
+    def frame(cls):
         m = ConcreteModel()
+        self = cls()
         self.configure_class(m)
 
         m.fs = FlowsheetBlock(dynamic=False)


### PR DESCRIPTION
## Fixes

This PR applies the [guidance from pytest](https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method) for class-scoped fixtures to the property test harness.
I have applied this fix to WaterTAP here: https://github.com/watertap-org/watertap/pull/1818

## Summary/Motivation:

The latest release of pytest is causing test failures in WaterTAP; see https://github.com/watertap-org/watertap/issues/1817

## Changes proposed in this PR:
- decorate class-scoped fixture in property test harness with `@classmethod`
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
