### PR TITLE
Stop logging capture while running Pytest

### DIFF
--- a/idaes/logger.py
+++ b/idaes/logger.py
@@ -287,8 +287,8 @@ class SolverLogInfo(object):
 def solver_log(logger, level=logging.ERROR):
     """Context manager to send solver output to a logger."""
     tee = logger.isEnabledFor(level)
-    # Deadlock between Pyomo and Pytest stdout capture observed on 7/23/26.
-    # See IDAES #1818 for more details.
+    # Temporary fix for deadlock between Pyomo and Pytest stdout
+    # capture observed on 7/23/26. See IDAES #1818 for more details.
     on_windows_pytest = sys.platform.startswith("win") and "pytest" in sys.modules
     if not solver_capture() or on_windows_pytest:
         yield SolverLogInfo(tee=tee)

--- a/idaes/logger.py
+++ b/idaes/logger.py
@@ -10,6 +10,7 @@
 # All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
 # for full copyright and license information.
 #################################################################################
+# This file contains code generated with the assistence of Gemini 3.5
 # TODO: Missing doc strings
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-class-docstring
@@ -291,5 +292,5 @@ def solver_log(logger, level=logging.ERROR):
     if not solver_capture() or on_windows_pytest:
         yield SolverLogInfo(tee=tee)
     else:
-        with capture_output(LogStream(level, logger), capture_fd=False):
+        with capture_output(LogStream(level, logger)):
             yield SolverLogInfo(tee=tee)

--- a/idaes/logger.py
+++ b/idaes/logger.py
@@ -10,7 +10,7 @@
 # All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
 # for full copyright and license information.
 #################################################################################
-# This file contains code generated with the assistence of Gemini 3.5
+# This file contains code generated with the assistance of Gemini 3.5
 # TODO: Missing doc strings
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-class-docstring

--- a/idaes/logger.py
+++ b/idaes/logger.py
@@ -287,7 +287,8 @@ class SolverLogInfo(object):
 def solver_log(logger, level=logging.ERROR):
     """Context manager to send solver output to a logger."""
     tee = logger.isEnabledFor(level)
-    # Bypass capturing on Windows under Pytest to prevent crashes and deadlocks
+    # Deadlock between Pyomo and Pytest stdout capture observed on 7/23/26.
+    # See IDAES #1818 for more details.
     on_windows_pytest = sys.platform.startswith("win") and "pytest" in sys.modules
     if not solver_capture() or on_windows_pytest:
         yield SolverLogInfo(tee=tee)

--- a/idaes/logger.py
+++ b/idaes/logger.py
@@ -14,6 +14,7 @@
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-class-docstring
 
+import sys
 import logging
 from contextlib import contextmanager
 
@@ -285,8 +286,10 @@ class SolverLogInfo(object):
 def solver_log(logger, level=logging.ERROR):
     """Context manager to send solver output to a logger."""
     tee = logger.isEnabledFor(level)
-    if not solver_capture():
+    # Bypass capturing on Windows under Pytest to prevent crashes and deadlocks
+    on_windows_pytest = sys.platform.startswith("win") and "pytest" in sys.modules
+    if not solver_capture() or on_windows_pytest:
         yield SolverLogInfo(tee=tee)
     else:
-        with capture_output(LogStream(level, logger)):
+        with capture_output(LogStream(level, logger), capture_fd=False):
             yield SolverLogInfo(tee=tee)

--- a/idaes/tests/test_logger.py
+++ b/idaes/tests/test_logger.py
@@ -10,12 +10,15 @@
 # All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
 # for full copyright and license information.
 #################################################################################
+import sys
 import pytest
 import idaes.logger as idaeslog
 import logging
 import pyomo.environ as pyo
 
 __author__ = "John Eslick"
+
+on_windows = sys.platform.startswith("win")
 
 
 @pytest.mark.unit
@@ -118,6 +121,10 @@ def test_solver_condition2():
 
 
 @pytest.mark.skipif(not pyo.SolverFactory("ipopt").available(False), reason="no Ipopt")
+@pytest.mark.skipif(
+    on_windows,
+    reason="Deadlock between Pyomo and Pytest stdout capture. See IDAES #1818",
+)
 @pytest.mark.unit
 def test_solver_log(caplog):
     solver = pyo.SolverFactory("ipopt")


### PR DESCRIPTION
## Fixes
Band-aid fix for #1818 .

## Summary/Motivation:
Fighting between Pytest and Pyomo's output capturing can cause tests to hang on Windows. This is a simple fix suggested by Gemini 3.5 to disable logger capture on Windows when Pytest is imported. We should discuss whether that is the way we should fix this or whether a different fix is desirable.

The test for solver logging capture is going to fail by design.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
