### PR TITLE
Set bound_relax_factor to 0

### DIFF
--- a/idaes/config.py
+++ b/idaes/config.py
@@ -528,7 +528,7 @@ def _new_idaes_config_block():
     cfg.declare(
         "default_solver",
         pyomo.common.config.ConfigValue(
-            default="ipopt",
+            default="ipopt_v2",
             domain=str,
             description="Default solver.  See Pyomo's SolverFactory for details.",
             doc="Default solver.  See Pyomo's SolverFactory for details.",


### PR DESCRIPTION
## Fixes:
#1567

## Summary/Motivation:
Frequently we get puzzling behavior, Pyomo warnings, or evaluation errors from IPOPT because, by default, it relaxes the variable bounds by a small amount. WaterTAP has successfully switched off this setting for several years without any major consequences.

## Changes proposed in this PR:
- Adds a default configuration option of `bound_relax_factor=0` 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
