### PR TITLE
Helmholtz pressure changer scalers

### DIFF
--- a/idaes/models_extra/power_generation/unit_models/helm/compressor.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/compressor.py
@@ -20,8 +20,9 @@ import pyomo.environ as pyo
 from pyomo.common.config import In
 from idaes.core import declare_process_block_class
 from idaes.models_extra.power_generation.unit_models.balance import BalanceBlockData
-from idaes.core.util import from_json, to_json, StoreSpec
+from idaes.core.scaling import CustomScalerBase
 from idaes.core.solvers import get_solver
+from idaes.core.util import from_json, to_json, StoreSpec
 import idaes.models.properties.helmholtz.helmholtz as hltz
 from idaes.models.properties.helmholtz.helmholtz import (
     HelmholtzThermoExpressions as ThermoExpr,
@@ -50,6 +51,84 @@ def _assert_properties(pb):
         raise
 
 
+class HelmIsentropicCompressorScaler(CustomScalerBase):
+    """
+    Base scaler for the HelmIsentropicCompressor
+    """
+
+    def variable_scaling_routine(
+        self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None
+    ):
+        """
+        Routine to apply scaling factors to variables in model.
+
+        Args:
+            model: model to be scaled
+            overwrite: whether to overwrite existing scaling factors
+            submodel_scalers: dict of Scalers to use for sub-models, keyed by submodel local name
+
+        Returns:
+            None
+        """
+        self.call_submodel_scaler_method(
+            model.control_volume,
+            method="variable_scaling_routine",
+            submodel_scalers=submodel_scalers,
+            overwrite=overwrite,
+        )
+
+        for t in model.flowsheet().time:
+            self.set_component_scaling_factor(
+                model.efficiency_isentropic[t], 1.5, overwrite=overwrite
+            )
+            self.set_component_scaling_factor(
+                model.ratioP[t], 1 / 3, overwrite=overwrite
+            )
+
+            sf_F = self.get_scaling_factor(
+                model.control_volume.properties_out[t].flow_mol, default=1, warning=True
+            )
+            # Compressor, so the stream should be in a vapor phase
+            sf_H = self.get_scaling_factor(
+                model.control_volume.properties_out[t].enth_mol_phase["Vap"],
+                default=1e-4,
+                warning=True,
+            )
+            self.set_component_scaling_factor(model.h_is[t], sf_H)
+            self.set_component_scaling_factor(model.work_isentropic[t], sf_F * sf_H)
+            self.set_component_scaling_factor(model.h_o[t], sf_H)
+
+    def constraint_scaling_routine(
+        self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None
+    ):
+        """
+        Routine to apply scaling factors to constraints in model.
+
+        Args:
+            model: model to be scaled
+            overwrite: whether to overwrite existing scaling factors
+            submodel_scalers: dict of Scalers to use for sub-models, keyed by submodel local name
+
+        Returns:
+            None
+        """
+        self.call_submodel_scaler_method(
+            model.control_volume,
+            method="constraint_scaling_routine",
+            submodel_scalers=submodel_scalers,
+            overwrite=overwrite,
+        )
+        for t in model.flowsheet().time:
+            self.scale_constraint_by_component(
+                model.eq_work[t], model.h_o[t], overwrite=overwrite
+            )
+            self.scale_constraint_by_component(
+                model.eq_pressure_ratio[t],
+                model.control_volume.properties_out[t].pressure,
+                overwrite=overwrite,
+            )
+
+
 @declare_process_block_class("HelmIsentropicCompressor")
 class HelmIsentropicCompressorData(BalanceBlockData):
     """
@@ -69,6 +148,8 @@ class HelmIsentropicCompressorData(BalanceBlockData):
     3) Pressure:
         0 = P_in[t] + deltaP[t] - P_out[t]
     """
+
+    default_scaler = HelmIsentropicCompressorScaler
 
     CONFIG = BalanceBlockData.CONFIG()
     # For dynamics assume pseudo-steady-state

--- a/idaes/models_extra/power_generation/unit_models/helm/pump.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/pump.py
@@ -18,12 +18,16 @@
 
 import pyomo.environ as pyo
 from pyomo.common.config import In
+
 from idaes.core import declare_process_block_class
-from idaes.models_extra.power_generation.unit_models.balance import BalanceBlockData
-from idaes.core.util import from_json, to_json, StoreSpec
+from idaes.core.scaling import CustomScalerBase
 from idaes.core.solvers import get_solver
-import idaes.models.properties.helmholtz.helmholtz as hltz
+from idaes.core.util import from_json, to_json, StoreSpec
 import idaes.core.util.scaling as iscale
+
+import idaes.models.properties.helmholtz.helmholtz as hltz
+from idaes.models_extra.power_generation.unit_models.balance import BalanceBlockData
+
 
 import idaes.logger as idaeslog
 
@@ -48,6 +52,77 @@ def _assert_properties(pb):
         raise
 
 
+class HelmPumpScaler(CustomScalerBase):
+    """
+    Scaler object for the HelmPump
+    """
+
+    def variable_scaling_routine(
+        self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None
+    ):
+        """
+        Routine to apply scaling factors to variables in model.
+
+        Args:
+            model: model to be scaled
+            overwrite: whether to overwrite existing scaling factors
+            submodel_scalers: dict of Scalers to use for sub-models, keyed by submodel local name
+
+        Returns:
+            None
+        """
+        self.call_submodel_scaler_method(
+            model.control_volume,
+            method="variable_scaling_routine",
+            submodel_scalers=submodel_scalers,
+            overwrite=overwrite,
+        )
+
+        for t in model.flowsheet().time:
+            self.set_component_scaling_factor(
+                model.efficiency_pump[t], 1, overwrite=overwrite
+            )
+            self.set_component_scaling_factor(
+                model.ratioP[t], 1 / 3, overwrite=overwrite
+            )
+
+            sf_work = self.get_scaling_factor(
+                model.control_volume.work[t], default=1e-3, warning=True
+            )
+            self.set_component_scaling_factor(model.work_fluid[t], sf_work)
+            self.set_component_scaling_factor(model.shaft_work[t], sf_work)
+
+    def constraint_scaling_routine(
+        self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None
+    ):
+        """
+        Routine to apply scaling factors to constraints in model.
+
+        Args:
+            model: model to be scaled
+            overwrite: whether to overwrite existing scaling factors
+            submodel_scalers: dict of Scalers to use for sub-models, keyed by submodel local name
+
+        Returns:
+            None
+        """
+        self.call_submodel_scaler_method(
+            model.control_volume,
+            method="constraint_scaling_routine",
+            submodel_scalers=submodel_scalers,
+            overwrite=overwrite,
+        )
+        for t in model.flowsheet().time:
+            self.scale_constraint_by_component(
+                model.eq_work[t], model.control_volume.work[t], overwrite=overwrite
+            )
+            self.scale_constraint_by_component(
+                model.eq_pressure_ratio[t],
+                model.control_volume.properties_out[t].pressure,
+                overwrite=overwrite,
+            )
+
+
 @declare_process_block_class("HelmPump")
 class HelmPumpData(BalanceBlockData):
     """
@@ -67,6 +142,8 @@ class HelmPumpData(BalanceBlockData):
     3) Pressure:
         0 = P_in[t] + deltaP[t] - P_out[t]
     """
+
+    default_scaler = HelmPumpScaler
 
     CONFIG = BalanceBlockData.CONFIG()
     # For dynamics assume pseudo-steady-state
@@ -107,7 +184,7 @@ class HelmPumpData(BalanceBlockData):
 
         pratio = self.ratioP = pyo.Var(
             self.flowsheet().time,
-            initialize=0.7,
+            initialize=0.7,  # Why isn't this greater than one?
             doc="Ratio of outlet to inlet pressure",
         )
 

--- a/idaes/models_extra/power_generation/unit_models/helm/pump.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/pump.py
@@ -89,8 +89,12 @@ class HelmPumpScaler(CustomScalerBase):
             sf_work = self.get_scaling_factor(
                 model.control_volume.work[t], default=1e-3, warning=True
             )
-            self.set_component_scaling_factor(model.work_fluid[t], sf_work)
-            self.set_component_scaling_factor(model.shaft_work[t], sf_work)
+            self.set_component_scaling_factor(
+                model.work_fluid[t], sf_work, overwrite=overwrite
+            )
+            self.set_component_scaling_factor(
+                model.shaft_work[t], sf_work, overwrite=overwrite
+            )
 
     def constraint_scaling_routine(
         self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None

--- a/idaes/models_extra/power_generation/unit_models/helm/tests/test_compare_to_generic.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/tests/test_compare_to_generic.py
@@ -16,6 +16,7 @@ import pytest
 
 import pyomo.environ as pyo
 import idaes.core
+from idaes.core.scaling.util import jacobian_cond
 import idaes.models.unit_models as cmodels
 import idaes.models_extra.power_generation.unit_models.helm as hmodels
 from idaes.models.properties.general_helmholtz import helmholtz_available
@@ -165,8 +166,18 @@ def test_compressor_pump_compare():
     m.fs.unit2.outlet.pressure[0].fix(Pout)
     m.fs.unit2.efficiency_isentropic.fix(eff)
 
+    helmholtz_scaler = m.fs.properties.default_state_scaler_class()
+    helmholtz_scaler.default_scaling_factors["flow_mol"] = 1e-4
+    m.fs.properties.default_state_scaler_object = helmholtz_scaler
+
+    compressor_scaler = m.fs.unit2.default_scaler()
+    compressor_scaler.scale_model(m.fs.unit2)
+
     m.fs.unit1.initialize()
     m.fs.unit2.initialize()
+
+    assert jacobian_cond(m.fs.unit2, scaled=False) == pytest.approx(1.09755e9, rel=1e-3)
+    assert jacobian_cond(m.fs.unit2, scaled=True) == pytest.approx(68.0093, rel=1e-3)
 
     # The pump calculations are a bit more approximate assuming incompressible
     # fluid entropy is independent of pressure, so the results here should be

--- a/idaes/models_extra/power_generation/unit_models/helm/tests/test_compare_to_generic.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/tests/test_compare_to_generic.py
@@ -104,8 +104,29 @@ def test_turbine():
     m.fs.unit2.outlet.pressure[0].fix(Pout)
     m.fs.unit1.efficiency_isentropic.fix(0.9)
     m.fs.unit2.efficiency_isentropic.fix(0.9)
+
+    helmholtz_scaler = m.fs.properties.default_state_scaler_class()
+    helmholtz_scaler.default_scaling_factors["flow_mol"] = 1e-3
+    m.fs.properties.default_state_scaler_object = helmholtz_scaler
+
+    generic_turbine_scaler = m.fs.unit1.default_scaler()
+    generic_turbine_scaler.scale_model(m.fs.unit1)
+
+    helm_turbine_scaler = m.fs.unit2.default_scaler()
+    helm_turbine_scaler.scale_model(m.fs.unit2)
+
     m.fs.unit1.initialize()
     m.fs.unit2.initialize()
+
+    assert jacobian_cond(m.fs.unit1, scaled=False) == pytest.approx(
+        6.28161e11, rel=1e-3
+    )
+    assert jacobian_cond(m.fs.unit1, scaled=True) == pytest.approx(7750.81, rel=1e-3)
+
+    assert jacobian_cond(m.fs.unit2, scaled=False) == pytest.approx(
+        5.09370e10, rel=1e-3
+    )
+    assert jacobian_cond(m.fs.unit2, scaled=True) == pytest.approx(2689.86, rel=1e-3)
 
     assert pyo.value(
         m.fs.unit1.control_volume.properties_out[0].temperature

--- a/idaes/models_extra/power_generation/unit_models/helm/tests/test_compare_to_generic.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/tests/test_compare_to_generic.py
@@ -48,8 +48,25 @@ def test_pump():
     m.fs.unit2.outlet.pressure[0].fix(Pout)
     m.fs.unit1.efficiency_pump.fix(eff)
     m.fs.unit2.efficiency_pump.fix(eff)
+
+    helmholtz_scaler = m.fs.properties.default_state_scaler_class()
+    helmholtz_scaler.default_scaling_factors["flow_mol"] = 1e-4
+    m.fs.properties.default_state_scaler_object = helmholtz_scaler
+
+    generic_pump_scaler = m.fs.unit1.default_scaler()
+    generic_pump_scaler.scale_model(m.fs.unit1)
+
+    helm_pump_scaler = m.fs.unit2.default_scaler()
+    helm_pump_scaler.scale_model(m.fs.unit2)
+
     m.fs.unit1.initialize()
     m.fs.unit2.initialize()
+
+    assert jacobian_cond(m.fs.unit1, scaled=False) == pytest.approx(4.21702e5, rel=1e-3)
+    assert jacobian_cond(m.fs.unit1, scaled=True) == pytest.approx(1.0458e4, rel=1e-3)
+
+    assert jacobian_cond(m.fs.unit2, scaled=False) == pytest.approx(3.20007e5, rel=1e-3)
+    assert jacobian_cond(m.fs.unit2, scaled=True) == pytest.approx(25.9220, rel=1e-3)
 
     assert pyo.value(m.fs.unit1.control_volume.work[0]) == pytest.approx(
         pyo.value(m.fs.unit2.control_volume.work[0]), rel=1e-7
@@ -127,8 +144,29 @@ def test_compressor():
     m.fs.unit2.outlet.pressure[0].fix(Pout)
     m.fs.unit1.efficiency_isentropic.fix(eff)
     m.fs.unit2.efficiency_isentropic.fix(eff)
+
+    helmholtz_scaler = m.fs.properties.default_state_scaler_class()
+    helmholtz_scaler.default_scaling_factors["flow_mol"] = 1e-3
+    m.fs.properties.default_state_scaler_object = helmholtz_scaler
+
+    generic_compressor_scaler = m.fs.unit1.default_scaler()
+    generic_compressor_scaler.scale_model(m.fs.unit1)
+
+    helm_compressor_scaler = m.fs.unit2.default_scaler()
+    helm_compressor_scaler.scale_model(m.fs.unit2)
+
     m.fs.unit1.initialize()
     m.fs.unit2.initialize()
+
+    assert jacobian_cond(m.fs.unit1, scaled=False) == pytest.approx(
+        4.56644e12, rel=1e-3
+    )
+    assert jacobian_cond(m.fs.unit1, scaled=True) == pytest.approx(2.73067e4, rel=1e-3)
+
+    assert jacobian_cond(m.fs.unit2, scaled=False) == pytest.approx(
+        1.41623e11, rel=1e-3
+    )
+    assert jacobian_cond(m.fs.unit2, scaled=True) == pytest.approx(4.18022e3, rel=1e-3)
 
     assert pyo.value(
         m.fs.unit1.control_volume.properties_out[0].temperature
@@ -170,11 +208,17 @@ def test_compressor_pump_compare():
     helmholtz_scaler.default_scaling_factors["flow_mol"] = 1e-4
     m.fs.properties.default_state_scaler_object = helmholtz_scaler
 
+    pump_scaler = m.fs.unit1.default_scaler()
+    pump_scaler.scale_model(m.fs.unit1)
+
     compressor_scaler = m.fs.unit2.default_scaler()
     compressor_scaler.scale_model(m.fs.unit2)
 
     m.fs.unit1.initialize()
     m.fs.unit2.initialize()
+
+    assert jacobian_cond(m.fs.unit1, scaled=False) == pytest.approx(3.2001e5, rel=1e-3)
+    assert jacobian_cond(m.fs.unit1, scaled=True) == pytest.approx(25.9220, rel=1e-3)
 
     assert jacobian_cond(m.fs.unit2, scaled=False) == pytest.approx(1.09755e9, rel=1e-3)
     assert jacobian_cond(m.fs.unit2, scaled=True) == pytest.approx(68.0093, rel=1e-3)

--- a/idaes/models_extra/power_generation/unit_models/helm/tests/test_valve.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/tests/test_valve.py
@@ -1,0 +1,265 @@
+#################################################################################
+# The Institute for the Design of Advanced Energy Systems Integrated Platform
+# Framework (IDAES IP) was produced under the DOE Institute for the
+# Design of Advanced Energy Systems (IDAES).
+#
+# Copyright (c) 2018-2026 by the software owners: The Regents of the
+# University of California, through Lawrence Berkeley National Laboratory,
+# National Technology & Engineering Solutions of Sandia, LLC, Carnegie Mellon
+# University, West Virginia University Research Corporation, et al.
+# All rights reserved.  Please see the files COPYRIGHT.md and LICENSE.md
+# for full copyright and license information.
+#################################################################################
+"""
+Tests for valve model
+"""
+
+import math
+import pytest
+import re
+
+from pyomo.environ import (
+    check_optimal_termination,
+    ConcreteModel,
+    units,
+    value,
+)
+from idaes.core import FlowsheetBlock
+from idaes.core.util.model_statistics import (
+    number_variables,
+    number_total_constraints,
+    number_unused_variables,
+)
+from idaes.core.util.testing import (
+    initialization_tester,
+)
+from idaes.core.scaling.util import jacobian_cond
+from idaes.core.solvers import get_solver
+from idaes.core.util import DiagnosticsToolbox
+from idaes.core.util.exceptions import ConfigurationError
+
+from idaes.models.properties import iapws95
+from idaes.models.properties.general_helmholtz import helmholtz_available
+from idaes.models_extra.power_generation.unit_models.helm import (
+    HelmValve,
+    ValveFunctionType,
+)
+
+# -----------------------------------------------------------------------------
+# Get default solver for testing
+solver = get_solver(solver="ipopt_v2")
+
+
+@pytest.mark.parametrize(
+    "phase",
+    ["Liq", "Vap"],
+    scope="class",
+)
+@pytest.mark.parametrize(
+    "callback_type",
+    [
+        ValveFunctionType.linear,
+        ValveFunctionType.quick_opening,
+        ValveFunctionType.equal_percentage,
+        ValveFunctionType.custom,
+    ],
+    scope="class",
+)
+@pytest.mark.skipif(not helmholtz_available(), reason="General Helmholtz not available")
+class TestHelmholtzValve(object):
+    @pytest.fixture(scope="class")
+    @classmethod
+    def valve_model(cls, phase, callback_type):
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+
+        # Build parameter block with the correct phase
+        if phase == "Liq":
+            pp = iapws95.PhaseType.L
+        elif phase == "Vap":
+            pp = iapws95.PhaseType.G
+        else:
+            raise AssertionError()
+        m.fs.properties = iapws95.Iapws95ParameterBlock(phase_presentation=pp)
+
+        if callback_type is ValveFunctionType.custom:
+
+            def valve_function_callback(blk):
+                @blk.Expression(blk.flowsheet().time)
+                def valve_function(b, t):
+                    return b.valve_opening[t] ** 2
+
+        else:
+            valve_function_callback = None
+
+        m.fs.valve = HelmValve(
+            valve_function=callback_type,
+            valve_function_callback=valve_function_callback,
+            property_package=m.fs.properties,
+            phase=phase,
+        )
+        fin = 1000  # mol/s
+        pin = 200000  # Pa
+        pout = 100000  # Pa
+        if phase == "Liq":
+            tin = 300  # K
+        elif phase == "Vap":
+            tin = 400  # K
+        else:
+            raise AssertionError()
+        hin = iapws95.htpx(T=tin * units.K, P=pin * units.Pa)  # J/mol
+        # Calculate the flow coefficient to give 1000 mol/s flow with given P
+        if phase == "Liq":
+            dP = pin - pout
+        elif phase == "Vap":
+            dP = pin**2 - pout**2
+        else:
+            raise AssertionError()
+        if callback_type == ValveFunctionType.linear:
+            cv = 1000 / math.sqrt(dP) / 0.5
+        elif callback_type == ValveFunctionType.quick_opening:
+            cv = 1000 / math.sqrt(dP) / math.sqrt(0.5)
+        elif callback_type == ValveFunctionType.equal_percentage:
+            cv = 1000 / math.sqrt(dP) / 100 ** (0.5 - 1)
+        elif callback_type == ValveFunctionType.custom:
+            cv = 1000 / math.sqrt(dP) / 0.5**2
+
+        # Set inlet conditions
+        m.fs.valve.inlet.enth_mol[0].fix(hin)
+        m.fs.valve.inlet.flow_mol[0].fix(fin)
+        m.fs.valve.inlet.pressure[0].fix(pin)
+        m.fs.valve.outlet.pressure[0].set_value(pout)
+        m.fs.valve.Cv.fix(cv)
+        m.fs.valve.valve_opening.fix(0.5)
+
+        # Scale valves
+        helmholtz_scaler = m.fs.properties.default_state_scaler_class()
+        helmholtz_scaler.default_scaling_factors["flow_mol"] = 1e-3
+        m.fs.properties.default_state_scaler_object = helmholtz_scaler
+
+        valve_scaler = m.fs.valve.default_scaler()
+        valve_scaler.scale_model(m.fs.valve)
+
+        return m
+
+    @pytest.mark.build
+    @pytest.mark.unit
+    def test_build(self, valve_model, callback_type):
+        unit = valve_model.fs.valve
+
+        assert hasattr(unit, "inlet")
+        assert len(unit.inlet.vars) == 3
+        assert hasattr(unit.inlet, "flow_mol")
+        assert hasattr(unit.inlet, "enth_mol")
+        assert hasattr(unit.inlet, "pressure")
+
+        assert hasattr(unit, "outlet")
+        assert len(unit.outlet.vars) == 3
+        assert hasattr(unit.outlet, "flow_mol")
+        assert hasattr(unit.outlet, "enth_mol")
+        assert hasattr(unit.outlet, "pressure")
+
+        assert hasattr(unit, "pressure_flow_equation")
+        assert hasattr(unit, "valve_opening")
+        assert hasattr(unit, "valve_function")
+
+        if callback_type is ValveFunctionType.equal_percentage:
+            # alpha valve function parameter is one more than others
+            assert number_variables(unit) == 10
+        else:
+            assert number_variables(unit) == 9
+
+        assert number_total_constraints(unit) == 4
+        assert number_unused_variables(unit) == 0
+
+    @pytest.mark.component
+    def test_structural_issues(self, valve_model):
+        dt = DiagnosticsToolbox(valve_model.fs.valve)
+        dt.assert_no_structural_warnings()
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_initialize(self, valve_model):
+        initialization_tester(valve_model, unit=valve_model.fs.valve, solver="ipopt_v2")
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solve(self, valve_model):
+        results = solver.solve(valve_model, tee=True)
+
+        # Check for optimal solution
+        assert check_optimal_termination(results)
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_solution(self, valve_model):
+        # calculated Cv to yield this solution
+        assert pytest.approx(1000, rel=1e-3) == value(
+            valve_model.fs.valve.outlet.flow_mol[0]
+        )
+        assert pytest.approx(100000, rel=1e-3) == value(
+            valve_model.fs.valve.outlet.pressure[0]
+        )
+
+    @pytest.mark.solver
+    @pytest.mark.skipif(solver is None, reason="Solver not available")
+    @pytest.mark.component
+    def test_numerical_issues(self, valve_model, phase, callback_type):
+        dt = DiagnosticsToolbox(valve_model)
+        dt.assert_no_numerical_warnings()
+        expected_condition_numbers = {
+            # phase, callback_type: (unscaled, scaled)
+            ("Liq", ValveFunctionType.linear): (5612.48, 234.796),
+            ("Vap", ValveFunctionType.linear): (2.40365e6, 257.844),
+            ("Liq", ValveFunctionType.quick_opening): (5612.48, 234.796),
+            ("Vap", ValveFunctionType.quick_opening): (2.40365e6, 257.844),
+            ("Liq", ValveFunctionType.equal_percentage): (5612.48, 234.796),
+            ("Vap", ValveFunctionType.equal_percentage): (2.40365e6, 257.844),
+            ("Liq", ValveFunctionType.custom): (5612.48, 234.796),
+            ("Vap", ValveFunctionType.custom): (2.40365e6, 257.844),
+        }
+        assert (phase, callback_type) in expected_condition_numbers
+        unscaled, scaled = expected_condition_numbers[(phase, callback_type)]
+        assert jacobian_cond(valve_model, scaled=False) == pytest.approx(
+            unscaled, rel=1e-3
+        )
+        assert jacobian_cond(valve_model, scaled=True) == pytest.approx(
+            scaled, rel=1e-3
+        )
+
+
+@pytest.mark.unit
+def test_custom_callback_exceptions():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=False)
+    m.fs.properties = iapws95.Iapws95ParameterBlock()
+
+    def valve_function_callback(blk):
+        @blk.Expression(blk.flowsheet().time)
+        def valve_function(b, t):
+            return b.valve_opening[t] ** 2
+
+    with pytest.raises(
+        ConfigurationError,
+        match=re.escape(
+            "A valve function callback was provided but the valve "
+            "function type is not custom."
+        ),
+    ):
+        m.fs.valve = HelmValve(
+            valve_function_callback=valve_function_callback,
+            property_package=m.fs.properties,
+            phase="Liq",
+        )
+    with pytest.raises(
+        ConfigurationError,
+        match=re.escape("No custom valve function callback provided"),
+    ):
+        m.fs.valve = HelmValve(
+            valve_function=ValveFunctionType.custom,
+            property_package=m.fs.properties,
+            phase="Liq",
+        )

--- a/idaes/models_extra/power_generation/unit_models/helm/turbine.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/turbine.py
@@ -74,9 +74,11 @@ class HelmIsentropicTurbineScaler(CustomScalerBase):
                 default=1e-4,
                 warning=True,
             )
-            self.set_component_scaling_factor(model.h_is[t], sf_H)
-            self.set_component_scaling_factor(model.work_isentropic[t], sf_F * sf_H)
-            self.set_component_scaling_factor(model.h_o[t], sf_H)
+            self.set_component_scaling_factor(model.h_is[t], sf_H, overwrite=overwrite)
+            self.set_component_scaling_factor(
+                model.work_isentropic[t], sf_F * sf_H, overwrite=overwrite
+            )
+            self.set_component_scaling_factor(model.h_o[t], sf_H, overwrite=overwrite)
 
     def constraint_scaling_routine(
         self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None

--- a/idaes/models_extra/power_generation/unit_models/helm/turbine.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/turbine.py
@@ -21,6 +21,7 @@ from pyomo.common.config import In
 from idaes.core import declare_process_block_class
 from idaes.models_extra.power_generation.unit_models.balance import BalanceBlockData
 from idaes.core.util import from_json, to_json, StoreSpec
+from idaes.core.scaling import CustomScalerBase
 from idaes.core.solvers import get_solver
 import idaes.models.properties.helmholtz.helmholtz as hltz
 from idaes.models.properties.helmholtz.helmholtz import (
@@ -30,6 +31,82 @@ import idaes.logger as idaeslog
 import idaes.core.util.scaling as iscale
 
 _log = idaeslog.getLogger(__name__)
+
+
+class HelmIsentropicTurbineScaler(CustomScalerBase):
+    """
+    Scaler object for the HelmIsentropicTurbine
+    """
+
+    def variable_scaling_routine(
+        self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None
+    ):
+        """
+        Routine to apply scaling factors to variables in model.
+
+        Args:
+            model: model to be scaled
+            overwrite: whether to overwrite existing scaling factors
+            submodel_scalers: dict of Scalers to use for sub-models, keyed by submodel local name
+
+        Returns:
+            None
+        """
+        self.call_submodel_scaler_method(
+            model.control_volume,
+            method="variable_scaling_routine",
+            submodel_scalers=submodel_scalers,
+            overwrite=overwrite,
+        )
+
+        for t in model.flowsheet().time:
+            self.set_component_scaling_factor(
+                model.efficiency_isentropic[t], 1, overwrite=overwrite
+            )
+            self.set_component_scaling_factor(model.ratioP[t], 1.5, overwrite=overwrite)
+
+            sf_F = self.get_scaling_factor(
+                model.control_volume.properties_in[t].flow_mol, default=1, warning=True
+            )
+            # Compressor, so the stream should be in a vapor phase
+            sf_H = self.get_scaling_factor(
+                model.control_volume.properties_in[t].enth_mol_phase["Vap"],
+                default=1e-4,
+                warning=True,
+            )
+            self.set_component_scaling_factor(model.h_is[t], sf_H)
+            self.set_component_scaling_factor(model.work_isentropic[t], sf_F * sf_H)
+            self.set_component_scaling_factor(model.h_o[t], sf_H)
+
+    def constraint_scaling_routine(
+        self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None
+    ):
+        """
+        Routine to apply scaling factors to constraints in model.
+
+        Args:
+            model: model to be scaled
+            overwrite: whether to overwrite existing scaling factors
+            submodel_scalers: dict of Scalers to use for sub-models, keyed by submodel local name
+
+        Returns:
+            None
+        """
+        self.call_submodel_scaler_method(
+            model.control_volume,
+            method="constraint_scaling_routine",
+            submodel_scalers=submodel_scalers,
+            overwrite=overwrite,
+        )
+        for t in model.flowsheet().time:
+            self.scale_constraint_by_component(
+                model.eq_work[t], model.h_o[t], overwrite=overwrite
+            )
+            self.scale_constraint_by_component(
+                model.eq_pressure_ratio[t],
+                model.control_volume.properties_out[t].pressure,
+                overwrite=overwrite,
+            )
 
 
 def _assert_properties(pb):
@@ -69,6 +146,8 @@ class HelmIsentropicTurbineData(BalanceBlockData):
     3) Pressure:
         0 = P_in[t] + deltaP[t] - P_out[t]
     """
+
+    default_scaler = HelmIsentropicTurbineScaler
 
     CONFIG = BalanceBlockData.CONFIG()
     # For dynamics assume pseudo-steady-state

--- a/idaes/models_extra/power_generation/unit_models/helm/valve_steam.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/valve_steam.py
@@ -332,7 +332,7 @@ ValveFunctionType.custom}""",
         sp = StoreSpec.value_isfixed_isactive(only_fixed=True)
         istate = to_json(self, return_dict=True, wts=sp)
 
-        # Store values for presure so they can be restored after estimating
+        # Store values for pressure so they can be restored after estimating
         # the outlet state
         P = {t: self.outlet.pressure[t].value for t in self.flowsheet().time}
         # Propagate state variables to outlet block

--- a/idaes/models_extra/power_generation/unit_models/helm/valve_steam.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/valve_steam.py
@@ -25,6 +25,7 @@ from pyomo.common.config import ConfigValue, In
 from idaes.core import declare_process_block_class
 from idaes.models_extra.power_generation.unit_models.balance import BalanceBlockData
 from idaes.core.util import from_json, to_json, StoreSpec
+from idaes.core.scaling import CustomScalerBase
 from idaes.core.solvers import get_solver
 import idaes.models.properties.helmholtz.helmholtz as hltz
 import idaes.logger as idaeslog
@@ -72,7 +73,7 @@ def _quick_open_callback(blk):
 
 
 def _equal_percentage_callback(blk):
-    blk.alpha = pyo.Var(initialize=1, doc="Valve function parameter")
+    blk.alpha = pyo.Var(initialize=100, doc="Valve function parameter")
     blk.alpha.fix()
 
     @blk.Expression(blk.flowsheet().time)
@@ -82,7 +83,7 @@ def _equal_percentage_callback(blk):
 
 def _liquid_pressure_flow_rule(b, t):
     """
-    For liquid F = Cv*sqrt(Pi**2 - Po**2)*f(x)
+    For liquid F = Cv*sqrt(Pi - Po)*f(x)
     """
     Po = b.control_volume.properties_out[t].pressure
     Pi = b.control_volume.properties_in[t].pressure
@@ -100,6 +101,67 @@ def _vapor_pressure_flow_rule(b, t):
     F = b.control_volume.properties_in[t].flow_mol
     fun = b.valve_function[t]
     return F**2 == b.Cv**2 * (Pi**2 - Po**2) * fun**2
+
+
+class HelmValveScaler(CustomScalerBase):
+    """
+    Base scaler for the HelmValve
+    """
+
+    def variable_scaling_routine(
+        self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None
+    ):
+        """
+        Routine to apply scaling factors to variables in model.
+
+        Args:
+            model: model to be scaled
+            overwrite: whether to overwrite existing scaling factors
+            submodel_scalers: dict of Scalers to use for sub-models, keyed by submodel local name
+
+        Returns:
+            None
+        """
+        self.call_submodel_scaler_method(
+            model.control_volume,
+            method="variable_scaling_routine",
+            submodel_scalers=submodel_scalers,
+            overwrite=overwrite,
+        )
+
+        for t in model.flowsheet().time:
+            # Register that this variable is naturally well-scaled
+            self.set_component_scaling_factor(
+                model.valve_opening[t], 1, overwrite=overwrite
+            )
+
+    def constraint_scaling_routine(
+        self, model, overwrite: bool = False, submodel_scalers: pyo.ComponentMap = None
+    ):
+        """
+        Routine to apply scaling factors to constraints in model.
+
+        Args:
+            model: model to be scaled
+            overwrite: whether to overwrite existing scaling factors
+            submodel_scalers: dict of Scalers to use for sub-models, keyed by submodel local name
+
+        Returns:
+            None
+        """
+        self.call_submodel_scaler_method(
+            model.control_volume,
+            method="constraint_scaling_routine",
+            submodel_scalers=submodel_scalers,
+            overwrite=overwrite,
+        )
+        for t in model.flowsheet().time:
+            sf_F = self.get_scaling_factor(
+                model.control_volume.properties_in[t].flow_mol, default=1, warning=True
+            )
+            self.set_component_scaling_factor(
+                model.pressure_flow_equation[t], sf_F**2, overwrite=overwrite
+            )
 
 
 @declare_process_block_class("HelmValve")
@@ -121,6 +183,8 @@ class HelmValveData(BalanceBlockData):
     3) Pressure:
         0 = P_in[t] + deltaP[t] - P_out[t]
     """
+
+    default_scaler = HelmValveScaler
 
     CONFIG = BalanceBlockData.CONFIG()
     # For dynamics assume pseudo-steady-state
@@ -191,10 +255,20 @@ ValveFunctionType.custom}""",
             initialize=1,
             doc="Fraction open for valve from 0 to 1",
         )
+        umeta = (
+            self.control_volume.config.property_package.get_metadata().get_derived_units
+        )
+
+        if self.config.phase == "Liq":
+            Cv_units = umeta("amount") / umeta("time") / umeta("pressure") ** 0.5
+        else:
+            # Vapor
+            Cv_units = umeta("amount") / umeta("time") / umeta("pressure")
+
         self.Cv = pyo.Var(
             initialize=0.1,
             doc="Valve flow coefficient, for vapor " "[mol/s/Pa] for liquid [mol/s/Pa]",
-            units=pyo.units.mol / pyo.units.s / pyo.units.Pa,
+            units=Cv_units,
         )
         # self.Cv.fix()
 
@@ -203,7 +277,7 @@ ValveFunctionType.custom}""",
         vfcb = self.config.valve_function_callback
         vfselect = self.config.valve_function
         if vfselect is not ValveFunctionType.custom and vfcb is not None:
-            _log.warning(
+            raise ConfigurationError(
                 "A valve function callback was provided but the valve "
                 "function type is not custom."
             )
@@ -257,8 +331,17 @@ ValveFunctionType.custom}""",
         # This will only restore the values of variables that were originally fixed
         sp = StoreSpec.value_isfixed_isactive(only_fixed=True)
         istate = to_json(self, return_dict=True, wts=sp)
+
+        # Store values for presure so they can be restored after estimating
+        # the outlet state
+        P = {t: self.outlet.pressure[t].value for t in self.flowsheet().time}
+        # Propagate state variables to outlet block
+        self.control_volume.estimate_outlet_state(always_estimate=True)
+
         # Check for alternate pressure specs
         for t in self.flowsheet().time:
+            # Restore stored value for pressure
+            self.outlet.pressure[t].set_value(P[t])
             if self.outlet.pressure[t].fixed:
                 self.deltaP[t].fix(
                     pyo.value(self.outlet.pressure[t] - self.inlet.pressure[t])
@@ -279,9 +362,10 @@ ValveFunctionType.custom}""",
                 self.valve_opening.unfix()
             elif v.fixed and self.pressure_flow_equation.active:
                 self.inlet.flow_mol[t].unfix()
-
-        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-            opt.solve(self, tee=slc.tee)
+        # import pdb; pdb.set_trace()
+        # with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+        #     opt.solve(self, tee=slc.tee)
+        opt.solve(self, tee=True)
 
         init_log.info("Steam valve initialization complete")
 

--- a/idaes/models_extra/power_generation/unit_models/helm/valve_steam.py
+++ b/idaes/models_extra/power_generation/unit_models/helm/valve_steam.py
@@ -362,10 +362,9 @@ ValveFunctionType.custom}""",
                 self.valve_opening.unfix()
             elif v.fixed and self.pressure_flow_equation.active:
                 self.inlet.flow_mol[t].unfix()
-        # import pdb; pdb.set_trace()
-        # with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
-        #     opt.solve(self, tee=slc.tee)
-        opt.solve(self, tee=True)
+
+        with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
+            opt.solve(self, tee=slc.tee)
 
         init_log.info("Steam valve initialization complete")
 


### PR DESCRIPTION
## Summary/Motivation:
As part of the modernization of power plant models, we are rolling out scaler objects for the unit models contained therein. This PR contains scaler objects for the Helmholtz compressor, pump, and turbine.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
