### PR TITLE
GenericStateBlock critical property constraint initialization

### DIFF
--- a/idaes/models/properties/modular_properties/base/generic_property.py
+++ b/idaes/models/properties/modular_properties/base/generic_property.py
@@ -2706,7 +2706,11 @@ class _GenericStateBlock(StateBlock):
                     # Initialize critical point properties
                     _initialize_critical_props(k)
                     # Add critical point constraints to cons_list
-                    cons_list += k.list_critical_property_constraint_names()
+                    ref_phase = k._get_critical_ref_phase()
+                    p_config = k.params.get_phase(ref_phase).config
+                    cons_list += (
+                        p_config.equation_of_state.list_critical_property_constraint_names()
+                    )
 
             # Bubble temperature initialization
             if hasattr(k, "_mole_frac_tbub"):


### PR DESCRIPTION
Changed GenericStateBlock initialize function to add critical point constraints to constraint list in the same way that "initialization_routine" does

## Fixes
GenericStateBlock initialize function now calls p_config.equation_of_state.list_critical_property_constraint_names()

## Summary/Motivation:
Using modular properties framework cubic equation of state, I tried to create an expression with stateblock[0].pressure_crit and it stopped initializing correctly, this change fixed it.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
