### PR TITLE
Optimization variables

### DIFF
--- a/idaes/core/util/diagnostics_tools/diagnostics_toolbox.py
+++ b/idaes/core/util/diagnostics_tools/diagnostics_toolbox.py
@@ -1272,7 +1272,7 @@ class DiagnosticsToolbox:
             footer="=",
         )
 
-    def _get_inactive_opt_vars(self):
+    def _get_inactive_optimization_variables(self):
         """
         Returns a list of user-designated optimization variables that
         do not appear in any active equality constraints.
@@ -1290,7 +1290,7 @@ class DiagnosticsToolbox:
                 inactive_opt_vars.append(var)
         return inactive_opt_vars
 
-    def _get_unused_opt_vars(self):
+    def _get_unused_optimization_variables(self):
         """
         Returns a list of user-designated optimization variables that
         do not appear in any active constraints or objectives.
@@ -1307,7 +1307,7 @@ class DiagnosticsToolbox:
                 unused_opt_vars.append(var)
         return unused_opt_vars
 
-    def display_unused_optimization_variables(self):
+    def display_unused_optimization_variables(self, stream):
         """
         Displays user-designated optimization variables that do not appear
         in any active constraints or objectives.
@@ -1362,9 +1362,10 @@ class DiagnosticsToolbox:
         # Therefore adjust the expected degrees of freedom by these "inactive"
         # variables. If such a variable is totally unused, we can flag it
         # elsewhere.
-        inactive_opt = self._get_inactive_opt_vars()
+        inactive_opt = self._get_inactive_optimization_variables()
         expected_dof = len(self.config.optimization_variables) - len(inactive_opt)
-        if dof != len(self.config.optimization_variables):
+
+        if dof != expected_dof:
             dstring = "Degrees"
             if abs(dof) == 1:
                 dstring = "Degree"
@@ -1391,13 +1392,13 @@ class DiagnosticsToolbox:
             )
             next_steps.append(self.display_fixed_optimization_variables.__name__ + "()")
 
-        n_unused_opt_vars = len(self._get_unused_opt_vars())
+        n_unused_opt_vars = len(self._get_unused_optimization_variables())
         if n_unused_opt_vars > 0:
-            if n_fixed_opt_vars == 1:
+            if n_unused_opt_vars == 1:
                 vword = "variable"
             else:
                 vword = "variables"
-            warnings.append(f"WARNING: {n_fixed_opt_vars} optimization {vword} unused")
+            warnings.append(f"WARNING: {n_unused_opt_vars} optimization {vword} unused")
             next_steps.append(
                 self.display_unused_optimization_variables.__name__ + "()"
             )

--- a/idaes/core/util/diagnostics_tools/diagnostics_toolbox.py
+++ b/idaes/core/util/diagnostics_tools/diagnostics_toolbox.py
@@ -26,6 +26,7 @@ from pyomo.environ import (
     Constraint,
     Objective,
     value,
+    Var,
 )
 from pyomo.core.base.block import BlockData
 from pyomo.core.base.constraint import ConstraintData
@@ -245,6 +246,14 @@ CONFIG.declare(
         description="Feasibility tolerance for identifying infeasible constraints and bounds",
     ),
 )
+CONFIG.declare(
+    "optimization_variables",
+    ConfigValue(
+        default=None,
+        description="Variables unfixed during optimization phase. Used to "
+        "interpret degrees of freedom and Dulmage Mendelsohn partition.",
+    ),
+)
 
 
 @document_kwargs_from_configdict(CONFIG)
@@ -306,6 +315,8 @@ class DiagnosticsToolbox:
             )
         self._model = model
         self.config = CONFIG(kwargs)
+        if self.config.optimization_variables is None:
+            self.config.optimization_variables = []
 
     @property
     def model(self):
@@ -1246,11 +1257,12 @@ class DiagnosticsToolbox:
         warnings = []
         next_steps = []
         dof = degrees_of_freedom(self._model)
-        if dof != 0:
+        n_opt = len(self.config.optimization_variables)
+        if dof != len(self.config.optimization_variables):
             dstring = "Degrees"
             if abs(dof) == 1:
                 dstring = "Degree"
-            warnings.append(f"WARNING: {dof} {dstring} of Freedom")
+            warnings.append(f"WARNING: {dof} {dstring} of Freedom (Expected {n_opt})")
         if len(uc) > 0:
             cstring = "Components"
             if len(uc) == 1:
@@ -1259,18 +1271,31 @@ class DiagnosticsToolbox:
             next_steps.append(
                 self.display_components_with_inconsistent_units.__name__ + "()"
             )
-        if any(len(x) > 0 for x in [uc_var, uc_con, oc_var, oc_con]):
+
+        # uc_var and uc_con contain lists of lists corresponding to each
+        # underconstrained block. In order to get the total number, we need
+        # to sum over all blocks.
+        n_uc_var = len(sum(uc_var, []))
+        n_uc_con = len(sum(uc_con, []))
+        uc_dof = n_uc_var - n_uc_con
+
+        # Display underconstrained set if there are any unexpected degrees of
+        # freedom and the underconstrained set is nonempty
+        display_uc = uc_dof != n_opt and any(len(x) > 0 for x in [uc_var, uc_con])
+        display_oc = any(len(x) > 0 for x in [oc_var, oc_con])
+
+        if display_uc or display_oc:
             warnings.append(
                 f"WARNING: Structural singularity found\n"
-                f"{TAB*2}Under-Constrained Set: {len(sum(uc_var, []))} "
-                f"variables, {len(sum(uc_con, []))} constraints\n"
+                f"{TAB*2}Under-Constrained Set: {n_uc_var} "
+                f"variables, {n_uc_con} constraints\n"
                 f"{TAB*2}Over-Constrained Set: {len(sum(oc_var, []))} "
                 f"variables, {len(sum(oc_con, []))} constraints"
             )
 
-        if any(len(x) > 0 for x in [uc_var, uc_con]):
+        if display_uc:
             next_steps.append(self.display_underconstrained_set.__name__ + "()")
-        if any(len(x) > 0 for x in [oc_var, oc_con]):
+        if display_oc:
             next_steps.append(self.display_overconstrained_set.__name__ + "()")
 
         if not ignore_evaluation_errors:

--- a/idaes/core/util/diagnostics_tools/diagnostics_toolbox.py
+++ b/idaes/core/util/diagnostics_tools/diagnostics_toolbox.py
@@ -26,7 +26,6 @@ from pyomo.environ import (
     Constraint,
     Objective,
     value,
-    Var,
 )
 from pyomo.core.base.block import BlockData
 from pyomo.core.base.constraint import ConstraintData
@@ -47,11 +46,13 @@ from idaes.core.util.misc import compact_expression_to_string
 from idaes.core.util.model_statistics import (
     variables_in_activated_constraints_set,
     variables_not_in_activated_constraints_set,
+    variables_in_activated_equalities_set,
     variables_with_none_value_in_activated_equalities_set,
     greybox_block_set,
     degrees_of_freedom,
     large_residuals_set,
     variables_near_bounds_set,
+    unused_variables_set,
 )
 from idaes.core.scaling.util import (
     get_jacobian,
@@ -369,8 +370,8 @@ class DiagnosticsToolbox:
 
         write_report_section(
             stream=stream,
-            lines_list=variables_not_in_activated_constraints_set(self._model),
-            title="The following variable(s) do not appear in any activated constraints within the model:",
+            lines_list=unused_variables_set(self._model),
+            title="The following variable(s) do not appear in any activated constraints or objectives within the model:",
             header="=",
             footer="=",
         )
@@ -1232,6 +1233,104 @@ class DiagnosticsToolbox:
             footer="=",
         )
 
+    def _get_fixed_opt_vars(self):
+        """
+        Returns a list of user-designated optimization variables that
+        are fixed.
+
+        Args:
+            None
+        Returns:
+            fixed_opt_vars - list of fixed optimization variables
+        """
+        fixed_opt_vars = []
+        for var in self.config.optimization_variables:
+            if var.fixed:
+                fixed_opt_vars.append(var)
+        return fixed_opt_vars
+
+    def display_fixed_optimization_variables(self, stream=None):
+        """
+        Displays user-designated optimization variables that are fixed.
+
+        Args:
+            stream: an I/O object to write the output to (default = stdout)
+
+        Returns:
+            None
+        """
+        if stream is None:
+            stream = sys.stdout
+
+        fixed_opt_vars = self._get_fixed_opt_vars()
+
+        write_report_section(
+            stream=stream,
+            lines_list=fixed_opt_vars,
+            title="The following optimization variable(s) are fixed:",
+            header="=",
+            footer="=",
+        )
+
+    def _get_inactive_opt_vars(self):
+        """
+        Returns a list of user-designated optimization variables that
+        do not appear in any active equality constraints.
+
+        Args:
+            None
+        Returns:
+            inactive_opt_vars - list of "inactive" optimization variables
+                (they may still appear in inequalities and Objectives)
+        """
+        inactive_opt_vars = []
+        vars_in_eqs = variables_in_activated_equalities_set(self._model)
+        for var in self.config.optimization_variables:
+            if var not in vars_in_eqs:
+                inactive_opt_vars.append(var)
+        return inactive_opt_vars
+
+    def _get_unused_opt_vars(self):
+        """
+        Returns a list of user-designated optimization variables that
+        do not appear in any active constraints or objectives.
+
+        Args:
+            None
+        Returns:
+            unused_opt_vars - list of unused optimization variables
+        """
+        unused_opt_vars = []
+        unused_vars = unused_variables_set(self._model)
+        for var in self.config.optimization_variables:
+            if var in unused_vars:
+                unused_opt_vars.append(var)
+        return unused_opt_vars
+
+    def display_unused_optimization_variables(self):
+        """
+        Displays user-designated optimization variables that do not appear
+        in any active constraints or objectives.
+
+        Args:
+            stream: an I/O object to write the output to (default = stdout)
+
+        Returns:
+            None
+        """
+        if stream is None:
+            stream = sys.stdout
+
+        unused_optimization_variables = self._get_unused_optimization_variables()
+
+        write_report_section(
+            stream=stream,
+            lines_list=unused_optimization_variables,
+            title="The following optimization variable(s) appear in no active constraint or objective:",
+            header="=",
+            footer="=",
+        )
+
     def _collect_structural_warnings(
         self, ignore_evaluation_errors=False, ignore_unit_consistency=False
     ):
@@ -1257,12 +1356,21 @@ class DiagnosticsToolbox:
         warnings = []
         next_steps = []
         dof = degrees_of_freedom(self._model)
-        n_opt = len(self.config.optimization_variables)
+        # degrees_of_freedom takes into account only variables in equality
+        # constraints. However, the user could have an optimization variable
+        # that exclusively appears in inequality constraints or Objectives.
+        # Therefore adjust the expected degrees of freedom by these "inactive"
+        # variables. If such a variable is totally unused, we can flag it
+        # elsewhere.
+        inactive_opt = self._get_inactive_opt_vars()
+        expected_dof = len(self.config.optimization_variables) - len(inactive_opt)
         if dof != len(self.config.optimization_variables):
             dstring = "Degrees"
             if abs(dof) == 1:
                 dstring = "Degree"
-            warnings.append(f"WARNING: {dof} {dstring} of Freedom (Expected {n_opt})")
+            warnings.append(
+                f"WARNING: {dof} {dstring} of Freedom (Expected {expected_dof})"
+            )
         if len(uc) > 0:
             cstring = "Components"
             if len(uc) == 1:
@@ -1270,6 +1378,28 @@ class DiagnosticsToolbox:
             warnings.append(f"WARNING: {len(uc)} {cstring} with inconsistent units")
             next_steps.append(
                 self.display_components_with_inconsistent_units.__name__ + "()"
+            )
+
+        n_fixed_opt_vars = len(self._get_fixed_opt_vars())
+        if n_fixed_opt_vars > 0:
+            if n_fixed_opt_vars == 1:
+                vword = "variable"
+            else:
+                vword = "variables"
+            warnings.append(
+                f"WARNING: {n_fixed_opt_vars} optimization {vword} unexpectedly fixed"
+            )
+            next_steps.append(self.display_fixed_optimization_variables.__name__ + "()")
+
+        n_unused_opt_vars = len(self._get_unused_opt_vars())
+        if n_unused_opt_vars > 0:
+            if n_fixed_opt_vars == 1:
+                vword = "variable"
+            else:
+                vword = "variables"
+            warnings.append(f"WARNING: {n_fixed_opt_vars} optimization {vword} unused")
+            next_steps.append(
+                self.display_unused_optimization_variables.__name__ + "()"
             )
 
         # uc_var and uc_con contain lists of lists corresponding to each
@@ -1281,7 +1411,9 @@ class DiagnosticsToolbox:
 
         # Display underconstrained set if there are any unexpected degrees of
         # freedom and the underconstrained set is nonempty
-        display_uc = uc_dof != n_opt and any(len(x) > 0 for x in [uc_var, uc_con])
+        display_uc = uc_dof != expected_dof and any(
+            len(x) > 0 for x in [uc_var, uc_con]
+        )
         display_oc = any(len(x) > 0 for x in [oc_var, oc_con])
 
         if display_uc or display_oc:

--- a/idaes/core/util/diagnostics_tools/tests/test_diagnostics_toolbox.py
+++ b/idaes/core/util/diagnostics_tools/tests/test_diagnostics_toolbox.py
@@ -187,6 +187,22 @@ The following optimization variable(s) are fixed:
         assert stream.getvalue() == expected
 
     @pytest.mark.component
+    def test_display_unused_optimization_variables(self, model):
+        dt = DiagnosticsToolbox(
+            model=model.b, optimization_variables=[model.b.v7, model.b.v8]
+        )
+        stream = StringIO()
+        dt.display_unused_optimization_variables(stream)
+        expected = """====================================================================================
+The following optimization variable(s) appear in no active constraint or objective:
+
+    b.v8
+
+====================================================================================
+"""
+        assert stream.getvalue() == expected
+
+    @pytest.mark.component
     def test_display_variables_fixed_to_zero(self, model):
         dt = DiagnosticsToolbox(model=model.b)
 
@@ -997,15 +1013,17 @@ The following constraints have no free variables:
         # Create structural singularities
         m.b.v2.unfix()
 
-        dt = DiagnosticsToolbox(model=m.b, optimization_variables=[m.b.v2])
+        dt = DiagnosticsToolbox(model=m.b, optimization_variables=[m.b.v2, m.b.v8])
 
         warnings, next_steps = dt._collect_structural_warnings()
 
-        assert len(warnings) == 1
+        assert len(warnings) == 2
         assert "WARNING: 1 Component with inconsistent units" in warnings
+        assert "WARNING: 1 optimization variable unused" in warnings
 
-        assert len(next_steps) == 1
+        assert len(next_steps) == 2
         assert "display_components_with_inconsistent_units()" in next_steps
+        assert "display_unused_optimization_variables()" in next_steps
 
     @pytest.mark.component
     def test_collect_structural_warnings_overconstrained(self, model):
@@ -1033,9 +1051,12 @@ The following constraints have no free variables:
         assert "display_overconstrained_set()" in next_steps
 
     @pytest.mark.component
-    def test_collect_structural_warnings_overconstrained_opt_var(self, model):
+    def test_collect_structural_warnings_overconstrained_opt_vars(self, model):
         # Clone model so we can add some singularities
         m = model.clone()
+        # Add a second unused var so we can test that the warning
+        # for unused optimization variables is appropriately pluralized
+        m.b.v9 = Var()
 
         # Fix units
         m.b.del_component(m.b.c1)
@@ -1044,20 +1065,25 @@ The following constraints have no free variables:
         # Create structural singularities
         m.b.v4.fix(2)
 
-        dt = DiagnosticsToolbox(model=m.b, optimization_variables=[m.b.v2])
+        dt = DiagnosticsToolbox(
+            model=m.b, optimization_variables=[m.b.v2, m.b.v8, m.b.v9]
+        )
 
         warnings, next_steps = dt._collect_structural_warnings()
 
-        assert len(warnings) == 3
+        assert len(warnings) == 4
         assert "WARNING: -1 Degree of Freedom (Expected 1)" in warnings
         assert "WARNING: 1 optimization variable unexpectedly fixed" in warnings
+        assert "WARNING: 2 optimization variables unused" in warnings
+
         assert """WARNING: Structural singularity found
         Under-Constrained Set: 0 variables, 0 constraints
         Over-Constrained Set: 1 variables, 2 constraints""" in warnings
 
-        assert len(next_steps) == 2
+        assert len(next_steps) == 3
         assert "display_overconstrained_set()" in next_steps
         assert "display_fixed_optimization_variables()" in next_steps
+        assert "display_unused_optimization_variables()" in next_steps
 
     @pytest.mark.component
     def test_collect_structural_warnings_square_opt_var(self, model):
@@ -1070,6 +1096,31 @@ The following constraints have no free variables:
         warnings, next_steps = dt._collect_structural_warnings()
 
         assert len(warnings) == 3
+        assert "WARNING: 0 Degrees of Freedom (Expected 3)" in warnings
+        assert "WARNING: 2 optimization variables unexpectedly fixed" in warnings
+        assert "WARNING: 1 Component with inconsistent units" in warnings
+
+        assert len(next_steps) == 2
+        assert "display_components_with_inconsistent_units()" in next_steps
+        assert "display_fixed_optimization_variables()" in next_steps
+
+    @pytest.mark.component
+    def test_collect_structural_warnings_square_opt_var_ineq_obj(self, model):
+        m = model.clone()
+        m.b.v9 = Var()
+        m.b.i1 = Constraint(expr=m.b.v8 >= 0)
+        m.b.obj1 = Objective(expr=m.b.v9**2)
+
+        dt = DiagnosticsToolbox(
+            model=m.b, optimization_variables=[m.b.v2, m.b.v3, m.b.v5, m.b.v8, m.b.v9]
+        )
+
+        warnings, next_steps = dt._collect_structural_warnings()
+
+        assert len(warnings) == 3
+        # m.b.v8 and m.b.v9 should not show up in the DOF, which considers
+        # only equality constraints, but should also not be considered unused
+        # because they show up in an inequality constraint and an objective.
         assert "WARNING: 0 Degrees of Freedom (Expected 3)" in warnings
         assert "WARNING: 2 optimization variables unexpectedly fixed" in warnings
         assert "WARNING: 1 Component with inconsistent units" in warnings

--- a/idaes/core/util/diagnostics_tools/tests/test_diagnostics_toolbox.py
+++ b/idaes/core/util/diagnostics_tools/tests/test_diagnostics_toolbox.py
@@ -80,7 +80,8 @@ class TestDiagnosticsToolbox:
             DiagnosticsToolbox(model=m.b)
 
     @pytest.fixture(scope="class")
-    def model(self):
+    @classmethod
+    def model(cls):
         m = ConcreteModel()
         m.b = Block()
 
@@ -962,7 +963,7 @@ The following constraints have no free variables:
 
         assert len(warnings) == 3
         assert "WARNING: 1 Component with inconsistent units" in warnings
-        assert "WARNING: 1 Degree of Freedom" in warnings
+        assert "WARNING: 1 Degree of Freedom (Expected 0)" in warnings
         assert """WARNING: Structural singularity found
         Under-Constrained Set: 3 variables, 2 constraints
         Over-Constrained Set: 0 variables, 0 constraints""" in warnings
@@ -970,6 +971,24 @@ The following constraints have no free variables:
         assert len(next_steps) == 2
         assert "display_components_with_inconsistent_units()" in next_steps
         assert "display_underconstrained_set()" in next_steps
+
+    @pytest.mark.component
+    def test_collect_structural_warnings_underconstrained_opt_vars(self, model):
+        # Clone model so we can add some singularities
+        m = model.clone()
+
+        # Create structural singularities
+        m.b.v2.unfix()
+
+        dt = DiagnosticsToolbox(model=m.b, optimization_variables=[m.b.v2])
+
+        warnings, next_steps = dt._collect_structural_warnings()
+
+        assert len(warnings) == 1
+        assert "WARNING: 1 Component with inconsistent units" in warnings
+
+        assert len(next_steps) == 1
+        assert "display_components_with_inconsistent_units()" in next_steps
 
     @pytest.mark.component
     def test_collect_structural_warnings_overconstrained(self, model):
@@ -988,13 +1007,53 @@ The following constraints have no free variables:
         warnings, next_steps = dt._collect_structural_warnings()
 
         assert len(warnings) == 2
-        assert "WARNING: -1 Degree of Freedom" in warnings
+        assert "WARNING: -1 Degree of Freedom (Expected 0)" in warnings
         assert """WARNING: Structural singularity found
         Under-Constrained Set: 0 variables, 0 constraints
         Over-Constrained Set: 1 variables, 2 constraints""" in warnings
 
         assert len(next_steps) == 1
         assert "display_overconstrained_set()" in next_steps
+
+    @pytest.mark.component
+    def test_collect_structural_warnings_overconstrained_opt_var(self, model):
+        # Clone model so we can add some singularities
+        m = model.clone()
+
+        # Fix units
+        m.b.del_component(m.b.c1)
+        m.b.c1 = Constraint(expr=m.v1 + m.b.v2 == 10 * units.m)
+
+        # Create structural singularities
+        m.b.v4.fix(2)
+
+        dt = DiagnosticsToolbox(model=m.b, optimization_variables=[m.b.v2])
+
+        warnings, next_steps = dt._collect_structural_warnings()
+
+        assert len(warnings) == 2
+        assert "WARNING: -1 Degree of Freedom (Expected 1)" in warnings
+        assert """WARNING: Structural singularity found
+        Under-Constrained Set: 0 variables, 0 constraints
+        Over-Constrained Set: 1 variables, 2 constraints""" in warnings
+
+        assert len(next_steps) == 1
+        assert "display_overconstrained_set()" in next_steps
+
+    @pytest.mark.component
+    def test_collect_structural_warnings_square_opt_var(self, model):
+        m = model.clone()
+
+        dt = DiagnosticsToolbox(model=m.b, optimization_variables=[m.b.v2])
+
+        warnings, next_steps = dt._collect_structural_warnings()
+
+        assert len(warnings) == 2
+        assert "WARNING: 0 Degrees of Freedom (Expected 1)" in warnings
+        assert "WARNING: 1 Component with inconsistent units" in warnings
+
+        assert len(next_steps) == 1
+        assert "display_components_with_inconsistent_units()" in next_steps
 
     @pytest.mark.component
     def test_collect_structural_cautions(self, model):

--- a/idaes/core/util/diagnostics_tools/tests/test_diagnostics_toolbox.py
+++ b/idaes/core/util/diagnostics_tools/tests/test_diagnostics_toolbox.py
@@ -160,13 +160,30 @@ The following external variable(s) appear in constraints within the model:
         dt.display_unused_variables(stream)
 
         expected = """====================================================================================
-The following variable(s) do not appear in any activated constraints within the model:
+The following variable(s) do not appear in any activated constraints or objectives within the model:
 
     b.v8
 
 ====================================================================================
 """
 
+        assert stream.getvalue() == expected
+
+    @pytest.mark.component
+    def test_display_fixed_optimization_variables(self, model):
+        dt = DiagnosticsToolbox(
+            model=model.b, optimization_variables=[model.b.v2, model.b.v3, model.b.v5]
+        )
+        stream = StringIO()
+        dt.display_fixed_optimization_variables(stream)
+        expected = """====================================================================================
+The following optimization variable(s) are fixed:
+
+    b.v2
+    b.v5
+
+====================================================================================
+"""
         assert stream.getvalue() == expected
 
     @pytest.mark.component
@@ -1031,29 +1048,35 @@ The following constraints have no free variables:
 
         warnings, next_steps = dt._collect_structural_warnings()
 
-        assert len(warnings) == 2
+        assert len(warnings) == 3
         assert "WARNING: -1 Degree of Freedom (Expected 1)" in warnings
+        assert "WARNING: 1 optimization variable unexpectedly fixed" in warnings
         assert """WARNING: Structural singularity found
         Under-Constrained Set: 0 variables, 0 constraints
         Over-Constrained Set: 1 variables, 2 constraints""" in warnings
 
-        assert len(next_steps) == 1
+        assert len(next_steps) == 2
         assert "display_overconstrained_set()" in next_steps
+        assert "display_fixed_optimization_variables()" in next_steps
 
     @pytest.mark.component
     def test_collect_structural_warnings_square_opt_var(self, model):
         m = model.clone()
 
-        dt = DiagnosticsToolbox(model=m.b, optimization_variables=[m.b.v2])
+        dt = DiagnosticsToolbox(
+            model=m.b, optimization_variables=[m.b.v2, m.b.v3, m.b.v5]
+        )
 
         warnings, next_steps = dt._collect_structural_warnings()
 
-        assert len(warnings) == 2
-        assert "WARNING: 0 Degrees of Freedom (Expected 1)" in warnings
+        assert len(warnings) == 3
+        assert "WARNING: 0 Degrees of Freedom (Expected 3)" in warnings
+        assert "WARNING: 2 optimization variables unexpectedly fixed" in warnings
         assert "WARNING: 1 Component with inconsistent units" in warnings
 
-        assert len(next_steps) == 1
+        assert len(next_steps) == 2
         assert "display_components_with_inconsistent_units()" in next_steps
+        assert "display_fixed_optimization_variables()" in next_steps
 
     @pytest.mark.component
     def test_collect_structural_cautions(self, model):

--- a/idaes/core/util/model_statistics.py
+++ b/idaes/core/util/model_statistics.py
@@ -1335,7 +1335,11 @@ def unused_variables_set(block):
         A ComponentSet including all Var components which do not appear within
         any Constraints in block
     """
-    return variables_set(block) - variables_in_activated_constraints_set(block)
+    return (
+        variables_set(block)
+        - variables_in_activated_constraints_set(block)
+        - variables_in_activated_objectives_set(block)
+    )
 
 
 def number_unused_variables(block):
@@ -1509,6 +1513,24 @@ def number_activated_objectives(block):
         Number of activated Objective components which appear in block
     """
     return sum(1 for _ in activated_objectives_generator(block))
+
+
+def variables_in_activated_objectives_set(block):
+    """
+    Method to return the set of variables that appear in activated Objective
+    components in a model.
+
+    Args:
+        block : model to be studied
+
+    Returns:
+        Set of variables in activated Objective components in block
+    """
+    var_set = ComponentSet()
+    for o in activated_objectives_generator(block):
+        for v in identify_variables(o.expr):
+            var_set.add(v)
+    return var_set
 
 
 def deactivated_objectives_generator(block):

--- a/idaes/core/util/tests/test_model_statistics.py
+++ b/idaes/core/util/tests/test_model_statistics.py
@@ -115,7 +115,7 @@ def m():
         m.b2[i].c2 = Constraint(expr=2 <= m.b2[i].v1)
 
         if i == "a":
-            m.b2[i].o1 = Objective(expr=m.b2[i].v1)
+            m.b2[i].o1 = Objective(expr=m.b2[i].v2["b"])
             m.b2[i].o2 = Objective(expr=m.b2[i].v1)
             m.b2[i].o2.deactivate()
             m.b2[i].c1.deactivate()
@@ -943,14 +943,14 @@ def test_number_fixed_variables_only_in_inequalities(m):
 # Unused and un-Transformed Variables
 @pytest.mark.unit
 def test_unused_variables_set(m):
-    assert len(unused_variables_set(m)) == 6
-    assert len(unused_variables_set(m.b2)) == 5
+    assert len(unused_variables_set(m)) == 5
+    assert len(unused_variables_set(m.b2)) == 4
 
 
 @pytest.mark.unit
 def test_number_unused_variables(m):
-    assert number_unused_variables(m) == 6
-    assert number_unused_variables(m.b2) == 5
+    assert number_unused_variables(m) == 5
+    assert number_unused_variables(m.b2) == 4
 
 
 @pytest.mark.unit
@@ -1077,6 +1077,13 @@ def test_activated_objectives_set(m):
 def test_number_activated_objectives(m):
     assert number_activated_objectives(m) == 1
     assert number_activated_objectives(m.b2) == 1
+
+
+@pytest.mark.unit
+def test_variables_in_activated_objectives_set(m):
+    vset = variables_in_activated_objectives_set(m)
+    assert len(vset) == 1
+    assert m.b2["a"].v2["b"] in vset
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary/Motivation:
The Flowsheet Inspector tool displays model diagnostic information after both initialization and optimization. The problem with displaying model diagnostic information is that an optimization model is always going to have positive degrees of freedom. That causes a DOF warning to be emitted, as well as a warning about structural singularity. 

The solution I propose is to add the `optimization_variables` config option to the `DiagnosticToolbox`. This is a list of variables that are known to be unfixed in order to optimize the flowsheet. If such a list is passed in, we expect the number of degrees of freedom to equal the number of "optimization variables" (barring the edge case of an "optimization variable" appearing exclusively in inequality constraints or the objective function). The Flowsheet Inspector will be modified in a future PR to have a way for the user to declare "optimization variables" and thereby allow the user to keep track of their degrees of freedom.

However, adding this option added a bunch of edge cases: what if an "optimization variable" is fixed? What if it's entirely unused? To solve these problems, additional methods were added to warn the user about these situations.

One idea for a future PR is to also add an option to check for structural singularity when the "optimization variables" are fixed. If the system is indeed structurally singular, then there is an algebraic relationship between the "optimization variables", and their values will be confined to a lower dimensional surface. This would indicate that the user doesn't understand their system well and that there are some other combinations of variables which are really being optimized.

## Changes proposed in this PR:
- Add the `optimization_variables` config argument to the `DiagnosticsToolbox`
- Adjust the `DiagnosticsToolbox` reporting for degrees of freedom and structural singularity to allow for the fast that the system has nonzero DOF
- Add the `display_fixed_optimization_variables` and `display_unused_optimization_variables` diagnostic methods to prevent user error when declaring these variables.
- Add the `variables_in_activated_objectives_set` model statistics option to keep track of variables in objective functions and modify the `unused_variables_set` method in model statistics so that variables that appear exclusively in objective expressions do not count as "unused".

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
