### PR TITLE
Fix dynamic versioning packaging issue

### DIFF
--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -15,6 +15,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Fetch canonical version tags
+      shell: bash
+      run: |
+        # Forks do not necessarily contain the tags setuptools-scm uses to
+        # calculate the package version. Always use the canonical tags.
+        git fetch --force --prune --prune-tags --tags \
+          https://github.com/IDAES/idaes-pse.git
       # IMPORTANT this requires the Conda env setup to be run before this action
     - name: Update pip and other packaging tools using Conda
       # -l: login shell, needed when using Conda run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - name: Checkout code to be packaged
         uses: actions/checkout@v6
+        with:
+          # setuptools-scm needs the complete tag history to determine the version.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -31,8 +34,53 @@ jobs:
 
       - name: Generate dist files
         run: |
-          pip install build wheel
+          pip install build packaging wheel
           python -m build
+
+      - name: Check versions in distribution metadata
+        env:
+          EXPECTED_TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import tarfile
+          import zipfile
+          from email.parser import BytesParser
+          from pathlib import Path
+
+          from packaging.version import Version
+
+          expected = str(Version(os.environ["EXPECTED_TAG"]))
+          artifacts = {
+              "wheel": next(Path("dist").glob("*.whl")),
+              "sdist": next(Path("dist").glob("*.tar.gz")),
+          }
+
+          with zipfile.ZipFile(artifacts["wheel"]) as archive:
+              metadata_path = next(
+                  name for name in archive.namelist()
+                  if name.endswith(".dist-info/METADATA")
+              )
+              wheel_metadata = BytesParser().parsebytes(archive.read(metadata_path))
+
+          with tarfile.open(artifacts["sdist"]) as archive:
+              pkg_info = next(
+                  member for member in archive.getmembers()
+                  if member.name.count("/") == 1
+                  and member.name.endswith("/PKG-INFO")
+              )
+              sdist_metadata = BytesParser().parse(
+                  archive.extractfile(pkg_info), headersonly=True
+              )
+
+          for artifact_type, metadata in (
+              ("wheel", wheel_metadata),
+              ("sdist", sdist_metadata),
+          ):
+              actual = metadata["Version"]
+              print(f"{artifact_type}: expected={expected}, actual={actual}")
+              assert actual == expected
+          PY
 
       - name: Check that the dist directory's size is below PyPI's maximum
         run: |

--- a/docs/tutorials/advanced_install/index.rst
+++ b/docs/tutorials/advanced_install/index.rst
@@ -57,15 +57,22 @@ Of course, replace MYNAME with your username. This will download all the files i
 
 Add Upstream Remote
 ^^^^^^^^^^^^^^^^^^^
-In order to guarantee that your fork can be synchronized with the "main" idaes-pse repo in the GitHub IDAES organization, you need to add a pointer to that repository as a *remote*. This repository will be called *upstream* and linked with the following command::
+In order to guarantee that your fork can be synchronized with the "main" idaes-pse repo in the GitHub IDAES organization, you need to add a pointer to that repository as a *remote*. This repository will be called *upstream*. The ``--tags`` option ensures that version tags used to determine the IDAES package version are included, and ``-f`` fetches the upstream repository immediately::
 
-    git remote add upstream https://github.com/IDAES/idaes-pse.git
+    git remote add --tags -f upstream https://github.com/IDAES/idaes-pse.git
+
+If you already have an ``upstream`` remote, configure it to fetch tags and fetch it once::
+
+    git config remote.upstream.tagOpt --tags
+    git fetch upstream
+
+This is a one-time configuration. Future ``git fetch upstream`` commands will fetch new version tags automatically, so no additional step is needed after each IDAES release.
 
 To check to see if you added the remote correctly use the following command::
 
      git remote -v
 
-You should see that there are two remotes, origin and upstream. Both have two lines showing the remote name, the url, and the access (fetch or push). Origin is the pointer to your fork and was automatically added with the clone command, while upstream is the pointer to the main idaes-pse repo that you just added.
+You should see that there are two remotes, origin and upstream. Both have two lines showing the remote name, the URL, and the access (fetch or push). Origin is the pointer to your fork and was automatically added with the clone command, while upstream is the pointer to the main idaes-pse repo that you just added.
 
 Create the Python Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/tutorials/advanced_install/index.rst
+++ b/docs/tutorials/advanced_install/index.rst
@@ -66,7 +66,7 @@ If you already have an ``upstream`` remote, configure it to fetch tags and fetch
     git config remote.upstream.tagOpt --tags
     git fetch upstream
 
-This is a one-time configuration. Future ``git fetch upstream`` commands will fetch new version tags automatically, so no additional step is needed after each IDAES release.
+This configuration only needs to be done once. Afterward, whenever you run git fetch upstream to synchronize with the upstream repository, Git will also fetch any new version tags.
 
 To check to see if you added the remote correctly use the following command::
 


### PR DESCRIPTION
## Fixes
#1840


## Summary/Motivation:

package rebuilt correctly here ! https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fnoarch%2Fidaes-pse-2.12.0-pyhd8ed1ab_2.conda

## Changes proposed in this PR:

* Updated the `publish.yml` workflow to ensure the full git tag history is fetched during checkout, which is required for `setuptools-scm` to correctly determine the package version. (`jobs` section in `.github/workflows/publish.yml`)
* Added a new step in the `publish.yml` workflow to check that the version in the built distribution metadata matches the expected git tag, preventing accidental version mismatches. (`jobs` section in `.github/workflows/publish.yml`)
* Modified the dependencies installed during the build step to include `packaging`, which is used in the new version check. (`jobs` section in `.github/workflows/publish.yml`)

* Updated the custom GitHub Action (`setup-idaes/action.yml`) to always fetch canonical tags from the upstream repository, ensuring that forks have the correct tags for version calculation. (`inputs` section in `.github/actions/setup-idaes/action.yml`)
* Improved the advanced installation documentation to instruct users to fetch tags when adding the upstream remote and to configure existing remotes to always fetch tags, ensuring local repositories have all necessary version tags. (`docs/tutorials/advanced_install/index.rst`)


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
