### PR TITLE
Propagate scaling suffix to temporary block

### DIFF
--- a/idaes/core/scaling/custom_scaler_base.py
+++ b/idaes/core/scaling/custom_scaler_base.py
@@ -35,7 +35,7 @@ from pyomo.common.deprecation import deprecation_warning
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 
 from idaes.core.scaling.scaling_base import CONFIG, ScalerBase
-from idaes.core.scaling.util import NominalValueExtractionVisitor
+from idaes.core.scaling.nominal_value_tools import NominalValueExtractionVisitor
 import idaes.logger as idaeslog
 from idaes.core.util.exceptions import BurntToast
 from idaes.core.util.misc import StrEnum

--- a/idaes/core/scaling/nominal_value_tools.py
+++ b/idaes/core/scaling/nominal_value_tools.py
@@ -1,5 +1,5 @@
 """
-The NominalValueExpressionWalker and supporting functions.
+The NominalValueExtractionVisitor and supporting functions.
 
 Authors: Andrew Lee, Douglas Allan
 """

--- a/idaes/core/scaling/nominal_value_tools.py
+++ b/idaes/core/scaling/nominal_value_tools.py
@@ -45,8 +45,6 @@ import idaes.logger as idaeslog
 
 _log = idaeslog.getLogger(__name__)
 
-TAB = " " * 4
-
 
 def get_nominal_value(component):
     """

--- a/idaes/core/scaling/nominal_value_tools.py
+++ b/idaes/core/scaling/nominal_value_tools.py
@@ -1,3 +1,15 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2026 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
 """
 The NominalValueExtractionVisitor and supporting functions.
 

--- a/idaes/core/scaling/nominal_value_tools.py
+++ b/idaes/core/scaling/nominal_value_tools.py
@@ -1,0 +1,343 @@
+"""
+The NominalValueExpressionWalker and supporting functions.
+
+Authors: Andrew Lee, Douglas Allan
+"""
+
+import math
+
+from pyomo.environ import (
+    Binary,
+    Boolean,
+    NegativeIntegers,
+    NegativeReals,
+    NonNegativeIntegers,
+    NonNegativeReals,
+    NonPositiveIntegers,
+    NonPositiveReals,
+    PositiveIntegers,
+    PositiveReals,
+    value,
+)
+from pyomo.core.base.var import VarData
+from pyomo.core.base.expression import ExpressionData
+from pyomo.core.base.param import ParamData
+from pyomo.core import expr as EXPR
+from pyomo.core.base.units_container import _PyomoUnit
+
+from pyomo.common.numeric_types import native_types
+
+from idaes.core.scaling.util import get_scaling_factor
+from idaes.core.util.exceptions import BurntToast
+import idaes.logger as idaeslog
+
+_log = idaeslog.getLogger(__name__)
+
+TAB = " " * 4
+
+
+def get_nominal_value(component):
+    """
+    Get the signed nominal value for a VarData or ParamData component.
+
+    For Params, the current value of the component will be returned.
+
+    For Vars, the nominal value is determined using the assigned scaling factor
+    and the sign determined based on the bounds and domain of the variable (defaulting to
+    positive). If no scaling factor is set, then the current value will be used if set,
+    otherwise the absolute nominal value will be equal to 1.
+
+    Args:
+        component: component to determine nominal value for
+
+    Returns:
+        signed float with nominal value
+
+    Raises:
+        TypeError if component is not instance of VarData or ParamData
+    """
+    # Determine if Var or Param
+    if isinstance(component, VarData):
+        # Get scaling factor for Var
+        sf = get_scaling_factor(component)
+        if sf is None:
+            # No scaling factor - see if Var has a value
+            if component.value is not None:
+                # If it has a value, use that as the nominal value
+                # As we are using the actual value, do not need to determine sign
+                return value(component)
+            else:
+                # Otherwise assign a nominal value of 1
+                sf = 1
+
+        # Try to determine expected sign of node
+        ub = component.ub
+        lb = component.lb
+        domain = component.domain
+
+        # To avoid NoneType errors, assign dummy values in place of None
+        if ub is None:
+            # No upper bound, take a positive value
+            ub = 1000
+        if lb is None:
+            # No lower bound, take a negative value
+            lb = -1000
+
+        if lb >= 0 or domain in [
+            NonNegativeReals,
+            PositiveReals,
+            PositiveIntegers,
+            NonNegativeIntegers,
+            Boolean,
+            Binary,
+        ]:
+            # Strictly positive
+            sign = 1
+        elif ub <= 0 or domain in [
+            NegativeReals,
+            NonPositiveReals,
+            NegativeIntegers,
+            NonPositiveIntegers,
+        ]:
+            # Strictly negative
+            sign = -1
+        else:
+            # Unbounded, see if there is a current value
+            # Assume positive until proven otherwise
+            sign = 1
+            if component.value is not None:
+                val = value(component)
+                if val < 0:
+                    # Assigned negative value, assume value will remain negative
+                    sign = -1
+
+        return sign / sf
+
+    elif isinstance(component, ParamData):
+        # Nominal value of a parameter is always its value
+        return value(component)
+    else:
+        # Not a Var or Param - invalid component type
+        raise TypeError(
+            f"get_nominal_value - {component.name} is not an instance of a Var or Param."
+        )
+
+
+class NominalValueExtractionVisitor(EXPR.StreamBasedExpressionVisitor):
+    """
+    Expression walker for collecting scaling factors in an expression and determining the
+    expected value of the expression using the scaling factors as nominal inputs.
+
+    By default, the get_nominal_value method is used to determine the nominal value for
+    all Vars and Params in the expression, however this can be changed by setting the
+    nominal_value_callback argument.
+
+    Returns a list of expected values for each additive term in the expression.
+
+    In order to properly assess the expected value of terms within functions, the sign
+    of each term is maintained throughout thus returned values may be negative. Functions
+    using this walker should handle these appropriately.
+    """
+
+    def __init__(self, nominal_value_callback=get_nominal_value):
+        """
+        Visitor class used to determine nominal values of all terms in an expression based on
+        scaling factors assigned to the associated variables. Do not use this class directly.
+
+        Args:
+            nominal_value_callback - method to use to get nominal value of root nodes.
+
+        Notes
+        -----
+        This class inherits from the :class:`StreamBasedExpressionVisitor` to implement
+        a walker that returns the nominal value corresponding to all additive terms in an
+        expression.
+        There are class attributes (dicts) that map the expression node type to the
+        particular method that should be called to return the nominal value of the node based
+        on the nominal value of its child arguments. This map is used in exitNode.
+        """
+        super().__init__()
+
+        self._nominal_value_callback = nominal_value_callback
+
+    def _get_magnitude_base_type(self, node):
+        try:
+            return [self._nominal_value_callback(node)]
+        except TypeError:
+            # Not a Var or Param - something went wrong
+            raise BurntToast(
+                "NominalValueExtractionVisitor found root node that was not a Var or Param. "
+                "This should never happen - please contact the developers with this bug."
+            )
+
+    def _get_nominal_value_for_sum_subexpression(self, child_nominal_values):
+        return sum(i for i in child_nominal_values)
+
+    def _get_nominal_value_for_sum(self, node, child_nominal_values):
+        # For sums, collect all child values into a list
+        mag = []
+        for i in child_nominal_values:
+            for j in i:
+                mag.append(j)
+        return mag
+
+    def _get_nominal_value_for_product(self, node, child_nominal_values):
+        mag = []
+        for i in child_nominal_values[0]:
+            for j in child_nominal_values[1]:
+                mag.append(i * j)
+        return mag
+
+    def _get_nominal_value_for_division(self, node, child_nominal_values):
+        numerator = self._get_nominal_value_for_sum_subexpression(
+            child_nominal_values[0]
+        )
+        denominator = self._get_nominal_value_for_sum_subexpression(
+            child_nominal_values[1]
+        )
+        if denominator == 0:
+            # Assign a nominal value of 1 so that we can continue
+            denominator = 1
+            # Log a warning for the user
+            _log.warning(
+                "Nominal value of 0 found in denominator of division expression. "
+                "Assigning a value of 1. You should check you scaling factors and models to "
+                "ensure there are no values of 0 that can appear in these functions."
+            )
+        return [numerator / denominator]
+
+    def _get_nominal_value_for_power(self, node, child_nominal_values):
+        # Use the absolute value of the base term to avoid possible complex numbers
+        base = abs(
+            self._get_nominal_value_for_sum_subexpression(child_nominal_values[0])
+        )
+        exponent = self._get_nominal_value_for_sum_subexpression(
+            child_nominal_values[1]
+        )
+
+        return [base**exponent]
+
+    def _get_nominal_value_single_child(self, node, child_nominal_values):
+        return child_nominal_values[0]
+
+    def _get_nominal_value_abs(self, node, child_nominal_values):
+        return [abs(i) for i in child_nominal_values[0]]
+
+    def _get_nominal_value_negation(self, node, child_nominal_values):
+        return [-i for i in child_nominal_values[0]]
+
+    def _get_nominal_value_for_unary_function(self, node, child_nominal_values):
+        func_name = node.getname()
+        func_nominal = self._get_nominal_value_for_sum_subexpression(
+            child_nominal_values[0]
+        )
+        func = getattr(math, func_name)
+        try:
+            return [func(func_nominal)]
+        except ValueError:
+            raise ValueError(
+                f"Evaluation error occurred when getting nominal value in {func_name} "
+                f"expression with input {func_nominal}. You should check you scaling factors "
+                f"and model to address any numerical issues or scale this constraint manually."
+            )
+
+    def _get_nominal_value_expr_if(self, node, child_nominal_values):
+        return child_nominal_values[1] + child_nominal_values[2]
+
+    def _get_nominal_value_external_function(self, node, child_nominal_values):
+        # First, need to get expected magnitudes of input terms, which may be sub-expressions
+        input_mag = []
+        for i in child_nominal_values:
+            if isinstance(i[0], str):
+                # Sometimes external functions might have string arguments
+                # Check here, and return the string if true
+                input_mag.append(i[0])
+            else:
+                input_mag.append(self._get_nominal_value_for_sum_subexpression(i))
+
+        # Next, create a copy of the external function with expected magnitudes as inputs
+        newfunc = node.create_node_with_local_data(input_mag)
+
+        # Evaluate new function and return the absolute value
+        return [value(newfunc)]
+
+    node_type_method_map = {
+        EXPR.EqualityExpression: _get_nominal_value_for_sum,
+        EXPR.InequalityExpression: _get_nominal_value_for_sum,
+        EXPR.RangedExpression: _get_nominal_value_for_sum,
+        EXPR.SumExpression: _get_nominal_value_for_sum,
+        EXPR.NPV_SumExpression: _get_nominal_value_for_sum,
+        EXPR.ProductExpression: _get_nominal_value_for_product,
+        EXPR.MonomialTermExpression: _get_nominal_value_for_product,
+        EXPR.NPV_ProductExpression: _get_nominal_value_for_product,
+        EXPR.DivisionExpression: _get_nominal_value_for_division,
+        EXPR.NPV_DivisionExpression: _get_nominal_value_for_division,
+        EXPR.PowExpression: _get_nominal_value_for_power,
+        EXPR.NPV_PowExpression: _get_nominal_value_for_power,
+        EXPR.NegationExpression: _get_nominal_value_negation,
+        EXPR.NPV_NegationExpression: _get_nominal_value_negation,
+        EXPR.AbsExpression: _get_nominal_value_abs,
+        EXPR.NPV_AbsExpression: _get_nominal_value_abs,
+        EXPR.UnaryFunctionExpression: _get_nominal_value_for_unary_function,
+        EXPR.NPV_UnaryFunctionExpression: _get_nominal_value_for_unary_function,
+        EXPR.Expr_ifExpression: _get_nominal_value_expr_if,
+        EXPR.ExternalFunctionExpression: _get_nominal_value_external_function,
+        EXPR.NPV_ExternalFunctionExpression: _get_nominal_value_external_function,
+        EXPR.LinearExpression: _get_nominal_value_for_sum,
+    }
+
+    def beforeChild(self, node, child, child_idx):
+        """
+        Callback for :class:`pyomo.core.current.StreamBasedExpressionVisitor`. This method
+        is called before entering a child node. If we encounter a named Expression with
+        a scaling hint, then we use that scaling hint instead of descending further into
+        the expression tree.
+        """
+        if isinstance(child, ExpressionData):
+            sf = get_scaling_factor(child, warning=False)
+            if sf is not None:
+                # Crude way to determine sign of expression. Maybe fbbt could be used here?
+                try:
+                    val = value(child)
+                except ValueError:
+                    # Some variable isn't defined, etc.
+                    val = 1
+                if val < 0:
+                    return (False, [-1 / sf])
+                else:
+                    return (False, [1 / sf])
+        return (True, None)
+
+    def exitNode(self, node, data):
+        """Callback for :class:`pyomo.core.current.StreamBasedExpressionVisitor`. This
+        method is called when moving back up the tree in a depth first search."""
+
+        # first check if the node is a leaf
+        nodetype = type(node)
+
+        if nodetype in native_types:
+            return [node]
+
+        node_func = self.node_type_method_map.get(nodetype, None)
+        if node_func is not None:
+            return node_func(self, node, data)
+
+        elif not node.is_expression_type():
+            # this is a leaf, but not a native type
+            if nodetype is _PyomoUnit:
+                return [1]
+            else:
+                return self._get_magnitude_base_type(node)
+                # might want to add other common types here
+
+        # not a leaf - check if it is a named expression
+        if (
+            hasattr(node, "is_named_expression_type")
+            and node.is_named_expression_type()
+        ):
+            return self._get_nominal_value_single_child(node, data)
+
+        raise TypeError(
+            f"An unhandled expression node type: {str(nodetype)} was encountered while "
+            f"retrieving the nominal value of expression {str(node)}"
+        )

--- a/idaes/core/scaling/tests/test_nominal_value_walker.py
+++ b/idaes/core/scaling/tests/test_nominal_value_walker.py
@@ -21,7 +21,8 @@ import pytest
 import pyomo.environ as pyo
 from pyomo.contrib.pynumero.asl import AmplInterface
 
-from idaes.core.scaling.util import NominalValueExtractionVisitor, set_scaling_factor
+from idaes.core.scaling import set_scaling_factor
+from idaes.core.scaling.nominal_value_tools import NominalValueExtractionVisitor
 from idaes.models.properties.modular_properties.eos.ceos_common import (
     cubic_roots_available,
     CubicThermoExpressions,

--- a/idaes/core/scaling/tests/test_util.py
+++ b/idaes/core/scaling/tests/test_util.py
@@ -296,6 +296,7 @@ class TestSuffixToFromDict:
     def scaled_model(self):
         m = _create_model()
         _scale_model(m)
+        return m
 
     @pytest.mark.unit
     def test_suffix_to_dict(self, scaled_model):

--- a/idaes/core/scaling/tests/test_util.py
+++ b/idaes/core/scaling/tests/test_util.py
@@ -37,6 +37,7 @@ from pyomo.common.fileutils import this_file_dir
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.contrib.pynumero.asl import AmplInterface
+from pyomo.util.subsystems import create_subsystem_block
 
 from idaes.core.scaling.util import (
     get_jacobian,
@@ -52,6 +53,7 @@ from idaes.core.scaling.util import (
     _set_block_suffixes_from_dict,
     list_unscaled_variables,
     list_unscaled_constraints,
+    propagate_scaling_factors_to_temporary_block,
     scaling_factors_to_dict,
     scaling_factors_from_dict,
     scaling_factors_to_json_file,
@@ -266,6 +268,25 @@ def _create_model():
     return m
 
 
+def _scale_model(m):
+    for bd in m.b.values():
+        bd.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        bd.scaling_factor[bd.v2] = 10
+
+        bd.scaling_hint = Suffix(direction=Suffix.EXPORT)
+        for k in m.s:
+            bd.scaling_hint[bd.e2[k]] = 1 / k
+
+    m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+    for i in m.s:
+        m.scaling_factor[m.v[i]] = 5 * i
+        m.scaling_factor[m.c[i]] = 5**i
+
+    m.scaling_hint = Suffix(direction=Suffix.EXPORT)
+    m.scaling_hint[m.e1] = 13
+    return m
+
+
 class TestSuffixToFromDict:
     @pytest.fixture
     def unscaled_model(self):
@@ -274,23 +295,7 @@ class TestSuffixToFromDict:
     @pytest.fixture
     def scaled_model(self):
         m = _create_model()
-
-        for bd in m.b.values():
-            bd.scaling_factor = Suffix(direction=Suffix.EXPORT)
-            bd.scaling_factor[bd.v2] = 10
-
-            bd.scaling_hint = Suffix(direction=Suffix.EXPORT)
-            for k in m.s:
-                bd.scaling_hint[bd.e2[k]] = 1 / k
-
-        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
-        for i in m.s:
-            m.scaling_factor[m.v[i]] = 5 * i
-            m.scaling_factor[m.c[i]] = 5**i
-
-        m.scaling_hint = Suffix(direction=Suffix.EXPORT)
-        m.scaling_hint[m.e1] = 13
-        return m
+        _scale_model(m)
 
     @pytest.mark.unit
     def test_suffix_to_dict(self, scaled_model):
@@ -2741,3 +2746,39 @@ def test_correct_set_identification():
         assert get_scaling_factor(m.xdot_disc_eq[0, i]) == approx(0.2)
         assert get_scaling_factor(m.xdot_disc_eq[1, i]) == approx(0.3)
         assert get_scaling_factor(m.xdot_disc_eq[2, i]) == approx(0.5)
+
+
+@pytest.mark.unit
+def test_propagate_scaling_factors_to_temporary_block():
+    m = _create_model()
+    _scale_model(m)
+
+    blk = create_subsystem_block(
+        constraints=[m.c[1], m.c[3]],
+        variables=[m.v[1], m.b[2].v2],  # m.v[3] should be an input variable
+    )
+
+    assert not hasattr(blk, "scaling_factor")
+    propagate_scaling_factors_to_temporary_block(blk)
+    assert hasattr(blk, "scaling_factor")
+    assert len(blk.scaling_factor) == 5
+    assert blk.scaling_factor[m.v[1]] == 5
+    assert blk.scaling_factor[m.v[3]] == 15
+    assert blk.scaling_factor[m.b[2].v2] == 10
+    assert blk.scaling_factor[m.c[1]] == 5
+    assert blk.scaling_factor[m.c[3]] == 125
+
+    # Now test what happens if a scaling factor suffix already exits
+    set_scaling_factor(m.b[2].v2, 137, overwrite=True)
+    # If a scaling factor doesn't exist on the original model
+    # for a variable, it should leave the existing scaling factor
+    # on the temporary block
+    del_scaling_factor(m.v[3])
+    propagate_scaling_factors_to_temporary_block(blk)
+    assert hasattr(blk, "scaling_factor")
+    assert len(blk.scaling_factor) == 5
+    assert blk.scaling_factor[m.v[1]] == 5
+    assert blk.scaling_factor[m.v[3]] == 15
+    assert blk.scaling_factor[m.b[2].v2] == 137
+    assert blk.scaling_factor[m.c[1]] == 5
+    assert blk.scaling_factor[m.c[3]] == 125

--- a/idaes/core/scaling/tests/test_util.py
+++ b/idaes/core/scaling/tests/test_util.py
@@ -2769,7 +2769,7 @@ def test_propagate_scaling_factors_to_temporary_block():
     assert blk.scaling_factor[m.c[1]] == 5
     assert blk.scaling_factor[m.c[3]] == 125
 
-    # Now test what happens if a scaling factor suffix already exits
+    # Now test what happens if a scaling factor suffix already exists
     set_scaling_factor(m.b[2].v2, 137, overwrite=True)
     # If a scaling factor doesn't exist on the original model
     # for a variable, it should leave the existing scaling factor

--- a/idaes/core/scaling/util.py
+++ b/idaes/core/scaling/util.py
@@ -56,6 +56,7 @@ from pyomo.core.base.param import ParamData
 from pyomo.core import expr as EXPR
 from pyomo.core.base.suffix import SuffixFinder
 from pyomo.core.base.units_container import _PyomoUnit
+from pyomo.common.deprecation import relocated_module_attribute
 
 from pyomo.common.collections import ComponentSet
 from pyomo.common.modeling import unique_component_name
@@ -822,311 +823,19 @@ def list_unscaled_constraints(blk: Block, descend_into: bool = True):
     return [c for c in unscaled_constraints_generator(blk, descend_into)]
 
 
-def get_nominal_value(component):
-    """
-    Get the signed nominal value for a VarData or ParamData component.
+relocated_module_attribute(
+    "get_nominal_value",
+    "idaes.core.scaling.nominal_value_tools.get_nominal_value",
+    version="2.13.0",
+    remove_in="2.14.0",
+)
 
-    For Params, the current value of the component will be returned.
-
-    For Vars, the nominal value is determined using the assigned scaling factor
-    and the sign determined based on the bounds and domain of the variable (defaulting to
-    positive). If no scaling factor is set, then the current value will be used if set,
-    otherwise the absolute nominal value will be equal to 1.
-
-    Args:
-        component: component to determine nominal value for
-
-    Returns:
-        signed float with nominal value
-
-    Raises:
-        TypeError if component is not instance of VarData or ParamData
-    """
-    # Determine if Var or Param
-    if isinstance(component, VarData):
-        # Get scaling factor for Var
-        sf = get_scaling_factor(component)
-        if sf is None:
-            # No scaling factor - see if Var has a value
-            if component.value is not None:
-                # If it has a value, use that as the nominal value
-                # As we are using the actual value, do not need to determine sign
-                return value(component)
-            else:
-                # Otherwise assign a nominal value of 1
-                sf = 1
-
-        # Try to determine expected sign of node
-        ub = component.ub
-        lb = component.lb
-        domain = component.domain
-
-        # To avoid NoneType errors, assign dummy values in place of None
-        if ub is None:
-            # No upper bound, take a positive value
-            ub = 1000
-        if lb is None:
-            # No lower bound, take a negative value
-            lb = -1000
-
-        if lb >= 0 or domain in [
-            NonNegativeReals,
-            PositiveReals,
-            PositiveIntegers,
-            NonNegativeIntegers,
-            Boolean,
-            Binary,
-        ]:
-            # Strictly positive
-            sign = 1
-        elif ub <= 0 or domain in [
-            NegativeReals,
-            NonPositiveReals,
-            NegativeIntegers,
-            NonPositiveIntegers,
-        ]:
-            # Strictly negative
-            sign = -1
-        else:
-            # Unbounded, see if there is a current value
-            # Assume positive until proven otherwise
-            sign = 1
-            if component.value is not None:
-                val = value(component)
-                if val < 0:
-                    # Assigned negative value, assume value will remain negative
-                    sign = -1
-
-        return sign / sf
-
-    elif isinstance(component, ParamData):
-        # Nominal value of a parameter is always its value
-        return value(component)
-    else:
-        # Not a Var or Param - invalid component type
-        raise TypeError(
-            f"get_nominal_value - {component.name} is not an instance of a Var or Param."
-        )
-
-
-class NominalValueExtractionVisitor(EXPR.StreamBasedExpressionVisitor):
-    """
-    Expression walker for collecting scaling factors in an expression and determining the
-    expected value of the expression using the scaling factors as nominal inputs.
-
-    By default, the get_nominal_value method is used to determine the nominal value for
-    all Vars and Params in the expression, however this can be changed by setting the
-    nominal_value_callback argument.
-
-    Returns a list of expected values for each additive term in the expression.
-
-    In order to properly assess the expected value of terms within functions, the sign
-    of each term is maintained throughout thus returned values may be negative. Functions
-    using this walker should handle these appropriately.
-    """
-
-    def __init__(self, nominal_value_callback=get_nominal_value):
-        """
-        Visitor class used to determine nominal values of all terms in an expression based on
-        scaling factors assigned to the associated variables. Do not use this class directly.
-
-        Args:
-            nominal_value_callback - method to use to get nominal value of root nodes.
-
-        Notes
-        -----
-        This class inherits from the :class:`StreamBasedExpressionVisitor` to implement
-        a walker that returns the nominal value corresponding to all additive terms in an
-        expression.
-        There are class attributes (dicts) that map the expression node type to the
-        particular method that should be called to return the nominal value of the node based
-        on the nominal value of its child arguments. This map is used in exitNode.
-        """
-        super().__init__()
-
-        self._nominal_value_callback = nominal_value_callback
-
-    def _get_magnitude_base_type(self, node):
-        try:
-            return [self._nominal_value_callback(node)]
-        except TypeError:
-            # Not a Var or Param - something went wrong
-            raise BurntToast(
-                "NominalValueExtractionVisitor found root node that was not a Var or Param. "
-                "This should never happen - please contact the developers with this bug."
-            )
-
-    def _get_nominal_value_for_sum_subexpression(self, child_nominal_values):
-        return sum(i for i in child_nominal_values)
-
-    def _get_nominal_value_for_sum(self, node, child_nominal_values):
-        # For sums, collect all child values into a list
-        mag = []
-        for i in child_nominal_values:
-            for j in i:
-                mag.append(j)
-        return mag
-
-    def _get_nominal_value_for_product(self, node, child_nominal_values):
-        mag = []
-        for i in child_nominal_values[0]:
-            for j in child_nominal_values[1]:
-                mag.append(i * j)
-        return mag
-
-    def _get_nominal_value_for_division(self, node, child_nominal_values):
-        numerator = self._get_nominal_value_for_sum_subexpression(
-            child_nominal_values[0]
-        )
-        denominator = self._get_nominal_value_for_sum_subexpression(
-            child_nominal_values[1]
-        )
-        if denominator == 0:
-            # Assign a nominal value of 1 so that we can continue
-            denominator = 1
-            # Log a warning for the user
-            _log.warning(
-                "Nominal value of 0 found in denominator of division expression. "
-                "Assigning a value of 1. You should check you scaling factors and models to "
-                "ensure there are no values of 0 that can appear in these functions."
-            )
-        return [numerator / denominator]
-
-    def _get_nominal_value_for_power(self, node, child_nominal_values):
-        # Use the absolute value of the base term to avoid possible complex numbers
-        base = abs(
-            self._get_nominal_value_for_sum_subexpression(child_nominal_values[0])
-        )
-        exponent = self._get_nominal_value_for_sum_subexpression(
-            child_nominal_values[1]
-        )
-
-        return [base**exponent]
-
-    def _get_nominal_value_single_child(self, node, child_nominal_values):
-        return child_nominal_values[0]
-
-    def _get_nominal_value_abs(self, node, child_nominal_values):
-        return [abs(i) for i in child_nominal_values[0]]
-
-    def _get_nominal_value_negation(self, node, child_nominal_values):
-        return [-i for i in child_nominal_values[0]]
-
-    def _get_nominal_value_for_unary_function(self, node, child_nominal_values):
-        func_name = node.getname()
-        func_nominal = self._get_nominal_value_for_sum_subexpression(
-            child_nominal_values[0]
-        )
-        func = getattr(math, func_name)
-        try:
-            return [func(func_nominal)]
-        except ValueError:
-            raise ValueError(
-                f"Evaluation error occurred when getting nominal value in {func_name} "
-                f"expression with input {func_nominal}. You should check you scaling factors "
-                f"and model to address any numerical issues or scale this constraint manually."
-            )
-
-    def _get_nominal_value_expr_if(self, node, child_nominal_values):
-        return child_nominal_values[1] + child_nominal_values[2]
-
-    def _get_nominal_value_external_function(self, node, child_nominal_values):
-        # First, need to get expected magnitudes of input terms, which may be sub-expressions
-        input_mag = []
-        for i in child_nominal_values:
-            if isinstance(i[0], str):
-                # Sometimes external functions might have string arguments
-                # Check here, and return the string if true
-                input_mag.append(i[0])
-            else:
-                input_mag.append(self._get_nominal_value_for_sum_subexpression(i))
-
-        # Next, create a copy of the external function with expected magnitudes as inputs
-        newfunc = node.create_node_with_local_data(input_mag)
-
-        # Evaluate new function and return the absolute value
-        return [value(newfunc)]
-
-    node_type_method_map = {
-        EXPR.EqualityExpression: _get_nominal_value_for_sum,
-        EXPR.InequalityExpression: _get_nominal_value_for_sum,
-        EXPR.RangedExpression: _get_nominal_value_for_sum,
-        EXPR.SumExpression: _get_nominal_value_for_sum,
-        EXPR.NPV_SumExpression: _get_nominal_value_for_sum,
-        EXPR.ProductExpression: _get_nominal_value_for_product,
-        EXPR.MonomialTermExpression: _get_nominal_value_for_product,
-        EXPR.NPV_ProductExpression: _get_nominal_value_for_product,
-        EXPR.DivisionExpression: _get_nominal_value_for_division,
-        EXPR.NPV_DivisionExpression: _get_nominal_value_for_division,
-        EXPR.PowExpression: _get_nominal_value_for_power,
-        EXPR.NPV_PowExpression: _get_nominal_value_for_power,
-        EXPR.NegationExpression: _get_nominal_value_negation,
-        EXPR.NPV_NegationExpression: _get_nominal_value_negation,
-        EXPR.AbsExpression: _get_nominal_value_abs,
-        EXPR.NPV_AbsExpression: _get_nominal_value_abs,
-        EXPR.UnaryFunctionExpression: _get_nominal_value_for_unary_function,
-        EXPR.NPV_UnaryFunctionExpression: _get_nominal_value_for_unary_function,
-        EXPR.Expr_ifExpression: _get_nominal_value_expr_if,
-        EXPR.ExternalFunctionExpression: _get_nominal_value_external_function,
-        EXPR.NPV_ExternalFunctionExpression: _get_nominal_value_external_function,
-        EXPR.LinearExpression: _get_nominal_value_for_sum,
-    }
-
-    def beforeChild(self, node, child, child_idx):
-        """
-        Callback for :class:`pyomo.core.current.StreamBasedExpressionVisitor`. This method
-        is called before entering a child node. If we encounter a named Expression with
-        a scaling hint, then we use that scaling hint instead of descending further into
-        the expression tree.
-        """
-        if isinstance(child, ExpressionData):
-            sf = get_scaling_factor(child, warning=False)
-            if sf is not None:
-                # Crude way to determine sign of expression. Maybe fbbt could be used here?
-                try:
-                    val = value(child)
-                except ValueError:
-                    # Some variable isn't defined, etc.
-                    val = 1
-                if val < 0:
-                    return (False, [-1 / sf])
-                else:
-                    return (False, [1 / sf])
-        return (True, None)
-
-    def exitNode(self, node, data):
-        """Callback for :class:`pyomo.core.current.StreamBasedExpressionVisitor`. This
-        method is called when moving back up the tree in a depth first search."""
-
-        # first check if the node is a leaf
-        nodetype = type(node)
-
-        if nodetype in native_types:
-            return [node]
-
-        node_func = self.node_type_method_map.get(nodetype, None)
-        if node_func is not None:
-            return node_func(self, node, data)
-
-        elif not node.is_expression_type():
-            # this is a leaf, but not a native type
-            if nodetype is _PyomoUnit:
-                return [1]
-            else:
-                return self._get_magnitude_base_type(node)
-                # might want to add other common types here
-
-        # not a leaf - check if it is a named expression
-        if (
-            hasattr(node, "is_named_expression_type")
-            and node.is_named_expression_type()
-        ):
-            return self._get_nominal_value_single_child(node, data)
-
-        raise TypeError(
-            f"An unhandled expression node type: {str(nodetype)} was encountered while "
-            f"retrieving the nominal value of expression {str(node)}"
-        )
+relocated_module_attribute(
+    "NominalValueExtractionVisitor",
+    "idaes.core.scaling.nominal_value_tools.NominalValueExtractionVisitor",
+    version="2.13.0",
+    remove_in="2.14.0",
+)
 
 
 # Based off of John Eslick's functions in the old scaling tools
@@ -1350,3 +1059,30 @@ def scale_time_discretization_equations(blk, time_set, time_scaling_factor):
                                         s_state,
                                         overwrite=False,
                                     )
+
+
+def propagate_scaling_factors_to_temporary_block(temporary_block: BlockData):
+    """
+    Copies scaling factors for variables and constraints on a temporary
+    block from their parent model to the temporary block, allowing the
+    temporary block to be scaled when solved. (Scaling factors on the
+    original model are not taken into account, see Pyomo #3800).
+
+    Args:
+        temporary_block: A BlockData object to which scaling factors are copied.
+
+    Returns:
+        None
+
+    """
+    if not hasattr(temporary_block, "scaling_factor"):
+        # if the subsystem block doesn't already have a scaling suffix, make one
+        temporary_block.scaling_factor = Suffix(direction=Suffix.EXPORT)
+    # first check the parent block for scaling factors
+    for comp in temporary_block.component_data_objects((Var, Constraint)):
+        sf = get_scaling_factor(comp)
+        if sf is not None:
+            # Can't use set_scaling_factor, because that would put the
+            # suffix on comp's parent block, which is not read when the
+            # .nl writer transcribes the temporary block.
+            temporary_block.scaling_factor[comp] = sf

--- a/idaes/core/scaling/util.py
+++ b/idaes/core/scaling/util.py
@@ -29,20 +29,11 @@ from scipy.sparse import diags
 from scipy.sparse.linalg import inv as spinv, norm as spnorm
 
 from pyomo.environ import (
-    Binary,
     Block,
     Boolean,
     Constraint,
     Expression,
-    NegativeIntegers,
-    NegativeReals,
-    NonNegativeIntegers,
-    NonNegativeReals,
-    NonPositiveIntegers,
-    NonPositiveReals,
     Objective,
-    PositiveIntegers,
-    PositiveReals,
     Reference,
     Suffix,
     value,
@@ -52,15 +43,11 @@ from pyomo.core.base.block import BlockData
 from pyomo.core.base.var import VarData
 from pyomo.core.base.constraint import ConstraintData
 from pyomo.core.base.expression import ExpressionData
-from pyomo.core.base.param import ParamData
-from pyomo.core import expr as EXPR
 from pyomo.core.base.suffix import SuffixFinder
-from pyomo.core.base.units_container import _PyomoUnit
 from pyomo.common.deprecation import relocated_module_attribute
 
 from pyomo.common.collections import ComponentSet
 from pyomo.common.modeling import unique_component_name
-from pyomo.common.numeric_types import native_types
 from pyomo.dae import DerivativeVar
 from pyomo.dae.flatten import slice_component_along_sets
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP


### PR DESCRIPTION
## Summary/Motivation:
As part of the PETSc rewrite, I added the function to propagate submodel scaling to a temporary block to the overall scaling tools. As per Pyomo/pyomo#3800, not including scaling suffixes from the original model when a temporary block is solved is the intended behavior. Therefore, if we want to include scaling suffixes, we need to copy them over manually.

## Changes proposed in this PR:
-Function to copy scaling suffixes to a temporary block
-Moved the `NominalValueExtractionVisitor` out of `scaling/util.py` into its own file.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
