### PR TITLE
Restrict coolprop version to <8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 [project.optional-dependencies]
 ui = ["idaes-ui", "idaes-connectivity"]
 coolprop = [
-  "coolprop>=7.0", # idaes.generic_models.properties.general.coolprop
+  "coolprop>=7.0,<8", # idaes.generic_models.properties.general.coolprop
 ]
 grid = [
   "gridx-prescient>=2.2.3", # idaes.tests.prescient


### PR DESCRIPTION
## Fixes
Temporary fix

## Summary/Motivation:

Cool prop [v8.0.0](https://github.com/CoolProp/CoolProp/releases/tag/v8.0.0) was released on Jun 27, this caused standard pytest and compatibility tests to have failures. 

## Changes proposed in this PR:
- Restrict coolprop version to <8
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
